### PR TITLE
Feature/Unfeasible problems (ANT-334)

### DIFF
--- a/src/libs/antares/CMakeLists.txt
+++ b/src/libs/antares/CMakeLists.txt
@@ -247,6 +247,9 @@ set(SRC_STUDY_PARAMETERS
 	study/parameters.h
 	study/parameters.hxx
 	study/parameters.cpp
+	study/UnfeasibleProblemBehavior.cpp
+    # TODO JMK : should be in a target_include_directories : but need to remove all .h from all SRC
+    study/UnfeasibleProblemBehavior.hpp
 	)
 source_group("study\\general data" FILES ${SRC_STUDY_PARAMETERS})
 
@@ -460,10 +463,12 @@ set(SRC
 	# variable selection
 	study/variable-print-info.h
 	study/variable-print-info.cpp
+    
+    # Enum 
+    # TODO JMK : should be in a target_include_directories : but need to remove all .h from all SRC
+    Enum.hpp
+    Enum.hxx
 )
-
-
-
 
 add_library( libantares-core-calendar STATIC
 	# separated target to reduce multiple unit compilations introduced by swap mode
@@ -471,8 +476,6 @@ add_library( libantares-core-calendar STATIC
 	date/date.h
 	date/date.cpp
 )
-
-
 
 macro(ADD_ANTARES_CORE name)
 	add_library(libantares-core${name} STATIC

--- a/src/libs/antares/CMakeLists.txt
+++ b/src/libs/antares/CMakeLists.txt
@@ -332,6 +332,22 @@ set(SRC_IO
 source_group("io" FILES ${SRC_IO})
 	
 
+set(SRC_EXCEPTION
+	exception/AssertionError.cpp
+    # TODO : should be in a target_include_directories : but need to remove all .h from all SRC
+	exception/AssertionError.hpp
+	exception/UnfeasibleProblemError.cpp
+    # TODO : should be in a target_include_directories : but need to remove all .h from all SRC
+	exception/UnfeasibleProblemError.hpp
+	)
+source_group("exception" FILES ${SRC_EXCEPTION})
+
+set(SRC_STDCXX
+	stdcxx/demangle.cpp
+    # TODO : should be in a target_include_directories : but need to remove all .h from all SRC
+	stdcxx/demangle.hpp
+	)
+source_group("stdcxx" FILES ${SRC_STDCXX})
 
 set(SRC
 	config.h  constants.h
@@ -465,7 +481,7 @@ set(SRC
 	study/variable-print-info.cpp
     
     # Enum 
-    # TODO JMK : should be in a target_include_directories : but need to remove all .h from all SRC
+    # TODO : should be in a target_include_directories : but need to remove all .h from all SRC
     Enum.hpp
     Enum.hxx
 )
@@ -505,6 +521,8 @@ macro(ADD_ANTARES_CORE name)
 		${SRC_STUDY_PART_HYDRO}
 		${SRC_STUDY_PART_THERMAL}
 		${SRC_STUDY_SCENARIO_BUILDER}
+        ${SRC_EXCEPTION}
+        ${SRC_STDCXX}
 		${SRC}
 	)
 	target_link_libraries(libantares-core${name}

--- a/src/libs/antares/Enum.hpp
+++ b/src/libs/antares/Enum.hpp
@@ -44,9 +44,6 @@ template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>
 std::string toString(const E& value);
 
 template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-bool isValid(const std::string& name);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
 E fromString(const std::string& name);
 
 }  // namespace Enum

--- a/src/libs/antares/Enum.hpp
+++ b/src/libs/antares/Enum.hpp
@@ -1,0 +1,63 @@
+/*
+** Copyright 2007-2018 RTE
+** Authors: Antares_Simulator Team
+**
+** This file is part of Antares_Simulator.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** There are special exceptions to the terms and conditions of the
+** license as they are applied to this software. View the full text of
+** the exceptions in file COPYING.txt in the directory of this software
+** distribution
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Antares_Simulator. If not, see <http://www.gnu.org/licenses/>.
+**
+** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
+*/
+#ifndef ANTARES_DATA_ENUM_HPP
+#define ANTARES_DATA_ENUM_HPP
+
+#include <initializer_list>
+#include <string>
+#include <type_traits>
+
+namespace Antares {
+
+namespace Data {
+
+namespace Enum {
+
+template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
+const std::initializer_list<std::string>& getNames();
+
+template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
+std::string toString(const E& value);
+
+template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
+E fromString(const std::string& name);
+
+}  // namespace Enum
+
+template <typename E>
+inline typename std::enable_if<std::is_enum<E>::value, std::ostream&>::type operator<<(std::ostream& stream, const E& value) {
+    stream << Data::Enum::toString(value);
+    return stream;
+}
+
+}  // namespace Data
+
+}  // namespace Antares
+
+#include <antares/Enum.hxx>
+
+#endif  // ANTARES_DATA_ENUM_HPP

--- a/src/libs/antares/Enum.hxx
+++ b/src/libs/antares/Enum.hxx
@@ -54,18 +54,6 @@ E fromString(const std::string& name) {
 }
 
 template <typename E, typename>
-bool isValid(const std::string& name) {
-    bool result = true;
-    const auto& names = getNames<E>();
-    const auto& it = std::find(names.begin(), names.end(), name);
-    if (it == names.end()) {
-        result = false;
-    }
-
-    return result;
-}
-
-template <typename E, typename>
 std::string toString(const E& value) {
     auto index = static_cast<unsigned long>(value);
     const auto& names = getNames<E>();

--- a/src/libs/antares/Enum.hxx
+++ b/src/libs/antares/Enum.hxx
@@ -1,0 +1,71 @@
+/*
+** Copyright 2007-2018 RTE
+** Authors: Antares_Simulator Team
+**
+** This file is part of Antares_Simulator.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** There are special exceptions to the terms and conditions of the
+** license as they are applied to this software. View the full text of
+** the exceptions in file COPYING.txt in the directory of this software
+** distribution
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Antares_Simulator. If not, see <http://www.gnu.org/licenses/>.
+**
+** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
+*/
+
+#ifndef ANTARES_DATA_ENUM_HXX
+#define ANTARES_DATA_ENUM_HXX
+
+#include <antares/Enum.hpp>
+
+namespace Antares
+{
+namespace Data
+{
+    
+namespace Enum {
+
+template <typename E, typename>
+E fromString(const std::string& name) {
+    const auto& names = getNames<E>();
+    const auto& it = std::find(names.begin(), names.end(), name);
+    if (it == names.end()) {
+        //TODO JMK : define Exception for Antares::Data namespace
+        //TODO JMK : define logging method
+        //throw powsybl::AssertionError(powsybl::logging::format("Unexpected %1% name: %2%", stdcxx::simpleClassName<E>(), name));
+    }
+
+    return static_cast<E>(it - names.begin());
+}
+
+template <typename E, typename>
+std::string toString(const E& value) {
+    auto index = static_cast<unsigned long>(value);
+    const auto& names = getNames<E>();
+    if (index >= names.size()) {
+        //TODO JMK : define Exception for Antares::Data namespace
+        //TODO JMK : define logging method
+        //throw throw powsybl::AssertionError(powsybl::logging::format("Unexpected %1% value: %2%", stdcxx::simpleClassName<E>(), index));
+    }
+    return *(names.begin() + index);
+}
+
+} // namespace Enum
+
+} // namespace Data
+
+} // namespace Antares
+
+#endif  // ANTARES_DATA_ENUM_HXX

--- a/src/libs/antares/Enum.hxx
+++ b/src/libs/antares/Enum.hxx
@@ -28,6 +28,9 @@
 #ifndef ANTARES_DATA_ENUM_HXX
 #define ANTARES_DATA_ENUM_HXX
 
+#include <antares/exception/AssertionError.hpp>
+#include <antares/stdcxx/demangle.hpp>
+
 #include <antares/Enum.hpp>
 
 namespace Antares
@@ -42,12 +45,22 @@ E fromString(const std::string& name) {
     const auto& names = getNames<E>();
     const auto& it = std::find(names.begin(), names.end(), name);
     if (it == names.end()) {
-        //TODO JMK : define Exception for Antares::Data namespace
-        //TODO JMK : define logging method
-        //throw powsybl::AssertionError(powsybl::logging::format("Unexpected %1% name: %2%", stdcxx::simpleClassName<E>(), name));
+        throw AssertionError("Unexpected " + stdcxx::simpleClassName<E>() + " name " +name);
     }
 
     return static_cast<E>(it - names.begin());
+}
+
+template <typename E, typename>
+bool isValid(const std::string& name) {
+    bool result = true;
+    const auto& names = getNames<E>();
+    const auto& it = std::find(names.begin(), names.end(), name);
+    if (it == names.end()) {
+        result = false;
+    }
+
+    return result;
 }
 
 template <typename E, typename>
@@ -55,9 +68,7 @@ std::string toString(const E& value) {
     auto index = static_cast<unsigned long>(value);
     const auto& names = getNames<E>();
     if (index >= names.size()) {
-        //TODO JMK : define Exception for Antares::Data namespace
-        //TODO JMK : define logging method
-        //throw throw powsybl::AssertionError(powsybl::logging::format("Unexpected %1% value: %2%", stdcxx::simpleClassName<E>(), index));
+        throw AssertionError("Unexpected " +  stdcxx::simpleClassName<E>() + " value " + std::to_string(index));
     }
     return *(names.begin() + index);
 }

--- a/src/libs/antares/Enum.hxx
+++ b/src/libs/antares/Enum.hxx
@@ -28,6 +28,8 @@
 #ifndef ANTARES_DATA_ENUM_HXX
 #define ANTARES_DATA_ENUM_HXX
 
+#include <algorithm>
+
 #include <antares/exception/AssertionError.hpp>
 #include <antares/stdcxx/demangle.hpp>
 

--- a/src/libs/antares/exception/AssertionError.cpp
+++ b/src/libs/antares/exception/AssertionError.cpp
@@ -24,43 +24,16 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#ifndef ANTARES_DATA_ENUM_HPP
-#define ANTARES_DATA_ENUM_HPP
-
-#include <initializer_list>
-#include <string>
-#include <type_traits>
+#include <antares/exception/AssertionError.hpp>
 
 namespace Antares {
 
 namespace Data {
 
-namespace Enum {
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-const std::initializer_list<std::string>& getNames();
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-std::string toString(const E& value);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-bool isValid(const std::string& name);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-E fromString(const std::string& name);
-
-}  // namespace Enum
-
-template <typename E>
-inline typename std::enable_if<std::is_enum<E>::value, std::ostream&>::type operator<<(std::ostream& stream, const E& value) {
-    stream << Data::Enum::toString(value);
-    return stream;
+AssertionError::AssertionError(const std::string& message) :
+    std::runtime_error(message) {
 }
 
 }  // namespace Data
 
 }  // namespace Antares
-
-#include <antares/Enum.hxx>
-
-#endif  // ANTARES_DATA_ENUM_HPP

--- a/src/libs/antares/exception/AssertionError.hpp
+++ b/src/libs/antares/exception/AssertionError.hpp
@@ -24,43 +24,24 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#ifndef ANTARES_DATA_ENUM_HPP
-#define ANTARES_DATA_ENUM_HPP
+#ifndef ANTARES_DATA_ASSERTIONERROR_HPP
+#define ANTARES_DATA_ASSERTIONERROR_HPP
 
-#include <initializer_list>
-#include <string>
-#include <type_traits>
+#include <stdexcept>
 
 namespace Antares {
 
 namespace Data {
 
-namespace Enum {
+class AssertionError : public std::runtime_error {
+public:
+    explicit AssertionError(const std::string& message);
 
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-const std::initializer_list<std::string>& getNames();
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-std::string toString(const E& value);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-bool isValid(const std::string& name);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-E fromString(const std::string& name);
-
-}  // namespace Enum
-
-template <typename E>
-inline typename std::enable_if<std::is_enum<E>::value, std::ostream&>::type operator<<(std::ostream& stream, const E& value) {
-    stream << Data::Enum::toString(value);
-    return stream;
-}
+    ~AssertionError() noexcept override = default;
+};
 
 }  // namespace Data
 
 }  // namespace Antares
 
-#include <antares/Enum.hxx>
-
-#endif  // ANTARES_DATA_ENUM_HPP
+#endif  // ANTARES_DATA_ASSERTIONERROR_HPP

--- a/src/libs/antares/exception/UnfeasibleProblemError.cpp
+++ b/src/libs/antares/exception/UnfeasibleProblemError.cpp
@@ -24,43 +24,16 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#ifndef ANTARES_DATA_ENUM_HPP
-#define ANTARES_DATA_ENUM_HPP
-
-#include <initializer_list>
-#include <string>
-#include <type_traits>
+#include <antares/exception/UnfeasibleProblemError.hpp>
 
 namespace Antares {
 
 namespace Data {
 
-namespace Enum {
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-const std::initializer_list<std::string>& getNames();
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-std::string toString(const E& value);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-bool isValid(const std::string& name);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-E fromString(const std::string& name);
-
-}  // namespace Enum
-
-template <typename E>
-inline typename std::enable_if<std::is_enum<E>::value, std::ostream&>::type operator<<(std::ostream& stream, const E& value) {
-    stream << Data::Enum::toString(value);
-    return stream;
+UnfeasibleProblemError::UnfeasibleProblemError(const std::string& message) :
+    std::runtime_error(message) {
 }
 
 }  // namespace Data
 
 }  // namespace Antares
-
-#include <antares/Enum.hxx>
-
-#endif  // ANTARES_DATA_ENUM_HPP

--- a/src/libs/antares/exception/UnfeasibleProblemError.hpp
+++ b/src/libs/antares/exception/UnfeasibleProblemError.hpp
@@ -24,43 +24,24 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#ifndef ANTARES_DATA_ENUM_HPP
-#define ANTARES_DATA_ENUM_HPP
+#ifndef ANTARES_DATA_UNFEASIBLEPROBLEMERROR_HPP
+#define ANTARES_DATA_UNFEASIBLEPROBLEMERROR_HPP
 
-#include <initializer_list>
-#include <string>
-#include <type_traits>
+#include <stdexcept>
 
 namespace Antares {
 
 namespace Data {
 
-namespace Enum {
+class UnfeasibleProblemError : public std::runtime_error {
+public:
+    explicit UnfeasibleProblemError(const std::string& message);
 
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-const std::initializer_list<std::string>& getNames();
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-std::string toString(const E& value);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-bool isValid(const std::string& name);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-E fromString(const std::string& name);
-
-}  // namespace Enum
-
-template <typename E>
-inline typename std::enable_if<std::is_enum<E>::value, std::ostream&>::type operator<<(std::ostream& stream, const E& value) {
-    stream << Data::Enum::toString(value);
-    return stream;
-}
+    ~UnfeasibleProblemError() noexcept override = default;
+};
 
 }  // namespace Data
 
 }  // namespace Antares
 
-#include <antares/Enum.hxx>
-
-#endif  // ANTARES_DATA_ENUM_HPP
+#endif  // ANTARES_DATA_UNFEASIBLEPROBLEMERROR_HPP

--- a/src/libs/antares/stdcxx/demangle.cpp
+++ b/src/libs/antares/stdcxx/demangle.cpp
@@ -1,0 +1,76 @@
+/*
+** Copyright 2007-2018 RTE
+** Authors: Antares_Simulator Team
+**
+** This file is part of Antares_Simulator.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** There are special exceptions to the terms and conditions of the
+** license as they are applied to this software. View the full text of
+** the exceptions in file COPYING.txt in the directory of this software
+** distribution
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Antares_Simulator. If not, see <http://www.gnu.org/licenses/>.
+**
+** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
+*/
+
+#include <antares/stdcxx/demangle.hpp>
+
+namespace stdcxx {
+
+std::string demangle(const char* name) {
+    
+    //TODO : for now no boost include, no demangle of class name
+/*
+#if defined(_WIN32) || defined(WIN32)
+    // under windows typeid(T).name() does not return a mangled name, but returns :
+    //  - "class T" if T is a class
+    //  - "struct T" if T is a struct
+    //  - "enum T" if T is an enum
+    //  - "union T" if T is an union
+    // so remove this useless prefix by removing everything found before the last ' ' character
+    std::string simplifiedName = name;
+    std::size_t index = simplifiedName.rfind(' ');
+    if (index != std::string::npos) {
+        simplifiedName = simplifiedName.substr(index + 1);
+    }
+
+    return boost::core::demangle(simplifiedName.c_str());
+#else
+    return boost::core::demangle(name);
+#endif
+*/
+
+    return name;
+}
+
+template <>
+std::string demangle(const std::type_info& type) {
+    return demangle(type.name());
+}
+
+
+std::string simpleClassName(const char* className) {    
+    const std::string& strClassName = demangle(className);
+    std::size_t index = strClassName.find_last_of("::");
+
+    return (index == std::string::npos) ? strClassName : strClassName.substr(index + 1, strClassName.size());
+}
+
+template <>
+std::string simpleClassName(const std::type_info& type) {
+    return simpleClassName(type.name());
+}
+
+}  // namespace stdcxx

--- a/src/libs/antares/stdcxx/demangle.hpp
+++ b/src/libs/antares/stdcxx/demangle.hpp
@@ -24,43 +24,41 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#ifndef ANTARES_DATA_ENUM_HPP
-#define ANTARES_DATA_ENUM_HPP
+#ifndef ANTARES_STDCXX_DEMANGLE_HPP
+#define ANTARES_STDCXX_DEMANGLE_HPP
 
-#include <initializer_list>
 #include <string>
-#include <type_traits>
+#include <typeinfo>
 
-namespace Antares {
+namespace stdcxx {
 
-namespace Data {
+std::string demangle(const char* name);
 
-namespace Enum {
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-const std::initializer_list<std::string>& getNames();
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-std::string toString(const E& value);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-bool isValid(const std::string& name);
-
-template <typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-E fromString(const std::string& name);
-
-}  // namespace Enum
-
-template <typename E>
-inline typename std::enable_if<std::is_enum<E>::value, std::ostream&>::type operator<<(std::ostream& stream, const E& value) {
-    stream << Data::Enum::toString(value);
-    return stream;
+template <typename T>
+std::string demangle() {
+    return demangle(typeid(T).name());
 }
 
-}  // namespace Data
+template <typename T>
+std::string demangle(const T& type) {
+    return demangle(typeid(type).name());
+}
 
-}  // namespace Antares
+template <>
+std::string demangle(const std::type_info& type);
 
-#include <antares/Enum.hxx>
+std::string simpleClassName(const char* className);
 
-#endif  // ANTARES_DATA_ENUM_HPP
+template <typename T>
+std::string simpleClassName() {
+    return simpleClassName(typeid(T).name());
+}
+
+template <typename T>
+std::string simpleClassName(const T& type) {
+    return simpleClassName(typeid(type).name());
+}
+
+}  // namespace stdcxx
+
+#endif  // ANTARES_STDCXX_DEMANGLE_HPP

--- a/src/libs/antares/study/UnfeasibleProblemBehavior.cpp
+++ b/src/libs/antares/study/UnfeasibleProblemBehavior.cpp
@@ -1,0 +1,91 @@
+/*
+** Copyright 2007-2018 RTE
+** Authors: Antares_Simulator Team
+**
+** This file is part of Antares_Simulator.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** There are special exceptions to the terms and conditions of the
+** license as they are applied to this software. View the full text of
+** the exceptions in file COPYING.txt in the directory of this software
+** distribution
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Antares_Simulator. If not, see <http://www.gnu.org/licenses/>.
+**
+** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
+*/
+
+#include <initializer_list>
+#include <string>
+
+#include <antares/study/UnfeasibleProblemBehavior.hpp>
+
+#include <antares/Enum.hpp>
+
+namespace Antares {
+    
+namespace Data {
+
+    const char* getIcon(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior) {
+        //TODO JMK : define icon
+        switch (unfeasibleProblemBehavior) {
+        case UnfeasibleProblemBehavior::WARNING_DRY:
+            return "images/16x16/light_green.png";
+        case UnfeasibleProblemBehavior::WARNING_MPS:
+            return "images/16x16/light_green.png";
+        case UnfeasibleProblemBehavior::ERROR_DRY:
+            return "images/16x16/light_orange.png";
+        case UnfeasibleProblemBehavior::ERROR_MPS:
+            return "images/16x16/light_orange.png";
+        default:
+            //TODO JMK : throw exception
+            return "";
+        }
+    }
+
+    std::string getDisplayName(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior) {
+        //TODO JMK : define display name
+        switch (unfeasibleProblemBehavior) {
+        case UnfeasibleProblemBehavior::WARNING_DRY:
+            return "Warning Dry";
+        case UnfeasibleProblemBehavior::WARNING_MPS:
+            return "Warning MPS";
+        case UnfeasibleProblemBehavior::ERROR_DRY:
+            return "Error Dry";
+        case UnfeasibleProblemBehavior::ERROR_MPS:
+            return "Error MPS";
+        default:
+            //TODO JMK : throw exception
+            return "";
+        }
+    }
+
+namespace Enum {
+
+    template <>
+    const std::initializer_list<std::string>& getNames<UnfeasibleProblemBehavior>() {
+
+        //Enum must be stored in lower case and without spaces because values  are trimmed and lowered in ini load
+        static std::initializer_list<std::string> s_unfeasibleProblemBehaviorNames{
+            "warning-dry",
+            "warning-mps",
+            "error-dry",
+            "error-mps"
+        };
+        return s_unfeasibleProblemBehaviorNames;
+    }
+} // namespace Enum
+   
+} // namespace Data
+
+} // namespace Antares

--- a/src/libs/antares/study/UnfeasibleProblemBehavior.cpp
+++ b/src/libs/antares/study/UnfeasibleProblemBehavior.cpp
@@ -28,6 +28,7 @@
 #include <initializer_list>
 #include <string>
 
+#include <antares/exception/AssertionError.hpp>
 #include <antares/study/UnfeasibleProblemBehavior.hpp>
 
 #include <antares/Enum.hpp>
@@ -36,25 +37,35 @@ namespace Antares {
     
 namespace Data {
 
-    const char* getIcon(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior) {
-        //TODO JMK : define icon
+    bool exportMPS(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior) {
         switch (unfeasibleProblemBehavior) {
         case UnfeasibleProblemBehavior::WARNING_DRY:
-            return "images/16x16/light_green.png";
-        case UnfeasibleProblemBehavior::WARNING_MPS:
-            return "images/16x16/light_green.png";
         case UnfeasibleProblemBehavior::ERROR_DRY:
-            return "images/16x16/light_orange.png";
+            return false;
+        case UnfeasibleProblemBehavior::WARNING_MPS:
         case UnfeasibleProblemBehavior::ERROR_MPS:
-            return "images/16x16/light_orange.png";
+            return true;
         default:
-            //TODO JMK : throw exception
+            throw AssertionError("Invalid UnfeasibleProblemBehavior " + std::to_string(static_cast<unsigned long>(unfeasibleProblemBehavior)));
             return "";
         }
     }
 
+    bool stopSimulation(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior) {
+        switch (unfeasibleProblemBehavior) {
+        case UnfeasibleProblemBehavior::WARNING_DRY:
+        case UnfeasibleProblemBehavior::WARNING_MPS:
+            return false;
+        case UnfeasibleProblemBehavior::ERROR_MPS:
+        case UnfeasibleProblemBehavior::ERROR_DRY:
+            return true;
+        default:
+            throw AssertionError("Invalid UnfeasibleProblemBehavior " + std::to_string(static_cast<unsigned long>(unfeasibleProblemBehavior)));
+            return "";
+        }
+    }    
+
     std::string getDisplayName(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior) {
-        //TODO JMK : define display name
         switch (unfeasibleProblemBehavior) {
         case UnfeasibleProblemBehavior::WARNING_DRY:
             return "Warning Dry";
@@ -65,8 +76,9 @@ namespace Data {
         case UnfeasibleProblemBehavior::ERROR_MPS:
             return "Error MPS";
         default:
-            //TODO JMK : throw exception
+            throw AssertionError("Invalid UnfeasibleProblemBehavior " + std::to_string(static_cast<unsigned long>(unfeasibleProblemBehavior)));
             return "";
+
         }
     }
 

--- a/src/libs/antares/study/UnfeasibleProblemBehavior.cpp
+++ b/src/libs/antares/study/UnfeasibleProblemBehavior.cpp
@@ -37,6 +37,22 @@ namespace Antares {
     
 namespace Data {
 
+    const char* getIcon(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior) {
+        switch (unfeasibleProblemBehavior) {
+        case UnfeasibleProblemBehavior::WARNING_DRY:
+            return "images/16x16/light_green.png";
+        case UnfeasibleProblemBehavior::WARNING_MPS:
+            return "images/16x16/light_green.png";
+        case UnfeasibleProblemBehavior::ERROR_DRY:
+            return "images/16x16/light_orange.png";
+        case UnfeasibleProblemBehavior::ERROR_MPS:
+            return "images/16x16/light_orange.png";
+        default:
+            throw AssertionError("Invalid UnfeasibleProblemBehavior " + std::to_string(static_cast<unsigned long>(unfeasibleProblemBehavior)));
+            return "";
+        }
+    }
+
     bool exportMPS(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior) {
         switch (unfeasibleProblemBehavior) {
         case UnfeasibleProblemBehavior::WARNING_DRY:

--- a/src/libs/antares/study/UnfeasibleProblemBehavior.hpp
+++ b/src/libs/antares/study/UnfeasibleProblemBehavior.hpp
@@ -1,0 +1,54 @@
+/*
+** Copyright 2007-2018 RTE
+** Authors: Antares_Simulator Team
+**
+** This file is part of Antares_Simulator.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** There are special exceptions to the terms and conditions of the
+** license as they are applied to this software. View the full text of
+** the exceptions in file COPYING.txt in the directory of this software
+** distribution
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Antares_Simulator. If not, see <http://www.gnu.org/licenses/>.
+**
+** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
+*/
+
+#ifndef ANTARES_DATA_UNFEASIBLEPROBLEMHAVIOR_HPP
+#define ANTARES_DATA_UNFEASIBLEPROBLEMHAVIOR_HPP
+
+namespace Antares {
+
+namespace Data {
+
+
+/*! Enum class to define unfeasible problem behavior */
+enum class UnfeasibleProblemBehavior : unsigned char {
+    WARNING_DRY, /*! Continue simulation without MPS export */
+	WARNING_MPS, /*! Continue simulation with MPS export */
+	ERROR_DRY,   /*! Stop simulation without MPS export */
+	ERROR_MPS    /*! Stop simulation with MPS export */
+};
+
+//TODO JMK : see for documentation syntax
+const char* getIcon(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior);
+
+//TODO JMK : see for documentation syntax
+ std::string getDisplayName(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior);
+
+}  // namespace Data
+
+}  // namespace Antares
+
+#endif  // ANTARES_DATA_UNFEASIBLEPROBLEMHAVIOR_HPP

--- a/src/libs/antares/study/UnfeasibleProblemBehavior.hpp
+++ b/src/libs/antares/study/UnfeasibleProblemBehavior.hpp
@@ -41,11 +41,29 @@ enum class UnfeasibleProblemBehavior : unsigned char {
 	ERROR_MPS    /*! Stop simulation with MPS export */
 };
 
-//TODO JMK : see for documentation syntax
-const char* getIcon(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior);
-
-//TODO JMK : see for documentation syntax
+/*!
+*  \brief Get display name from UnfeasibleProblemBehavior enum
+*
+*  \param unfeasibleProblemBehavior : UnfeasibleProblemBehavior enum
+*  \return displayName
+*/
  std::string getDisplayName(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior);
+
+ /*!
+*  \brief Define if MPS must be exported in case of unfeasible problem
+*
+*  \param unfeasibleProblemBehavior : UnfeasibleProblemBehavior enum
+*  \return true if MPS must be exported, false otherwise
+*/
+ bool exportMPS(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior);
+
+ /*!
+*  \brief Define if simulation must be stopped in case of unfeasible problem
+*
+*  \param unfeasibleProblemBehavior : UnfeasibleProblemBehavior enum
+*  \return true if simulation must be stopped, false otherwise
+*/
+ bool stopSimulation(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior);
 
 }  // namespace Data
 

--- a/src/libs/antares/study/UnfeasibleProblemBehavior.hpp
+++ b/src/libs/antares/study/UnfeasibleProblemBehavior.hpp
@@ -42,6 +42,14 @@ enum class UnfeasibleProblemBehavior : unsigned char {
 };
 
 /*!
+*  \brief Get icon from UnfeasibleProblemBehavior enum
+*
+*  \param unfeasibleProblemBehavior : UnfeasibleProblemBehavior enum
+*  \return icon
+*/
+const char* getIcon(const UnfeasibleProblemBehavior& unfeasibleProblemBehavior);
+
+/*!
 *  \brief Get display name from UnfeasibleProblemBehavior enum
 *
 *  \param unfeasibleProblemBehavior : UnfeasibleProblemBehavior enum

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -510,7 +510,7 @@ namespace Data
 				result = false;
 				d.include.unfeasibleProblemBehavior = UnfeasibleProblemBehavior::ERROR_MPS;
 				logs.warning() << "parameters: invalid unfeasible problem behavior. Got '" << value
-					<< "'. reset to " << Enum::toString<UnfeasibleProblemBehavior>(d.include.unfeasibleProblemBehavior);
+					<< "'. reset to " << Enum::toString(d.include.unfeasibleProblemBehavior);
 			}
 
             return result;

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -40,6 +40,7 @@
 #include <antares/study/memory-usage.h>
 #include "../solver/variable/economy/all.h"
 
+#include <antares/exception/AssertionError.hpp>
 #include <antares/Enum.hxx>
 
 using namespace Yuni;
@@ -501,12 +502,14 @@ namespace Data
             bool result = true;
 			const std::string& string = value.to<std::string>();
 
-			if (Enum::isValid<UnfeasibleProblemBehavior>(string))
+			try
 			{
 				d.include.unfeasibleProblemBehavior = Enum::fromString<UnfeasibleProblemBehavior>(string);
 			}
-			else
+			catch(AssertionError& ex)
 			{
+				logs.warning() << "Assertion error for unfeasible problem behavior from string conversion : " << ex.what();
+
 				result = false;
 				d.include.unfeasibleProblemBehavior = UnfeasibleProblemBehavior::ERROR_MPS;
 				logs.warning() << "parameters: invalid unfeasible problem behavior. Got '" << value

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -40,10 +40,9 @@
 #include <antares/study/memory-usage.h>
 #include "../solver/variable/economy/all.h"
 
+#include <antares/Enum.hxx>
 
 using namespace Yuni;
-
-
 
 namespace Antares
 {
@@ -286,6 +285,9 @@ namespace Data
 		simplexOptimizationRange       = sorWeek;
 
 		include.exportMPS              = false;
+		
+		//TODO JMK : confirm default value
+		include.unfeasibleProblemBehavior = UnfeasibleProblemBehavior::ERROR_DRY;
 
 		timeSeriesAccuracyOnCorrelation = 0;
 
@@ -495,6 +497,15 @@ namespace Data
 			d.initialReservoirLevels.iniLevels = irlColdStart;
 			return false;
 		}
+        if (key == "include-unfeasible-problem-behavior")
+        {
+            bool result = true;
+
+            //TODO JMK : Check if value is correct
+			d.include.unfeasibleProblemBehavior = Enum::fromString<UnfeasibleProblemBehavior>(value.to<std::string>());
+
+            return result;
+        }
 
 
 		// Error
@@ -1475,6 +1486,9 @@ namespace Data
 			section->add("include-primaryreserve",    include.reserve.primary);
 
 			section->add("include-exportmps",         include.exportMPS);
+
+            // Unfeasible problem behavior
+			section->add("include-unfeasible-problem-behavior", Enum::toString(include.unfeasibleProblemBehavior));
 		}
 
 		// Other preferences

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -286,8 +286,7 @@ namespace Data
 
 		include.exportMPS              = false;
 		
-		//TODO JMK : confirm default value
-		include.unfeasibleProblemBehavior = UnfeasibleProblemBehavior::ERROR_DRY;
+		include.unfeasibleProblemBehavior = UnfeasibleProblemBehavior::ERROR_MPS;
 
 		timeSeriesAccuracyOnCorrelation = 0;
 
@@ -500,9 +499,19 @@ namespace Data
         if (key == "include-unfeasible-problem-behavior")
         {
             bool result = true;
+			const std::string& string = value.to<std::string>();
 
-            //TODO JMK : Check if value is correct
-			d.include.unfeasibleProblemBehavior = Enum::fromString<UnfeasibleProblemBehavior>(value.to<std::string>());
+			if (Enum::isValid<UnfeasibleProblemBehavior>(string))
+			{
+				d.include.unfeasibleProblemBehavior = Enum::fromString<UnfeasibleProblemBehavior>(string);
+			}
+			else
+			{
+				result = false;
+				d.include.unfeasibleProblemBehavior = UnfeasibleProblemBehavior::ERROR_MPS;
+				logs.warning() << "parameters: invalid unfeasible problem behavior. Got '" << value
+					<< "'. reset to " << Enum::toString<UnfeasibleProblemBehavior>(d.include.unfeasibleProblemBehavior);
+			}
 
             return result;
         }

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -37,13 +37,14 @@
 # include "fwd.h"
 # include "variable-print-info.h"
 
+#include <antares/study/UnfeasibleProblemBehavior.hpp>
+
 using namespace std;
 
 namespace Antares
 {
 namespace Data
-{
-
+{   
 	/*!
 	** \brief General data for a study
 	**
@@ -382,6 +383,11 @@ namespace Data
 
 			//! a flag to export all mps files
 			bool exportMPS;
+
+			//TODO JMK : confirm documentation syntax
+			//!Enum to define unfeasible problem behavior \see UnfeasibleProblemBehavior
+			UnfeasibleProblemBehavior unfeasibleProblemBehavior;
+
 		} include;
 
 		// Shedding

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -384,7 +384,6 @@ namespace Data
 			//! a flag to export all mps files
 			bool exportMPS;
 
-			//TODO JMK : confirm documentation syntax
 			//!Enum to define unfeasible problem behavior \see UnfeasibleProblemBehavior
 			UnfeasibleProblemBehavior unfeasibleProblemBehavior;
 

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -68,31 +68,18 @@ bool OPT_AppelDuSolveurPne( PROBLEME_HEBDO * , uint , int );
 
 bool OPT_AppelDuSolveurLineaire( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace, int NumIntervalle )
 {
+	bool result = false;
 
 	if ( ProblemeHebdo->SolveurDuProblemeLineaire == ANTARES_SIMPLEXE )
 	{
-		if ( OPT_AppelDuSimplexe( ProblemeHebdo, numSpace, NumIntervalle ) == true )
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		result = OPT_AppelDuSimplexe(ProblemeHebdo, numSpace, NumIntervalle);
 	}
 	else
 	{
-		if ( OPT_AppelDuSolveurPne( ProblemeHebdo, numSpace, NumIntervalle ) == true )
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		result = OPT_AppelDuSolveurPne(ProblemeHebdo, numSpace, NumIntervalle);
 	}
 
-	return true;
+	return result;
 }
 
 
@@ -278,35 +265,6 @@ bool OPT_AppelDuSimplexe( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace, int Num
 		logs.error() << "* last resort shedding status,";
 		logs.error() << "* negative hurdle costs on lines with infinite capacity,";
 		logs.error() << "* Hydro reservoir impossible to manage with cumulative options \"hard bounds without heuristic\"";
-	
-	
-		if (0)
-		{
-			logs.info() << LOG_UI_DISPLAY_MESSAGES_OFF;
-			logs.info() << "Here is the trace:";
-
-			for (Cnt = 0 ; Cnt < ProblemeAResoudre->NombreDeContraintes; ++Cnt)
-			{
-				logs.info().appendFormat(
-						"Constraint %ld sens %c B %e",
-						Cnt,ProblemeAResoudre->Sens[Cnt],ProblemeAResoudre->SecondMembre[Cnt]);
-
-				il = ProblemeAResoudre->IndicesDebutDeLigne[Cnt];
-				ilMax = il + ProblemeAResoudre->NombreDeTermesDesLignes[Cnt];
-				while (il < ilMax)
-				{
-					Var = ProblemeAResoudre->IndicesColonnes[il];
-					logs.info().appendFormat("      il %ld coeff %e var %ld xmin %e xmax %e type %ld cout %e",
-							il,  ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes[il],
-							Var, ProblemeAResoudre->Xmin[Var],
-							ProblemeAResoudre->Xmax[Var],
-							ProblemeAResoudre->TypeDeVariable[Var], ProblemeAResoudre->CoutLineaire[Var]);
-					il++;
-				}
-			}
-
-			logs.info() << LOG_UI_DISPLAY_MESSAGES_ON;
-		}
 
 		//Write MPS only if exportMPSOnError is activated and MPS weren't exported before with ExportMPS option
 		if ( ProblemeHebdo->ExportMPS == NON_ANTARES && ProblemeHebdo->exportMPSOnError)
@@ -750,6 +708,4 @@ void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( void * Prob, uint numSpace, char
 	free ( Nombre );
 
 	fclose( Flot );
-
-	return;
 }

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -308,8 +308,8 @@ bool OPT_AppelDuSimplexe( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace, int Num
 			logs.info() << LOG_UI_DISPLAY_MESSAGES_ON;
 		}
 
-	
-		if ( ProblemeHebdo->ExportMPS == NON_ANTARES)
+		//Write MPS only if exportMPSOnError is activated and MPS weren't exported before with ExportMPS option
+		if ( ProblemeHebdo->ExportMPS == NON_ANTARES && ProblemeHebdo->exportMPSOnError)
 		{
 			OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &Probleme, numSpace, ANTARES_SIMPLEXE );
 		}
@@ -366,7 +366,6 @@ bool OPT_AppelDuSolveurPne( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace, int N
 
 
 	PNE_Solveur( &ProblemePourPne );
-
 
 	if ( ProblemeHebdo->ExportMPS == OUI_ANTARES)
 		OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &ProblemePourPne, numSpace, ANTARES_PNE );
@@ -467,7 +466,8 @@ bool OPT_AppelDuSolveurPne( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace, int N
 			logs.info() << LOG_UI_DISPLAY_MESSAGES_ON;
 		}
 
-		if ( ProblemeHebdo->ExportMPS == NON_ANTARES)
+		//Write MPS only if exportMPSOnError is activated and MPS weren't exported before with ExportMPS option
+		if ( ProblemeHebdo->ExportMPS == NON_ANTARES && ProblemeHebdo->exportMPSOnError)
 		{	
 			OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &ProblemePourPne, numSpace, ANTARES_PNE );	
 		}

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -66,255 +66,258 @@ bool OPT_AppelDuSimplexe( PROBLEME_HEBDO * , uint, int );
 bool OPT_AppelDuSolveurPne( PROBLEME_HEBDO * , uint , int );
 
 
-
-
-
 bool OPT_AppelDuSolveurLineaire( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace, int NumIntervalle )
 {
 
-
-
-
-if ( ProblemeHebdo->SolveurDuProblemeLineaire == ANTARES_SIMPLEXE ) {
-  if ( OPT_AppelDuSimplexe( ProblemeHebdo, numSpace, NumIntervalle ) == true ) {
-	  return true;
+	if ( ProblemeHebdo->SolveurDuProblemeLineaire == ANTARES_SIMPLEXE )
+	{
+		if ( OPT_AppelDuSimplexe( ProblemeHebdo, numSpace, NumIntervalle ) == true )
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
 	}
-	else {
-	  return false;
+	else
+	{
+		if ( OPT_AppelDuSolveurPne( ProblemeHebdo, numSpace, NumIntervalle ) == true )
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
 	}
-}
-else {
-  if ( OPT_AppelDuSolveurPne( ProblemeHebdo, numSpace, NumIntervalle ) == true ) {
-	  return true;
-	}
-	else {
-	  return false;
-	}
-}
 
-return true;
+	return true;
 }
 
 
 
 bool OPT_AppelDuSimplexe( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace, int NumIntervalle )
 {
-int Var; int Cnt; double * pt; int il; int ilMax; int Classe; char PremierPassage;
-double CoutOpt; PROBLEME_ANTARES_A_RESOUDRE * ProblemeAResoudre; PROBLEME_SIMPLEXE Probleme;
-PROBLEME_SPX * ProbSpx;
+	int Var; int Cnt; double * pt; int il; int ilMax; int Classe; char PremierPassage;
+	double CoutOpt; PROBLEME_ANTARES_A_RESOUDRE * ProblemeAResoudre; PROBLEME_SIMPLEXE Probleme;
+	PROBLEME_SPX * ProbSpx;
+	ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
+	PremierPassage = OUI_ANTARES;
+	Classe = ProblemeAResoudre->NumeroDeClasseDeManoeuvrabiliteActiveEnCours;
+	ProbSpx = (PROBLEME_SPX *) ((ProblemeAResoudre->ProblemesSpxDUneClasseDeManoeuvrabilite[Classe])->ProblemeSpx[(int) NumIntervalle]);
 
+	RESOLUTION:
 
-
-
-
-
-ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
-
-PremierPassage = OUI_ANTARES;
-
-Classe = ProblemeAResoudre->NumeroDeClasseDeManoeuvrabiliteActiveEnCours;
-ProbSpx = (PROBLEME_SPX *) ((ProblemeAResoudre->ProblemesSpxDUneClasseDeManoeuvrabilite[Classe])->ProblemeSpx[(int) NumIntervalle]);
-
-RESOLUTION:
-
-if ( ProbSpx == NULL ) {
-	Probleme.Contexte            = SIMPLEXE_SEUL;
-	Probleme.BaseDeDepartFournie = NON_SPX;
-}
-else {
-
-  if (ProblemeHebdo->ReinitOptimisation == OUI_ANTARES ) {	
-    if ( ProbSpx != NULL ) {
-      SPX_LibererProbleme( ProbSpx );
-      (ProblemeAResoudre->ProblemesSpxDUneClasseDeManoeuvrabilite[Classe])->ProblemeSpx[(int) NumIntervalle] = NULL;			
-    }	
-		ProbSpx                      = NULL;
-  	Probleme.Contexte            = SIMPLEXE_SEUL;
-	  Probleme.BaseDeDepartFournie = NON_SPX;	
-	}
-	
-	else {
-	  
-	  Probleme.Contexte            = BRANCH_AND_BOUND_OU_CUT_NOEUD;
-	  
-	  Probleme.BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
-
-	  
-	  
-	  
-	  SPX_ModifierLeVecteurCouts( ProbSpx, ProblemeAResoudre->CoutLineaire, ProblemeAResoudre->NombreDeVariables );
-
-	  
-	  SPX_ModifierLeVecteurSecondMembre( ProbSpx, ProblemeAResoudre->SecondMembre, ProblemeAResoudre->Sens, ProblemeAResoudre->NombreDeContraintes );
-	}
-	
-}
-
-
-Probleme.NombreMaxDIterations = -1; 
-Probleme.DureeMaxDuCalcul     = -1.;
-
-Probleme.CoutLineaire      = ProblemeAResoudre->CoutLineaire;
-Probleme.X                 = ProblemeAResoudre->X;
-Probleme.Xmin              = ProblemeAResoudre->Xmin;
-Probleme.Xmax              = ProblemeAResoudre->Xmax;
-Probleme.NombreDeVariables = ProblemeAResoudre->NombreDeVariables;
-Probleme.TypeDeVariable    = ProblemeAResoudre->TypeDeVariable;
-
-Probleme.NombreDeContraintes                   = ProblemeAResoudre->NombreDeContraintes;
-Probleme.IndicesDebutDeLigne                   = ProblemeAResoudre->IndicesDebutDeLigne;
-Probleme.NombreDeTermesDesLignes               = ProblemeAResoudre->NombreDeTermesDesLignes;
-Probleme.IndicesColonnes                       = ProblemeAResoudre->IndicesColonnes;
-Probleme.CoefficientsDeLaMatriceDesContraintes = ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes;
-Probleme.Sens                                  = ProblemeAResoudre->Sens;
-Probleme.SecondMembre                          = ProblemeAResoudre->SecondMembre;
-
-Probleme.ChoixDeLAlgorithme = SPX_DUAL;
-
-Probleme.TypeDePricing               = PRICING_STEEPEST_EDGE ;
-
-if (PremierPassage == NON_ANTARES) Probleme.FaireDuScaling = NON_SPX;
-if (PremierPassage == OUI_ANTARES) Probleme.FaireDuScaling = OUI_SPX;
-
-Probleme.StrategieAntiDegenerescence = AGRESSIF;
-
-Probleme.PositionDeLaVariable       = ProblemeAResoudre->PositionDeLaVariable;
-Probleme.NbVarDeBaseComplementaires = 0; 
-Probleme.ComplementDeLaBase         = ProblemeAResoudre->ComplementDeLaBase;
-
-Probleme.LibererMemoireALaFin = NON_SPX;
-
-Probleme.UtiliserCoutMax = NON_SPX;
-Probleme.CoutMax = 0.0;
-
-Probleme.CoutsMarginauxDesContraintes = ProblemeAResoudre->CoutsMarginauxDesContraintes;
-Probleme.CoutsReduits                 = ProblemeAResoudre->CoutsReduits;
-
-# ifndef NDEBUG
-  if ( PremierPassage == OUI_ANTARES ) Probleme.AffichageDesTraces = NON_SPX;
-  else Probleme.AffichageDesTraces = OUI_SPX;
-# else
-  Probleme.AffichageDesTraces = NON_SPX;
-# endif
-
-Probleme.NombreDeContraintesCoupes = 0;
-
-
-ProbSpx = SPX_Simplexe( &Probleme , ProbSpx );
-
-if ( ProbSpx != NULL ) {  
-	(ProblemeAResoudre->ProblemesSpxDUneClasseDeManoeuvrabilite[Classe])->ProblemeSpx[NumIntervalle] = (void *) ProbSpx;
-}
-
-if ( ProblemeHebdo->ExportMPS == OUI_ANTARES) OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &Probleme, numSpace, ANTARES_SIMPLEXE );
-
-ProblemeAResoudre->ExistenceDUneSolution = Probleme.ExistenceDUneSolution;
-
-
-
-if ( ProblemeAResoudre->ExistenceDUneSolution != OUI_SPX && PremierPassage == OUI_ANTARES && ProbSpx != NULL ) {
-  if ( ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE ) {
-    
-	  SPX_LibererProbleme( ProbSpx );
-	  logs.info() << " Solver: Standard resolution failed"; 
-	  logs.info() << " Solver: Retry in safe mode";			//second trial w/o scaling 
-	 
-	  if (Logs::Verbosity::Debug::enabled)
-	  {
-	  
-		logs.info() << " solver: resetting";
-	  }
-	  ProbSpx = NULL;
-	  PremierPassage = NON_ANTARES;
-	  goto RESOLUTION;
-	}
-	else {
-	  logs.info(); 
-	  logs.error() << "Internal error: insufficient memory";
-	  logs.info(); 
-	  AntaresSolverEmergencyShutdown();
-	  return false;
-	}
-}
-
-if ( ProblemeAResoudre->ExistenceDUneSolution == OUI_SPX ) {
-	if (PremierPassage == NON_ANTARES)
+	if ( ProbSpx == NULL )
 	{
-		logs.info() << " Solver: Safe resolution succeeded";
+		Probleme.Contexte            = SIMPLEXE_SEUL;
+		Probleme.BaseDeDepartFournie = NON_SPX;
 	}
-  CoutOpt = 0.0;
-	
-	for ( Var = 0 ; Var < ProblemeAResoudre->NombreDeVariables ; Var++ ) {
-	  
-    CoutOpt+= ProblemeAResoudre->CoutLineaire[Var] * ProblemeAResoudre->X[Var];		
-		
-		pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees[Var];
-		if ( pt != NULL ) *pt = ProblemeAResoudre->X[Var];
-		pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsReduits[Var];
-		if ( pt != NULL ) *pt = ProblemeAResoudre->CoutsReduits[Var];
-	}
-
-	if (ProblemeHebdo->numeroOptimisation[NumIntervalle] == PREMIERE_OPTIMISATION)
-		ProblemeHebdo->coutOptimalSolution1[NumIntervalle] = CoutOpt;
 	else
-		ProblemeHebdo->coutOptimalSolution2[NumIntervalle] = CoutOpt;
-
-	
-	for ( Cnt = 0; Cnt < ProblemeAResoudre->NombreDeContraintes; Cnt++ ) {
-		pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsMarginaux[Cnt];
-		if ( pt != NULL ) *pt = ProblemeAResoudre->CoutsMarginauxDesContraintes[Cnt];
+	{
+		if (ProblemeHebdo->ReinitOptimisation == OUI_ANTARES )
+		{	
+			if ( ProbSpx != NULL )
+			{
+				SPX_LibererProbleme( ProbSpx );
+				(ProblemeAResoudre->ProblemesSpxDUneClasseDeManoeuvrabilite[Classe])->ProblemeSpx[(int) NumIntervalle] = NULL;			
+			}	
+			ProbSpx  = NULL;
+			Probleme.Contexte = SIMPLEXE_SEUL;
+			Probleme.BaseDeDepartFournie = NON_SPX;	
+		}
+		else
+		{
+			Probleme.Contexte            = BRANCH_AND_BOUND_OU_CUT_NOEUD;
+			Probleme.BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
+			SPX_ModifierLeVecteurCouts( ProbSpx, ProblemeAResoudre->CoutLineaire, ProblemeAResoudre->NombreDeVariables );
+			SPX_ModifierLeVecteurSecondMembre( ProbSpx, ProblemeAResoudre->SecondMembre, ProblemeAResoudre->Sens, ProblemeAResoudre->NombreDeContraintes );
+		}
 	}
-}
-else {
+
+
+	Probleme.NombreMaxDIterations = -1; 
+	Probleme.DureeMaxDuCalcul     = -1.;
+
+	Probleme.CoutLineaire      = ProblemeAResoudre->CoutLineaire;
+	Probleme.X                 = ProblemeAResoudre->X;
+	Probleme.Xmin              = ProblemeAResoudre->Xmin;
+	Probleme.Xmax              = ProblemeAResoudre->Xmax;
+	Probleme.NombreDeVariables = ProblemeAResoudre->NombreDeVariables;
+	Probleme.TypeDeVariable    = ProblemeAResoudre->TypeDeVariable;
+
+	Probleme.NombreDeContraintes                   = ProblemeAResoudre->NombreDeContraintes;
+	Probleme.IndicesDebutDeLigne                   = ProblemeAResoudre->IndicesDebutDeLigne;
+	Probleme.NombreDeTermesDesLignes               = ProblemeAResoudre->NombreDeTermesDesLignes;
+	Probleme.IndicesColonnes                       = ProblemeAResoudre->IndicesColonnes;
+	Probleme.CoefficientsDeLaMatriceDesContraintes = ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes;
+	Probleme.Sens                                  = ProblemeAResoudre->Sens;
+	Probleme.SecondMembre                          = ProblemeAResoudre->SecondMembre;
+
+	Probleme.ChoixDeLAlgorithme = SPX_DUAL;
+	Probleme.TypeDePricing               = PRICING_STEEPEST_EDGE ;
+
 	if (PremierPassage == NON_ANTARES)
-	{
-		logs.info() << " Solver: Safe resolution failed";
-	}
-	logs.error() << "Infeasible linear problem encountered. Possible causes:";
-	logs.error() << "* binding constraints,";
-	logs.error() << "* last resort shedding status,";
-	logs.error() << "* negative hurdle costs on lines with infinite capacity,";
-	logs.error() << "* Hydro reservoir impossible to manage with cumulative options \"hard bounds without heuristic\"";
-	
-	
-	
-	
-	if (0)
-	{
-		logs.info() << LOG_UI_DISPLAY_MESSAGES_OFF;
-		logs.info() << "Here is the trace:";
-		for (Cnt = 0 ; Cnt < ProblemeAResoudre->NombreDeContraintes; ++Cnt) {
-			
-			logs.info().appendFormat("Constraint %ld sens %c B %e",
-				Cnt,ProblemeAResoudre->Sens[Cnt],ProblemeAResoudre->SecondMembre[Cnt]);
+		Probleme.FaireDuScaling = NON_SPX;
+	if (PremierPassage == OUI_ANTARES)
+		Probleme.FaireDuScaling = OUI_SPX;
 
-			il = ProblemeAResoudre->IndicesDebutDeLigne[Cnt];
-			ilMax = il + ProblemeAResoudre->NombreDeTermesDesLignes[Cnt];
-			while (il < ilMax) {
-				Var = ProblemeAResoudre->IndicesColonnes[il];
-				logs.info().appendFormat("      il %ld coeff %e var %ld xmin %e xmax %e type %ld cout %e",
-						il,  ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes[il],
-						Var, ProblemeAResoudre->Xmin[Var],
-						ProblemeAResoudre->Xmax[Var],
-						ProblemeAResoudre->TypeDeVariable[Var], ProblemeAResoudre->CoutLineaire[Var]);
-				il++;
+	Probleme.StrategieAntiDegenerescence = AGRESSIF;
+
+	Probleme.PositionDeLaVariable       = ProblemeAResoudre->PositionDeLaVariable;
+	Probleme.NbVarDeBaseComplementaires = 0; 
+	Probleme.ComplementDeLaBase         = ProblemeAResoudre->ComplementDeLaBase;
+
+	Probleme.LibererMemoireALaFin = NON_SPX;
+
+	Probleme.UtiliserCoutMax = NON_SPX;
+	Probleme.CoutMax = 0.0;
+
+	Probleme.CoutsMarginauxDesContraintes = ProblemeAResoudre->CoutsMarginauxDesContraintes;
+	Probleme.CoutsReduits                 = ProblemeAResoudre->CoutsReduits;
+
+	# ifndef NDEBUG
+	if ( PremierPassage == OUI_ANTARES )
+		Probleme.AffichageDesTraces = NON_SPX;
+	else
+		Probleme.AffichageDesTraces = OUI_SPX;
+	# else
+	Probleme.AffichageDesTraces = NON_SPX;
+	# endif
+
+	Probleme.NombreDeContraintesCoupes = 0;
+
+
+	ProbSpx = SPX_Simplexe( &Probleme , ProbSpx );
+
+
+	if ( ProbSpx != NULL )
+	{  
+		(ProblemeAResoudre->ProblemesSpxDUneClasseDeManoeuvrabilite[Classe])->ProblemeSpx[NumIntervalle] = (void *) ProbSpx;
+	}
+
+	if ( ProblemeHebdo->ExportMPS == OUI_ANTARES)
+		OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &Probleme, numSpace, ANTARES_SIMPLEXE );
+
+	ProblemeAResoudre->ExistenceDUneSolution = Probleme.ExistenceDUneSolution;
+
+
+
+	if ( ProblemeAResoudre->ExistenceDUneSolution != OUI_SPX && PremierPassage == OUI_ANTARES && ProbSpx != NULL )
+	{
+		if ( ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE )
+		{
+			SPX_LibererProbleme( ProbSpx );
+			logs.info() << " Solver: Standard resolution failed"; 
+			logs.info() << " Solver: Retry in safe mode";			//second trial w/o scaling
+
+			if (Logs::Verbosity::Debug::enabled)
+			{
+				logs.info() << " solver: resetting";
 			}
+			ProbSpx = NULL;
+			PremierPassage = NON_ANTARES;
+			goto RESOLUTION;
 		}
 
-		
-		logs.info() << LOG_UI_DISPLAY_MESSAGES_ON;
+		else
+		{
+			logs.info(); 
+			logs.error() << "Internal error: insufficient memory";
+			logs.info(); 
+			AntaresSolverEmergencyShutdown();
+			return false;
+		}
 	}
+
+	if ( ProblemeAResoudre->ExistenceDUneSolution == OUI_SPX )
+	{
+		if (PremierPassage == NON_ANTARES)
+		{
+			logs.info() << " Solver: Safe resolution succeeded";
+		}
+		CoutOpt = 0.0;
+	
+		for ( Var = 0 ; Var < ProblemeAResoudre->NombreDeVariables ; Var++ )
+		{
+			CoutOpt+= ProblemeAResoudre->CoutLineaire[Var] * ProblemeAResoudre->X[Var];		
+		
+			pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees[Var];
+			if ( pt != NULL )
+				*pt = ProblemeAResoudre->X[Var];
+
+			pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsReduits[Var];
+			if ( pt != NULL )
+				*pt = ProblemeAResoudre->CoutsReduits[Var];
+		}
+
+		if (ProblemeHebdo->numeroOptimisation[NumIntervalle] == PREMIERE_OPTIMISATION)
+			ProblemeHebdo->coutOptimalSolution1[NumIntervalle] = CoutOpt;
+		else
+			ProblemeHebdo->coutOptimalSolution2[NumIntervalle] = CoutOpt;
 
 	
-  if ( ProblemeHebdo->ExportMPS == NON_ANTARES) {
-	  OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &Probleme, numSpace, ANTARES_SIMPLEXE );
+		for ( Cnt = 0; Cnt < ProblemeAResoudre->NombreDeContraintes; Cnt++ )
+		{
+			pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsMarginaux[Cnt];
+			if ( pt != NULL )
+				*pt = ProblemeAResoudre->CoutsMarginauxDesContraintes[Cnt];
+		}
 	}
 
-	return false;
-}
+	else
+	{
+		if (PremierPassage == NON_ANTARES)
+		{
+			logs.info() << " Solver: Safe resolution failed";
+		}
 
-return true;
+		logs.error() << "Infeasible linear problem encountered. Possible causes:";
+		logs.error() << "* binding constraints,";
+		logs.error() << "* last resort shedding status,";
+		logs.error() << "* negative hurdle costs on lines with infinite capacity,";
+		logs.error() << "* Hydro reservoir impossible to manage with cumulative options \"hard bounds without heuristic\"";
+	
+	
+		if (0)
+		{
+			logs.info() << LOG_UI_DISPLAY_MESSAGES_OFF;
+			logs.info() << "Here is the trace:";
 
+			for (Cnt = 0 ; Cnt < ProblemeAResoudre->NombreDeContraintes; ++Cnt)
+			{
+				logs.info().appendFormat(
+						"Constraint %ld sens %c B %e",
+						Cnt,ProblemeAResoudre->Sens[Cnt],ProblemeAResoudre->SecondMembre[Cnt]);
+
+				il = ProblemeAResoudre->IndicesDebutDeLigne[Cnt];
+				ilMax = il + ProblemeAResoudre->NombreDeTermesDesLignes[Cnt];
+				while (il < ilMax)
+				{
+					Var = ProblemeAResoudre->IndicesColonnes[il];
+					logs.info().appendFormat("      il %ld coeff %e var %ld xmin %e xmax %e type %ld cout %e",
+							il,  ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes[il],
+							Var, ProblemeAResoudre->Xmin[Var],
+							ProblemeAResoudre->Xmax[Var],
+							ProblemeAResoudre->TypeDeVariable[Var], ProblemeAResoudre->CoutLineaire[Var]);
+					il++;
+				}
+			}
+
+			logs.info() << LOG_UI_DISPLAY_MESSAGES_ON;
+		}
+
+	
+		if ( ProblemeHebdo->ExportMPS == NON_ANTARES)
+		{
+			OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &Probleme, numSpace, ANTARES_SIMPLEXE );
+		}
+
+		return false;
+	}
+
+	return true;
 }
 
 
@@ -322,154 +325,157 @@ return true;
 
 bool OPT_AppelDuSolveurPne( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace, int NumIntervalle )
 {
-int Var; int Cnt; double * pt; int il; int ilMax; double CoutOpt; PROBLEME_ANTARES_A_RESOUDRE * ProblemeAResoudre;
-int * TypeEntierOuReel; PROBLEME_A_RESOUDRE ProblemePourPne; double u;
+	int Var; int Cnt; double * pt; int il; int ilMax; double CoutOpt; PROBLEME_ANTARES_A_RESOUDRE * ProblemeAResoudre;
+	int * TypeEntierOuReel; PROBLEME_A_RESOUDRE ProblemePourPne; double u;
+	ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
+	TypeEntierOuReel = (int *) ProblemeAResoudre->CoutsReduits;
 
-ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
-
-TypeEntierOuReel = (int *) ProblemeAResoudre->CoutsReduits; 
-for ( Var = 0 ; Var < ProblemeAResoudre->NombreDeVariables ; Var++ ) TypeEntierOuReel[Var] = REEL;
-
-
-
-ProblemePourPne.NombreDeVariables       = ProblemeAResoudre->NombreDeVariables;
-ProblemePourPne.TypeDeVariable          = TypeEntierOuReel;
-ProblemePourPne.TypeDeBorneDeLaVariable = ProblemeAResoudre->TypeDeVariable; 
-ProblemePourPne.X                       = ProblemeAResoudre->X;
-ProblemePourPne.Xmax                    = ProblemeAResoudre->Xmax;
-ProblemePourPne.Xmin                    = ProblemeAResoudre->Xmin;
-ProblemePourPne.CoutLineaire            = ProblemeAResoudre->CoutLineaire;
-ProblemePourPne.NombreDeContraintes                   = ProblemeAResoudre->NombreDeContraintes;
-ProblemePourPne.SecondMembre                          = ProblemeAResoudre->SecondMembre;
-ProblemePourPne.Sens                                  = ProblemeAResoudre->Sens;
-ProblemePourPne.IndicesDebutDeLigne                   = ProblemeAResoudre->IndicesDebutDeLigne;
-ProblemePourPne.NombreDeTermesDesLignes               = ProblemeAResoudre->NombreDeTermesDesLignes;
-ProblemePourPne.CoefficientsDeLaMatriceDesContraintes = ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes;
-ProblemePourPne.IndicesColonnes                       = ProblemeAResoudre->IndicesColonnes;
-ProblemePourPne.VariablesDualesDesContraintes         = ProblemeAResoudre->CoutsMarginauxDesContraintes;
-ProblemePourPne.SortirLesDonneesDuProbleme = NON_PNE;
-ProblemePourPne.AlgorithmeDeResolution     = SIMPLEXE;   
-ProblemePourPne.CoupesLiftAndProject       = NON_PNE; 
-ProblemePourPne.AffichageDesTraces = NON_PNE;
-ProblemePourPne.FaireDuPresolve = OUI_PNE ; 
-if ( ProblemeAResoudre->NumeroDOptimisation == DEUXIEME_OPTIMISATION ) {
-  ProblemePourPne.FaireDuPresolve = NON_PNE; 
-
-}
+	for ( Var = 0 ; Var < ProblemeAResoudre->NombreDeVariables ; Var++ )
+		TypeEntierOuReel[Var] = REEL;
 
 
 
-ProblemePourPne.TempsDExecutionMaximum       = 0;  
-ProblemePourPne.NombreMaxDeSolutionsEntieres = -1;   
-ProblemePourPne.ToleranceDOptimalite         = 1.e-4; 
-
-
-
-
-
-
-
-PNE_Solveur( &ProblemePourPne );
-
-if ( ProblemeHebdo->ExportMPS == OUI_ANTARES) OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &ProblemePourPne, numSpace, ANTARES_PNE );
-
-ProblemeAResoudre->ExistenceDUneSolution = ProblemePourPne.ExistenceDUneSolution;
-
-if ( ProblemeAResoudre->ExistenceDUneSolution == ARRET_CAR_ERREUR_INTERNE ) {
-  logs.info(); 
-  logs.error() << "Internal error: insufficient memory";
-  logs.info(); 
-  AntaresSolverEmergencyShutdown();
-  return false;
-}
-
-
-bool sol_opt_trouvee = (ProblemeAResoudre->ExistenceDUneSolution == SOLUTION_OPTIMALE_TROUVEE);
-sol_opt_trouvee = (sol_opt_trouvee || ProblemeAResoudre->ExistenceDUneSolution == SOLUTION_OPTIMALE_TROUVEE_MAIS_QUELQUES_CONTRAINTES_SONT_VIOLEES);
-if (sol_opt_trouvee) {
-  CoutOpt = 0.0;
-	
-
-	
-	for ( Var = 0 ; Var < ProblemeAResoudre->NombreDeVariables ; Var++ ) ProblemeAResoudre->CoutsReduits[Var] = ProblemeAResoudre->CoutLineaire[Var];
-  for ( Cnt = 0 ; Cnt < ProblemeAResoudre->NombreDeContraintes; Cnt++ ) {
-	  il = ProblemeAResoudre->IndicesDebutDeLigne[Cnt];
-		ilMax = il + ProblemeAResoudre->NombreDeTermesDesLignes[Cnt];
-		u = ProblemeAResoudre->CoutsMarginauxDesContraintes[Cnt];
-		while ( il < ilMax ) {
-      Var = ProblemeAResoudre->IndicesColonnes[il];
-			ProblemeAResoudre->CoutsReduits[Var] -= u * ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes[il];
-  	  il++;
-		}
-	}
-	
-	for ( Var = 0 ; Var < ProblemeAResoudre->NombreDeVariables ; Var++ ) {
-	  
-    CoutOpt+= ProblemeAResoudre->CoutLineaire[Var] * ProblemeAResoudre->X[Var];		
-		
-		pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees[Var];
-		if ( pt != NULL ) *pt = ProblemeAResoudre->X[Var];
-		pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsReduits[Var];
-		if ( pt != NULL ) *pt = ProblemeAResoudre->CoutsReduits[Var];
-	}
-
-	if (ProblemeHebdo->numeroOptimisation[NumIntervalle] == PREMIERE_OPTIMISATION)
-		ProblemeHebdo->coutOptimalSolution1[NumIntervalle] = CoutOpt;
-	else
-		ProblemeHebdo->coutOptimalSolution2[NumIntervalle] = CoutOpt;
-
-	
-	for ( Cnt = 0; Cnt < ProblemeAResoudre->NombreDeContraintes; Cnt++ ) {
-		pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsMarginaux[Cnt];
-		if ( pt != NULL ) *pt = ProblemeAResoudre->CoutsMarginauxDesContraintes[Cnt];
-	}
-	
-}
-else {
-	logs.error() << "Infeasible linear problem encountered. Possible causes:";
-	logs.error() << "* binding constraints,";
-	logs.error() << "* last resort shedding status,";
-	logs.error() << "* negative hurdle costs on lines with infinite capacity,";
-	logs.error() << "* Hydro reservoir impossible to manage with cumulative options \"hard bounds without heuristic\"";
-
-	
-	
-	
-	if (0)
+	ProblemePourPne.NombreDeVariables       = ProblemeAResoudre->NombreDeVariables;
+	ProblemePourPne.TypeDeVariable          = TypeEntierOuReel;
+	ProblemePourPne.TypeDeBorneDeLaVariable = ProblemeAResoudre->TypeDeVariable; 
+	ProblemePourPne.X                       = ProblemeAResoudre->X;
+	ProblemePourPne.Xmax                    = ProblemeAResoudre->Xmax;
+	ProblemePourPne.Xmin                    = ProblemeAResoudre->Xmin;
+	ProblemePourPne.CoutLineaire            = ProblemeAResoudre->CoutLineaire;
+	ProblemePourPne.NombreDeContraintes                   = ProblemeAResoudre->NombreDeContraintes;
+	ProblemePourPne.SecondMembre                          = ProblemeAResoudre->SecondMembre;
+	ProblemePourPne.Sens                                  = ProblemeAResoudre->Sens;
+	ProblemePourPne.IndicesDebutDeLigne                   = ProblemeAResoudre->IndicesDebutDeLigne;
+	ProblemePourPne.NombreDeTermesDesLignes               = ProblemeAResoudre->NombreDeTermesDesLignes;
+	ProblemePourPne.CoefficientsDeLaMatriceDesContraintes = ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes;
+	ProblemePourPne.IndicesColonnes                       = ProblemeAResoudre->IndicesColonnes;
+	ProblemePourPne.VariablesDualesDesContraintes         = ProblemeAResoudre->CoutsMarginauxDesContraintes;
+	ProblemePourPne.SortirLesDonneesDuProbleme = NON_PNE;
+	ProblemePourPne.AlgorithmeDeResolution     = SIMPLEXE;   
+	ProblemePourPne.CoupesLiftAndProject       = NON_PNE; 
+	ProblemePourPne.AffichageDesTraces = NON_PNE;
+	ProblemePourPne.FaireDuPresolve = OUI_PNE ; 
+	if ( ProblemeAResoudre->NumeroDOptimisation == DEUXIEME_OPTIMISATION )
 	{
-		logs.info() << LOG_UI_DISPLAY_MESSAGES_OFF;
-		logs.info() << "Here is the trace:";
-		for (Cnt = 0 ; Cnt < ProblemeAResoudre->NombreDeContraintes; ++Cnt) {
-			
-			logs.info().appendFormat("Constraint %ld sens %c B %e",
-				Cnt,ProblemeAResoudre->Sens[Cnt],ProblemeAResoudre->SecondMembre[Cnt]);
+	  ProblemePourPne.FaireDuPresolve = NON_PNE;
+	}
 
+	ProblemePourPne.TempsDExecutionMaximum       = 0;  
+	ProblemePourPne.NombreMaxDeSolutionsEntieres = -1;   
+	ProblemePourPne.ToleranceDOptimalite         = 1.e-4; 
+
+
+	PNE_Solveur( &ProblemePourPne );
+
+
+	if ( ProblemeHebdo->ExportMPS == OUI_ANTARES)
+		OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &ProblemePourPne, numSpace, ANTARES_PNE );
+
+	ProblemeAResoudre->ExistenceDUneSolution = ProblemePourPne.ExistenceDUneSolution;
+
+	if ( ProblemeAResoudre->ExistenceDUneSolution == ARRET_CAR_ERREUR_INTERNE )
+	{
+		logs.info(); 
+		logs.error() << "Internal error: insufficient memory";
+		logs.info(); 
+		AntaresSolverEmergencyShutdown();
+		return false;
+	}
+
+
+	bool sol_opt_trouvee = (ProblemeAResoudre->ExistenceDUneSolution == SOLUTION_OPTIMALE_TROUVEE);
+	sol_opt_trouvee = (sol_opt_trouvee || ProblemeAResoudre->ExistenceDUneSolution == SOLUTION_OPTIMALE_TROUVEE_MAIS_QUELQUES_CONTRAINTES_SONT_VIOLEES);
+	if (sol_opt_trouvee)
+	{
+		CoutOpt = 0.0;
+
+		for ( Var = 0 ; Var < ProblemeAResoudre->NombreDeVariables ; Var++ )
+			ProblemeAResoudre->CoutsReduits[Var] = ProblemeAResoudre->CoutLineaire[Var];
+
+		for ( Cnt = 0 ; Cnt < ProblemeAResoudre->NombreDeContraintes; Cnt++ )
+		{
 			il = ProblemeAResoudre->IndicesDebutDeLigne[Cnt];
 			ilMax = il + ProblemeAResoudre->NombreDeTermesDesLignes[Cnt];
-			while (il < ilMax) {
+			u = ProblemeAResoudre->CoutsMarginauxDesContraintes[Cnt];
+			while ( il < ilMax )
+			{
 				Var = ProblemeAResoudre->IndicesColonnes[il];
-				logs.info().appendFormat("      il %ld coeff %e var %ld xmin %e xmax %e type %ld cout %e",
-						il,  ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes[il],
-						Var, ProblemeAResoudre->Xmin[Var],
-						ProblemeAResoudre->Xmax[Var],
-						ProblemeAResoudre->TypeDeVariable[Var], ProblemeAResoudre->CoutLineaire[Var]);
+				ProblemeAResoudre->CoutsReduits[Var] -= u * ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes[il];
 				il++;
 			}
 		}
-
+	
+		for ( Var = 0 ; Var < ProblemeAResoudre->NombreDeVariables ; Var++ )
+		{
+			CoutOpt+= ProblemeAResoudre->CoutLineaire[Var] * ProblemeAResoudre->X[Var];		
 		
-		logs.info() << LOG_UI_DISPLAY_MESSAGES_ON;
-	}
+			pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees[Var];
+			if ( pt != NULL )
+				*pt = ProblemeAResoudre->X[Var];
+
+			pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsReduits[Var];
+			if ( pt != NULL )
+				*pt = ProblemeAResoudre->CoutsReduits[Var];
+		}
+
+
+		if (ProblemeHebdo->numeroOptimisation[NumIntervalle] == PREMIERE_OPTIMISATION)
+			ProblemeHebdo->coutOptimalSolution1[NumIntervalle] = CoutOpt;
+		else
+			ProblemeHebdo->coutOptimalSolution2[NumIntervalle] = CoutOpt;
 
 	
-  if ( ProblemeHebdo->ExportMPS == NON_ANTARES) {	
-	 OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &ProblemePourPne, numSpace, ANTARES_PNE );	
-	}
+		for ( Cnt = 0; Cnt < ProblemeAResoudre->NombreDeContraintes; Cnt++ )
+		{
+			pt = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsMarginaux[Cnt];
+			if ( pt != NULL )
+				*pt = ProblemeAResoudre->CoutsMarginauxDesContraintes[Cnt];
+		}
 	
-	return false;
-}
+	}
+	else
+	{
+		logs.error() << "Infeasible linear problem encountered. Possible causes:";
+		logs.error() << "* binding constraints,";
+		logs.error() << "* last resort shedding status,";
+		logs.error() << "* negative hurdle costs on lines with infinite capacity,";
+		logs.error() << "* Hydro reservoir impossible to manage with cumulative options \"hard bounds without heuristic\"";
 
-return true;
+		if (0)
+		{
+			logs.info() << LOG_UI_DISPLAY_MESSAGES_OFF;
+			logs.info() << "Here is the trace:";
+			for (Cnt = 0 ; Cnt < ProblemeAResoudre->NombreDeContraintes; ++Cnt)
+			{
+				logs.info().appendFormat("Constraint %ld sens %c B %e",
+					Cnt, ProblemeAResoudre->Sens[Cnt], ProblemeAResoudre->SecondMembre[Cnt]);
+
+				il = ProblemeAResoudre->IndicesDebutDeLigne[Cnt];
+				ilMax = il + ProblemeAResoudre->NombreDeTermesDesLignes[Cnt];
+				while (il < ilMax)
+				{
+					Var = ProblemeAResoudre->IndicesColonnes[il];
+					logs.info().appendFormat("      il %ld coeff %e var %ld xmin %e xmax %e type %ld cout %e",
+							il,  ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes[il],
+							Var, ProblemeAResoudre->Xmin[Var],
+							ProblemeAResoudre->Xmax[Var],
+							ProblemeAResoudre->TypeDeVariable[Var], ProblemeAResoudre->CoutLineaire[Var]);
+					il++;
+				}
+			}
+		
+			logs.info() << LOG_UI_DISPLAY_MESSAGES_ON;
+		}
+
+		if ( ProblemeHebdo->ExportMPS == NON_ANTARES)
+		{	
+			OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( (void *) &ProblemePourPne, numSpace, ANTARES_PNE );	
+		}
+	
+		return false;
+	}
+
+	return true;
 }
 
 
@@ -491,7 +497,6 @@ void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(void * Prob, uint numSpace, 
 	if (!Flot)
 		exit(2);
 
-	
 	fprintf(Flot,"* Optimal criterion value :   %11.10e\n", CoutOptimalDeLaSolution);	
 
 	fclose( Flot );
@@ -503,269 +508,248 @@ void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(void * Prob, uint numSpace, 
 
 void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS( void * Prob, uint numSpace, char Type )
 {
-FILE * Flot; int Cnt; int Var; int il; int ilk; int ilMax; char * Nombre;
-int * Cder; int * Cdeb; int * NumeroDeContrainte; int * Csui; double CoutOpt;
-PROBLEME_SIMPLEXE * Probleme; PROBLEME_A_RESOUDRE * ProblemePourPne;
+	FILE * Flot; int Cnt; int Var; int il; int ilk; int ilMax; char * Nombre;
+	int * Cder; int * Cdeb; int * NumeroDeContrainte; int * Csui; double CoutOpt;
+	PROBLEME_SIMPLEXE * Probleme; PROBLEME_A_RESOUDRE * ProblemePourPne;
 
 
-int NombreDeVariables; int * TypeDeBorneDeLaVariable;
-double * Xmax; double * Xmin; double * CoutLineaire; int NombreDeContraintes;
-double * SecondMembre; char * Sens; int * IndicesDebutDeLigne;
-int * NombreDeTermesDesLignes;	double * CoefficientsDeLaMatriceDesContraintes;
-int * IndicesColonnes; int ExistenceDUneSolution; double * X;
+	int NombreDeVariables; int * TypeDeBorneDeLaVariable;
+	double * Xmax; double * Xmin; double * CoutLineaire; int NombreDeContraintes;
+	double * SecondMembre; char * Sens; int * IndicesDebutDeLigne;
+	int * NombreDeTermesDesLignes;	double * CoefficientsDeLaMatriceDesContraintes;
+	int * IndicesColonnes; int ExistenceDUneSolution; double * X;
 
 
-if ( Type == ANTARES_SIMPLEXE ) {
-  Probleme = (PROBLEME_SIMPLEXE *) Prob;
+	if ( Type == ANTARES_SIMPLEXE )
+	{
+		Probleme = (PROBLEME_SIMPLEXE *) Prob;
 
-  ExistenceDUneSolution	  = Probleme->ExistenceDUneSolution;            
-  if ( ExistenceDUneSolution == OUI_SPX ) ExistenceDUneSolution = OUI_ANTARES;	
+		ExistenceDUneSolution	  = Probleme->ExistenceDUneSolution;            
+		if ( ExistenceDUneSolution == OUI_SPX )
+			ExistenceDUneSolution = OUI_ANTARES;	
 
-  NombreDeVariables       = Probleme->NombreDeVariables;
-  TypeDeBorneDeLaVariable = Probleme->TypeDeVariable;
-  Xmax                    = Probleme->Xmax;
-  Xmin                    = Probleme->Xmin;
-  X                       = Probleme->X;
-  CoutLineaire            = Probleme->CoutLineaire;
-  NombreDeContraintes                   = Probleme->NombreDeContraintes;
-  SecondMembre                          = Probleme->SecondMembre;
-  Sens                                  = Probleme->Sens;
-  IndicesDebutDeLigne                   = Probleme->IndicesDebutDeLigne;
-  NombreDeTermesDesLignes               = Probleme->NombreDeTermesDesLignes;
-  CoefficientsDeLaMatriceDesContraintes = Probleme->CoefficientsDeLaMatriceDesContraintes;
-  IndicesColonnes                       = Probleme->IndicesColonnes;
-}
-else {
+		NombreDeVariables       = Probleme->NombreDeVariables;
+		TypeDeBorneDeLaVariable = Probleme->TypeDeVariable;
+		Xmax                    = Probleme->Xmax;
+		Xmin                    = Probleme->Xmin;
+		X                       = Probleme->X;
+		CoutLineaire            = Probleme->CoutLineaire;
+		NombreDeContraintes                   = Probleme->NombreDeContraintes;
+		SecondMembre                          = Probleme->SecondMembre;
+		Sens                                  = Probleme->Sens;
+		IndicesDebutDeLigne                   = Probleme->IndicesDebutDeLigne;
+		NombreDeTermesDesLignes               = Probleme->NombreDeTermesDesLignes;
+		CoefficientsDeLaMatriceDesContraintes = Probleme->CoefficientsDeLaMatriceDesContraintes;
+		IndicesColonnes                       = Probleme->IndicesColonnes;
+	}
+
+	else
+	{
+		ProblemePourPne = (PROBLEME_A_RESOUDRE *) Prob;
+
+		ExistenceDUneSolution	  = ProblemePourPne->ExistenceDUneSolution;            
+		if ( ExistenceDUneSolution == SOLUTION_OPTIMALE_TROUVEE )
+			ExistenceDUneSolution = OUI_ANTARES;
+
+		NombreDeVariables       = ProblemePourPne->NombreDeVariables;
+		TypeDeBorneDeLaVariable = ProblemePourPne->TypeDeBorneDeLaVariable; 
+		Xmax                    = ProblemePourPne->Xmax;
+		Xmin                    = ProblemePourPne->Xmin;
+		X                       = ProblemePourPne->X;
+		CoutLineaire            = ProblemePourPne->CoutLineaire;
+		NombreDeContraintes                   = ProblemePourPne->NombreDeContraintes;
+		SecondMembre                          = ProblemePourPne->SecondMembre;
+		Sens                                  = ProblemePourPne->Sens;
+		IndicesDebutDeLigne                   = ProblemePourPne->IndicesDebutDeLigne;
+		NombreDeTermesDesLignes               = ProblemePourPne->NombreDeTermesDesLignes;
+		CoefficientsDeLaMatriceDesContraintes = ProblemePourPne->CoefficientsDeLaMatriceDesContraintes;
+		IndicesColonnes                       = ProblemePourPne->IndicesColonnes;	
+	}
+
+
+	if ( ExistenceDUneSolution == OUI_ANTARES )
+	{
+		CoutOpt = 0;
+		for ( Var = 0 ; Var < NombreDeVariables ; Var++ )
+			CoutOpt += CoutLineaire[Var] * X[Var];
+	}
+
+
+	for ( ilMax = -1 , Cnt = 0 ; Cnt < NombreDeContraintes; Cnt++ )
+	{
+		if ( ( IndicesDebutDeLigne[Cnt] + NombreDeTermesDesLignes[Cnt] - 1 ) > ilMax )
+		{
+			ilMax = IndicesDebutDeLigne[Cnt] + NombreDeTermesDesLignes[Cnt] - 1;
+		}
+	}
+
+	ilMax+= NombreDeContraintes; 
+
+	Cder               = (int *) malloc( NombreDeVariables * sizeof( int ) );
+	Cdeb               = (int *) malloc( NombreDeVariables * sizeof( int ) );
+	NumeroDeContrainte = (int *) malloc( ilMax             * sizeof( int ) );
+	Csui               = (int *) malloc( ilMax             * sizeof( int ) );
+	Nombre             = (char *) malloc( 1024 );
+
+	if ( Cder == NULL || Cdeb == NULL || NumeroDeContrainte == NULL || Csui == NULL || Nombre == NULL )
+	{
+		logs.fatal() << "Not enough memory";
+		AntaresSolverEmergencyShutdown();
+	}
+
+
+	for ( Var = 0 ; Var < NombreDeVariables ; Var++ )
+		Cdeb[Var] = -1;
+
+	for ( Cnt = 0 ; Cnt < NombreDeContraintes ; Cnt++ )
+	{
+		il    = IndicesDebutDeLigne[Cnt];
+		ilMax = il + NombreDeTermesDesLignes[Cnt];
+		while ( il < ilMax )
+		{
+			Var = IndicesColonnes[il];
+			if ( Cdeb[Var] < 0 )
+			{
+				Cdeb              [Var] = il;
+				NumeroDeContrainte[il]  = Cnt;
+				Csui              [il]  = -1;
+				Cder              [Var] = il;
+			}
+			else
+			{
+				ilk                     = Cder[Var];
+				Csui              [ilk] = il;
+				NumeroDeContrainte[il]  = Cnt;
+				Csui              [il]  = -1;
+				Cder              [Var] = il;
+			}
+
+			il++;
+		}
+	}
+
+	free( Cder );
+
+	auto& study = *Data::Study::Current::Get();
+	Flot = study.createMPSFileIntoOutput(numSpace);
+
+	if (!Flot)
+		exit(2);
+
+	fprintf(Flot, "* Number of variables:   %d\n", NombreDeVariables);
+	fprintf(Flot, "* Number of constraints: %d\n", NombreDeContraintes);
+	fprintf(Flot, "NAME          Pb Solve\n");
+	fprintf(Flot, "ROWS\n");
+	fprintf(Flot, " N  OBJECTIF\n");
+
+	for ( Cnt = 0 ; Cnt < NombreDeContraintes ; Cnt++ )
+	{
+		if ( Sens[Cnt] == '=' )
+		{
+			fprintf(Flot, " E  R%07d\n", Cnt);
+		}
+		else if (  Sens[Cnt] == '<' )
+		{
+			fprintf(Flot, " L  R%07d\n",Cnt);
+		}
+		else if (  Sens[Cnt] == '>' )
+		{
+			fprintf(Flot, " G  R%07d\n", Cnt);
+		}
+		else
+		{
+			fprintf(Flot, "PNE_EcrireJeuDeDonneesMPS : le sens de la contrainte %c ne fait pas partie des sens reconnus\n", Sens[Cnt]);
+			AntaresSolverEmergencyShutdown(); 
+			exit(0);
+		}
+	}
+
+
+	fprintf(Flot, "COLUMNS\n");
+	for ( Var = 0 ; Var < NombreDeVariables ; Var++ )
+	{
+		if ( CoutLineaire[Var] != 0.0 )
+		{
+			SNPRINTF(Nombre, 1024, "%-.10lf", CoutLineaire[Var]);
+			fprintf(Flot, "    C%07d  OBJECTIF  %s\n", Var, Nombre);
+		}
+
+		il = Cdeb[Var];
+		while ( il >= 0 )
+		{
+			SNPRINTF(Nombre, 1024, "%-.10lf", CoefficientsDeLaMatriceDesContraintes[il]);
+			fprintf(Flot, "    C%07d  R%07d  %s\n", Var, NumeroDeContrainte[il],Nombre);
+			il = Csui[il];
+		}
+	}
+
+	fprintf(Flot, "RHS\n");
+	for ( Cnt = 0 ; Cnt < NombreDeContraintes ; Cnt++ )
+	{
+		if ( SecondMembre[Cnt] != 0.0 )
+		{
+			SNPRINTF(Nombre, 1024, "%-.9lf",SecondMembre[Cnt]);
+			fprintf(Flot, "    RHSVAL    R%07d  %s\n", Cnt, Nombre);
+		}
+	}
+
+	fprintf(Flot, "BOUNDS\n");
+
+	for ( Var = 0 ; Var < NombreDeVariables ; Var++ )
+	{
+		if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_FIXE )
+		{
+			SNPRINTF(Nombre, 1024, "%-.9lf", Xmin[Var]);
+     
+			fprintf(Flot, " FX BNDVALUE  C%07d  %s\n", Var, Nombre);
+			continue;
+		}
   
-  ProblemePourPne = (PROBLEME_A_RESOUDRE *) Prob;
-
-  ExistenceDUneSolution	  = ProblemePourPne->ExistenceDUneSolution;            
-  if ( ExistenceDUneSolution == SOLUTION_OPTIMALE_TROUVEE ) ExistenceDUneSolution = OUI_ANTARES;
-
-  NombreDeVariables       = ProblemePourPne->NombreDeVariables;
-  TypeDeBorneDeLaVariable = ProblemePourPne->TypeDeBorneDeLaVariable; 
-  Xmax                    = ProblemePourPne->Xmax;
-  Xmin                    = ProblemePourPne->Xmin;
-  X                       = ProblemePourPne->X;
-  CoutLineaire            = ProblemePourPne->CoutLineaire;
-  NombreDeContraintes                   = ProblemePourPne->NombreDeContraintes;
-  SecondMembre                          = ProblemePourPne->SecondMembre;
-  Sens                                  = ProblemePourPne->Sens;
-  IndicesDebutDeLigne                   = ProblemePourPne->IndicesDebutDeLigne;
-  NombreDeTermesDesLignes               = ProblemePourPne->NombreDeTermesDesLignes;
-  CoefficientsDeLaMatriceDesContraintes = ProblemePourPne->CoefficientsDeLaMatriceDesContraintes;
-  IndicesColonnes                       = ProblemePourPne->IndicesColonnes;	
-}
-
-
-if ( ExistenceDUneSolution == OUI_ANTARES ) {
-  CoutOpt = 0;
-	for ( Var = 0 ; Var < NombreDeVariables ; Var++ ) CoutOpt += CoutLineaire[Var] * X[Var];
-	
-}
-
-
-for ( ilMax = -1 , Cnt = 0 ; Cnt < NombreDeContraintes; Cnt++ ) {
-  if ( ( IndicesDebutDeLigne[Cnt] + NombreDeTermesDesLignes[Cnt] - 1 ) > ilMax ) {
-    ilMax = IndicesDebutDeLigne[Cnt] + NombreDeTermesDesLignes[Cnt] - 1;
-  }
-}
-ilMax+= NombreDeContraintes; 
-
-Cder               = (int *) malloc( NombreDeVariables * sizeof( int ) );
-Cdeb               = (int *) malloc( NombreDeVariables * sizeof( int ) );
-NumeroDeContrainte = (int *) malloc( ilMax             * sizeof( int ) );
-Csui               = (int *) malloc( ilMax             * sizeof( int ) );
-Nombre             = (char *) malloc( 1024 );
-if ( Cder == NULL || Cdeb == NULL || NumeroDeContrainte == NULL || Csui == NULL || Nombre == NULL ) {
-	logs.fatal() << "Not enough memory";
-	AntaresSolverEmergencyShutdown();
-}
-
-for ( Var = 0 ; Var < NombreDeVariables ; Var++ ) Cdeb[Var] = -1;
-for ( Cnt = 0 ; Cnt < NombreDeContraintes ; Cnt++ ) {
-  il    = IndicesDebutDeLigne[Cnt];
-  ilMax = il + NombreDeTermesDesLignes[Cnt];
-  while ( il < ilMax ) {
-    Var = IndicesColonnes[il];
-    if ( Cdeb[Var] < 0 ) {
-      Cdeb              [Var] = il;
-      NumeroDeContrainte[il]  = Cnt;
-      Csui              [il]  = -1;
-      Cder              [Var] = il;
-    }
-    else {
-      ilk                     = Cder[Var];
-      Csui              [ilk] = il;
-      NumeroDeContrainte[il]  = Cnt;
-      Csui              [il]  = -1;
-      Cder              [Var] = il;
-    }
-    il++;
-  }
-}
-free( Cder );
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-auto& study = *Data::Study::Current::Get();
-Flot = study.createMPSFileIntoOutput(numSpace);
-if (!Flot)
-	exit(2);
-
-
-fprintf(Flot,"* Number of variables:   %d\n",NombreDeVariables);
-fprintf(Flot,"* Number of constraints: %d\n",NombreDeContraintes);
-
-
-
-
-
-
-
-
-
-
-
-
-fprintf(Flot,"NAME          Pb Solve\n");
-
-
-fprintf(Flot,"ROWS\n");
-
-
-
-
-
-
-
-
-
-
-
-fprintf(Flot," N  OBJECTIF\n");
-
-for ( Cnt = 0 ; Cnt < NombreDeContraintes ; Cnt++ ) {
-  if ( Sens[Cnt] == '=' ) {
-    fprintf(Flot," E  R%07d\n",Cnt);
-  }
-  else if (  Sens[Cnt] == '<' ) {
-    fprintf(Flot," L  R%07d\n",Cnt);
-  }
-  else if (  Sens[Cnt] == '>' ) {
-    fprintf(Flot," G  R%07d\n",Cnt);
-  }
-  else {
-    fprintf(Flot,"PNE_EcrireJeuDeDonneesMPS : le sens de la contrainte %c ne fait pas partie des sens reconnus\n",
-            Sens[Cnt]);
-	AntaresSolverEmergencyShutdown(); 
-    exit(0);
-  }
-}
-
-
-fprintf(Flot,"COLUMNS\n");
-for ( Var = 0 ; Var < NombreDeVariables ; Var++ ) {
-  if ( CoutLineaire[Var] != 0.0 ) {
-    SNPRINTF(Nombre,1024,"%-.10lf",CoutLineaire[Var]);
-     
-    fprintf(Flot,"    C%07d  OBJECTIF  %s\n",Var,Nombre);
-  }
-  il = Cdeb[Var];
-  while ( il >= 0 ) {
-    SNPRINTF(Nombre,1024,"%-.10lf",CoefficientsDeLaMatriceDesContraintes[il]);
-     
-    fprintf(Flot,"    C%07d  R%07d  %s\n",Var,NumeroDeContrainte[il],Nombre);
-    il = Csui[il];
-  }
-}
-
-
-fprintf(Flot,"RHS\n");
-for ( Cnt = 0 ; Cnt < NombreDeContraintes ; Cnt++ ) {
-  if ( SecondMembre[Cnt] != 0.0 ) {
-    SNPRINTF(Nombre,1024,"%-.9lf",SecondMembre[Cnt]);
-     
-    fprintf(Flot,"    RHSVAL    R%07d  %s\n",Cnt,Nombre);
-  }
-}
-
-
-fprintf(Flot,"BOUNDS\n");
-
-
-
-
-
-
-
-
-
-
-
-
-for ( Var = 0 ; Var < NombreDeVariables ; Var++ ) {
-  if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_FIXE ) {
-    SNPRINTF(Nombre,1024,"%-.9lf",Xmin[Var]);
-     
-    fprintf(Flot," FX BNDVALUE  C%07d  %s\n",Var,Nombre);
-    continue;
-  }
-  
-  
-  if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_BORNEE_DES_DEUX_COTES ) {
-    if ( Xmin[Var] != 0.0 ) {
-      SNPRINTF(Nombre,1024,"%-.9lf",Xmin[Var]);
-       
-      fprintf(Flot," LO BNDVALUE  C%07d  %s\n",Var,Nombre);
-    }
-    SNPRINTF(Nombre,1024,"%-.9lf",Xmax[Var]);
-     
-    fprintf(Flot," UP BNDVALUE  C%07d  %s\n",Var,Nombre);
-  }
-  if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_BORNEE_INFERIEUREMENT ) {
-    if ( Xmin[Var] != 0.0 ) {
-      SNPRINTF(Nombre,1024,"%-.9lf",Xmin[Var]);
-       
-      fprintf(Flot," LO BNDVALUE  C%07d  %s\n",Var,Nombre);
-    }
-  }
-  if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_BORNEE_SUPERIEUREMENT ) {
-    fprintf(Flot," MI BNDVALUE  C%07d\n",Var);
-    if ( Xmax[Var] != 0.0 ) {
-      SNPRINTF(Nombre,1024,"%-.9lf",Xmax[Var]);
-       
-      fprintf(Flot," UP BNDVALUE  C%07d  %s\n",Var,Nombre);
-    }
-  }
-  if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_NON_BORNEE ) {
-    fprintf(Flot," FR BNDVALUE  C%07d\n",Var);
-  }
-}
-
-
-fprintf(Flot,"ENDATA\n");
-
-free ( Cdeb );
-free ( NumeroDeContrainte );
-free ( Csui );
-free ( Nombre );
-
-fclose( Flot );
-
-return;
+		if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_BORNEE_DES_DEUX_COTES )
+		{
+			if ( Xmin[Var] != 0.0 )
+			{
+				SNPRINTF(Nombre, 1024, "%-.9lf", Xmin[Var]);
+				fprintf(Flot," LO BNDVALUE  C%07d  %s\n",Var,Nombre);
+			}
+
+			SNPRINTF(Nombre, 1024, "%-.9lf", Xmax[Var]);
+			fprintf(Flot, " UP BNDVALUE  C%07d  %s\n", Var, Nombre);
+		}
+		
+		if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_BORNEE_INFERIEUREMENT )
+		{
+			if ( Xmin[Var] != 0.0 )
+			{
+				SNPRINTF(Nombre, 1024, "%-.9lf", Xmin[Var]);
+				fprintf(Flot, " LO BNDVALUE  C%07d  %s\n", Var, Nombre);
+			}
+		}
+
+		if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_BORNEE_SUPERIEUREMENT )
+		{
+			fprintf(Flot, " MI BNDVALUE  C%07d\n", Var);
+			if ( Xmax[Var] != 0.0 )
+			{
+				SNPRINTF(Nombre, 1024, "%-.9lf", Xmax[Var]);
+				fprintf(Flot, " UP BNDVALUE  C%07d  %s\n", Var, Nombre);
+			}
+		}
+
+		if ( TypeDeBorneDeLaVariable[Var] == VARIABLE_NON_BORNEE )
+		{
+			fprintf(Flot, " FR BNDVALUE  C%07d\n", Var);
+		}
+	}
+
+	fprintf(Flot, "ENDATA\n");
+
+	free ( Cdeb );
+	free ( NumeroDeContrainte );
+	free ( Csui );
+	free ( Nombre );
+
+	fclose( Flot );
+
+	return;
 }

--- a/src/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/opt_fonctions.h
@@ -32,7 +32,7 @@
 # include "../simulation/sim_structure_donnees.h"
 
 
-bool OPT_OptimisationHebdomadaire( PROBLEME_HEBDO *, uint);
+void OPT_OptimisationHebdomadaire( PROBLEME_HEBDO *, uint);
 void OPT_NumeroDeJourDuPasDeTemps( PROBLEME_HEBDO * );
 void OPT_NumeroDIntervalleOptimiseDuPasDeTemps( PROBLEME_HEBDO * );
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire( PROBLEME_HEBDO * );

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -26,36 +26,6 @@
 */
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #include <math.h>
 #include "opt_structure_probleme_a_resoudre.h"
 
@@ -77,25 +47,27 @@ using namespace Antares::Data;
 
 
 
-
 bool OPT_OptimisationHebdomadaire( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace )
 {
-if ( ProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE ) {
-	if (!OPT_PilotageOptimisationLineaire( ProblemeHebdo, numSpace )) {
+	if ( ProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE )
+	{
+		if (!OPT_PilotageOptimisationLineaire( ProblemeHebdo, numSpace ))
+		{
+			return false;
+		}
+		return true;
+	}
+
+	if ( ProblemeHebdo->TypeDOptimisation != OPTIMISATION_QUADRATIQUE )
+	{
+		logs.fatal() << "Bug: TypeDOptimisation, OPTIMISATION_LINEAIRE ou OPTIMISATION_QUADRATIQUE non initialise";
+		AntaresSolverEmergencyShutdown(); 
 		return false;
 	}
-	return true;
-}
 
-if ( ProblemeHebdo->TypeDOptimisation != OPTIMISATION_QUADRATIQUE ) {
-	logs.fatal() << "Bug: TypeDOptimisation, OPTIMISATION_LINEAIRE ou OPTIMISATION_QUADRATIQUE non initialise";
-	AntaresSolverEmergencyShutdown(); 
-	return false;
-}
+	OPT_LiberationProblemesSimplexe( ProblemeHebdo );
 
-OPT_LiberationProblemesSimplexe( ProblemeHebdo );
-
-return OPT_PilotageOptimisationQuadratique( ProblemeHebdo );
+	return OPT_PilotageOptimisationQuadratique( ProblemeHebdo );
 }
 
 

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -54,6 +54,7 @@ void OPT_OptimisationHebdomadaire( PROBLEME_HEBDO * pProblemeHebdo, uint numSpac
 	{
 		if (!OPT_PilotageOptimisationLineaire(pProblemeHebdo, numSpace ))
 		{
+            logs.error() << "Linear optimization failed";
 			throw UnfeasibleProblemError("Linear optimization failed");
 		}
 	}
@@ -62,6 +63,7 @@ void OPT_OptimisationHebdomadaire( PROBLEME_HEBDO * pProblemeHebdo, uint numSpac
 		OPT_LiberationProblemesSimplexe(pProblemeHebdo);
 		if (!OPT_PilotageOptimisationQuadratique(pProblemeHebdo))
 		{
+            logs.error() << "Quadratic optimization failed";
 			throw UnfeasibleProblemError("Quadratic optimization failed");
 		}
 	}

--- a/src/solver/optimisation/opt_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_optimisation_lineaire.cpp
@@ -46,143 +46,134 @@ using namespace Antares;
 using namespace Yuni;
 
 
-
-
-
-bool OPT_OptimisationLineaire(  PROBLEME_HEBDO * ProblemeHebdo,
+bool OPT_OptimisationLineaire(	PROBLEME_HEBDO * ProblemeHebdo,
 								uint numSpace,
-                                CLASSE_DE_MANOEUVRABILITE ClasseDeManoeuvrabilite,
-															 	char CalculerLesPmin,
-															 	char CalculerLesPmax,
-															 	char FaireDerniereOptimisation )
+								CLASSE_DE_MANOEUVRABILITE ClasseDeManoeuvrabilite,
+								char CalculerLesPmin,
+								char CalculerLesPmax,
+								char FaireDerniereOptimisation )
 {
-int PdtHebdo; int PremierPdtDeLIntervalle; int DernierPdtDeLIntervalle;
-int NumeroDeLIntervalle; int LongueurDuPasDeTemps  ; int NombreDePasDeTempsPourUneOptimisation;
+	int PdtHebdo; int PremierPdtDeLIntervalle; int DernierPdtDeLIntervalle;
+	int NumeroDeLIntervalle; int LongueurDuPasDeTemps  ; int NombreDePasDeTempsPourUneOptimisation;
 
-LongueurDuPasDeTemps = (int) ClasseDeManoeuvrabilite;
+	LongueurDuPasDeTemps = (int) ClasseDeManoeuvrabilite;
 
-ProblemeHebdo->NombreDePasDeTemps            = ProblemeHebdo->NombreDePasDeTempsRef            / LongueurDuPasDeTemps;
-ProblemeHebdo->NombreDePasDeTempsDUneJournee = ProblemeHebdo->NombreDePasDeTempsDUneJourneeRef / LongueurDuPasDeTemps;
+	ProblemeHebdo->NombreDePasDeTemps            = ProblemeHebdo->NombreDePasDeTempsRef            / LongueurDuPasDeTemps;
+	ProblemeHebdo->NombreDePasDeTempsDUneJournee = ProblemeHebdo->NombreDePasDeTempsDUneJourneeRef / LongueurDuPasDeTemps;
 
-if ( ProblemeHebdo->OptimisationAuPasHebdomadaire == NON_ANTARES ) {
-  ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTempsDUneJournee;
-}
-else {
-  ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTemps;
-}
+	if ( ProblemeHebdo->OptimisationAuPasHebdomadaire == NON_ANTARES )
+	{
+		ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTempsDUneJournee;
+	}
+	else
+	{
+		ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTemps;
+	}
 
-NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation;
+	NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation;
 
-
-(ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation = PREMIERE_OPTIMISATION;
-
-
-OPT_NumeroDeJourDuPasDeTemps( ProblemeHebdo );
-
-OPT_NumeroDIntervalleOptimiseDuPasDeTemps( ProblemeHebdo );
-
-OPT_GenererLesDonneesSelonLePasDeTempsDeLaClasseDeManoeuvrabilite( ProblemeHebdo, ClasseDeManoeuvrabilite );
+	(ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation = PREMIERE_OPTIMISATION;
 
 
+	OPT_NumeroDeJourDuPasDeTemps( ProblemeHebdo );
 
-OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire( ProblemeHebdo );
+	OPT_NumeroDIntervalleOptimiseDuPasDeTemps( ProblemeHebdo );
 
+	OPT_GenererLesDonneesSelonLePasDeTempsDeLaClasseDeManoeuvrabilite( ProblemeHebdo, ClasseDeManoeuvrabilite );
 
+	OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire( ProblemeHebdo );
 
-OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire( ProblemeHebdo, numSpace );
+	OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire( ProblemeHebdo, numSpace );
 
-OptimisationHebdo:
+	OptimisationHebdo:
 
+	for (	PdtHebdo = 0 , NumeroDeLIntervalle = 0 ; PdtHebdo < ProblemeHebdo->NombreDePasDeTemps;
+			PdtHebdo = DernierPdtDeLIntervalle , NumeroDeLIntervalle++ )
+	{
+		PremierPdtDeLIntervalle = PdtHebdo;
+		DernierPdtDeLIntervalle = PdtHebdo + NombreDePasDeTempsPourUneOptimisation;
 
-for ( PdtHebdo = 0 , NumeroDeLIntervalle = 0 ; PdtHebdo < ProblemeHebdo->NombreDePasDeTemps;
-      PdtHebdo = DernierPdtDeLIntervalle , NumeroDeLIntervalle++ ) {
-
-	PremierPdtDeLIntervalle = PdtHebdo;
-	DernierPdtDeLIntervalle = PdtHebdo + NombreDePasDeTempsPourUneOptimisation;
-
-		
-	OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire( ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, NumeroDeLIntervalle );
+		OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire( ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, NumeroDeLIntervalle );
 	
-  
+		OPT_InitialiserLeSecondMembreDuProblemeLineaire( ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, NumeroDeLIntervalle );
 
+		OPT_InitialiserLesCoutsLineaire( ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, numSpace );
 
-
-
-
-
-
-
+		ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle]++;
 	
-	OPT_InitialiserLeSecondMembreDuProblemeLineaire( ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, NumeroDeLIntervalle );
-
-	
-
-	OPT_InitialiserLesCoutsLineaire( ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, numSpace );
-
-	
-	ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle]++;
-	
-	
-	if (!OPT_AppelDuSolveurLineaire( ProblemeHebdo, numSpace, NumeroDeLIntervalle )) {
-	  logs.debug().appendFormat("Flexibility level: %ld",
+		if (!OPT_AppelDuSolveurLineaire( ProblemeHebdo, numSpace, NumeroDeLIntervalle ))
+		{
+			logs.debug().appendFormat(
+								"Flexibility level: %ld",
 	                            ProblemeHebdo->ClasseDeManoeuvrabiliteActive[
 															(ProblemeHebdo->ProblemeAResoudre)->NumeroDeClasseDeManoeuvrabiliteActiveEnCours
 															]);
-	  return false;
-	}
+			return false;
+		}
 
-	if ( ProblemeHebdo->ExportMPS == OUI_ANTARES || ProblemeHebdo->Expansion == OUI_ANTARES)
-		OPT_EcrireResultatFonctionObjectiveAuFormatTXT((void *) ProblemeHebdo, numSpace, NumeroDeLIntervalle);
+		if ( ProblemeHebdo->ExportMPS == OUI_ANTARES || ProblemeHebdo->Expansion == OUI_ANTARES)
+			OPT_EcrireResultatFonctionObjectiveAuFormatTXT((void *) ProblemeHebdo, numSpace, NumeroDeLIntervalle);
 
 	
-	if (ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle] == DEUXIEME_OPTIMISATION)
-		ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle] = 0;
-}
-
-if ( ProblemeHebdo->OptimisationMUTetMDT == OUI_ANTARES ) {
-  
-  if ( (ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation == PREMIERE_OPTIMISATION ) {	
-    if ( ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == NON_ANTARES ) {
-      
-      OPT_CalculerLesPminThermiquesEnFonctionDeMUTetMDT( ProblemeHebdo );
-		}
-		else if ( ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == OUI_ANTARES ) {
-      OPT_AjusterLeNombreMinDeGroupesDemarresCoutsDeDemarrage( ProblemeHebdo );
-		}
-		else printf("BUG: l'indicateur ProblemeHebdo->OptimisationAvecCoutsDeDemarrage doit etre initialise a OUI_ANTARES ou NON_ANTARES\n");
-
-    (ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation = DEUXIEME_OPTIMISATION;
-
-	if (ProblemeHebdo->Expansion == NON_ANTARES) goto OptimisationHebdo;
-  }
-  return true;
-}
-
-/* L'optimisation hebdomadaire est terminee, on peut fixer la Pmax de la classe de manoeuvrabilite en cours
-   si celle-ci est differente de Classe01 */
-if ( (ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation == PREMIERE_OPTIMISATION && ClasseDeManoeuvrabilite != Classe01) {
-	if ( CalculerLesPmax == OUI_ANTARES ) {
-	  OPT_AjusterLesPmaxThermiques( ProblemeHebdo, ClasseDeManoeuvrabilite );
+		if (ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle] == DEUXIEME_OPTIMISATION)
+			ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle] = 0;
 	}
-}
 
-/* Ajustement des Pmin pour approcher des durees min de marche */
-if ( (ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation == PREMIERE_OPTIMISATION && ClasseDeManoeuvrabilite == Classe01 ) {
-	if ( CalculerLesPmin == OUI_ANTARES ) {
-	  OPT_AjusterLesPminThermiques( ProblemeHebdo );
-    if ( FaireDerniereOptimisation == NON_ANTARES ) {
-			/* Sera utilise dans la 2eme volee des optimisations */
-			OPT_SauvegarderLesPminThermiques( ProblemeHebdo );
+
+	if ( ProblemeHebdo->OptimisationMUTetMDT == OUI_ANTARES )
+	{
+		if ( (ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation == PREMIERE_OPTIMISATION )
+		{	
+			if ( ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == NON_ANTARES )
+			{
+				OPT_CalculerLesPminThermiquesEnFonctionDeMUTetMDT( ProblemeHebdo );
+			}
+			else if ( ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == OUI_ANTARES ) 
+			{
+				OPT_AjusterLeNombreMinDeGroupesDemarresCoutsDeDemarrage( ProblemeHebdo );
+			}
+			else
+				printf("BUG: l'indicateur ProblemeHebdo->OptimisationAvecCoutsDeDemarrage doit etre initialise a OUI_ANTARES ou NON_ANTARES\n");
+
+			(ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation = DEUXIEME_OPTIMISATION;
+
+			if (ProblemeHebdo->Expansion == NON_ANTARES)
+				goto OptimisationHebdo;
 		}
-		else {
-		  /* Cas sans reserve J-1: on vient de calculer les Pmin et on fait une reoptimisation avec ces Pmin */
-		  (ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation = DEUXIEME_OPTIMISATION;
-		  goto OptimisationHebdo;
+		
+		return true;
+	}
+
+	/* L'optimisation hebdomadaire est terminee, on peut fixer la Pmax de la classe de manoeuvrabilite en cours
+	   si celle-ci est differente de Classe01 */
+	if ( (ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation == PREMIERE_OPTIMISATION && ClasseDeManoeuvrabilite != Classe01)
+	{
+		if ( CalculerLesPmax == OUI_ANTARES ) {
+			OPT_AjusterLesPmaxThermiques( ProblemeHebdo, ClasseDeManoeuvrabilite );
 		}
 	}
-}
 
-return true;
+	/* Ajustement des Pmin pour approcher des durees min de marche */
+	if ( (ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation == PREMIERE_OPTIMISATION && ClasseDeManoeuvrabilite == Classe01 )
+	{
+		if ( CalculerLesPmin == OUI_ANTARES )
+		{
+			OPT_AjusterLesPminThermiques( ProblemeHebdo );
+			if ( FaireDerniereOptimisation == NON_ANTARES )
+			{
+				/* Sera utilise dans la 2eme volee des optimisations */
+				OPT_SauvegarderLesPminThermiques( ProblemeHebdo );
+			}
+			else
+			{
+				/* Cas sans reserve J-1: on vient de calculer les Pmin et on fait une reoptimisation avec ces Pmin */
+				(ProblemeHebdo->ProblemeAResoudre)->NumeroDOptimisation = DEUXIEME_OPTIMISATION;
+				goto OptimisationHebdo;
+			}
+		}
+	}
+
+	return true;
 }
 
 

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -26,10 +26,6 @@
 */
 
 
-
-
-
-
 # include "opt_structure_probleme_a_resoudre.h"
 
 # include "../simulation/simulation.h"
@@ -43,136 +39,122 @@
 
 
 
-
 bool OPT_PilotageOptimisationLineaire( PROBLEME_HEBDO * ProblemeHebdo, uint numSpace)
 {
-int i; PROBLEME_ANTARES_A_RESOUDRE * ProblemeAResoudre; CLASSE_DE_MANOEUVRABILITE Classe;
-char CalculerLesPmin; char CalculerLesPmax; char FaireDerniereOptimisation;
+	int i; PROBLEME_ANTARES_A_RESOUDRE * ProblemeAResoudre; CLASSE_DE_MANOEUVRABILITE Classe;
+	char CalculerLesPmin; char CalculerLesPmax; char FaireDerniereOptimisation;
 
-CONTRAINTES_COUPLANTES * MatriceDesContraintesCouplantes; int iMx; int CntCouplante;
-int * OffsetTemporelSurLInterco;  int Pays; double x; int ix; int OnReboucle;
+	CONTRAINTES_COUPLANTES * MatriceDesContraintesCouplantes; int iMx; int CntCouplante;
+	int * OffsetTemporelSurLInterco;  int Pays; double x; int ix; int OnReboucle;
 
-
-ProblemeHebdo->OptimisationMUTetMDT = OUI_ANTARES;
-
-
+	ProblemeHebdo->OptimisationMUTetMDT = OUI_ANTARES;
  
- 
-ProblemeHebdo->SolveurDuProblemeLineaire = ANTARES_SIMPLEXE;
-if (0 && ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == OUI_ANTARES && ProblemeHebdo->Expansion == NON_ANTARES) {
-  ProblemeHebdo->SolveurDuProblemeLineaire = ANTARES_PNE;
-} // disable call to PNE until presolve and scaling issues are fixed
+	ProblemeHebdo->SolveurDuProblemeLineaire = ANTARES_SIMPLEXE;
+	if (0 && ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == OUI_ANTARES && ProblemeHebdo->Expansion == NON_ANTARES) {
+		ProblemeHebdo->SolveurDuProblemeLineaire = ANTARES_PNE;
+	} // disable call to PNE until presolve and scaling issues are fixed
 
 
- 
+	if (ProblemeHebdo->LeProblemeADejaEteInstancie == NON_ANTARES )
+	{
+		if (ProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE)
+		{	
+			ProblemeHebdo->NombreDeZonesDeReserveJMoins1 = ProblemeHebdo->NombreDePays;
+			for ( Pays = 0 ; Pays < ProblemeHebdo->NombreDePays ; Pays++ ) {
+				ProblemeHebdo->NumeroDeZoneDeReserveJMoins1[Pays] = Pays;
+				ProblemeHebdo->CoutDeDefaillanceEnReserve[Pays] = 1.e+6;			
+			}
 
+			ProblemeHebdo->ContrainteDeReserveJMoins1ParZone = NON_ANTARES;		
+			ProblemeHebdo->NombreDePasDeTempsRef            = ProblemeHebdo->NombreDePasDeTemps;
+			ProblemeHebdo->NombreDePasDeTempsDUneJourneeRef = ProblemeHebdo->NombreDePasDeTempsDUneJournee;
+			ProblemeHebdo->NombreDeJours = (int) (ProblemeHebdo->NombreDePasDeTemps / ProblemeHebdo->NombreDePasDeTempsDUneJournee);
 
-
-if (ProblemeHebdo->LeProblemeADejaEteInstancie == NON_ANTARES ) {
-	if (ProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE) {	
+			if ( ProblemeHebdo->OptimisationAuPasHebdomadaire == NON_ANTARES )
+			{
+				ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTempsDUneJournee;
+			}
+			else
+			{
+				ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTemps; 
+			}
 		
+			OPT_AllocDuProblemeAOptimiser( ProblemeHebdo );
 		
-		
-
-
-
-
-
-
- 		
-		
-		
-    ProblemeHebdo->NombreDeZonesDeReserveJMoins1 = ProblemeHebdo->NombreDePays;
-	  for ( Pays = 0 ; Pays < ProblemeHebdo->NombreDePays ; Pays++ ) {
-		  ProblemeHebdo->NumeroDeZoneDeReserveJMoins1[Pays] = Pays;
-      ProblemeHebdo->CoutDeDefaillanceEnReserve[Pays] = 1.e+6;			
+			OPT_ChainagesDesIntercoPartantDUnNoeud( ProblemeHebdo );
 		}
-    ProblemeHebdo->ContrainteDeReserveJMoins1ParZone = NON_ANTARES;		
- 		
-				
-		ProblemeHebdo->NombreDePasDeTempsRef            = ProblemeHebdo->NombreDePasDeTemps;
-		ProblemeHebdo->NombreDePasDeTempsDUneJourneeRef = ProblemeHebdo->NombreDePasDeTempsDUneJournee;
-		ProblemeHebdo->NombreDeJours = (int) (ProblemeHebdo->NombreDePasDeTemps / ProblemeHebdo->NombreDePasDeTempsDUneJournee);
-		if ( ProblemeHebdo->OptimisationAuPasHebdomadaire == NON_ANTARES ) {
-			ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTempsDUneJournee;
-		}
-		else {
-			ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTemps; 
-		}
-		
-		OPT_AllocDuProblemeAOptimiser( ProblemeHebdo );
-		
-		OPT_ChainagesDesIntercoPartantDUnNoeud( ProblemeHebdo );
+
+		ProblemeHebdo->LeProblemeADejaEteInstancie = OUI_ANTARES;
 	}
 
-	ProblemeHebdo->LeProblemeADejaEteInstancie = OUI_ANTARES;
-}
+	ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
 
-ProblemeAResoudre = ProblemeHebdo->ProblemeAResoudre;
+	OPT_VerifierPresenceReserveJmoins1( ProblemeHebdo );
 
-OPT_VerifierPresenceReserveJmoins1( ProblemeHebdo );
+	CalculerLesPmin = OUI_ANTARES;
+	CalculerLesPmax = OUI_ANTARES;
 
+	OPT_SauvegarderLesPmaxThermiques( ProblemeHebdo );
 
-CalculerLesPmin = OUI_ANTARES;
-CalculerLesPmax = OUI_ANTARES;
-
-OPT_SauvegarderLesPmaxThermiques( ProblemeHebdo );
-
-if ( ProblemeHebdo->YaDeLaReserveJmoins1 == OUI_ANTARES ) FaireDerniereOptimisation = NON_ANTARES;
-else FaireDerniereOptimisation = OUI_ANTARES;
+	if ( ProblemeHebdo->YaDeLaReserveJmoins1 == OUI_ANTARES )
+		FaireDerniereOptimisation = NON_ANTARES;
+	else
+		FaireDerniereOptimisation = OUI_ANTARES;
 
 
+	OPT_InitialiserLesPminHebdo( ProblemeHebdo );
 
+	OPT_InitialiserLesContrainteDEnergieHydrauliqueParIntervalleOptimise( ProblemeHebdo );
 
-OPT_InitialiserLesPminHebdo( ProblemeHebdo );
+	OPT_MaxDesPmaxHydrauliques( ProblemeHebdo );
 
-OPT_InitialiserLesContrainteDEnergieHydrauliqueParIntervalleOptimise( ProblemeHebdo );
+	if ( ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == OUI_ANTARES )
+	{
+		 OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage( ProblemeHebdo );
+	}
 
-OPT_MaxDesPmaxHydrauliques( ProblemeHebdo );
+	if ( ProblemeHebdo->OptimisationMUTetMDT == NON_ANTARES )
+	{
+		for ( i = 0 ; i < ProblemeHebdo->NombreDeClassesDeManoeuvrabiliteActives ; i++ )
+		{
+			ProblemeAResoudre->NumeroDeClasseDeManoeuvrabiliteActiveEnCours = i;
+			Classe = ProblemeHebdo->ClasseDeManoeuvrabiliteActive[i];
 
+			if (!OPT_OptimisationLineaire( ProblemeHebdo, numSpace, Classe, CalculerLesPmin, CalculerLesPmax, FaireDerniereOptimisation ))
+				return false;
+		}
 
-if ( ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == OUI_ANTARES ) {
-  OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage( ProblemeHebdo );
-}
-
-if ( ProblemeHebdo->OptimisationMUTetMDT == NON_ANTARES ) {
-  for ( i = 0 ; i < ProblemeHebdo->NombreDeClassesDeManoeuvrabiliteActives ; i++ ) {
-	  ProblemeAResoudre->NumeroDeClasseDeManoeuvrabiliteActiveEnCours = i;
-	  Classe = ProblemeHebdo->ClasseDeManoeuvrabiliteActive[i];
+		if ( ProblemeHebdo->YaDeLaReserveJmoins1 == OUI_ANTARES )
+		{
+			CalculerLesPmin = NON_ANTARES;
+			CalculerLesPmax = OUI_ANTARES;
+    
+			OPT_RestaurerLesPmaxThermiques( ProblemeHebdo ); 
+			OPT_RestaurerLesPminThermiques( ProblemeHebdo );		 
 	  
-	  if (!OPT_OptimisationLineaire( ProblemeHebdo, numSpace, Classe, CalculerLesPmin, CalculerLesPmax, FaireDerniereOptimisation )) return false;
-  }
+			ProblemeHebdo->YaDeLaReserveJmoins1	= NON_ANTARES;
+			FaireDerniereOptimisation = NON_ANTARES;
 
-  if ( ProblemeHebdo->YaDeLaReserveJmoins1 == OUI_ANTARES ) {
-    
-    CalculerLesPmin = NON_ANTARES;
-    CalculerLesPmax = OUI_ANTARES;
-    
-    OPT_RestaurerLesPmaxThermiques( ProblemeHebdo ); 
-    
-
-
-	  OPT_RestaurerLesPminThermiques( ProblemeHebdo );		 
-	  
-    ProblemeHebdo->YaDeLaReserveJmoins1	= NON_ANTARES;
-    FaireDerniereOptimisation = NON_ANTARES;
-    for ( i = 0 ; i < ProblemeHebdo->NombreDeClassesDeManoeuvrabiliteActives ; i++ ) {
-	    ProblemeAResoudre->NumeroDeClasseDeManoeuvrabiliteActiveEnCours = i;
-	    Classe = ProblemeHebdo->ClasseDeManoeuvrabiliteActive[i];
+			for ( i = 0 ; i < ProblemeHebdo->NombreDeClassesDeManoeuvrabiliteActives ; i++ )
+			{
+				ProblemeAResoudre->NumeroDeClasseDeManoeuvrabiliteActiveEnCours = i;
+				Classe = ProblemeHebdo->ClasseDeManoeuvrabiliteActive[i];
 	    
-	    if (!OPT_OptimisationLineaire( ProblemeHebdo, numSpace, Classe, CalculerLesPmin, CalculerLesPmax, FaireDerniereOptimisation  )) return false;
-    }
-  }
-}
-else {
-  
-	i = ProblemeHebdo->NombreDeClassesDeManoeuvrabiliteActives - 1;
-  ProblemeAResoudre->NumeroDeClasseDeManoeuvrabiliteActiveEnCours = i;
-	Classe = ProblemeHebdo->ClasseDeManoeuvrabiliteActive[i];
+				if ( ! OPT_OptimisationLineaire( ProblemeHebdo, numSpace, Classe, CalculerLesPmin, CalculerLesPmax, FaireDerniereOptimisation) )
+					return false;
+			}
+		}
+	}
+	else
+	{
+		i = ProblemeHebdo->NombreDeClassesDeManoeuvrabiliteActives - 1;
+		ProblemeAResoudre->NumeroDeClasseDeManoeuvrabiliteActiveEnCours = i;
+		Classe = ProblemeHebdo->ClasseDeManoeuvrabiliteActive[i];
 	
-	if (!OPT_OptimisationLineaire( ProblemeHebdo, numSpace, Classe, CalculerLesPmin, CalculerLesPmax, FaireDerniereOptimisation )) return false;
-}
+		if (!OPT_OptimisationLineaire( ProblemeHebdo, numSpace, Classe, CalculerLesPmin, CalculerLesPmax, FaireDerniereOptimisation )) 
+			return false;
+	}
 
-return true;
+	return true;
 }
 

--- a/src/solver/simulation/adequacy-draft.cpp
+++ b/src/solver/simulation/adequacy-draft.cpp
@@ -109,7 +109,7 @@ namespace Simulation
 								Variable::State& state, 
 								uint numSpace,
 								yearRandomNumbers &, 
-								uint &  
+								std::list<uint> &  
 							)
 	{
 		

--- a/src/solver/simulation/adequacy-draft.h
+++ b/src/solver/simulation/adequacy-draft.h
@@ -76,7 +76,7 @@ namespace Simulation
 					Variable::State& state, 
 					uint numSpace,
 					yearRandomNumbers & randomForYear,
-					uint & failedWeek
+					std::list<uint> & failedWeekList
 				 );
 		void simulationEnd();
 

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -243,7 +243,9 @@ namespace Simulation
 				}
 				catch (Data::AssertionError& ex)
 				{
+					//Indicate failed week list (first week of the year is "week number one" for the user but w=0 for the loop)
 					failedWeekList.push_back(w + 1);
+
 					//Stop simulation
 					logs.error("Assertion error for week " + std::to_string(w + 1) + " simulation is stopped : " + ex.what());
 					return false;
@@ -253,7 +255,7 @@ namespace Simulation
 					//need to clean next problemeHebdo
 					reinitOptim = true;
 
-					//Indicate failed week in list (add 1 to indicate real week number)
+					//Indicate failed week list (first week of the year is "week number one" for the user but w=0 for the loop)
 					failedWeekList.push_back(w+1);
 
 					//Define if simulation must be stopped

--- a/src/solver/simulation/adequacy.h
+++ b/src/solver/simulation/adequacy.h
@@ -82,7 +82,7 @@ namespace Simulation
 					Variable::State& state, 
 					uint numSpace,
 					yearRandomNumbers & randomForYear,
-					uint & failedWeek
+					std::list<uint> & failedWeekList
 				 );
 
 		void incrementProgression(Progression::Task & progression);

--- a/src/solver/simulation/common-dispatchable-margin.cpp
+++ b/src/solver/simulation/common-dispatchable-margin.cpp
@@ -67,8 +67,7 @@ namespace Solver
 namespace Simulation
 {
 
-
-	bool DispatchableMarginForAllAreas(	const Data::Study& study, 
+	void DispatchableMarginForAllAreas(	const Data::Study& study, 
 										PROBLEME_HEBDO& problem,
 										uint numSpace,
 										uint hourInYear, 
@@ -108,7 +107,6 @@ namespace Simulation
 				}
 			}
 		});
-		return true;
 	}
 
 

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -30,6 +30,8 @@
 #include <antares/study/study.h>
 #include <antares/study/area/scratchpad.h>
 #include <antares/study/memory-usage.h>
+#include <antares/exception/UnfeasibleProblemError.hpp>
+
 #include "common-eco-adq.h"
 #include <antares/logs.h>
 #include <cassert>
@@ -84,12 +86,15 @@ namespace Simulation
 			}
 		}
 
-		if (not OPT_OptimisationHebdomadaire(&problem, 0))
+		try
 		{
-			
-			
-			study.runtime->quadraticOptimizationHasFailed = true;
+			OPT_OptimisationHebdomadaire(&problem, 0);
 		}
+		catch (Data::UnfeasibleProblemError& ex)
+		{
+			study.runtime->quadraticOptimizationHasFailed = true;
+		}	
+		
 
 		for (uint i = 0; i < (uint) problem.NombreDePasDeTemps; ++i)
 		{

--- a/src/solver/simulation/common-eco-adq.h
+++ b/src/solver/simulation/common-eco-adq.h
@@ -99,7 +99,7 @@ namespace Simulation
 	** \param hourInYear The hour in the year of the first hour in the current week
 	** \param nbHours The number of hour for a week
 	*/
-	bool RemixHydroForAllAreas(const Data::Study& study, PROBLEME_HEBDO& problem, uint numSpace, uint hourInYear, uint nbHours);
+	void RemixHydroForAllAreas(const Data::Study& study, PROBLEME_HEBDO& problem, uint numSpace, uint hourInYear, uint nbHours);
 
 	/*
 	** \brief Computing levels from hydro generation, natural and pumping inflows
@@ -117,7 +117,7 @@ namespace Simulation
 	** \param hourInYear The hour in the year of the first hour in the current week
 	** \param nbHours The number of hour for a week
 	*/
-	bool DispatchableMarginForAllAreas(	const Data::Study& study,
+	void DispatchableMarginForAllAreas(	const Data::Study& study,
 										PROBLEME_HEBDO& problem, 
 										uint numSpace,
 										uint hourInYear, 

--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -55,6 +55,7 @@
 #include <yuni/core/math.h>
 #include <antares/study/study.h>
 #include <antares/study/memory-usage.h>
+#include <antares/exception/AssertionError.hpp>
 #include "common-eco-adq.h"
 #include <antares/logs.h>
 #include <cassert>
@@ -263,32 +264,35 @@ namespace Simulation
 
 
 
-	bool RemixHydroForAllAreas(const Data::Study& study, PROBLEME_HEBDO& problem, uint numSpace, uint hourInYear, uint nbHour)
+	void RemixHydroForAllAreas(const Data::Study& study, PROBLEME_HEBDO& problem, uint numSpace, uint hourInYear, uint nbHour)
 	{
 		assert(nbHour == 168 && "endHour seems invalid");
 		(void) nbHour;
 		assert(study.parameters.mode != Data::stdmAdequacyDraft);
 
-		if (study.parameters.shedding.policy != Data::shpShavePeaks)
-			return true;
-
-		switch (study.parameters.simplexOptimizationRange)
+		if (study.parameters.shedding.policy == Data::shpShavePeaks)
 		{
+			bool result = true;
+
+			switch (study.parameters.simplexOptimizationRange)
+			{
 			case Data::sorWeek:
-				return Remix<  168 >(study, problem, numSpace, hourInYear);
+				result =  Remix<  168 >(study, problem, numSpace, hourInYear);
+				break;
 			case Data::sorDay:
-				return Remix<   24 >(study, problem, numSpace, hourInYear);
+				result = Remix<   24 >(study, problem, numSpace, hourInYear);
+				break;
 			case Data::sorUnknown:
 				logs.fatal() << "invalid simplex optimization range";
 				break;
+			}
+
+			if (!result)
+			{
+				throw new Data::AssertionError("Error in simplex optimisation. Check logs for more details.");
+			}
 		}
-		return false;
 	}
-
-
-
-
-
 } 
 } 
 } 

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -29,6 +29,8 @@
 #include <antares/study/memory-usage.h>
 #include "economy.h"
 #include <antares/study.h>
+#include <antares/exception/UnfeasibleProblemError.hpp>
+#include <antares/exception/AssertionError.hpp>
 #include <yuni/core/math.h>
 #include "simulation.h"
 #include "../optimisation/opt_fonctions.h"
@@ -124,17 +126,19 @@ namespace Simulation
 						Variable::State& state, 
 						uint numSpace,
 						yearRandomNumbers & randomForYear,
-						uint & failedWeek
+						std::list<uint>& failedWeekList
 					  )
 	{
 		
-		
-		PrepareRandomNumbers(study, *pProblemesHebdo[numSpace], randomForYear);
+		//No failed week at year start
+		failedWeekList.clear();
 
+		PrepareRandomNumbers(study, *pProblemesHebdo[numSpace], randomForYear);
 		
 		state.startANewYear();
 		
 		int hourInTheYear = pStartTime;
+		bool reinitOptim = true;
 
 		for (uint w = 0; w != pNbWeeks; ++w)
 		{
@@ -144,74 +148,82 @@ namespace Simulation
 
 			
 			::SIM_RenseignementProblemeHebdo(*pProblemesHebdo[numSpace], state, numSpace, hourInTheYear);
-
 			
-			if (not ::OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace], numSpace))
+			//Reinit optimisation if needed
+			pProblemesHebdo[numSpace]->ReinitOptimisation = reinitOptim ? OUI_ANTARES : NON_ANTARES;
+			reinitOptim = false;
+
+			try
 			{
-				
-				
-				failedWeek = w;
+				OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace], numSpace);
+				DispatchableMarginForAllAreas(study, *pProblemesHebdo[numSpace], numSpace, hourInTheYear, nbHoursInAWeek);
+
+
+
+				computingHydroLevels(study, *pProblemesHebdo[numSpace], nbHoursInAWeek, false);
+
+				RemixHydroForAllAreas(study, *pProblemesHebdo[numSpace], numSpace, hourInTheYear, nbHoursInAWeek);
+
+				computingHydroLevels(study, *pProblemesHebdo[numSpace], nbHoursInAWeek, true);
+
+				interpolateWaterValue(study, *pProblemesHebdo[numSpace], state, hourInTheYear, nbHoursInAWeek);
+
+				updatingWeeklyFinalHydroLevel(study, *pProblemesHebdo[numSpace], nbHoursInAWeek);
+
+
+				variables.weekBegin(state);
+				uint previousHourInTheYear = state.hourInTheYear;
+
+				for (uint hw = 0; hw != nbHoursInAWeek; ++hw, ++state.hourInTheYear, ++state.hourInTheSimulation)
+				{
+
+					state.hourInTheWeek = hw;
+
+					state.ntc = pProblemesHebdo[numSpace]->ValeursDeNTC[hw];
+
+
+					variables.hourBegin(state.hourInTheYear);
+
+
+
+					variables.hourForEachArea(state, numSpace);
+
+					variables.hourEnd(state, state.hourInTheYear);
+				}
+
+				state.hourInTheYear = previousHourInTheYear;
+				variables.weekForEachArea(state, numSpace);
+				variables.weekEnd(state);
+
+
+				for (int opt = 0; opt < 7; opt++)
+				{
+					state.optimalSolutionCost1 += pProblemesHebdo[numSpace]->coutOptimalSolution1[opt];
+					state.optimalSolutionCost2 += pProblemesHebdo[numSpace]->coutOptimalSolution2[opt];
+				}
+
+			}
+			catch (Data::AssertionError& ex)
+			{
+				failedWeekList.push_back(w + 1);
+				//Stop simulation
+				logs.error("Assertion error for week " + std::to_string(w + 1) + " simulation is stopped : " + ex.what());
 				return false;
 			}
-
-			
-			
-			if (not DispatchableMarginForAllAreas(study, *pProblemesHebdo[numSpace], numSpace, hourInTheYear, nbHoursInAWeek))
+			catch (Data::UnfeasibleProblemError& ex)
 			{
-				failedWeek = w;
-				return false;
+				//need to clean next problemeHebdo
+				reinitOptim = true;
+
+				//Indicate failed week list (add 1 to indicate real week number)
+				failedWeekList.push_back(w+1);
+
+				//Define if simulation must be stopped
+				if (Data::stopSimulation(study.parameters.include.unfeasibleProblemBehavior))
+				{
+					return false;
+				}
 			}
-
-			
-			
-			computingHydroLevels(study, *pProblemesHebdo[numSpace], nbHoursInAWeek, false);
-
-			
-			if (not RemixHydroForAllAreas(study, *pProblemesHebdo[numSpace], numSpace, hourInTheYear, nbHoursInAWeek))
-			{
-				failedWeek = w;
-				return false;
-			}
-
-			
-			computingHydroLevels(study, *pProblemesHebdo[numSpace], nbHoursInAWeek, true);
-
-			interpolateWaterValue(study, *pProblemesHebdo[numSpace], state, hourInTheYear, nbHoursInAWeek);
-
-			updatingWeeklyFinalHydroLevel(study, *pProblemesHebdo[numSpace], nbHoursInAWeek);
-			
-
-			variables.weekBegin(state);
-			uint previousHourInTheYear = state.hourInTheYear;
-
-			for (uint hw = 0; hw != nbHoursInAWeek ; ++hw, ++state.hourInTheYear, ++state.hourInTheSimulation)
-			{
-				
-				state.hourInTheWeek = hw;
-				
-				state.ntc = pProblemesHebdo[numSpace]->ValeursDeNTC[hw];
-
-				
-				variables.hourBegin(state.hourInTheYear);
-				
-				
-				
-				variables.hourForEachArea(state, numSpace);
-				
-				variables.hourEnd(state, state.hourInTheYear);
-			}
-
-			state.hourInTheYear = previousHourInTheYear; 
-			variables.weekForEachArea(state, numSpace);
-			variables.weekEnd(state);
-
-			
-			for (int opt = 0; opt < 7; opt++)
-			{
-				state.optimalSolutionCost1 += pProblemesHebdo[numSpace]->coutOptimalSolution1[opt];
-				state.optimalSolutionCost2 += pProblemesHebdo[numSpace]->coutOptimalSolution2[opt];
-			}
-
 			
 			hourInTheYear += nbHoursInAWeek;
 

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -205,7 +205,9 @@ namespace Simulation
 			}
 			catch (Data::AssertionError& ex)
 			{
+				//Indicate failed week list (first week of the year is "week number one" for the user but w=0 for the loop)
 				failedWeekList.push_back(w + 1);
+
 				//Stop simulation
 				logs.error("Assertion error for week " + std::to_string(w + 1) + " simulation is stopped : " + ex.what());
 				return false;
@@ -215,7 +217,7 @@ namespace Simulation
 				//need to clean next problemeHebdo
 				reinitOptim = true;
 
-				//Indicate failed week list (add 1 to indicate real week number)
+				//Indicate failed week list (first week of the year is "week number one" for the user but w=0 for the loop)
 				failedWeekList.push_back(w+1);
 
 				//Define if simulation must be stopped

--- a/src/solver/simulation/economy.h
+++ b/src/solver/simulation/economy.h
@@ -80,7 +80,7 @@ namespace Simulation
 					Variable::State& state,
 					uint numSpace,
 					yearRandomNumbers & randomForYear,
-					uint & failedWeek
+					std::list<uint> & failedWeekList
 				 );
 
 		void incrementProgression(Progression::Task & progression);

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -120,6 +120,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study, PROBLEME_HEBDO& problem
 
 	
 	problem.ExportMPS					  = study.parameters.include.exportMPS; 
+	problem.exportMPSOnError			  = Data::exportMPS(parameters.include.unfeasibleProblemBehavior);
 
 	
 	problem.OptimisationAvecCoutsDeDemarrage = (study.parameters.unitCommitment.ucMode == Antares::Data::UnitCommitmentMode::ucMILP) ? OUI_ANTARES : NON_ANTARES ;
@@ -408,10 +409,6 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem, Antares::Solver::Va
 		problem.coutOptimalSolution1[opt] = 0.;
 		problem.coutOptimalSolution2[opt] = 0.;
 	}
-
-
-	
-	problem.ReinitOptimisation = (study.runtime->weekInTheYear[numSpace]==0) ? OUI_ANTARES : NON_ANTARES;
 
 	for (uint k = 0; k < studyruntime.interconnectionsCount; ++k)
 	{

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -627,7 +627,8 @@ struct PROBLEME_HEBDO {
 	char OptimisationMUTetMDT;
 
 	
-	char ExportMPS; 
+	char ExportMPS;
+	bool exportMPSOnError;
 	
 	char WaterValueAccurate;	/* OUI_ANTARES /NON_ANTARES*/ 
 	

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -102,6 +102,39 @@ namespace Simulation
 			bool hydroHotStart;
 
 		private:
+
+			/*
+			** \brief Log failed week
+			**
+			** \param y     MC Year
+			** \param study The Antares study
+			** \param failedWeek List of failing week
+			*/
+			void logFailedWeek(int y, const Data::Study& study, const std::list<int>& failedWeekList)
+			{
+				if (failedWeekList.size() != 0)
+				{
+					std::stringstream failedWeekStr;
+					std::copy(failedWeekList.begin(), failedWeekList.end(), std::ostream_iterator<int>(failedWeekStr, " "));
+
+					std::string s = failedWeekStr.str();
+					s = s.substr(0, s.length() - 1);  // get rid of the trailing space
+
+					std::string failedStr = failedWeekList.size() != 1 ? " failed at weeks " : " failed at week ";
+
+					logs.info(); // empty line
+
+					if (Data::stopSimulation(study.parameters.include.unfeasibleProblemBehavior))
+					{
+						logs.fatal() << "Year " << y + 1 << failedStr << s << ".";
+					}
+					else
+					{
+						logs.warning() << "Year " << y + 1 << failedStr << s << ".";
+					}
+				}
+			}
+
 			virtual void onExecute() override
 			{
 				if(isFirstPerformedYearOfASet[y])
@@ -169,27 +202,7 @@ namespace Simulation
 					}
 
 					//Log failing weeks
-					if (failedWeekList.size() != 0)
-					{
-						std::stringstream failedWeekStr;
-						std::copy(failedWeekList.begin(), failedWeekList.end(), std::ostream_iterator<int>(failedWeekStr, " "));
-
-						std::string s = failedWeekStr.str();
-						s = s.substr(0, s.length() - 1);  // get rid of the trailing space
-
-						std::string failedStr = failedWeekList.size() != 1 ? " failed at weeks " : " failed at week ";
-						
-						logs.info(); // empty line
-
-						if (Data::stopSimulation(study.parameters.include.unfeasibleProblemBehavior))
-						{
-							logs.fatal() << "Year " << y + 1 << failedStr << s << ".";
-						}
-						else
-						{
-							logs.warning() << "Year " << y + 1 << failedStr << s << ".";
-						}
-					}
+					logFailedWeek(y, study, failedWeekList);					
 
 					// 6.5 - Flush all memory into the swap files
 					// This is mandatory for big studies, with numerous areas and thermal clusters

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -110,7 +110,7 @@ namespace Simulation
 			** \param study The Antares study
 			** \param failedWeek List of failing week
 			*/
-			void logFailedWeek(int y, const Data::Study& study, const std::list<int>& failedWeekList)
+			void logFailedWeek(int y, const Data::Study& study, const std::list<uint>& failedWeekList)
 			{
 				if (failedWeekList.size() != 0)
 				{

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -157,15 +157,39 @@ namespace Simulation
 						Antares::memory.flushAll();
 					
 					// 6 - The Solver itself
-					uint failedWeek = 0;
-					if ( not simulationObj-> year(progression, state[numSpace], numSpace, randomForCurrentYear, failedWeek) )
+					std::list<uint> failedWeekList;
+					if ( not simulationObj-> year(progression, state[numSpace], numSpace, randomForCurrentYear, failedWeekList) )
 					{
 						// Something goes wrong with this year. We have to restarting it
-						logs.info(); // empty line
-						logs.fatal() << "Year " << y + 1 << " failed at week " << failedWeek + 1 << ".";
+						yearFailed[y] = true;
 					}
 					else
-						yearFailed[y] = false;
+					{
+						yearFailed[y] = false;						
+					}
+
+					//Log failing weeks
+					if (failedWeekList.size() != 0)
+					{
+						std::stringstream failedWeekStr;
+						std::copy(failedWeekList.begin(), failedWeekList.end(), std::ostream_iterator<int>(failedWeekStr, " "));
+
+						std::string s = failedWeekStr.str();
+						s = s.substr(0, s.length() - 1);  // get rid of the trailing space
+
+						std::string failedStr = failedWeekList.size() != 1 ? " failed at weeks " : " failed at week ";
+						
+						logs.info(); // empty line
+
+						if (Data::stopSimulation(study.parameters.include.unfeasibleProblemBehavior))
+						{
+							logs.fatal() << "Year " << y + 1 << failedStr << s << ".";
+						}
+						else
+						{
+							logs.warning() << "Year " << y + 1 << failedStr << s << ".";
+						}
+					}
 
 					// 6.5 - Flush all memory into the swap files
 					// This is mandatory for big studies, with numerous areas and thermal clusters

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -289,7 +289,7 @@ namespace Options
             label  = Component::CreateLabel(this, wxT("Unfeasible problem behavior"));
 
 			const Data::UnfeasibleProblemBehavior& defaultValue = Data::UnfeasibleProblemBehavior::ERROR_DRY;
-            button = new Component::Button(this, Data::getDisplayName(defaultValue), Data::getIcon(defaultValue));
+            button = new Component::Button(this, Data::getDisplayName(defaultValue));
             button->SetBackgroundColour(bgColor);
             button->menu(true);
             onPopup.bind(this, &Optimization::onPopupMenuUnfeasibleBehavior);
@@ -400,8 +400,7 @@ namespace Options
 				study.parameters.include.exportMPS              = false;
 				study.parameters.simplexOptimizationRange       = Data::sorWeek;
 
-				//TODO JMK : confirm default value
-				study.parameters.include.unfeasibleProblemBehavior = Data::UnfeasibleProblemBehavior::ERROR_DRY;
+				study.parameters.include.unfeasibleProblemBehavior = Data::UnfeasibleProblemBehavior::ERROR_MPS;
 
 				refresh();
 				MarkTheStudyAsModified();
@@ -449,7 +448,6 @@ namespace Options
 		ResetButtonSpecify(pBtnExportMPS, study.parameters.include.exportMPS);
 
 		//Unfeasible problem behavior
-		pBtnUnfeasibleProblemBehavior->image(Data::getIcon(study.parameters.include.unfeasibleProblemBehavior));
 		pBtnUnfeasibleProblemBehavior->caption(Data::getDisplayName(study.parameters.include.unfeasibleProblemBehavior));
 				
 		// Simplex Optimization Range
@@ -530,7 +528,7 @@ namespace Options
 		//Warning dry
 		{
 			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::WARNING_DRY;
-			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value));
 			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 						 wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorWarningDry), nullptr, this);
 		}
@@ -538,14 +536,14 @@ namespace Options
         //Warning mps
 		{
 			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::WARNING_MPS;
-			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value));
 			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorWarningMps), nullptr, this);
 		}
         //Error dry
 		{
 			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::ERROR_DRY;
-			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value));
 			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorErrorDry), nullptr, this);
 		}
@@ -553,7 +551,7 @@ namespace Options
         //Error mps
 		{
 			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::ERROR_MPS;
-			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value));
 			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorErrorMps), nullptr, this);
 		}

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -40,16 +40,12 @@
 
 using namespace Yuni;
 
-
-
 namespace Antares
 {
 namespace Window
 {
 namespace Options
 {
-
-
 	static void ResetButton(Component::Button* button, bool value)
 	{
 		assert(button != NULL);
@@ -288,6 +284,21 @@ namespace Options
 			pBtnExportMPS = button;
 		}
 
+		//Unfeasible problem behavior
+        {
+            label  = Component::CreateLabel(this, wxT("Unfeasible problem behavior"));
+
+			const Data::UnfeasibleProblemBehavior& defaultValue = Data::UnfeasibleProblemBehavior::ERROR_DRY;
+            button = new Component::Button(this, Data::getDisplayName(defaultValue), Data::getIcon(defaultValue));
+            button->SetBackgroundColour(bgColor);
+            button->menu(true);
+            onPopup.bind(this, &Optimization::onPopupMenuUnfeasibleBehavior);
+            button->onPopupMenu(onPopup);
+            s->Add(label, 0, wxRIGHT | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL);
+            s->Add(button, 0, wxLEFT | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL);
+            pBtnUnfeasibleProblemBehavior = button;
+        }
+
 		// Simplex optimization range
 		{
 			label  = Component::CreateLabel(this, wxT("Simplex optimization range"));
@@ -389,6 +400,9 @@ namespace Options
 				study.parameters.include.exportMPS              = false;
 				study.parameters.simplexOptimizationRange       = Data::sorWeek;
 
+				//TODO JMK : confirm default value
+				study.parameters.include.unfeasibleProblemBehavior = Data::UnfeasibleProblemBehavior::ERROR_DRY;
+
 				refresh();
 				MarkTheStudyAsModified();
 				return;
@@ -434,6 +448,10 @@ namespace Options
 		// Export mps
 		ResetButtonSpecify(pBtnExportMPS, study.parameters.include.exportMPS);
 
+		//Unfeasible problem behavior
+		pBtnUnfeasibleProblemBehavior->image(Data::getIcon(study.parameters.include.unfeasibleProblemBehavior));
+		pBtnUnfeasibleProblemBehavior->caption(Data::getDisplayName(study.parameters.include.unfeasibleProblemBehavior));
+				
 		// Simplex Optimization Range
 		if (Data::sorDay == study.parameters.simplexOptimizationRange)
 		{
@@ -506,6 +524,40 @@ namespace Options
 		menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 			wxCommandEventHandler(Optimization::onSelectTransCapInfinite), nullptr, this);
 	}
+
+    void Optimization::onPopupMenuUnfeasibleBehavior(Component::Button&, wxMenu& menu, void*)
+    {
+		//Warning dry
+		{
+			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::WARNING_DRY;
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
+			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
+						 wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorWarningDry), nullptr, this);
+		}
+        
+        //Warning mps
+		{
+			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::WARNING_MPS;
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
+			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
+				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorWarningMps), nullptr, this);
+		}
+        //Error dry
+		{
+			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::ERROR_DRY;
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
+			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
+				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorErrorDry), nullptr, this);
+		}
+
+        //Error mps
+		{
+			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::ERROR_MPS;
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
+			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
+				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorErrorMps), nullptr, this);
+		}
+    }
 
 
 	void Optimization::onSelectModeInclude(wxCommandEvent&)
@@ -649,8 +701,39 @@ namespace Options
 		}
 	}
 
+	void Optimization::onSelectUnfeasibleBehavior(const  Data::UnfeasibleProblemBehavior& unfeasibleProblemBehavior)
+	{
+		auto study = Data::Study::Current::Get();
+		if (!(!study))
+		{
+			if (study->parameters.include.unfeasibleProblemBehavior != unfeasibleProblemBehavior)
+			{
+				study->parameters.include.unfeasibleProblemBehavior = unfeasibleProblemBehavior;
+				refresh();
+				MarkTheStudyAsModified();
+			}
+		}
+	}
 
+    void Optimization::onSelectUnfeasibleBehaviorWarningDry(wxCommandEvent& )
+    {
+		onSelectUnfeasibleBehavior(Data::UnfeasibleProblemBehavior::WARNING_DRY);
+    }
 
+    void Optimization::onSelectUnfeasibleBehaviorWarningMps(wxCommandEvent& )
+    {
+		onSelectUnfeasibleBehavior(Data::UnfeasibleProblemBehavior::WARNING_MPS);
+    }
+
+    void Optimization::onSelectUnfeasibleBehaviorErrorDry(wxCommandEvent& )
+    {
+		onSelectUnfeasibleBehavior(Data::UnfeasibleProblemBehavior::ERROR_DRY);
+    }
+
+    void Optimization::onSelectUnfeasibleBehaviorErrorMps(wxCommandEvent& )
+    {
+		onSelectUnfeasibleBehavior(Data::UnfeasibleProblemBehavior::ERROR_MPS);
+    }
 
 } // namespace Options
 } // namespace Window

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -289,7 +289,7 @@ namespace Options
             label  = Component::CreateLabel(this, wxT("Unfeasible problem behavior"));
 
 			const Data::UnfeasibleProblemBehavior& defaultValue = Data::UnfeasibleProblemBehavior::ERROR_DRY;
-            button = new Component::Button(this, Data::getDisplayName(defaultValue));
+            button = new Component::Button(this, Data::getDisplayName(defaultValue), Data::getIcon(defaultValue));
             button->SetBackgroundColour(bgColor);
             button->menu(true);
             onPopup.bind(this, &Optimization::onPopupMenuUnfeasibleBehavior);
@@ -448,6 +448,7 @@ namespace Options
 		ResetButtonSpecify(pBtnExportMPS, study.parameters.include.exportMPS);
 
 		//Unfeasible problem behavior
+		pBtnUnfeasibleProblemBehavior->image(Data::getIcon(study.parameters.include.unfeasibleProblemBehavior));
 		pBtnUnfeasibleProblemBehavior->caption(Data::getDisplayName(study.parameters.include.unfeasibleProblemBehavior));
 				
 		// Simplex Optimization Range
@@ -528,7 +529,7 @@ namespace Options
 		//Warning dry
 		{
 			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::WARNING_DRY;
-			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value));
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
 			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 						 wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorWarningDry), nullptr, this);
 		}
@@ -536,14 +537,14 @@ namespace Options
         //Warning mps
 		{
 			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::WARNING_MPS;
-			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value));
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
 			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorWarningMps), nullptr, this);
 		}
         //Error dry
 		{
 			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::ERROR_DRY;
-			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value));
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
 			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorErrorDry), nullptr, this);
 		}
@@ -551,7 +552,7 @@ namespace Options
         //Error mps
 		{
 			const Data::UnfeasibleProblemBehavior& value = Data::UnfeasibleProblemBehavior::ERROR_MPS;
-			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value));
+			wxMenuItem* it = Menu::CreateItem(&menu, wxID_ANY, Data::getDisplayName(value), Data::getIcon(value), wxEmptyString);
 			menu.Connect(it->GetId(), wxEVT_COMMAND_MENU_SELECTED,
 				wxCommandEventHandler(Optimization::onSelectUnfeasibleBehaviorErrorMps), nullptr, this);
 		}

--- a/src/ui/simulator/windows/options/optimization/optimization.h
+++ b/src/ui/simulator/windows/options/optimization/optimization.h
@@ -31,9 +31,11 @@
 # include "../../../toolbox/components/button.h"
 # include <wx/dialog.h>
 
+#include <antares/study/UnfeasibleProblemBehavior.hpp>
 
 namespace Antares
 {
+
 namespace Window
 {
 namespace Options
@@ -86,11 +88,19 @@ namespace Options
 		void onSelectLinkTypeLocal(wxCommandEvent& evt);
 		void onSelectLinkTypeAC(wxCommandEvent& evt);
 
+        void onSelectUnfeasibleBehaviorWarningDry(wxCommandEvent& evt);
+        void onSelectUnfeasibleBehaviorWarningMps(wxCommandEvent& evt);
+        void onSelectUnfeasibleBehaviorErrorDry(wxCommandEvent& evt);
+        void onSelectUnfeasibleBehaviorErrorMps(wxCommandEvent& evt);
+		void onSelectUnfeasibleBehavior(const Data::UnfeasibleProblemBehavior& unfeasibleProblemBehavior);
+
+
 		void onPopupMenu(Component::Button&, wxMenu& menu, void*, const PopupInfo& info);
 		void onPopupMenuSimplex(Component::Button&, wxMenu& menu, void*);
 		void onPopupMenuSpecify(Component::Button&, wxMenu& menu, void*, const PopupInfo& info);
 		void onPopupMenuTransmissionCapacities(Component::Button&, wxMenu& menu, void*);
 		void onPopupMenuLinkType(Component::Button&, wxMenu& menu, void*);
+        void onPopupMenuUnfeasibleBehavior(Component::Button&, wxMenu& menu, void*);
 
 		void onInternalMotion(wxMouseEvent&);
 
@@ -108,8 +118,10 @@ namespace Options
 		Component::Button* pBtnSimplexOptimizationRange;
 
 		Component::Button* pBtnExportMPS;
+        Component::Button* pBtnUnfeasibleProblemBehavior;
 		bool* pTargetRef;
 
+		
 	}; // class Optimization
 
 


### PR DESCRIPTION
Add option to allow simulation to continue in case of an unfeasible problem.

4 options define by enum `UnfeasibleProblemBehavior`:
- stop simulation and save MPS `ERROR_MPS`
- stop simulation and don't save MPS `ERROR_DRY`
- continue simulation and save MPS      `WARNING_MPS`
- continue simulation and don't save MPS `WARNING_DRY`

Change done in:
- UI to display and change option
- study .ini save to load and save option
- solver to use option to continue or stop simulation
- solver to use option to save or not MPS