### PR TITLE
Fix/58 bc marked skipped

### DIFF
--- a/src/libs/antares/study/constraint/constraint.cpp
+++ b/src/libs/antares/study/constraint/constraint.cpp
@@ -1243,9 +1243,7 @@ namespace Data
 				s << " + ";
 			SNPRINTF(tmp, sizeof(tmp), "%.2f", i->second);
 
-			s << '(' << (const char*)tmp << " x "
-				<< (i->first)->getName();
-			//<< (i->first)->from->name << '.' << (i->first)->with->name;
+			s << '(' << (const char*)tmp << " x " << (i->first)->getName();
 
 			auto at = pLinkOffsets.find(i->first);
 			if(at != pLinkOffsets.end())
@@ -1280,6 +1278,9 @@ namespace Data
 				if (o < 0)
 					s << " x (t - " << Math::Abs(pClusterOffsets.find(i->first)->second) << ')';
 			}
+
+			if (not (i->first)->enabled || (i->first)->mustrun)
+				s << " x N/A";
 
 			s << ')';
 			first = false;

--- a/src/ui/simulator/application/main/main.cpp
+++ b/src/ui/simulator/application/main/main.cpp
@@ -716,6 +716,9 @@ namespace Forms
 			SystemParameterHaveChanged = false;
 		}
 
+		if (page.name() == wxT("bindingconstraints"))
+			OnStudyConstraintModified(nullptr);
+
 		// Notify any subscriber that the selection of the main notebook
 		// has changed.
 		OnMainNotebookChanged();

--- a/src/ui/simulator/toolbox/components/datagrid/gridhelper.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/gridhelper.cpp
@@ -96,6 +96,7 @@ namespace Datagrid
 			// Disabled
 			pStyles[CellStyle::cellStyleDisabled]->SetBackgroundColour(wxColour(245, 224, 213));
 			pStyles[CellStyle::cellStyleDisabled]->SetTextColour(wxColour(50, 50, 60));
+			pStyles[CellStyle::cellStyleDisabled]->SetReadOnly(true);
 			// Warning
 			pStyles[CellStyle::cellStyleWarning]->SetBackgroundColour(wxColour(255, 184, 62));
 			pStyles[CellStyle::cellStyleWarning]->SetTextColour(wxColour(98, 47, 1));

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/offsets.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/offsets.cpp
@@ -116,7 +116,7 @@ namespace BindingConstraint
 					{
 						if ((study->uiinfo->constraint(x))->enabled())
 						{
-							if ((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->clusterCount() > 0)
+							if ((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->enabledClusterCount() > 0)
 								return wxT("   Yes   ");
 							return wxT("   Skipped   ");
 						}
@@ -163,7 +163,7 @@ namespace BindingConstraint
 				return IRenderer::cellStyleConstraintWeightCount;
 			case 3:
 				return ((study->uiinfo->constraint(x))->enabled() &&
-					((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->clusterCount() > 0))
+					((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->enabledClusterCount() > 0))
 					? IRenderer::cellStyleConstraintEnabled
 					: IRenderer::cellStyleConstraintDisabled;
 			case 4:
@@ -413,7 +413,7 @@ namespace BindingConstraint
 			{
 				if ((study->uiinfo->constraint(x))->enabled())
 				{
-					if ((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->clusterCount() > 0)
+					if ((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->enabledClusterCount() > 0)
 						return wxT("   Yes   ");
 					return wxT("   Skipped   ");
 				}
@@ -423,11 +423,17 @@ namespace BindingConstraint
 			return wxEmptyString;
 		}
 
-		const int i = cellNumericIntValue(x, y);
+		// Cluster is must-run : this cluster state is printed in the grid
+		if (study->uiinfo->cluster(y - 5)->mustrun)
+			return wxT("   must-run   ");
 
+		// Cluster is disabled : this cluster state is printed in the grid
+		if (not study->uiinfo->cluster(y - 5)->enabled)
+			return wxT("   disabled   ");
+
+		const int i = cellNumericIntValue(x, y);
 		if (!Math::Zero(i))
 			return wxString::Format(wxT("%d"), i);
-
 		return pZero;
 	}
 
@@ -460,7 +466,7 @@ namespace BindingConstraint
 			return IRenderer::cellStyleConstraintWeightCount;
 		case 3:
 			return ((study->uiinfo->constraint(x))->enabled() &&
-				((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->clusterCount() > 0))
+				((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->enabledClusterCount() > 0))
 				? IRenderer::cellStyleConstraintEnabled
 				: IRenderer::cellStyleConstraintDisabled;
 		case 4:
@@ -532,7 +538,11 @@ namespace BindingConstraint
 		{
 			uint clusterIndex = y - 5;
 			assert(clusterIndex < uiinfo.clusterCount());
-
+			bool clusterEnabled = uiinfo.cluster(clusterIndex)->enabled;
+			bool clusterMustRun = uiinfo.cluster(clusterIndex)->mustrun;
+			if (not clusterEnabled || clusterMustRun)
+				return true;
+			
 			int o;
 			if (value.to(o))
 			{

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/offsets.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/offsets.cpp
@@ -468,11 +468,10 @@ namespace BindingConstraint
 
 		default:
 		{
-			//return IRenderer::cellStyleCustom;
 			if (study->uiinfo->cluster(y - 5)->enabled && ! study->uiinfo->cluster(y - 5)->mustrun)
 				return IRenderer::cellStyleCustom;
 			else
-				return IRenderer::cellStyleWarning;
+				return IRenderer::cellStyleDisabled;
 		}
 		}
 	}

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/weights.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/weights.cpp
@@ -529,11 +529,15 @@ namespace BindingConstraint
 		{
 			uint clusterIndex = y - 5;
 			assert(clusterIndex < uiinfo.clusterCount());
+			bool clusterEnabled = uiinfo.cluster(clusterIndex)->enabled;
+			bool clusterMustRun = uiinfo.cluster(clusterIndex)->mustrun;
+			if (not clusterEnabled || clusterMustRun)
+				return true;
 
 			double d;
 			if (value.to(d))
 			{
-				if (clusterIndex < uiinfo.clusterCount() && uiinfo.cluster(clusterIndex)->enabled && not uiinfo.cluster(clusterIndex)->mustrun)
+				if (clusterIndex < uiinfo.clusterCount())
 				{
 					constraint->weight(uiinfo.cluster(clusterIndex), d);
 					if (pControl)

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/weights.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/weights.cpp
@@ -457,11 +457,10 @@ namespace BindingConstraint
 
 		default:
 		{
-			//return IRenderer::cellStyleCustom;
 			if (study->uiinfo->cluster(y - 5)->enabled && !study->uiinfo->cluster(y - 5)->mustrun)
 				return IRenderer::cellStyleCustom;
 			else
-				return IRenderer::cellStyleWarning;
+				return IRenderer::cellStyleDisabled;
 		}
 		}
 	}

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/weights.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/weights.cpp
@@ -116,7 +116,7 @@ namespace BindingConstraint
 					{
 						if ((study->uiinfo->constraint(x))->enabled())
 						{
-							if (((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->clusterCount() > 0))
+							if (((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->enabledClusterCount() > 0))
 								return wxT("   Yes   ");
 							return wxT("   Skipped   ");
 						}
@@ -161,7 +161,7 @@ namespace BindingConstraint
 				return IRenderer::cellStyleConstraintWeightCount;
 			case 3:
 				return ((study->uiinfo->constraint(x))->enabled() &&
-					((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->clusterCount() > 0))
+					((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->enabledClusterCount() > 0))
 					? IRenderer::cellStyleConstraintEnabled
 					: IRenderer::cellStyleConstraintDisabled;
 			case 4:
@@ -404,7 +404,7 @@ namespace BindingConstraint
 			{
 				if ((study->uiinfo->constraint(x))->enabled())
 				{
-					if (((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->clusterCount() > 0))
+					if (((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->enabledClusterCount() > 0))
 						return wxT("   Yes   ");
 					return wxT("   Skipped   ");
 				}
@@ -413,6 +413,14 @@ namespace BindingConstraint
 			}
 			return wxEmptyString;
 		}
+
+		// Cluster is must-run : this cluster state is printed in the grid
+		if (study->uiinfo->cluster(y - 5)->mustrun)
+			return wxT("   must-run   ");
+		
+		// Cluster is disabled : this cluster state is printed in the grid
+		if(not study->uiinfo->cluster(y - 5)->enabled)
+			return wxT("   disabled   ");
 
 		const double d = cellNumericValue(x, y);
 		if (!Math::Zero(d))
@@ -449,7 +457,7 @@ namespace BindingConstraint
 			return IRenderer::cellStyleConstraintWeightCount;
 		case 3:
 			return ((study->uiinfo->constraint(x))->enabled() &&
-				((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->clusterCount() > 0))
+				((study->uiinfo->constraint(x))->linkCount() > 0 || (study->uiinfo->constraint(x))->enabledClusterCount() > 0))
 				? IRenderer::cellStyleConstraintEnabled
 				: IRenderer::cellStyleConstraintDisabled;
 		case 4:
@@ -525,7 +533,7 @@ namespace BindingConstraint
 			double d;
 			if (value.to(d))
 			{
-				if (clusterIndex < uiinfo.clusterCount())
+				if (clusterIndex < uiinfo.clusterCount() && uiinfo.cluster(clusterIndex)->enabled && not uiinfo.cluster(clusterIndex)->mustrun)
 				{
 					constraint->weight(uiinfo.cluster(clusterIndex), d);
 					if (pControl)

--- a/src/ui/simulator/toolbox/input/bindingconstraint/bindingconstraint.cpp
+++ b/src/ui/simulator/toolbox/input/bindingconstraint/bindingconstraint.cpp
@@ -158,7 +158,7 @@ namespace InputSelector
 				}
 
 				auto* item = new Toolbox::Spotlight::ItemConstraint(&constraint);
-				if (constraint.enabled())
+				if (constraint.enabled() && (constraint.linkCount() > 0 || constraint.enabledClusterCount() > 0))
 				{
 					if (pBmpOn)
 						item->image(*pBmpOn);

--- a/src/ui/simulator/toolbox/input/bindingconstraint/bindingconstraint.cpp
+++ b/src/ui/simulator/toolbox/input/bindingconstraint/bindingconstraint.cpp
@@ -131,8 +131,8 @@ namespace InputSelector
 			Data::BindConstList::iterator j;
 			Data::BindConstList::iterator endJ;
 
-				j = layerFilteredItems.begin();
-				endJ = layerFilteredItems.end();
+			j = layerFilteredItems.begin();
+			endJ = layerFilteredItems.end();
 			
 
 			for (; j != endJ; ++j)

--- a/src/ui/simulator/windows/bindingconstraint/bindingconstraint.cpp
+++ b/src/ui/simulator/windows/bindingconstraint/bindingconstraint.cpp
@@ -191,7 +191,7 @@ namespace Window
 
 
 
-		class BindingConstraintWeightsPanel final :
+	class BindingConstraintWeightsPanel final :
 		public Component::Panel,
 		public Yuni::IEventObserver<BindingConstraintWeightsPanel>
 	{

--- a/src/ui/simulator/windows/bindingconstraint/bindingconstraint.h
+++ b/src/ui/simulator/windows/bindingconstraint/bindingconstraint.h
@@ -79,7 +79,6 @@ namespace Window
 		void onEdit(void*);
 		void onDeleteAll(void*);
 		void onEditFromMouse(wxMouseEvent&);
-		void onBuild(void*);
 		
 	private:
 		Component::Notebook::Page* pPageList;


### PR DESCRIPTION
- In panel "Binding constraint > Summary", the bullet related to a BC (binding constraint) must turn red in the following situations : 
   - if all links or clusters weights are nil
   - if the only non nil weights are clusters weights and these clusters are disabled or must-run
- Still in panel "Binding constraint > Summary", if a BC involves disabled or must-run clusters, they are marked as N/A by adding "x N/A" to their corresponding term in the BC.
- In the panels "Binding constraint > Weights > Thermal clusters" and  "Binding constraint > Offsets > Thermal clusters", disabled or must-run clusters are highlighted by "disabled" or "must-run" in the corresponding cells. These cells content cannot be changed unless user jumps to "Themal" tab and makes these clusters regular.
- In the previous panels, as well as in their "... > Links" counterparts, a BC should be marked as "Skipped" (on line "On/Off") if :
   - all links or clusters weights are nil
   - the only non nil weights are clusters weights and these clusters are disabled or must-run