### PR TITLE
Scenario builder + hydro levels : bug fix

### DIFF
--- a/src/solver/hydro/daily2/h2o2_j_instanciation.c
+++ b/src/solver/hydro/daily2/h2o2_j_instanciation.c
@@ -342,7 +342,7 @@ DONNEES_MENSUELLES_ETENDUES * H2O2_J_Instanciation( void )
 
 		
 		
-		ProblemeLineaireEtenduPartieFixe[i]->CoutLineaire[CorrespondanceDesVariables[i]->NumeroVar_waste] = 32 * 68 + 1;
+		ProblemeLineaireEtenduPartieFixe[i]->CoutLineaire[CorrespondanceDesVariables[i]->NumeroVar_waste] = 34.0;
 
 		
 		ProblemeLineaireEtenduPartieFixe[i]->CoutLineaire[CorrespondanceDesVariables[i]->NumeroVar_deviationMax] = 2.0;

--- a/src/solver/hydro/daily2/h2o2_j_instanciation.c
+++ b/src/solver/hydro/daily2/h2o2_j_instanciation.c
@@ -342,7 +342,7 @@ DONNEES_MENSUELLES_ETENDUES * H2O2_J_Instanciation( void )
 
 		
 		
-		ProblemeLineaireEtenduPartieFixe[i]->CoutLineaire[CorrespondanceDesVariables[i]->NumeroVar_waste] = 34.0;
+		ProblemeLineaireEtenduPartieFixe[i]->CoutLineaire[CorrespondanceDesVariables[i]->NumeroVar_waste] = 32 * 68 + 1;
 
 		
 		ProblemeLineaireEtenduPartieFixe[i]->CoutLineaire[CorrespondanceDesVariables[i]->NumeroVar_deviationMax] = 2.0;

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -452,14 +452,6 @@ namespace Antares
 			uint firstDaySimu = study.parameters.simulationDays.first;
 			state.problemeHebdo->previousSimulationFinalLevel[z] = valgen.NiveauxReservoirsDebutJours[firstDaySimu] * reservoirCapacity;
 
-			// Possibly update the intial level from scenario builder
-			if (study.parameters.useCustomScenario)
-			{
-				double levelFromScenarioBuilder = study.scenarioHydroLevels[z][y];
-				if(levelFromScenarioBuilder > 0.)
-					state.problemeHebdo->previousSimulationFinalLevel[z] = levelFromScenarioBuilder * reservoirCapacity;
-			}
-
 			# if HYDRO_DAILY_SOLVER_DEBUG != 0
 			{
 				String folder;

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -470,14 +470,6 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem, Antares::Solver::Va
 			
 			problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir = problem.previousSimulationFinalLevel[k];
 
-			// Possibly update the intial level from scenario builder
-			if (study.parameters.useCustomScenario)
-			{
-				double levelFromScenarioBuilder = study.scenarioHydroLevels[k][state.year];
-				if(levelFromScenarioBuilder > 0.)
-					problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir = levelFromScenarioBuilder * area.hydro.reservoirCapacity;
-			}
-
 			problem.CaracteristiquesHydrauliques[k]->LevelForTimeInterval = problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir; /*for first 24-hour optim*/  
 			double nivInit = problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir;
 			if (nivInit < 0.)

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -1259,6 +1259,14 @@ namespace Simulation
 				int firstDayOfMonth = study.calendar.months[initResLevelOnSimMonth].daysYear.first;
 
 				double randomLevel = pHydroManagement.randomReservoirLevel(min[firstDayOfMonth], avg[firstDayOfMonth], max[firstDayOfMonth]);
+
+				// Possibly update the intial level from scenario builder
+				if (study.parameters.useCustomScenario)
+				{
+					double levelFromScenarioBuilder = study.scenarioHydroLevels[areaIndex][y];
+					if(levelFromScenarioBuilder > 0.)
+						randomLevel = levelFromScenarioBuilder;
+				}
 				
 				if (pHydroHotStart)
 				{

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -1264,7 +1264,7 @@ namespace Simulation
 				if (study.parameters.useCustomScenario)
 				{
 					double levelFromScenarioBuilder = study.scenarioHydroLevels[areaIndex][y];
-					if(levelFromScenarioBuilder > 0.)
+					if(levelFromScenarioBuilder >= 0.)
 						randomLevel = levelFromScenarioBuilder;
 				}
 				


### PR DESCRIPTION
For a year and area, a scenario builder initial hydro level is meant to be the level applied at the initialization date of the heuristic.
It is not meant to be (like it was done before this commit) the initial level of the year and are, whatever the initialization date of the heuristic.