### PR TITLE
Use xdg-open instead of outdated gnome-open

### DIFF
--- a/src/ui/simulator/application/main/help.cpp
+++ b/src/ui/simulator/application/main/help.cpp
@@ -58,7 +58,7 @@ static inline void OpenPDF(const AnyString& url)
         cmd << wxT("explorer.exe \"") << Resources::WxFindFile(u) << wxT("\"");
     }
     else
-        cmd << wxT("gnome-open \"") << Resources::WxFindFile(url) << wxT("\"");
+        cmd << wxT("xdg-open \"") << Resources::WxFindFile(url) << wxT("\"");
 
     wxExecute(cmd);
 }

--- a/src/ui/simulator/application/main/menu.cpp
+++ b/src/ui/simulator/application/main/menu.cpp
@@ -138,9 +138,9 @@ wxMenu* ApplWnd::createMenuFiles()
     {
         Menu::CreateItem(pMenuFile,
                          mnIDOpenExplorer,
-                         wxT("Open in Gnome Nautilus..."),
+                         wxT("Open in file explorer..."),
                          "images/16x16/empty.png",
-                         wxT("Open the folder in Gnome Nautilus"));
+                         wxT("Open the folder in file explorer"));
     }
 
     Menu::CreateItem(pMenuFile,
@@ -652,7 +652,7 @@ void ApplWnd::evtOnOpenStudyFolderInExplorer(wxCommandEvent&)
             wxExecute(wxString(wxT("explorer.exe \""))
                       << wxStringFromUTF8(study->folder) << wxT("\""));
         else
-            wxExecute(wxString(wxT("gnome-open \""))
+            wxExecute(wxString(wxT("xdg-open \""))
                       << wxStringFromUTF8(study->folder) << wxT("\""));
     }
 }
@@ -668,7 +668,7 @@ void ApplWnd::evtOnOpenOutputInExplorer(wxCommandEvent& evt)
                 wxExecute(wxString(wxT("explorer.exe \""))
                           << wxStringFromUTF8((*i)->path) << wxT("\""));
             else
-                wxExecute(wxString(wxT("gnome-open \""))
+                wxExecute(wxString(wxT("xdg-open \""))
                           << wxStringFromUTF8((*i)->path) << wxT("\""));
             return;
         }

--- a/src/ui/simulator/application/main/refresh.cpp
+++ b/src/ui/simulator/application/main/refresh.cpp
@@ -252,7 +252,7 @@ void ApplWnd::refreshMenuOutput()
     if (System::windows)
         item = pMenuOutput->AppendSubMenu(new wxMenu(), wxT("Open in Windows Explorer..."));
     else
-        item = pMenuOutput->AppendSubMenu(new wxMenu(), wxT("Open in Gnome Nautilus..."));
+        item = pMenuOutput->AppendSubMenu(new wxMenu(), wxT("Open in file explorer..."));
 
     // The current total number of item for the current category
     total = 0;

--- a/src/ui/simulator/windows/analyzer/analyzer.cpp
+++ b/src/ui/simulator/windows/analyzer/analyzer.cpp
@@ -1584,7 +1584,7 @@ void AnalyzerWizard::onBrowseMenu(Component::Button&, wxMenu& menu, void*)
     if (System::windows)
         it = Menu::CreateItem(&menu, wxID_ANY, wxT("Open in Windows Explorer"));
     else
-        it = Menu::CreateItem(&menu, wxID_ANY, wxT("Open in Gnome Nautilus"));
+        it = Menu::CreateItem(&menu, wxID_ANY, wxT("Open in file explorer"));
     menu.Connect(it->GetId(),
                  wxEVT_COMMAND_MENU_SELECTED,
                  wxCommandEventHandler(AnalyzerWizard::onBrowseOpenInExplorer),
@@ -1668,7 +1668,7 @@ void AnalyzerWizard::onBrowseOpenInExplorer(wxCommandEvent&)
     if (System::windows)
         wxExecute(wxString(wxT("explorer.exe \"")) << path << wxT("\""));
     else
-        wxExecute(wxString(wxT("gnome-open \"")) << path << wxT("\""));
+        wxExecute(wxString(wxT("xdg-open \"")) << path << wxT("\""));
 }
 
 void AnalyzerWizard::onBrowseReset(wxCommandEvent&)


### PR DESCRIPTION
* Not all Linux distributions use Gnome as a session manager (Kubuntu uses [Kde](https://kde.org/fr/), etc.)
* Not all Linux distributions have Nautilus as a file explorer (Kde uses [Dolphin](https://apps.kde.org/en/dolphin), XFCE uses [Thunar](https://doc.ubuntu-fr.org/thunar), Cinnamon/Unity use [nemo](https://doc.ubuntu-fr.org/nemo), etc.)
* Command `gnome-open` has been outdated since about 2012, see
https://askubuntu.com/questions/68961/what-can-i-use-instead-of-gnome-open
* Use widely available `xdg-open` command instead