### PR TITLE
Downloading tests and examples

### DIFF
--- a/src/distrib/CMakeLists.txt.in
+++ b/src/distrib/CMakeLists.txt.in
@@ -6,7 +6,7 @@ message(STATUS "Submodule examples update with ${ANTARES_EXAMPLES_TAG} tag")
 
 # Update example submodules as needed
 
-execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init 
+execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init @PROJECT_SOURCE_DIR@/../resources/examples
 				WORKING_DIRECTORY @PROJECT_SOURCE_DIR@/../resources/
 				RESULT_VARIABLE GIT_SUBMOD_RESULT)
 if(NOT GIT_SUBMOD_RESULT EQUAL "0")

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ if(Python3_Interpreter_FOUND)
         message(STATUS "Submodule test update with ${ANTARES_TEST_TAG} tag")
 
         # Update test submodules as needed
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init 
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init ${PROJECT_SOURCE_DIR}/resources/Antares_Simulator_Tests
                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/resources/
                         RESULT_VARIABLE GIT_SUBMOD_RESULT)
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")


### PR DESCRIPTION
Downloads of tests (Antares_Simulator_Tests) and examples (Antares_Simulator_Examples) used to be made together at cmake configuration time.
We keep on downloading tests at configuration time, but we download examples at packaging time (CPack).
This PR is related to #137 