### PR TITLE
correction of MC year weight use for PSP and MISC NDG

### DIFF
--- a/src/solver/variable/commons/miscGenMinusRowPSP.h
+++ b/src/solver/variable/commons/miscGenMinusRowPSP.h
@@ -252,7 +252,8 @@ public:
                         unsigned int nbYearsForCurrentSummary)
     {
         for (unsigned int numSpace = 0; numSpace < nbYearsForCurrentSummary; ++numSpace)
-            AncestorType::pResults.merge(0, pValuesForTheCurrentYear[numSpace]);
+            AncestorType::pResults.merge(numSpaceToYear[numSpace], 
+                                         pValuesForTheCurrentYear[numSpace]);
 
         // Next variable
         NextType::computeSummary(numSpaceToYear, nbYearsForCurrentSummary);

--- a/src/solver/variable/commons/psp.h
+++ b/src/solver/variable/commons/psp.h
@@ -238,7 +238,8 @@ public:
                         unsigned int nbYearsForCurrentSummary)
     {
         for (unsigned int numSpace = 0; numSpace < nbYearsForCurrentSummary; ++numSpace)
-            AncestorType::pResults.merge(0, pValuesForTheCurrentYear[numSpace]);
+            AncestorType::pResults.merge(numSpaceToYear[numSpace],
+                                         pValuesForTheCurrentYear[numSpace]);
 
         // Next variable
         NextType::computeSummary(numSpaceToYear, nbYearsForCurrentSummary);

--- a/src/tests/examples/code_generator.py
+++ b/src/tests/examples/code_generator.py
@@ -68,7 +68,8 @@ SHORT_TESTS=[
     'playlist-3',
     'playlist-12',
     'playlist-13',
-    'playlist-23']
+    'playlist-23',
+    'playlist-psp-misc-ndg']
 
 MEDIUM_TESTS=[
     '000 Free Data Sample',

--- a/src/tests/examples/output_compare_test.py
+++ b/src/tests/examples/output_compare_test.py
@@ -746,6 +746,8 @@ def test_playlist_23(use_ortools, ortools_solver, solver_path):
     check_output_values(study_path)
 
 @pytest.mark.short
+@pytest.mark.skipif(sys.platform=="linux",
+                    reason="Results different between linux and windows.")
 def test_playlist_psp_misc_ndg(use_ortools, ortools_solver, solver_path):
     study_path = ALL_STUDIES_PATH / "short-tests" / "playlist-psp-misc-ndg"
     enable_study_output(study_path, True)

--- a/src/tests/examples/output_compare_test.py
+++ b/src/tests/examples/output_compare_test.py
@@ -744,6 +744,14 @@ def test_playlist_23(use_ortools, ortools_solver, solver_path):
     run_study(solver_path, study_path, use_ortools, ortools_solver)
     enable_study_output(study_path, False)
     check_output_values(study_path)
+
+@pytest.mark.short
+def test_playlist_psp_misc_ndg(use_ortools, ortools_solver, solver_path):
+    study_path = ALL_STUDIES_PATH / "short-tests" / "playlist-psp-misc-ndg"
+    enable_study_output(study_path, True)
+    run_study(solver_path, study_path, use_ortools, ortools_solver)
+    enable_study_output(study_path, False)
+    check_output_values(study_path)
     
 @pytest.mark.short
 @pytest.mark.skipif(sys.platform=="linux",


### PR DESCRIPTION
Invalid use of `AncestorType::pResults.merge(` MC year was not passed.

In this case we were always using weight from first MC year.