### PR TITLE
Scenario builder + hydro levels : bug fix

### DIFF
--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -470,14 +470,6 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem, Antares::Solver::Va
 			
 			problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir = problem.previousSimulationFinalLevel[k];
 
-			// Possibly update the intial level from scenario builder
-			if (study.parameters.useCustomScenario)
-			{
-				double levelFromScenarioBuilder = study.scenarioHydroLevels[k][state.year];
-				if(levelFromScenarioBuilder > 0.)
-					problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir = levelFromScenarioBuilder * area.hydro.reservoirCapacity;
-			}
-
 			problem.CaracteristiquesHydrauliques[k]->LevelForTimeInterval = problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir; /*for first 24-hour optim*/  
 			double nivInit = problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir;
 			if (nivInit < 0.)


### PR DESCRIPTION
It is NOT correct to update hydro levels with scenario builder hydro levels at the beginning of each week.
Hydro levels are already updated at the beginning of each year in the hydro heuristic, and with scenario builder data if asked by user.
Priority of hydro levels from scenario builder over hot start is not affected by this small change.