### PR TITLE
Determine first week of the simulation (for xpansion outputs) - 2

### DIFF
--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -192,6 +192,12 @@ RESOLUTION:
     Probleme.AffichageDesTraces = NON_SPX;
 #endif
 
+    // Xpansion : dumping fixed and changing part of the optimization problem, into the MPS format.
+    //		- Only for first optimization
+    //		- If mode Xpansion is asked
+    //		- For time beeing, only for simplex, without use of ortools
+
+
     Probleme.NombreDeContraintesCoupes = 0;
 
     if (ortoolsUsed)

--- a/src/solver/simulation/adequacy-draft.cpp
+++ b/src/solver/simulation/adequacy-draft.cpp
@@ -74,7 +74,8 @@ bool AdequacyDraft::year(Progression::Task& progression,
                          Variable::State& state,
                          uint numSpace,
                          yearRandomNumbers&,
-                         std::list<uint>&)
+                         std::list<uint>&,
+                         bool)
 {
     SIM_RenseignementValeursPourTouteLAnnee(study, numSpace);
 

--- a/src/solver/simulation/adequacy-draft.h
+++ b/src/solver/simulation/adequacy-draft.h
@@ -77,7 +77,8 @@ protected:
               Variable::State& state,
               uint numSpace,
               yearRandomNumbers& randomForYear,
-              std::list<uint>& failedWeekList);
+              std::list<uint>& failedWeekList,
+              bool isFirstPerformedYearOfSimulation);
     void simulationEnd();
 
     void incrementProgression(Progression::Task& progression);

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -143,7 +143,8 @@ bool Adequacy::year(Progression::Task& progression,
                     Variable::State& state,
                     uint numSpace,
                     yearRandomNumbers& randomForYear,
-                    std::list<uint>& failedWeekList)
+                    std::list<uint>& failedWeekList,
+                    bool isFirstPerformedYearOfSimulation)
 {
     // No failed week at year start
     failedWeekList.clear();
@@ -153,6 +154,8 @@ bool Adequacy::year(Progression::Task& progression,
     state.startANewYear();
 
     int hourInTheYear = pStartTime;
+    if (isFirstPerformedYearOfSimulation)
+        pProblemesHebdo[numSpace]->firstWeekOfSimulation = true;
     bool reinitOptim = true;
 
     for (uint w = 0; w != pNbWeeks; ++w)
@@ -340,6 +343,8 @@ bool Adequacy::year(Progression::Task& progression,
         variables.weekEnd(state);
 
         hourInTheYear += nbHoursInAWeek;
+
+        pProblemesHebdo[numSpace]->firstWeekOfSimulation = false;
 
         ++progression;
     }

--- a/src/solver/simulation/adequacy.h
+++ b/src/solver/simulation/adequacy.h
@@ -81,7 +81,8 @@ protected:
               Variable::State& state,
               uint numSpace,
               yearRandomNumbers& randomForYear,
-              std::list<uint>& failedWeekList);
+              std::list<uint>& failedWeekList,
+              bool isFirstPerformedYearOfSimulation);
 
     void incrementProgression(Progression::Task& progression);
 

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -116,7 +116,8 @@ bool Economy::year(Progression::Task& progression,
                    Variable::State& state,
                    uint numSpace,
                    yearRandomNumbers& randomForYear,
-                   std::list<uint>& failedWeekList)
+                   std::list<uint>& failedWeekList,
+                   bool isFirstPerformedYearOfSimulation)
 {
     // No failed week at year start
     failedWeekList.clear();
@@ -126,6 +127,8 @@ bool Economy::year(Progression::Task& progression,
     state.startANewYear();
 
     int hourInTheYear = pStartTime;
+    if (isFirstPerformedYearOfSimulation)
+        pProblemesHebdo[numSpace]->firstWeekOfSimulation = true;
     bool reinitOptim = true;
 
     for (uint w = 0; w != pNbWeeks; ++w)
@@ -214,6 +217,8 @@ bool Economy::year(Progression::Task& progression,
         }
 
         hourInTheYear += nbHoursInAWeek;
+
+        pProblemesHebdo[numSpace]->firstWeekOfSimulation = false;
 
         ++progression;
     }

--- a/src/solver/simulation/economy.h
+++ b/src/solver/simulation/economy.h
@@ -80,7 +80,8 @@ protected:
               Variable::State& state,
               uint numSpace,
               yearRandomNumbers& randomForYear,
-              std::list<uint>& failedWeekList);
+              std::list<uint>& failedWeekList,
+              bool isFirstPerformedYearOfSimulation);
 
     void incrementProgression(Progression::Task& progression);
 

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -58,6 +58,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
     auto& parameters = study.parameters;
 
     problem.Expansion = parameters.expansion ? OUI_ANTARES : NON_ANTARES;
+    problem.firstWeekOfSimulation = false;
 
     problem.hydroHotStart
       = (parameters.initialReservoirLevels.iniLevels == Antares::Data::irlHotStart);

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -512,6 +512,7 @@ struct PROBLEME_HEBDO
     double** BruitSurCoutHydraulique;
 
     unsigned int HeureDansLAnnee;
+    bool firstWeekOfSimulation;
 
     char LeProblemeADejaEteInstancie;
     char TypeDOptimisation;

--- a/src/solver/simulation/solver.h
+++ b/src/solver/simulation/solver.h
@@ -110,7 +110,6 @@ private:
     **
     ** \return The max number of years in a set of parallel years (to be executed or not)
     */
-    template<bool PerformCalculationsT>
     uint buildSetsOfParallelYears(uint firstYear,
                                   uint endYear,
                                   std::vector<setOfParallelYears>& setsOfParallelYears);
@@ -151,7 +150,6 @@ private:
     ** \param firstYear The first real MC year
     ** \param endYear   The last MC year
     */
-    template<bool PerformCalculationsT>
     void loopThroughYears(uint firstYear, uint endYear, std::vector<Variable::State>& state);
 
 private:

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -191,7 +191,7 @@ private:
                 Antares::memory.flushAll();
 
             // 6 - The Solver itself
-            bool isFirstPerformedYearOfSimulation = isFirstPerformedYearOfASet[y] && not firstSetParallelWasRun;
+            bool isFirstPerformedYearOfSimulation = isFirstPerformedYearOfASet[y] && not firstSetParallelWithAPerformedYearWasRun;
             std::list<uint> failedWeekList;
             if (not simulationObj->year(
                                          progression,

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -191,9 +191,17 @@ private:
                 Antares::memory.flushAll();
 
             // 6 - The Solver itself
+            bool isFirstPerformedYearOfSimulation = isFirstPerformedYearOfASet[y] && not firstSetParallelWasRun;
             std::list<uint> failedWeekList;
             if (not simulationObj->year(
-                  progression, state[numSpace], numSpace, randomForCurrentYear, failedWeekList))
+                                         progression,
+                                         state[numSpace],
+                                         numSpace,
+                                         randomForCurrentYear,
+                                         failedWeekList,
+                                         isFirstPerformedYearOfSimulation
+                                       )
+                )
             {
                 // Something goes wrong with this year. We have to restarting it
                 yearFailed[y] = true;
@@ -378,7 +386,7 @@ void ISimulation<Impl>::run()
         logs.info() << " Starting the simulation";
         TimeElapsed time("MC Years");
         uint finalYear = 1 + study.runtime->rangeLimits.year[Data::rangeEnd];
-        loopThroughYears<true>(0, finalYear, state);
+        loopThroughYears(0, finalYear, state);
 
         // Destroy the TS Generators if any
         // It will export the time-series into the output in the same time
@@ -1051,7 +1059,6 @@ void ISimulation<Impl>::regenerateTimeSeries(uint year)
 }
 
 template<class Impl>
-template<bool PerformCalculationsT>
 uint ISimulation<Impl>::buildSetsOfParallelYears(
   uint firstYear,
   uint endYear,
@@ -1071,7 +1078,7 @@ uint ISimulation<Impl>::buildSetsOfParallelYears(
     for (uint y = firstYear; y < endYear; ++y)
     {
         unsigned int indexSpace = 999999;
-        bool performCalculations = PerformCalculationsT && yearsFilter[y];
+        bool performCalculations = yearsFilter[y];
 
         // Do we refresh just before this year ? If yes a new set of parallel years has to be
         // created
@@ -1461,7 +1468,6 @@ void ISimulation<Impl>::computeAnnualCostsStatistics(
 }
 
 template<class Impl>
-template<bool PerformCalculationsT>
 void ISimulation<Impl>::loopThroughYears(uint firstYear,
                                          uint endYear,
                                          std::vector<Variable::State>& state)
@@ -1481,7 +1487,7 @@ void ISimulation<Impl>::loopThroughYears(uint firstYear,
     // actually executed in a set. A set contains some years to be actually executed (at most
     // "pNbMaxPerformedYearsInParallel" years) and some others to skip.
     uint maxNbYearsPerformedInAset
-      = buildSetsOfParallelYears<PerformCalculationsT>(firstYear, endYear, setsOfParallelYears);
+      = buildSetsOfParallelYears(firstYear, endYear, setsOfParallelYears);
     // Related to annual costs statistics (printed in output into separate files)
     pAnnualCostsStatistics.setNbPerformedYears(pNbYearsReallyPerformed);
 


### PR DESCRIPTION
Antares for Xpansion

The current PR is the same than #110 but it is mergeable in the current develp branch. 

When asking Xpansion mode, the first week of the simulation dumps the fixed part of the first optimization problem on disk, and every week dumps the its own variable part of the optimization problem.
