### PR TITLE
Add USE_PRECOMPILED_EXT option use

### DIFF
--- a/.github/workflows/dockerHubPublish.yml
+++ b/.github/workflows/dockerHubPublish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/update_docker_hub_repo
 
 jobs:
 

--- a/.github/workflows/linux-BUILD_DEPS.yml
+++ b/.github/workflows/linux-BUILD_DEPS.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - release/*
+      - fix/*
 jobs:
 
   linux:
@@ -34,7 +35,7 @@ jobs:
 
     - name: Configure
       run: |
-           cmake -B _build -S src -DDEPS_INSTALL_DIR=./rte-antares-deps-Release -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DBUILD_OPENSSL=ON -DBUILD_curl=ON -DBUILD_wxWidgets=ON
+           cmake -B _build -S src -DDEPS_INSTALL_DIR=./rte-antares-deps-Release -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DUSE_PRECOMPILED_EXT=ON
 
     - name: Build
       run: |

--- a/.github/workflows/linux-BUILD_DEPS.yml
+++ b/.github/workflows/linux-BUILD_DEPS.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Install libraries
       run: |
            sudo apt-get update --fix-missing
-           sudo apt-get install uuid-dev libssl-dev
+           sudo apt-get install libuuid1 uuid-dev libssh2-1 libssh2-1-dev libidn2-0 libidn2-dev libidn11 libidn11-dev gtk2.0 libb64-dev libjpeg-dev libtiff-dev libsecret-1-dev
            
     - name: Download pre-compiled librairies
       run: |
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.0/rte-antares-deps-${{matrix.os}}-Release-all.tar.gz
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-Release-all.tar.gz
            tar -xvf rte-antares-deps-${{matrix.os}}-Release-all.tar.gz
            rm -rf rte-antares-deps-${{matrix.os}}-Release-all.tar.gz
            

--- a/.github/workflows/linux-BUILD_DEPS.yml
+++ b/.github/workflows/linux-BUILD_DEPS.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - release/*
-      - fix/*
 jobs:
 
   linux:

--- a/.github/workflows/linux-system.yml
+++ b/.github/workflows/linux-system.yml
@@ -28,7 +28,7 @@ jobs:
            
     - name: Download pre-compiled librairies
       run: |
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.0/rte-antares-deps-${{matrix.os}}-Release-solver.tar.gz
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-Release-solver.tar.gz
            tar -xvf rte-antares-deps-${{matrix.os}}-Release-solver.tar.gz
            rm -rf rte-antares-deps-${{matrix.os}}-Release-solver.tar.gz
            

--- a/.github/workflows/releasesLinux.yml
+++ b/.github/workflows/releasesLinux.yml
@@ -31,7 +31,7 @@ jobs:
     
     - name: Download pre-compiled librairies
       run: |
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.0/rte-antares-deps-${{matrix.os}}-Release-solver.tar.gz
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-Release-solver.tar.gz
            tar -xvf rte-antares-deps-${{matrix.os}}-Release-solver.tar.gz
            rm -rf rte-antares-deps-${{matrix.os}}-Release-solver.tar.gz
            

--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Download pre-compiled librairies
       run: |
            choco install wget
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.0/rte-antares-deps-${{matrix.os}}-${{matrix.architecture}}-Release-solver.zip
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-${{matrix.architecture}}-Release-solver.zip
            Expand-Archive ./rte-antares-deps-${{matrix.os}}-${{matrix.architecture}}-Release-solver.zip -DestinationPath .
            rm rte-antares-deps-${{matrix.os}}-${{matrix.architecture}}-Release-solver.zip
            

--- a/.github/workflows/windows-BUILD_DEPS.yml
+++ b/.github/workflows/windows-BUILD_DEPS.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - release/*
+      - fix/*
 jobs:
 
   windows:
@@ -30,7 +31,7 @@ jobs:
 
     - name: Configure
       run: |
-           cmake -B _build -S src -DDEPS_INSTALL_DIR=rte-antares-deps-Release -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DBUILD_OPENSSL=ON -DBUILD_curl=ON -DBUILD_wxWidgets=ON
+           cmake -B _build -S src -DDEPS_INSTALL_DIR=rte-antares-deps-Release -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DUSE_PRECOMPILED_EXT=ON
            
     - name: Build
       run: |

--- a/.github/workflows/windows-BUILD_DEPS.yml
+++ b/.github/workflows/windows-BUILD_DEPS.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Download pre-compiled librairies
       run: |
            choco install wget
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.0/rte-antares-deps-${{matrix.os}}-x64-Release-all.zip
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-all.zip
            Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-all.zip -DestinationPath .
            rm rte-antares-deps-${{matrix.os}}-x64-Release-all.zip
            

--- a/.github/workflows/windows-BUILD_DEPS.yml
+++ b/.github/workflows/windows-BUILD_DEPS.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - release/*
-      - fix/*
 jobs:
 
   windows:

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Download pre-compiled librairies
       run: |
            choco install wget
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.0/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
            Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip -DestinationPath .
            rm rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
            

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "src/antares-deps"]
 	path = src/antares-deps
 	url = https://github.com/AntaresSimulatorTeam/antares-deps.git
-	branch = fix/new_option_for_precompiled_use
+	branch = v1.0.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "src/antares-deps"]
 	path = src/antares-deps
 	url = https://github.com/AntaresSimulatorTeam/antares-deps.git
-	branch = v1.0.0
+	branch = fix/new_option_for_precompiled_use

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -186,6 +186,8 @@ Dependency install directory can be specified with `DEPS_INSTALL_DIR`. By defaul
 Note :
 > `DEPS_INSTALL_DIR` is added to `CMAKE_PREFIX_PATH`
 
+> If the dependency install directory contains CURL, OPENSSL or wxWidgets pre-compiled libraries an additionnal option must be used at configure time `-DUSE_PRECOMPILED_EXT=ON`
+
 ## [Building Antares Solution](#build)
 
 Antares source directory is named `[antares_src]` in all following commands.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,6 +106,7 @@ The install procedure can be done
 - by using a package manager. Depending on the OS we propose a solution
   - using VCPKG (Only tested on windows)
   - using the official package manager of the linux distribution
+- by using pre-compiled external libraries provided by [Antares dependencies compilation repository](https://github.com/AntaresSimulatorTeam/antares-deps/releases/tag/v1.0.1)
 
 
 ### [Using VCPKG](#vcpkg)
@@ -187,6 +188,15 @@ Note :
 > `DEPS_INSTALL_DIR` is added to `CMAKE_PREFIX_PATH`
 
 > If the dependency install directory contains CURL, OPENSSL or wxWidgets pre-compiled libraries an additionnal option must be used at configure time `-DUSE_PRECOMPILED_EXT=ON`
+
+### Pre-compiled libraries download : release version only
+You can download pre-compiled antares-deps archive from [Antares dependencies compilation repository](https://github.com/AntaresSimulatorTeam/antares-deps/releases/tag/v1.0.1). Only release version are available.
+
+For Ubuntu 20.04 there are still some system librairies that must be installed :
+
+```
+sudo apt-get install libuuid1 uuid-dev libssh2-1 libssh2-1-dev libidn2-0 libidn2-dev libidn11 libidn11-dev gtk2.0 libb64-dev libjpeg-dev libtiff-dev libsecret-1-dev
+```
 
 ## [Building Antares Solution](#build)
 
@@ -277,6 +287,20 @@ Note :
 
 ```
 cmake -B _build -S [antares_src] -DBUILD_DEPS=ON -DCMAKE_BUILD_TYPE=release ..
+```
+- Build
+ ```
+cmake --build _build --config release -j8
+```
+Note :
+> Compilation can be done on several processors with ```-j``` option.
+
+### Linux/Window building with pre-compiled external librairies
+- Download and extract [pre-compiled archive](https://github.com/AntaresSimulatorTeam/antares-deps/releases/tag/v1.0.1)
+- Configure build with CMake using ```DEPS_INSTALL_DIR``` and `USE_PRECOMPILED_EXT` option.
+
+```
+cmake -B _build -S [antares_src] -DDEPS_INSTALL_DIR=<deps_install_dir> -DCMAKE_BUILD_TYPE=release -DUSE_PRECOMPILED_EXT=ON..
 ```
 - Build
  ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,7 +207,7 @@ endif()
 
 #gflags needed for ortools
 set(GFLAGS_USE_TARGET_NAMESPACE TRUE) 
-find_package(gflags REQUIRED)
+find_package(gflags)
 
 find_package(ortools)
 if(NOT ortools_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,7 +207,7 @@ endif()
 
 #gflags needed for ortools
 set(GFLAGS_USE_TARGET_NAMESPACE TRUE) 
-find_package(gflags)
+find_package(gflags REQUIRED)
 
 find_package(ortools)
 if(NOT ortools_FOUND)

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,10 +1,7 @@
 
-message(STATUS "wxWidgets_ROOT_DIR : ${wxWidgets_ROOT_DIR}")
-message(STATUS "wxWidgets_USE_STATIC : ${wxWidgets_USE_STATIC}")
 
 if (USE_PRECOMPILED_EXT AND UNIX)
-set (wxWidgets_CONFIG_EXECUTABLE ${DEPS_INSTALL_DIR}/bin/wx-config)
-message(STATUS "wxWidgets_CONFIG_EXECUTABLE : ${wxWidgets_CONFIG_EXECUTABLE}")
+    set (wxWidgets_CONFIG_EXECUTABLE ${DEPS_INSTALL_DIR}/bin/wx-config)
 endif()
 
 #wxWidget required

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -2,6 +2,10 @@
 message(STATUS "wxWidgets_ROOT_DIR : ${wxWidgets_ROOT_DIR}")
 message(STATUS "wxWidgets_USE_STATIC : ${wxWidgets_USE_STATIC}")
 
+if (USE_PRECOMPILED_EXT AND UNIX)
+set (wxWidgets_CONFIG_EXECUTABLE ${DEPS_INSTALL_DIR}/bin/wx-config)
+message(STATUS "wxWidgets_CONFIG_EXECUTABLE : ${wxWidgets_CONFIG_EXECUTABLE}")
+endif()
 
 #wxWidget required
 find_package(wxWidgets REQUIRED COMPONENTS net core base richtext propgrid aui adv html xml)

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,4 +1,7 @@
 
+message(STATUS "wxWidgets_ROOT_DIR : ${wxWidgets_ROOT_DIR}")
+
+
 #wxWidget required
 find_package(wxWidgets REQUIRED COMPONENTS net core base richtext propgrid aui adv html xml)
 include(${wxWidgets_USE_FILE})

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 message(STATUS "wxWidgets_ROOT_DIR : ${wxWidgets_ROOT_DIR}")
+message(STATUS "wxWidgets_USE_STATIC : ${wxWidgets_USE_STATIC}")
 
 
 #wxWidget required


### PR DESCRIPTION
For antares-deps pre-compiled archive use, some definitions must be added at configure time.
antares-deps was updated in version 1.0.1, it now supports `USE_PRECOMPILED_EXT `option. submodule is updated