### PR TITLE
Simplify ON_min computation

### DIFF
--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -319,35 +319,8 @@ void State::yearEndBuildFromThermalClusterIndex(const uint clusterAreaWideIndex,
                 {
                 case Antares::Data::UnitCommitmentMode::ucHeuristic:
                 {
-                    /*if (thermalClusterPMinOfAGroup > 0.) // code 5.0.2
-                    {
-                            ON_min[h] = Math::Max(
-                                                    static_cast<uint>(Math::Ceil(thermalClusterProduction
-                    / currentCluster->nominalCapacityWithSpinning)),
-                                                    static_cast<uint>(Math::Ceil(thermalClusterPMinOfTheClusterForYear[h]
-                    / currentCluster->pminOfAGroup)) );
-
-                    }
-                    else*/
-                    //	ON_min[h] = static_cast<uint>(Math::Ceil(thermalClusterProduction /
-                    // currentCluster->nominalCapacityWithSpinning)); // code 5.0.3b<7
-                    // 5.0.3b7
-                    if (currentCluster->pminOfAGroup[numSpace] > 0.)
-                    {
-                        ON_min[h] = Math::Max(
-                          Math::Min(static_cast<uint>(
-                                      Math::Floor(thermalClusterPMinOfTheClusterForYear[h]
-                                                  / currentCluster->pminOfAGroup[numSpace])),
-                                    static_cast<uint>(
-                                      Math::Ceil(thermalClusterAvailableProduction
-                                                 / currentCluster->nominalCapacityWithSpinning))),
-                          static_cast<uint>(
-                            Math::Ceil(thermalClusterProduction
-                                       / currentCluster->nominalCapacityWithSpinning)));
-                    }
-                    else
-                        ON_min[h] = static_cast<uint>(Math::Ceil(
-                          thermalClusterProduction / currentCluster->nominalCapacityWithSpinning));
+                    ON_min[h] = static_cast<uint>(Math::Ceil(
+                      thermalClusterProduction / currentCluster->nominalCapacityWithSpinning));
                     break;
                 }
                 case Antares::Data::UnitCommitmentMode::ucMILP:


### PR DESCRIPTION
max(min(a,b),b)=b for all (a,b)

with
```
a = static_cast<uint>(Math::Floor(thermalClusterPMinOfTheClusterForYear[h]
    / currentCluster->pminOfAGroup[numSpace]));

b = static_cast<uint>(Math::Ceil(thermalClusterAvailableProduction
  / currentCluster->nominalCapacityWithSpinning));
```