### PR TITLE
Refresh span set by user cannot be less than 1

### DIFF
--- a/src/ui/simulator/toolbox/components/datagrid/renderer/simulation.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/simulation.cpp
@@ -28,6 +28,8 @@
 #include "simulation.h"
 #include <wx/panel.h>
 #include <yuni/core/math.h>
+#include <algorithm>
+#include <math.h>
 
 using namespace Yuni;
 
@@ -188,22 +190,23 @@ bool SimulationTSManagement::cellValue(int x, int y, const String& value)
     {
         if (!conversionValid)
             break;
+        uint refreshSpan = std::max((int)std::round(d), 1);
         switch (x)
         {
         case 0:
-            study->parameters.refreshIntervalLoad = (uint)Math::Round(d);
+            study->parameters.refreshIntervalLoad = refreshSpan;
             return true;
         case 1:
-            study->parameters.refreshIntervalThermal = (uint)Math::Round(d);
+            study->parameters.refreshIntervalThermal = refreshSpan;
             return true;
         case 2:
-            study->parameters.refreshIntervalHydro = (uint)Math::Round(d);
+            study->parameters.refreshIntervalHydro = refreshSpan;
             return true;
         case 3:
-            study->parameters.refreshIntervalWind = (uint)Math::Round(d);
+            study->parameters.refreshIntervalWind = refreshSpan;
             return true;
         case 4:
-            study->parameters.refreshIntervalSolar = (uint)Math::Round(d);
+            study->parameters.refreshIntervalSolar = refreshSpan;
             return true;
         }
         break;


### PR DESCRIPTION
This PR refers to issue #186.

It fixes the first point of the issue.
FYI, the second point is already taken of, in another way than asked in the issue #186 though.
Indeed, in case a **refresh = yes** and **refresh span** is **0** on disk (see **generaldata.ini**) : 
- a log report pop up shows up when opening the study
-  the **refresh span** is automatically set  to **1**

![warning-refresh-span](https://user-images.githubusercontent.com/62292552/109834039-11029600-7c42-11eb-9edb-ce787637e348.PNG)
