### PR TITLE
Skip connection to license server 2

### DIFF
--- a/src/ui/simulator/windows/proxy/proxysetup.cpp
+++ b/src/ui/simulator/windows/proxy/proxysetup.cpp
@@ -111,8 +111,7 @@ LicenseCouldNotConnectToInternetServer::LicenseCouldNotConnectToInternetServer(w
             "please click on \"Cancel\", then unfold Antares help (\"?\") menu and\n"
             "select \"Continue offline\"."),
         false,
-        false,
-        +1);
+        false);
     contentSizer->AddSpacer(20);
     contentSizer->Add(titlespacer, 0, wxALL | wxEXPAND);
     contentSizer->AddSpacer(40);

--- a/src/ui/simulator/windows/proxy/proxysetup.cpp
+++ b/src/ui/simulator/windows/proxy/proxysetup.cpp
@@ -105,6 +105,14 @@ LicenseCouldNotConnectToInternetServer::LicenseCouldNotConnectToInternetServer(w
       false,
       false);
     subtitle->Enable(false);
+    auto* offline_title = Component::CreateLabel(
+        this,
+        wxT("If you wish to stay offline (disable sending anonymous usage metrics),\n"
+            "please click on \"Cancel\", then unfold Antares help (\"?\") menu and\n"
+            "select \"Continue offline\"."),
+        false,
+        false,
+        +1);
     contentSizer->AddSpacer(20);
     contentSizer->Add(titlespacer, 0, wxALL | wxEXPAND);
     contentSizer->AddSpacer(40);
@@ -114,6 +122,8 @@ LicenseCouldNotConnectToInternetServer::LicenseCouldNotConnectToInternetServer(w
     subtitlespacer->Add(title, 0, wxLEFT);
     subtitlespacer->AddSpacer(3);
     subtitlespacer->Add(subtitle, 0, wxLEFT);
+    subtitlespacer->AddSpacer(10);
+    subtitlespacer->Add(offline_title, 0, wxLEFT);
     subtitlespacer->AddStretchSpacer();
     titlespacer->AddSpacer(10);
     titlespacer->Add(subtitlespacer, 1, wxALL | wxALIGN_CENTER_VERTICAL | wxLEFT);

--- a/src/ui/simulator/windows/proxy/proxysetup.cpp
+++ b/src/ui/simulator/windows/proxy/proxysetup.cpp
@@ -69,6 +69,9 @@ LicenseCouldNotConnectToInternetServer::LicenseCouldNotConnectToInternetServer(w
  pEditProxyPass(nullptr),
  pCanceled(true)
 {
+    // TODO : a lot of pointer variables are not destroyed after usage here : sizers, titles, ...
+    // TODO : They have to be deleted to avoid memory leaks.
+    
     assert(parent);
 
     // Background color
@@ -105,7 +108,7 @@ LicenseCouldNotConnectToInternetServer::LicenseCouldNotConnectToInternetServer(w
       false,
       false);
     subtitle->Enable(false);
-    auto* offline_title = Component::CreateLabel(
+    pOffline_title = Component::CreateLabel(
         this,
         wxT("If you wish to stay offline (disable sending anonymous usage metrics),\n"
             "please click on \"Cancel\", then unfold Antares help (\"?\") menu and\n"
@@ -122,7 +125,7 @@ LicenseCouldNotConnectToInternetServer::LicenseCouldNotConnectToInternetServer(w
     subtitlespacer->AddSpacer(3);
     subtitlespacer->Add(subtitle, 0, wxLEFT);
     subtitlespacer->AddSpacer(10);
-    subtitlespacer->Add(offline_title, 0, wxLEFT);
+    subtitlespacer->Add(pOffline_title, 0, wxLEFT);
     subtitlespacer->AddStretchSpacer();
     titlespacer->AddSpacer(10);
     titlespacer->Add(subtitlespacer, 1, wxALL | wxALIGN_CENTER_VERTICAL | wxLEFT);
@@ -234,8 +237,8 @@ LicenseCouldNotConnectToInternetServer::LicenseCouldNotConnectToInternetServer(w
 
 LicenseCouldNotConnectToInternetServer::~LicenseCouldNotConnectToInternetServer()
 {
-    // MakeModal(false);
     Component::Spotlight::FrameClose();
+    delete pOffline_title;
 }
 
 void LicenseCouldNotConnectToInternetServer::onClose(void*)

--- a/src/ui/simulator/windows/proxy/proxysetup.cpp
+++ b/src/ui/simulator/windows/proxy/proxysetup.cpp
@@ -110,9 +110,9 @@ LicenseCouldNotConnectToInternetServer::LicenseCouldNotConnectToInternetServer(w
     subtitle->Enable(false);
     pOffline_title = Component::CreateLabel(
         this,
-        wxT("If you wish to stay offline (disable sending anonymous usage metrics),\n"
-            "please click on \"Cancel\", then unfold Antares help (\"?\") menu and\n"
-            "select \"Continue offline\"."),
+        wxT("If you wish to stay offline in all future sessions,\n"
+            "click on \"Cancel\", and select \"Continue offline\"\n"
+            "in the Antares help (\"?\") menu."),
         false,
         false);
     contentSizer->AddSpacer(20);

--- a/src/ui/simulator/windows/proxy/proxysetup.h
+++ b/src/ui/simulator/windows/proxy/proxysetup.h
@@ -82,6 +82,8 @@ private:
     wxSizer* pFlexSizer;
     bool pCanceled;
 
+    wxStaticText* pOffline_title;
+
 }; // class LicenseCoudtNotConnectToInternetServer
 
 } // namespace Window


### PR DESCRIPTION
When opening Antares GUI, the connection to license server dialog box is displayed.
Add a text informing the user of how to continue using Antares without connection to the server at all (offline usage),
for this session or the any further session.