### PR TITLE
Main renewable cluster frame : adding property sub-frame

### DIFF
--- a/src/libs/antares/study/study.h
+++ b/src/libs/antares/study/study.h
@@ -316,6 +316,19 @@ public:
                               bool force = false);
     //@}
 
+    //! \name Renewable clusters
+    //@{
+    /*!
+    ** \brief Rename a renewable cluster
+    **
+    ** \param cluster The cluster
+    ** \return True if the operation succeeded, false otherwise
+    */
+    bool renewableClusterRename(RenewableCluster* cluster,
+                                RenewableClusterName newName,
+                                bool force = false);
+    //@}
+
     //! \name Read-only
     //@{
     /*!

--- a/src/ui/simulator/application/main/create.cpp
+++ b/src/ui/simulator/application/main/create.cpp
@@ -648,7 +648,7 @@ void ApplWnd::createNBRenewable()
 
     // pageThermalTimeSeries = panel->pageThermalTimeSeries;
     // pageThermalPrepro = panel->pageThermalPrepro;
-    // pageThermalCommon = panel->pageThermalCommon;
+    pageRenewableCommon = panel->pageRenewableCommon;
     pageRenewableClusterList = panel->pageRenewableClusterList;
 }
 

--- a/src/ui/simulator/application/main/main.cpp
+++ b/src/ui/simulator/application/main/main.cpp
@@ -252,6 +252,7 @@ ApplWnd::ApplWnd() :
  pageThermalPrepro(nullptr),
  pageThermalCommon(nullptr),
  pageRenewableClusterList(nullptr),
+ pageRenewableCommon(nullptr),
  pageLinksSummary(nullptr),
  pageLinksDetails(nullptr),
  pageNodalOptim(nullptr),
@@ -917,6 +918,8 @@ void ApplWnd::selectAllDefaultPages()
         pageThermalCommon->select();
     if (pageRenewableClusterList)
         pageRenewableClusterList->select();
+    if (pageRenewableCommon)
+        pageRenewableCommon->select();
     if (pageLinksDetails)
         pageLinksDetails->select();
     if (pageWindPreproDailyProfile)

--- a/src/ui/simulator/application/main/main.h
+++ b/src/ui/simulator/application/main/main.h
@@ -722,6 +722,7 @@ private:
     Component::Notebook::Page* pageThermalCommon;
 
     Component::Notebook::Page* pageRenewableClusterList;
+    Component::Notebook::Page* pageRenewableCommon;
 
     Component::Notebook::Page* pageLinksSummary;
     Component::Notebook::Page* pageLinksDetails;

--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -90,11 +90,15 @@ Event<void(Data::AreaLink*)> OnStudyLinkDelete;
 
 Event<void()> OnStudySimulationSettingsChanged;
 Event<void()> OnStudyNodalOptimizationChanged;
+
 Event<void()> OnStudyThermalClusterCommonSettingsChanged;
 Event<void(Data::ThermalCluster*)> OnStudyThermalClusterRenamed;
+Event<void(Data::Area*)> OnStudyThermalClusterGroupChanged;
+
 Event<void()> OnStudyRenewableClusterCommonSettingsChanged;
 Event<void(Data::RenewableCluster*)> OnStudyRenewableClusterRenamed;
-Event<void(Data::Area*)> OnStudyThermalClusterGroupChanged;
+Event<void(Data::Area*)> OnStudyRenewableClusterGroupChanged;
+
 Event<void()> OnStudyUpdatePlaylist;
 Event<void(const void*)> OnInspectorRefresh;
 Event<void()> OnStudyScenarioBuilderDataAreLoaded;

--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -92,6 +92,8 @@ Event<void()> OnStudySimulationSettingsChanged;
 Event<void()> OnStudyNodalOptimizationChanged;
 Event<void()> OnStudyThermalClusterCommonSettingsChanged;
 Event<void(Data::ThermalCluster*)> OnStudyThermalClusterRenamed;
+Event<void()> OnStudyRenewableClusterCommonSettingsChanged;
+Event<void(Data::RenewableCluster*)> OnStudyRenewableClusterRenamed;
 Event<void(Data::Area*)> OnStudyThermalClusterGroupChanged;
 Event<void()> OnStudyUpdatePlaylist;
 Event<void(const void*)> OnInspectorRefresh;

--- a/src/ui/simulator/application/study.h
+++ b/src/ui/simulator/application/study.h
@@ -292,6 +292,16 @@ extern Yuni::Event<void(Data::ThermalCluster*)> OnStudyThermalClusterRenamed;
 extern Yuni::Event<void(Data::Area*)> OnStudyThermalClusterGroupChanged;
 
 /*!
+** \brief Event: The common settings of a renewable cluster has been changed
+**
+** This event may concern one or several renewable clusters.
+*/
+extern Yuni::Event<void()> OnStudyRenewableClusterCommonSettingsChanged;
+
+extern Yuni::Event<void(Data::RenewableCluster*)> OnStudyRenewableClusterRenamed;
+extern Yuni::Event<void(Data::Area*)> OnStudyRenewableClusterGroupChanged;
+
+/*!
 ** \brief Event triggered when the data related to the Scenario Builder are loaded
 **
 ** This event means that some components must update their content.

--- a/src/ui/simulator/cmake/windows-studyparts.cmake
+++ b/src/ui/simulator/cmake/windows-studyparts.cmake
@@ -22,6 +22,8 @@ set(SRC_UI_WINDOWS_STUDYPARTS
 		windows/hydro/levelsandvalues.cpp
 		windows/thermal/cluster.h
 		windows/thermal/cluster.cpp
+		windows/renewables/cluster.h
+		windows/renewables/cluster.cpp
 		windows/thermal/panel.h
 		windows/thermal/panel.cpp
 		windows/renewables/panel.h

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/area/renewable.areasummary.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/area/renewable.areasummary.cpp
@@ -55,8 +55,9 @@ RenewableClusterSummarySingleArea::~RenewableClusterSummarySingleArea()
 
 wxString RenewableClusterSummarySingleArea::rowCaption(int rowIndx) const
 {
-    if (pArea)
-        return wxStringFromUTF8(pArea->renewable.list.byIndex[rowIndx]->name());
+    // gp : causes a crash when saving a study
+    // if (pArea)
+    //     return wxStringFromUTF8(pArea->renewable.list.byIndex[rowIndx]->name());
     return wxEmptyString;
 }
 
@@ -75,6 +76,7 @@ wxString RenewableClusterSummarySingleArea::columnCaption(int colIndx) const
 
 wxString RenewableClusterSummarySingleArea::cellValue(int x, int y) const
 {
+    /*
     Data::RenewableCluster* cluster = (pArea and (uint) y < pArea->renewable.list.size())
                                       ? pArea->renewable.list.byIndex[y]
                                       : nullptr;
@@ -89,11 +91,13 @@ wxString RenewableClusterSummarySingleArea::cellValue(int x, int y) const
     case 2:
         return DoubleToWxString(cluster->nominalCapacity);
     }
+    */
     return wxEmptyString;
 }
 
 double RenewableClusterSummarySingleArea::cellNumericValue(int x, int y) const
 {
+    /*
     Data::RenewableCluster* cluster = (pArea and (uint) y < pArea->renewable.list.size())
                                       ? pArea->renewable.list.byIndex[y]
                                       : nullptr;
@@ -108,16 +112,19 @@ double RenewableClusterSummarySingleArea::cellNumericValue(int x, int y) const
     case 3:
         return cluster->nominalCapacity;
     }
+    */
     return 0.;
 }
 
 void RenewableClusterSummarySingleArea::onAreaChanged(Antares::Data::Area* area)
 {
+    /*
     if (pArea != area)
     {
         pArea = area;
         RefreshAllControls(pControl);
     }
+    */
 }
 
 IRenderer::CellStyle RenewableClusterSummarySingleArea::cellStyle(int col, int row) const

--- a/src/ui/simulator/toolbox/input/renewable-cluster.cpp
+++ b/src/ui/simulator/toolbox/input/renewable-cluster.cpp
@@ -90,13 +90,11 @@ namespace InputSelector
     if (area)
         area->onAreaChanged.connect(this, &RenewableCluster::areaHasChanged);
 
-    /*
-    OnStudyThermalClusterRenamed.connect(this, &ThermalCluster::onStudyThermalClusterRenamed);
+    OnStudyRenewableClusterRenamed.connect(this, &RenewableCluster::onStudyRenewableClusterRenamed);
     OnStudyThermalClusterGroupChanged.connect(this,
-                                              &ThermalCluster::onStudyThermalClusterGroupChanged);
+                                              &RenewableCluster::onStudyRenewableClusterGroupChanged);
     OnStudyThermalClusterCommonSettingsChanged.connect(
-      this, &ThermalCluster::onStudyThermalClusterCommonSettingsChanged);
-    */
+      this, &RenewableCluster::onStudyRenewableClusterCommonSettingsChanged);
 }
 
 RenewableCluster::~RenewableCluster()
@@ -248,13 +246,13 @@ void RenewableCluster::renameAggregate(Antares::Data::ThermalCluster* cluster,
     OnStudyThermalClusterRenamed(cluster);
     Window::Inspector::Refresh();
 }
+*/
 
-void RenewableCluster::onStudyThermalClusterRenamed(Antares::Data::ThermalCluster* cluster)
+void RenewableCluster::onStudyRenewableClusterRenamed(Antares::Data::RenewableCluster* cluster)
 {
     if (cluster->parentArea == pArea)
         updateInnerValues();
 }
-*/
 
 void RenewableCluster::evtPopupDelete(wxCommandEvent&)
 {
@@ -627,8 +625,7 @@ void RenewableCluster::onDeleteDropdown(Antares::Component::Button&, wxMenu& men
     */
 }
 
-/*
-void RenewableCluster::onStudyThermalClusterGroupChanged(Antares::Data::Area* area)
+void RenewableCluster::onStudyRenewableClusterGroupChanged(Antares::Data::Area* area)
 {
     if (area && area == pArea)
     {
@@ -638,12 +635,11 @@ void RenewableCluster::onStudyThermalClusterGroupChanged(Antares::Data::Area* ar
     }
 }
 
-void RenewableCluster::onStudyThermalClusterCommonSettingsChanged()
+void RenewableCluster::onStudyRenewableClusterCommonSettingsChanged()
 {
     updateInnerValues();
     Refresh();
 }
-*/
 
 } // namespace InputSelector
 } // namespace Toolbox

--- a/src/ui/simulator/toolbox/input/renewable-cluster.cpp
+++ b/src/ui/simulator/toolbox/input/renewable-cluster.cpp
@@ -31,7 +31,7 @@
 #include "../../application/study.h"
 #include "../../application/main.h"
 #include "../../application/wait.h"
-// #include "../../windows/inspector.h"
+#include "../../windows/inspector.h"
 // #include <assert.h>
 #include "../resources.h"
 #include "../create.h"
@@ -91,9 +91,9 @@ namespace InputSelector
         area->onAreaChanged.connect(this, &RenewableCluster::areaHasChanged);
 
     OnStudyRenewableClusterRenamed.connect(this, &RenewableCluster::onStudyRenewableClusterRenamed);
-    OnStudyThermalClusterGroupChanged.connect(this,
+    OnStudyRenewableClusterGroupChanged.connect(this,
                                               &RenewableCluster::onStudyRenewableClusterGroupChanged);
-    OnStudyThermalClusterCommonSettingsChanged.connect(
+    OnStudyRenewableClusterCommonSettingsChanged.connect(
       this, &RenewableCluster::onStudyRenewableClusterCommonSettingsChanged);
 }
 
@@ -305,10 +305,11 @@ void RenewableCluster::internalDeletePlant(void*)
         // study->scenarioRulesLoadIfNotAvailable();
 
         // Update the list
-        // Window::Inspector::RemoveThermalCluster(toDelete);
+        Window::Inspector::RemoveRenewableCluster(toDelete);
         pLastSelectedRenewableCluster = nullptr;
         onClusterChanged(nullptr);
 
+        // gp : uncomment this when GUI's scenario builder comes up 
         // We have to rebuild the scenario builder data, if required
         // ScenarioBuilderUpdater updaterSB(
         //   *study); // this will create a temp file, and save it during destructor call
@@ -578,27 +579,8 @@ void RenewableCluster::delayedSelection(Component::HTMLListbox::Item::IItem::Ptr
         WIP::Locker wip;
         wxWindowUpdateLocker updater(&mainFrm);
         onClusterChanged(cluster);
-        // Window::Inspector::SelectThermalCluster(cluster);
+        Window::Inspector::SelectRenewableCluster(cluster);
         updateInnerValues();
-
-        // Selecting Binding constraints containing the cluster
-
-        /*
-        Data::BindingConstraint::Set constraintlist;
-
-        auto study = Data::Study::Current::Get();
-
-        const Data::BindConstList::iterator cEnd = study->bindingConstraints.end();
-        for (Data::BindConstList::iterator i = study->bindingConstraints.begin(); i != cEnd; ++i)
-        {
-            // alias to the current constraint
-            Data::BindingConstraint* constraint = *i;
-
-            if (constraint->contains(cluster))
-                constraintlist.insert(constraint);
-        }
-        Window::Inspector::AddBindingConstraints(constraintlist);
-        */
     }
 }
 

--- a/src/ui/simulator/toolbox/input/renewable-cluster.h
+++ b/src/ui/simulator/toolbox/input/renewable-cluster.h
@@ -131,11 +131,11 @@ private:
     */
     void onRnSelected(Component::HTMLListbox::Item::IItem::Ptr item);
 
-    // void onStudyThermalClusterCommonSettingsChanged();
+    void onStudyRenewableClusterCommonSettingsChanged();
 
-    // void onStudyThermalClusterRenamed(Antares::Data::ThermalCluster* cluster);
+    void onStudyRenewableClusterRenamed(Antares::Data::RenewableCluster* cluster);
 
-    // void onStudyThermalClusterGroupChanged(Antares::Data::Area* area);
+    void onStudyRenewableClusterGroupChanged(Antares::Data::Area* area);
 
     void onDeleteDropdown(Antares::Component::Button&, wxMenu& menu, void*);
 

--- a/src/ui/simulator/windows/inspector/accumulator.hxx
+++ b/src/ui/simulator/windows/inspector/accumulator.hxx
@@ -234,6 +234,21 @@ static const wxChar* arrayClusterGroup[] = {wxT("Gas"),
 
 enum
 {
+    arrayRnClusterGroupCount = 9
+};
+static const wxChar* arrayRnClusterGroup[] = { wxT("Wind Onshore"),
+                                               wxT("Wind Offshore"),
+                                               wxT("Solar Thermal"),
+                                               wxT("Solar PV"),
+                                               wxT("Solar Rooftop"),
+                                               wxT("ENR 1"),
+                                               wxT("ENR 2"),
+                                               wxT("ENR 3"),
+                                               wxT("ENR 4"),
+                                               nullptr };
+
+enum
+{
     thermalLawCount = 2
 };
 static const wxChar* thermalLaws[] = {wxT("uniform"), wxT("geometric"), nullptr};
@@ -931,6 +946,9 @@ struct PAreaSpilledEnergyCost
     }
 };
 
+// ----------------
+// THERMAL CLUSTERS
+// ----------------
 struct PClusterEnabled
 {
     typedef bool Type;
@@ -1310,6 +1328,75 @@ struct PConstraintType
     static wxString ConvertToString(const Type v)
     {
         return wxStringFromUTF8(Data::BindingConstraint::TypeToCString(v));
+    }
+};
+
+// --------------------
+// RENEWABLE CLUSTERS
+// --------------------
+struct PRnClusterArea
+{
+    typedef wxString Type;
+    static Type Value(const Data::RenewableCluster* cluster)
+    {
+        return wxStringFromUTF8(cluster->parentArea->name);
+    }
+    static wxString ConvertToString(const Type v)
+    {
+        return v;
+    }
+};
+
+struct PRnClusterGroup
+{
+    typedef wxString Type;
+    static Type Value(const Data::RenewableCluster* cluster)
+    {
+        return wxStringFromUTF8(cluster->group());
+    }
+    static wxString ConvertToString(const Type v)
+    {
+        return v;
+    }
+};
+
+struct PRnClusterEnabled
+{
+    typedef bool Type;
+    static Type Value(const Data::RenewableCluster* cluster)
+    {
+        return cluster->enabled;
+    }
+    static wxString ConvertToString(const Type v)
+    {
+        return v ? wxT("True") : wxT("False");
+    }
+};
+
+struct PRnClusterUnitCount
+{
+    typedef uint Type;
+    static Type Value(const Data::RenewableCluster* cluster)
+    {
+        // return cluster->unitCount;
+        return 5;
+    }
+    static wxString ConvertToString(const Type v)
+    {
+        return wxString() << v;
+    }
+};
+
+struct PRnClusterNomCapacity
+{
+    typedef double Type;
+    static Type Value(const Data::RenewableCluster* cluster)
+    {
+        return cluster->nominalCapacity;
+    }
+    static wxString ConvertToString(const Type v)
+    {
+        return DoubleToWxString(v);
     }
 };
 

--- a/src/ui/simulator/windows/inspector/data.cpp
+++ b/src/ui/simulator/windows/inspector/data.cpp
@@ -48,6 +48,7 @@ void InspectorData::clear()
         areas.clear();
         links.clear();
         ThClusters.clear();
+        RnClusters.clear();
         constraints.clear();
         studies.clear();
         empty = true;
@@ -56,7 +57,7 @@ void InspectorData::clear()
 
 uint InspectorData::totalNbOfItems() const
 {
-    return (uint)areas.size() + (uint)links.size() + (uint)ThClusters.size()
+    return (uint)areas.size() + (uint)links.size() + (uint)ThClusters.size() + (uint)RnClusters.size()
            + (uint)constraints.size();
 }
 

--- a/src/ui/simulator/windows/inspector/data.cpp
+++ b/src/ui/simulator/windows/inspector/data.cpp
@@ -47,7 +47,7 @@ void InspectorData::clear()
     {
         areas.clear();
         links.clear();
-        clusters.clear();
+        ThClusters.clear();
         constraints.clear();
         studies.clear();
         empty = true;
@@ -56,7 +56,7 @@ void InspectorData::clear()
 
 uint InspectorData::totalNbOfItems() const
 {
-    return (uint)areas.size() + (uint)links.size() + (uint)clusters.size()
+    return (uint)areas.size() + (uint)links.size() + (uint)ThClusters.size()
            + (uint)constraints.size();
 }
 

--- a/src/ui/simulator/windows/inspector/data.h
+++ b/src/ui/simulator/windows/inspector/data.h
@@ -78,7 +78,9 @@ public:
     //! All selected links
     Data::AreaLink::Set links;
     //! All selected thermal clusters
-    Data::ThermalCluster::Set clusters;
+    Data::ThermalCluster::Set ThClusters;
+    //! All selected renewable clusters
+    Data::RenewableCluster::Set RnClusters;
     //! All selected binding constraints
     Data::BindingConstraint::Set constraints;
     //! All studies

--- a/src/ui/simulator/windows/inspector/data.hxx
+++ b/src/ui/simulator/windows/inspector/data.hxx
@@ -35,7 +35,7 @@ namespace Inspector
 {
 inline void InspectorData::determineEmpty()
 {
-    empty = areas.empty() and links.empty() and clusters.empty() and constraints.empty()
+    empty = areas.empty() and links.empty() and ThClusters.empty() and constraints.empty()
             and studies.empty();
 }
 

--- a/src/ui/simulator/windows/inspector/data.hxx
+++ b/src/ui/simulator/windows/inspector/data.hxx
@@ -35,7 +35,7 @@ namespace Inspector
 {
 inline void InspectorData::determineEmpty()
 {
-    empty = areas.empty() and links.empty() and ThClusters.empty() and constraints.empty()
+    empty = areas.empty() and links.empty() and ThClusters.empty() and RnClusters.empty() and constraints.empty()
             and studies.empty();
 }
 

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -126,7 +126,7 @@ void Frame::onSelectAllLinks(wxCommandEvent&)
                 data->links.insert(i->second);
         }
         data->areas.clear();
-        data->clusters.clear();
+        data->ThClusters.clear();
         data->empty = data->links.empty();
         gInspector->delayApplyGlobalSelection();
     }
@@ -140,7 +140,7 @@ void Frame::onSelectLink(wxCommandEvent& evt)
         data->links.clear();
         data->links.insert((Data::AreaLink*)mapIDPointer[evt.GetId()]);
         data->areas.clear();
-        data->clusters.clear();
+        data->ThClusters.clear();
         data->empty = data->links.empty();
         gInspector->delayApplyGlobalSelection();
     }
@@ -159,7 +159,7 @@ void Frame::onSelectAllLinksFromArea(wxCommandEvent& evt)
         for (auto i = area->links.begin(); i != end; ++i)
             data->links.insert(i->second);
         data->areas.clear();
-        data->clusters.clear();
+        data->ThClusters.clear();
         data->empty = data->links.empty();
         gInspector->delayApplyGlobalSelection();
     }
@@ -170,18 +170,18 @@ void Frame::onSelectAllPlants(wxCommandEvent&)
     InspectorData::Ptr data = gData;
     if (!(!data) and gInspector)
     {
-        data->clusters.clear();
+        data->ThClusters.clear();
         auto areaEnd = data->areas.end();
         for (auto i = data->areas.begin(); i != areaEnd; ++i)
         {
             Data::Area& area = *(*i);
             auto end = area.thermal.list.end();
             for (auto i = area.thermal.list.begin(); i != end; ++i)
-                data->clusters.insert(i->second);
+                data->ThClusters.insert(i->second);
         }
         data->areas.clear();
         data->links.clear();
-        data->empty = data->clusters.empty();
+        data->empty = data->ThClusters.empty();
         gInspector->delayApplyGlobalSelection();
     }
 }
@@ -191,11 +191,11 @@ void Frame::onSelectPlant(wxCommandEvent& evt)
     InspectorData::Ptr data = gData;
     if (!(!data) and gInspector and evt.GetEventObject())
     {
-        data->clusters.clear();
-        data->clusters.insert((Data::ThermalCluster*)mapIDPointer[evt.GetId()]);
+        data->ThClusters.clear();
+        data->ThClusters.insert((Data::ThermalCluster*)mapIDPointer[evt.GetId()]);
         data->areas.clear();
         data->links.clear();
-        data->empty = data->clusters.empty();
+        data->empty = data->ThClusters.empty();
         gInspector->delayApplyGlobalSelection();
     }
 }
@@ -208,13 +208,13 @@ void Frame::onSelectAllPlantsFromArea(wxCommandEvent& evt)
         Data::Area* area = (Data::Area*)mapIDPointer[evt.GetId()];
         if (!area)
             return;
-        data->clusters.clear();
+        data->ThClusters.clear();
         auto end = area->thermal.list.end();
         for (auto i = area->thermal.list.begin(); i != end; ++i)
-            data->clusters.insert(i->second);
+            data->ThClusters.insert(i->second);
         data->areas.clear();
         data->links.clear();
-        data->empty = data->clusters.empty();
+        data->empty = data->ThClusters.empty();
         gInspector->delayApplyGlobalSelection();
     }
 }
@@ -481,51 +481,73 @@ Frame::Frame(wxWindow* parent, bool allowAnyObject) :
       = page->AppendIn(lid, new wxBoolProperty(wxT("annual"), wxT("annual"), true));
 
     // --- THERMAL CLUSTERS ---
-    pPGClusterSeparator = Group(pg, wxEmptyString, wxEmptyString);
+    // gp : all thermal property names should be renamed "th-cluster.<something>" instead of "cluster.<something>"
+    pPGThClusterSeparator = Group(pg, wxEmptyString, wxEmptyString);
     Group(pg, wxT("THERMAL CLUSTERS"), wxT("cluster.title"));
-    pPGClusterGeneral = Category(pg, wxT("General"), wxT("cluster.general"));
-    pPGClusterName = P_STRING("Name", "cluster.name");
+    pPGThClusterGeneral = Category(pg, wxT("General"), wxT("cluster.general"));
+    pPGThClusterName = P_STRING("Name", "cluster.name");
 
-    wxPGChoices chs;
+    wxPGChoices ThGroupChoices;
     for (uint i = 0; i != arrayClusterGroupCount; ++i)
-        chs.Add(arrayClusterGroup[i], i);
-    pPGClusterGroup = page->Append(
-      new wxEditEnumProperty(wxT("group"), wxT("cluster.group"), chs, wxEmptyString));
+        ThGroupChoices.Add(arrayClusterGroup[i], i);
+    pPGThClusterGroup = page->Append(
+      new wxEditEnumProperty(wxT("group"), wxT("cluster.group"), ThGroupChoices, wxEmptyString));
 
-    pPGClusterArea = P_STRING("area", "cluster.area");
-    pg->DisableProperty(pPGClusterArea);
+    pPGThClusterArea = P_STRING("area", "cluster.area");
+    pg->DisableProperty(pPGThClusterArea);
 
-    pPGClusterParams = Category(pg, wxT("Operating parameters"), wxT("cluster.params"));
-    pPGClusterEnabled = P_BOOL("Enabled", "cluster.enabled");
-    pPGClusterUnitCount = P_UINT("Unit", "cluster.unit");
-    pPGClusterNominalCapacity = P_FLOAT("Nominal capacity (MW)", "cluster.nominal_capacity");
-    pPGClusterInstalled = P_FLOAT("Installed (MW)", "cluster.installed");
-    pg->DisableProperty(pPGClusterInstalled);
-    pPGClusterMustRun = P_BOOL("Must run", "cluster.must-run");
+    pPGThClusterParams = Category(pg, wxT("Operating parameters"), wxT("cluster.params"));
+    pPGThClusterEnabled = P_BOOL("Enabled", "cluster.enabled");
+    pPGThClusterUnitCount = P_UINT("Unit", "cluster.unit");
+    pPGThClusterNominalCapacity = P_FLOAT("Nominal capacity (MW)", "cluster.nominal_capacity");
+    pPGThClusterInstalled = P_FLOAT("Installed (MW)", "cluster.installed");
+    pg->DisableProperty(pPGThClusterInstalled);
+    pPGThClusterMustRun = P_BOOL("Must run", "cluster.must-run");
 
-    pPGClusterMinStablePower = P_FLOAT("Min Stable Power (MW)", "cluster.minstablepower");
-    pPGClusterMinUpTime = page->Append(
+    pPGThClusterMinStablePower = P_FLOAT("Min Stable Power (MW)", "cluster.minstablepower");
+    pPGThClusterMinUpTime = page->Append(
       new wxEnumProperty(wxT("Min. Up Time"), wxT("cluster.minuptime"), arrayMinUpDownTime));
-    pPGClusterMinDownTime = page->Append(
+    pPGThClusterMinDownTime = page->Append(
       new wxEnumProperty(wxT("Min. Down Time"), wxT("cluster.mindowntime"), arrayMinUpDownTime));
 
-    pPGClusterSpinning = P_FLOAT("Spinning (%)", "cluster.spinning");
-    pPGClusterSpinning->SetAttribute(wxPG_ATTR_MAX, 99.99);
-    pPGClusterCO2 = P_FLOAT("CO2 (Tons/MWh)", "cluster.co2");
+    pPGThClusterSpinning = P_FLOAT("Spinning (%)", "cluster.spinning");
+    pPGThClusterSpinning->SetAttribute(wxPG_ATTR_MAX, 99.99);
+    pPGThClusterCO2 = P_FLOAT("CO2 (Tons/MWh)", "cluster.co2");
 
-    pPGClusterCosts = Category(pg, wxT("Operating costs"), wxT("cluster.costs"));
-    pPGClusterMarginalCost = P_FLOAT("Marginal (\u20AC/MWh)", "cluster.opcost_marginal");
-    pPGClusterFixedCost = P_FLOAT("Fixed (\u20AC/hour)", "cluster.opcost_fixed");
-    pPGClusterStartupCost = P_FLOAT("Startup (\u20AC/startup)", "cluster.opcost_startup");
-    pPGClusterOperatingCost = P_FLOAT("Market bid (\u20AC/MWh)", "cluster.opcost_marketbid");
-    pPGClusterRandomSpread = P_FLOAT("Spread (\u20AC/MWh)", "cluster.opcost_spread");
+    pPGThClusterCosts = Category(pg, wxT("Operating costs"), wxT("cluster.costs"));
+    pPGThClusterMarginalCost = P_FLOAT("Marginal (\u20AC/MWh)", "cluster.opcost_marginal");
+    pPGThClusterFixedCost = P_FLOAT("Fixed (\u20AC/hour)", "cluster.opcost_fixed");
+    pPGThClusterStartupCost = P_FLOAT("Startup (\u20AC/startup)", "cluster.opcost_startup");
+    pPGThClusterOperatingCost = P_FLOAT("Market bid (\u20AC/MWh)", "cluster.opcost_marketbid");
+    pPGThClusterRandomSpread = P_FLOAT("Spread (\u20AC/MWh)", "cluster.opcost_spread");
 
-    pPGClusterReliabilityModel
+    pPGThClusterReliabilityModel
       = Category(pg, wxT("Reliability model"), wxT("cluster.reliabilitymodel"));
-    pPGClusterVolatilityForced = P_FLOAT("Volatility (forced)", "cluster.forcedVolatility");
-    pPGClusterVolatilityPlanned = P_FLOAT("Volatility (planned)", "cluster.plannedVolatility");
-    pPGClusterLawForced = P_ENUM("Law (forced)", "cluster.forcedlaw", thermalLaws);
-    pPGClusterLawPlanned = P_ENUM("Law (planned)", "cluster.plannedlaw", thermalLaws);
+    pPGThClusterVolatilityForced = P_FLOAT("Volatility (forced)", "cluster.forcedVolatility");
+    pPGThClusterVolatilityPlanned = P_FLOAT("Volatility (planned)", "cluster.plannedVolatility");
+    pPGThClusterLawForced = P_ENUM("Law (forced)", "cluster.forcedlaw", thermalLaws);
+    pPGThClusterLawPlanned = P_ENUM("Law (planned)", "cluster.plannedlaw", thermalLaws);
+
+    // --- RENEWABLE CLUSTERS ---
+    pPGRnClusterSeparator = Group(pg, wxEmptyString, wxEmptyString);
+    Group(pg, wxT("RENEWABLE CLUSTERS"), wxT("rn-cluster.title"));
+    pPGRnClusterGeneral = Category(pg, wxT("General"), wxT("rn-cluster.general"));
+    pPGRnClusterName = P_STRING("Name", "rn-cluster.name");
+
+    wxPGChoices RnGroupChoices;
+    for (uint i = 0; i != arrayRnClusterGroupCount; ++i)
+        RnGroupChoices.Add(arrayRnClusterGroup[i], i);
+    pPGRnClusterGroup = page->Append(
+        new wxEditEnumProperty(wxT("group"), wxT("rn-cluster.group"), RnGroupChoices, wxEmptyString));
+
+    pPGRnClusterArea = P_STRING("area", "rn-cluster.area");
+    pg->DisableProperty(pPGRnClusterArea);
+
+    pPGRnClusterParams = Category(pg, wxT("Operating parameters"), wxT("rn-cluster.params"));
+    pPGRnClusterEnabled = P_BOOL("Enabled", "rn-cluster.enabled");
+    pPGRnClusterUnitCount = P_UINT("Unit", "rn-cluster.unit");
+    pPGRnClusterNominalCapacity = P_FLOAT("Nominal capacity (MW)", "rn-cluster.nominal_capacity");
+
 
     // --- CONSTRAINT ---
     pPGConstraintSeparator = Group(pg, wxEmptyString, wxEmptyString);
@@ -864,74 +886,114 @@ void Frame::apply(const InspectorData::Ptr& data)
     // ----------------
     // THERMAL CLUSTERS
     // ----------------
-    hide = !data || data->clusters.empty();
-    multiple = (data and data->clusters.size() > 1);
-    pPGClusterSeparator->Hide(hide);
+    hide = !data || data->ThClusters.empty();
+    multiple = (data and data->ThClusters.size() > 1);
+    pPGThClusterSeparator->Hide(hide);
     p = PROPERTY("cluster.title");
     p->Hide(hide);
     if (!hide)
     {
-        pPGClusterName->Hide(multiple);
+        pPGThClusterName->Hide(multiple);
         if (!multiple) // only one thermal cluster
         {
             p->SetLabel(wxT("THERMAL CLUSTER"));
-            pPGClusterName->SetValueFromString(
-              wxStringFromUTF8((*(data->clusters.begin()))->name()));
+            pPGThClusterName->SetValueFromString(
+              wxStringFromUTF8((*(data->ThClusters.begin()))->name()));
         }
         else
-            p->SetLabel(wxString() << data->clusters.size() << wxT(" THERMAL CLUSTERS"));
+            p->SetLabel(wxString() << data->ThClusters.size() << wxT(" THERMAL CLUSTERS"));
 
         // Parent Area
-        Accumulator<PClusterArea>::Apply(pPGClusterArea, data->clusters);
+        Accumulator<PClusterArea>::Apply(pPGThClusterArea, data->ThClusters);
         // Group
-        Accumulator<PClusterGroup>::Apply(pPGClusterGroup, data->clusters);
+        Accumulator<PClusterGroup>::Apply(pPGThClusterGroup, data->ThClusters);
         // Must run
-        Accumulator<PClusterMustRun>::Apply(pPGClusterMustRun, data->clusters);
+        Accumulator<PClusterMustRun>::Apply(pPGThClusterMustRun, data->ThClusters);
         // Enabled
-        Accumulator<PClusterEnabled>::Apply(pPGClusterEnabled, data->clusters);
+        Accumulator<PClusterEnabled>::Apply(pPGThClusterEnabled, data->ThClusters);
         // Unit count
-        Accumulator<PClusterUnitCount>::Apply(pPGClusterUnitCount, data->clusters);
+        Accumulator<PClusterUnitCount>::Apply(pPGThClusterUnitCount, data->ThClusters);
         // Nominal capacity
-        Accumulator<PClusterNomCapacity>::Apply(pPGClusterNominalCapacity, data->clusters);
+        Accumulator<PClusterNomCapacity>::Apply(pPGThClusterNominalCapacity, data->ThClusters);
         // Installed
-        Accumulator<PClusterInstalled, Add>::Apply(pPGClusterInstalled, data->clusters);
+        Accumulator<PClusterInstalled, Add>::Apply(pPGThClusterInstalled, data->ThClusters);
         // Min. Up Time
-        Accumulator<PClusterMinUpTime>::Apply(pPGClusterMinUpTime, data->clusters);
+        Accumulator<PClusterMinUpTime>::Apply(pPGThClusterMinUpTime, data->ThClusters);
         // Min. Down Time
-        Accumulator<PClusterMinDownTime>::Apply(pPGClusterMinDownTime, data->clusters);
+        Accumulator<PClusterMinDownTime>::Apply(pPGThClusterMinDownTime, data->ThClusters);
         // Min. Stable Power
-        Accumulator<PClusterMinStablePower>::Apply(pPGClusterMinStablePower, data->clusters);
+        Accumulator<PClusterMinStablePower>::Apply(pPGThClusterMinStablePower, data->ThClusters);
         // Spinning
-        Accumulator<PClusterSpinning>::Apply(pPGClusterSpinning, data->clusters);
+        Accumulator<PClusterSpinning>::Apply(pPGThClusterSpinning, data->ThClusters);
         // CO2
-        Accumulator<PClusterCO2>::Apply(pPGClusterCO2, data->clusters);
+        Accumulator<PClusterCO2>::Apply(pPGThClusterCO2, data->ThClusters);
         // Volatility
-        Accumulator<PClusterVolatilityPlanned>::Apply(pPGClusterVolatilityPlanned, data->clusters);
-        Accumulator<PClusterVolatilityForced>::Apply(pPGClusterVolatilityForced, data->clusters);
+        Accumulator<PClusterVolatilityPlanned>::Apply(pPGThClusterVolatilityPlanned, data->ThClusters);
+        Accumulator<PClusterVolatilityForced>::Apply(pPGThClusterVolatilityForced, data->ThClusters);
         // Laws
-        Accumulator<PClusterLawPlanned>::Apply(pPGClusterLawPlanned, data->clusters);
-        Accumulator<PClusterLawForced>::Apply(pPGClusterLawForced, data->clusters);
+        Accumulator<PClusterLawPlanned>::Apply(pPGThClusterLawPlanned, data->ThClusters);
+        Accumulator<PClusterLawForced>::Apply(pPGThClusterLawForced, data->ThClusters);
         // Costs
-        Accumulator<PClusterMarginalCost>::Apply(pPGClusterMarginalCost, data->clusters);
-        Accumulator<PClusterReference>::Apply(pPGClusterOperatingCost, data->clusters);
-        Accumulator<PClusterFixedCost>::Apply(pPGClusterFixedCost, data->clusters);
-        Accumulator<PClusterStartupCost>::Apply(pPGClusterStartupCost, data->clusters);
-        Accumulator<PClusterRandomSpread>::Apply(pPGClusterRandomSpread, data->clusters);
+        Accumulator<PClusterMarginalCost>::Apply(pPGThClusterMarginalCost, data->ThClusters);
+        Accumulator<PClusterReference>::Apply(pPGThClusterOperatingCost, data->ThClusters);
+        Accumulator<PClusterFixedCost>::Apply(pPGThClusterFixedCost, data->ThClusters);
+        Accumulator<PClusterStartupCost>::Apply(pPGThClusterStartupCost, data->ThClusters);
+        Accumulator<PClusterRandomSpread>::Apply(pPGThClusterRandomSpread, data->ThClusters);
 
         // check Nominal capacity with thermal modulation
-        AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(pPGClusterNominalCapacity,
-                                                                   data->clusters);
+        AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(pPGThClusterNominalCapacity,
+                                                                   data->ThClusters);
         // check Min. Stable Power with thermal modulation
-        AccumulatorCheck<PClusterMinStablePowerColor>::ApplyTextColor(pPGClusterMinStablePower,
-                                                                      data->clusters);
+        AccumulatorCheck<PClusterMinStablePowerColor>::ApplyTextColor(pPGThClusterMinStablePower,
+                                                                      data->ThClusters);
         // check Min. Stable Power with thermal modulation
-        AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pPGClusterSpinning, data->clusters);
+        AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pPGThClusterSpinning, data->ThClusters);
     }
 
-    pPGClusterParams->Hide(hide);
-    pPGClusterReliabilityModel->Hide(hide);
-    pPGClusterCosts->Hide(hide);
-    pPGClusterGeneral->Hide(hide);
+    pPGThClusterParams->Hide(hide);
+    pPGThClusterReliabilityModel->Hide(hide);
+    pPGThClusterCosts->Hide(hide);
+    pPGThClusterGeneral->Hide(hide);
+
+    // --------------------
+    // RENEWABLE CLUSTERS
+    // --------------------
+    hide = !data || data->RnClusters.empty();
+    multiple = (data and data->RnClusters.size() > 1);
+    pPGRnClusterSeparator->Hide(hide);
+    p = PROPERTY("rn-cluster.title");
+    p->Hide(hide);
+    if (!hide)
+    {
+        pPGRnClusterName->Hide(multiple);
+        if (!multiple) // only one thermal cluster
+        {
+            p->SetLabel(wxT("RENEWABLE CLUSTER"));
+            pPGRnClusterName->SetValueFromString(
+                wxStringFromUTF8((*(data->RnClusters.begin()))->name()));
+        }
+        else
+            p->SetLabel(wxString() << data->ThClusters.size() << wxT(" RENEWABLE CLUSTERS"));
+
+        // Parent Area
+        Accumulator<PRnClusterArea>::Apply(pPGRnClusterArea, data->RnClusters);
+        // Group
+        Accumulator<PRnClusterGroup>::Apply(pPGRnClusterGroup, data->RnClusters);
+        // Enabled
+        Accumulator<PRnClusterEnabled>::Apply(pPGRnClusterEnabled, data->RnClusters);
+        // Unit count
+        Accumulator<PRnClusterUnitCount>::Apply(pPGRnClusterUnitCount, data->RnClusters);
+        // Nominal capacity
+        Accumulator<PRnClusterNomCapacity>::Apply(pPGRnClusterNominalCapacity, data->RnClusters);
+
+        // gp : what should we do with that ?
+        // check Nominal capacity with thermal modulation
+        // AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(pPGRnClusterNominalCapacity,
+        //    data->RnClusters);
+    }
+
+    pPGRnClusterParams->Hide(hide);
+    pPGRnClusterGeneral->Hide(hide);
 
     // -----------
     // CONSTRAINTS

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -127,6 +127,7 @@ void Frame::onSelectAllLinks(wxCommandEvent&)
         }
         data->areas.clear();
         data->ThClusters.clear();
+        data->RnClusters.clear();
         data->empty = data->links.empty();
         gInspector->delayApplyGlobalSelection();
     }
@@ -141,6 +142,7 @@ void Frame::onSelectLink(wxCommandEvent& evt)
         data->links.insert((Data::AreaLink*)mapIDPointer[evt.GetId()]);
         data->areas.clear();
         data->ThClusters.clear();
+        data->RnClusters.clear();
         data->empty = data->links.empty();
         gInspector->delayApplyGlobalSelection();
     }
@@ -160,6 +162,7 @@ void Frame::onSelectAllLinksFromArea(wxCommandEvent& evt)
             data->links.insert(i->second);
         data->areas.clear();
         data->ThClusters.clear();
+        data->RnClusters.clear();
         data->empty = data->links.empty();
         gInspector->delayApplyGlobalSelection();
     }
@@ -966,14 +969,14 @@ void Frame::apply(const InspectorData::Ptr& data)
     if (!hide)
     {
         pPGRnClusterName->Hide(multiple);
-        if (!multiple) // only one thermal cluster
+        if (!multiple) // only one renewable cluster
         {
             p->SetLabel(wxT("RENEWABLE CLUSTER"));
             pPGRnClusterName->SetValueFromString(
                 wxStringFromUTF8((*(data->RnClusters.begin()))->name()));
         }
         else
-            p->SetLabel(wxString() << data->ThClusters.size() << wxT(" RENEWABLE CLUSTERS"));
+            p->SetLabel(wxString() << data->RnClusters.size() << wxT(" RENEWABLE CLUSTERS"));
 
         // Parent Area
         Accumulator<PRnClusterArea>::Apply(pPGRnClusterArea, data->RnClusters);

--- a/src/ui/simulator/windows/inspector/frame.h
+++ b/src/ui/simulator/windows/inspector/frame.h
@@ -198,35 +198,46 @@ private:
     wxPGProperty* pPGLinkWidth;
 
     // About Thermal clusters
-    wxPGProperty* pPGClusterSeparator;
-    wxPGProperty* pPGClusterGeneral;
-    wxPGProperty* pPGClusterParams;
-    wxPGProperty* pPGClusterReliabilityModel;
-    wxPGProperty* pPGClusterCosts;
-    wxPGProperty* pPGClusterName;
-    wxPGProperty* pPGClusterNominalCapacity;
-    wxPGProperty* pPGClusterEnabled;
-    wxPGProperty* pPGClusterUnitCount;
-    wxPGProperty* pPGClusterInstalled;
-    wxPGProperty* pPGClusterMustRun;
-    wxPGProperty* pPGClusterGroup;
-    wxPGProperty* pPGClusterArea;
-    wxPGProperty* pPGClusterCO2;
-    wxPGProperty* pPGClusterVolatilityForced;
-    wxPGProperty* pPGClusterVolatilityPlanned;
-    wxPGProperty* pPGClusterLawForced;
-    wxPGProperty* pPGClusterLawPlanned;
-    wxPGProperty* pPGClusterSpinning;
+    wxPGProperty* pPGThClusterSeparator;
+    wxPGProperty* pPGThClusterGeneral;
+    wxPGProperty* pPGThClusterParams;
+    wxPGProperty* pPGThClusterReliabilityModel;
+    wxPGProperty* pPGThClusterCosts;
+    wxPGProperty* pPGThClusterName;
+    wxPGProperty* pPGThClusterNominalCapacity;
+    wxPGProperty* pPGThClusterEnabled;
+    wxPGProperty* pPGThClusterUnitCount;
+    wxPGProperty* pPGThClusterInstalled;
+    wxPGProperty* pPGThClusterMustRun;
+    wxPGProperty* pPGThClusterGroup;
+    wxPGProperty* pPGThClusterArea;
+    wxPGProperty* pPGThClusterCO2;
+    wxPGProperty* pPGThClusterVolatilityForced;
+    wxPGProperty* pPGThClusterVolatilityPlanned;
+    wxPGProperty* pPGThClusterLawForced;
+    wxPGProperty* pPGThClusterLawPlanned;
+    wxPGProperty* pPGThClusterSpinning;
 
-    wxPGProperty* pPGClusterMarginalCost;
-    wxPGProperty* pPGClusterFixedCost;
-    wxPGProperty* pPGClusterStartupCost;
-    wxPGProperty* pPGClusterOperatingCost;
-    wxPGProperty* pPGClusterRandomSpread;
+    wxPGProperty* pPGThClusterMarginalCost;
+    wxPGProperty* pPGThClusterFixedCost;
+    wxPGProperty* pPGThClusterStartupCost;
+    wxPGProperty* pPGThClusterOperatingCost;
+    wxPGProperty* pPGThClusterRandomSpread;
 
-    wxPGProperty* pPGClusterMinStablePower;
-    wxPGProperty* pPGClusterMinUpTime;
-    wxPGProperty* pPGClusterMinDownTime;
+    wxPGProperty* pPGThClusterMinStablePower;
+    wxPGProperty* pPGThClusterMinUpTime;
+    wxPGProperty* pPGThClusterMinDownTime;
+
+    // About Renewable clusters
+    wxPGProperty* pPGRnClusterSeparator;
+    wxPGProperty* pPGRnClusterGeneral;
+    wxPGProperty* pPGRnClusterName;
+    wxPGProperty* pPGRnClusterGroup;
+    wxPGProperty* pPGRnClusterArea;
+    wxPGProperty* pPGRnClusterParams;
+    wxPGProperty* pPGRnClusterEnabled;
+    wxPGProperty* pPGRnClusterUnitCount;
+    wxPGProperty* pPGRnClusterNominalCapacity;
 
     // About constraints
     wxPGProperty* pPGConstraintSeparator;

--- a/src/ui/simulator/windows/inspector/grid.h
+++ b/src/ui/simulator/windows/inspector/grid.h
@@ -79,6 +79,8 @@ protected:
     bool onPropertyChanging_Cluster(wxPGProperty*,
                                     const PropertyNameType& name,
                                     const wxVariant& value);
+    bool onPropertyChanging_RenewableClusters(const PropertyNameType& name,
+                                              const wxVariant& value);
     bool onPropertyChanging_L(wxPGProperty*, const PropertyNameType& name, const wxVariant& value);
     bool onPropertyChanging_S(wxPGProperty*, const PropertyNameType& name, const wxVariant& value);
 

--- a/src/ui/simulator/windows/inspector/grid.h
+++ b/src/ui/simulator/windows/inspector/grid.h
@@ -76,7 +76,7 @@ protected:
     bool onPropertyChanging_Constraint(wxPGProperty*,
                                        const PropertyNameType& name,
                                        const wxVariant& value);
-    bool onPropertyChanging_Cluster(wxPGProperty*,
+    bool onPropertyChanging_ThermalCluster(wxPGProperty*,
                                     const PropertyNameType& name,
                                     const wxVariant& value);
     bool onPropertyChanging_RenewableClusters(const PropertyNameType& name,

--- a/src/ui/simulator/windows/inspector/inspector.cpp
+++ b/src/ui/simulator/windows/inspector/inspector.cpp
@@ -357,6 +357,7 @@ void AddLink(const Data::AreaLink* link)
     }
 }
 
+// gp : never used - to be removed
 void AddThermalCluster(const Data::ThermalCluster* cluster)
 {
     if (!gData)
@@ -442,6 +443,16 @@ void RemoveLink(const Data::AreaLink* link)
 void RemoveThermalCluster(const Data::ThermalCluster* cluster)
 {
     if (!(!gData) && gData->ThClusters.erase(const_cast<Data::ThermalCluster*>(cluster)))
+    {
+        gData->determineEmpty();
+        if (gInspector)
+            gInspector->apply(gData);
+    }
+}
+
+void RemoveRenewableCluster(const Data::RenewableCluster* cluster)
+{
+    if (!(!gData) && gData->RnClusters.erase(const_cast<Data::RenewableCluster*>(cluster)))
     {
         gData->determineEmpty();
         if (gInspector)
@@ -558,6 +569,7 @@ void SelectThermalCluster(const Data::ThermalCluster* cluster)
         gInspector->apply(gData);
 }
 
+// gp : never used - to be removed
 void SelectThermalClusters(const Data::ThermalCluster::Vector& clusters)
 {
     if (!gData)
@@ -573,6 +585,20 @@ void SelectThermalClusters(const Data::ThermalCluster::Vector& clusters)
               = (gData->ThClusters).insert(const_cast<Data::ThermalCluster*>(*i)).second || notEmpty;
 
         if (notEmpty)
+            gData->empty = false;
+    }
+    if (gInspector)
+        gInspector->apply(gData);
+}
+
+void SelectRenewableCluster(const Data::RenewableCluster* cluster)
+{
+    if (!gData)
+        gData = new InspectorData(*Data::Study::Current::Get());
+    gData->clear();
+    if (cluster)
+    {
+        if (gData->RnClusters.insert(const_cast<Data::RenewableCluster*>(cluster)).second)
             gData->empty = false;
     }
     if (gInspector)
@@ -616,7 +642,8 @@ uint CopyToClipboard()
             }
         }
     }
-
+    // gp : to be taken care of for renewable clusters
+    // gp : Find "import-thermal-cluster:" and make same thing for renewables
     // copying thermal plants if any
     {
         auto end = gData->ThClusters.end();
@@ -771,6 +798,7 @@ bool LinksSelected(std::map<Data::AreaName, std::map<Data::AreaName, bool>>& set
     return true;
 }
 
+// gp : never used - to be removed
 bool IsThermalClusterSelected(const Data::AreaName& area, const Data::ThermalClusterName& name)
 {
     (void)area;

--- a/src/ui/simulator/windows/inspector/inspector.cpp
+++ b/src/ui/simulator/windows/inspector/inspector.cpp
@@ -92,7 +92,7 @@ uint SelectionLinksCount()
 
 uint SelectionThermalClusterCount()
 {
-    return ((!(!gData)) ? (uint)gData->clusters.size() : 0);
+    return ((!(!gData)) ? (uint)gData->ThClusters.size() : 0);
 }
 
 uint SelectionBindingConstraintCount()
@@ -102,7 +102,7 @@ uint SelectionBindingConstraintCount()
 
 uint SelectionTotalCount()
 {
-    return (!(!gData)) ? (uint)gData->constraints.size() + (uint)gData->clusters.size()
+    return (!(!gData)) ? (uint)gData->constraints.size() + (uint)gData->ThClusters.size()
                            + (uint)gData->links.size() + (uint)gData->areas.size()
                        : 0;
 }
@@ -361,7 +361,7 @@ void AddThermalCluster(const Data::ThermalCluster* cluster)
 {
     if (!gData)
         gData = new InspectorData(*Data::Study::Current::Get());
-    if (gData->clusters.insert(const_cast<Data::ThermalCluster*>(cluster)).second)
+    if (gData->ThClusters.insert(const_cast<Data::ThermalCluster*>(cluster)).second)
     {
         gData->empty = false;
         if (gInspector)
@@ -379,7 +379,7 @@ void AddThermalClusters(const Data::ThermalCluster::Vector& list)
     bool notEmpty = false;
     Data::ThermalCluster::Vector::const_iterator end = list.end();
     for (Data::ThermalCluster::Vector::const_iterator i = list.begin(); i != end; ++i)
-        notEmpty = gData->clusters.insert(const_cast<Data::ThermalCluster*>(*i)).second || notEmpty;
+        notEmpty = gData->ThClusters.insert(const_cast<Data::ThermalCluster*>(*i)).second || notEmpty;
 
     if (notEmpty)
     {
@@ -399,7 +399,7 @@ void AddThermalClusters(const Data::ThermalCluster::Set& list)
     bool notEmpty = false;
     Data::ThermalCluster::Set::const_iterator end = list.end();
     for (Data::ThermalCluster::Set::const_iterator i = list.begin(); i != end; ++i)
-        notEmpty = gData->clusters.insert(const_cast<Data::ThermalCluster*>(*i)).second || notEmpty;
+        notEmpty = gData->ThClusters.insert(const_cast<Data::ThermalCluster*>(*i)).second || notEmpty;
 
     if (notEmpty)
     {
@@ -441,7 +441,7 @@ void RemoveLink(const Data::AreaLink* link)
 
 void RemoveThermalCluster(const Data::ThermalCluster* cluster)
 {
-    if (!(!gData) && gData->clusters.erase(const_cast<Data::ThermalCluster*>(cluster)))
+    if (!(!gData) && gData->ThClusters.erase(const_cast<Data::ThermalCluster*>(cluster)))
     {
         gData->determineEmpty();
         if (gInspector)
@@ -551,7 +551,7 @@ void SelectThermalCluster(const Data::ThermalCluster* cluster)
     gData->clear();
     if (cluster)
     {
-        if (gData->clusters.insert(const_cast<Data::ThermalCluster*>(cluster)).second)
+        if (gData->ThClusters.insert(const_cast<Data::ThermalCluster*>(cluster)).second)
             gData->empty = false;
     }
     if (gInspector)
@@ -570,7 +570,7 @@ void SelectThermalClusters(const Data::ThermalCluster::Vector& clusters)
         auto end = clusters.end();
         for (auto i = clusters.begin(); i != end; ++i)
             notEmpty
-              = (gData->clusters).insert(const_cast<Data::ThermalCluster*>(*i)).second || notEmpty;
+              = (gData->ThClusters).insert(const_cast<Data::ThermalCluster*>(*i)).second || notEmpty;
 
         if (notEmpty)
             gData->empty = false;
@@ -619,8 +619,8 @@ uint CopyToClipboard()
 
     // copying thermal plants if any
     {
-        auto end = gData->clusters.end();
-        for (auto i = gData->clusters.begin(); i != end; ++i)
+        auto end = gData->ThClusters.end();
+        for (auto i = gData->ThClusters.begin(); i != end; ++i)
         {
             text << "import-thermal-cluster:" << (*i)->parentArea->name << '@' << (*i)->name()
                  << "\n";

--- a/src/ui/simulator/windows/inspector/inspector.h
+++ b/src/ui/simulator/windows/inspector/inspector.h
@@ -185,6 +185,18 @@ void AddThermalClusters(const Data::ThermalCluster::Set& clusters);
 void RemoveThermalCluster(const Data::ThermalCluster* cluster);
 //@}
 
+//! \name Renewable clusters
+//@{
+/*!
+** \brief Clear the selection then Add a renewable cluster
+*/
+void SelectRenewableCluster(const Data::RenewableCluster* cluster);
+
+/*!
+** \brief Remove a renewable cluster from the selection
+*/
+void RemoveRenewableCluster(const Data::RenewableCluster* cluster);
+
 //! \name Data::Binding constraints
 //@{
 /*!

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -522,7 +522,7 @@ bool InspectorGrid::onPropertyChanging_Constraint(wxPGProperty*,
     return false;
 }
 
-bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
+bool InspectorGrid::onPropertyChanging_ThermalCluster(wxPGProperty*,
                                                const PropertyNameType& name,
                                                const wxVariant& value)
 {
@@ -1124,7 +1124,7 @@ bool InspectorGrid::onPropertyChanging_RenewableClusters(const PropertyNameType&
         {
             const SetType::iterator end = set.end();
             for (SetType::iterator i = set.begin(); i != end; ++i)
-                OnStudyThermalClusterGroupChanged(*i);
+                OnStudyRenewableClusterGroupChanged(*i);
         }
 
         return true;
@@ -1595,7 +1595,7 @@ void InspectorGrid::OnPropertyChanging(wxPropertyGridEvent& event)
         }
         case 'l':
             // cluster
-            result = onPropertyChanging_Cluster(property, propName, value);
+            result = onPropertyChanging_ThermalCluster(property, propName, value);
         }
         break;
     }

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -529,12 +529,12 @@ bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
     InspectorData::Ptr& data = pCurrentSelection;
     if (!data)
         return false;
-    Data::ThermalCluster::Set::iterator end = data->clusters.end();
-    Data::ThermalCluster::Set::iterator i = data->clusters.begin();
+    Data::ThermalCluster::Set::iterator end = data->ThClusters.end();
+    Data::ThermalCluster::Set::iterator i = data->ThClusters.begin();
 
     if (name == "cluster.name")
     {
-        if (data->clusters.size() != 1)
+        if (data->ThClusters.size() != 1)
             return false;
         Data::ThermalClusterName name;
         wxStringToString(value.GetString(), name);
@@ -542,7 +542,7 @@ bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
         if (!name)
             return false;
 
-        Data::ThermalCluster* cluster = *(data->clusters.begin());
+        Data::ThermalCluster* cluster = *(data->ThClusters.begin());
         auto study = Data::Study::Current::Get();
         if (!(!study) && study->thermalClusterRename(cluster, name))
         {
@@ -636,7 +636,7 @@ bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
             logs.error() << "A thermal cluster can not have more than 100 units";
             for (; i != end; ++i)
                 (*i)->unitCount = 100;
-            Accumulator<PClusterUnitCount>::Apply(pFrame.pPGClusterUnitCount, data->clusters);
+            Accumulator<PClusterUnitCount>::Apply(pFrame.pPGThClusterUnitCount, data->ThClusters);
         }
         else
         {
@@ -645,7 +645,7 @@ bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
         }
         // refresh the installed capacity
         if (data)
-            Accumulator<PClusterInstalled, Add>::Apply(pFrame.pPGClusterInstalled, data->clusters);
+            Accumulator<PClusterInstalled, Add>::Apply(pFrame.pPGThClusterInstalled, data->ThClusters);
 
         // Notify
         OnStudyThermalClusterCommonSettingsChanged();
@@ -671,17 +671,17 @@ bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
         // refresh the installed capacity
         if (data)
         {
-            Accumulator<PClusterNomCapacity>::Apply(pFrame.pPGClusterNominalCapacity,
-                                                    data->clusters);
-            Accumulator<PClusterInstalled, Add>::Apply(pFrame.pPGClusterInstalled, data->clusters);
+            Accumulator<PClusterNomCapacity>::Apply(pFrame.pPGThClusterNominalCapacity,
+                                                    data->ThClusters);
+            Accumulator<PClusterInstalled, Add>::Apply(pFrame.pPGThClusterInstalled, data->ThClusters);
 
             // apply check and colour
             AccumulatorCheck<PClusterMinStablePowerColor>::ApplyTextColor(
-              pFrame.pPGClusterMinStablePower, data->clusters);
+              pFrame.pPGThClusterMinStablePower, data->ThClusters);
             AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(
-              pFrame.pPGClusterNominalCapacity, data->clusters);
-            AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pFrame.pPGClusterSpinning,
-                                                                    data->clusters);
+              pFrame.pPGThClusterNominalCapacity, data->ThClusters);
+            AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pFrame.pPGThClusterSpinning,
+                                                                    data->ThClusters);
         }
         // Notify
         OnStudyThermalClusterCommonSettingsChanged();
@@ -703,11 +703,11 @@ bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
 
         // pFrame.delayApply();
         AccumulatorCheck<PClusterMinStablePowerColor>::ApplyTextColor(
-          pFrame.pPGClusterMinStablePower, data->clusters);
-        AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(pFrame.pPGClusterNominalCapacity,
-                                                                   data->clusters);
-        AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pFrame.pPGClusterSpinning,
-                                                                data->clusters);
+          pFrame.pPGThClusterMinStablePower, data->ThClusters);
+        AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(pFrame.pPGThClusterNominalCapacity,
+                                                                   data->ThClusters);
+        AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pFrame.pPGThClusterSpinning,
+                                                                data->ThClusters);
         // Notify
         OnStudyThermalClusterCommonSettingsChanged();
         return true;
@@ -782,11 +782,11 @@ bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
 
         // apply check and colour
         AccumulatorCheck<PClusterMinStablePowerColor>::ApplyTextColor(
-          pFrame.pPGClusterMinStablePower, data->clusters);
-        AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(pFrame.pPGClusterNominalCapacity,
-                                                                   data->clusters);
-        AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pFrame.pPGClusterSpinning,
-                                                                data->clusters);
+          pFrame.pPGThClusterMinStablePower, data->ThClusters);
+        AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(pFrame.pPGThClusterNominalCapacity,
+                                                                   data->ThClusters);
+        AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pFrame.pPGThClusterSpinning,
+                                                                data->ThClusters);
         // Notify
         OnStudyThermalClusterCommonSettingsChanged();
         return true;
@@ -1034,6 +1034,171 @@ bool InspectorGrid::onPropertyChanging_Cluster(wxPGProperty*,
 
     return false;
 }
+
+bool InspectorGrid::onPropertyChanging_RenewableClusters(const PropertyNameType& name, const wxVariant& value)
+{
+    InspectorData::Ptr& data = pCurrentSelection;
+    if (!data)
+        return false;
+    Data::RenewableCluster::Set::iterator end = data->RnClusters.end();
+    Data::RenewableCluster::Set::iterator i = data->RnClusters.begin();
+
+    if (name == "rn-cluster.name")
+    {
+        if (data->RnClusters.size() != 1)
+            return false;
+        // gp : RenewableClusterName will be renamed soon into ClusterName
+        Data::RenewableClusterName name;
+        wxStringToString(value.GetString(), name);
+        name.trim(" \r\n\t");
+        if (!name)
+            return false;
+
+        Data::RenewableCluster* cluster = *(data->RnClusters.begin());
+        auto study = Data::Study::Current::Get();
+        if (!(!study) && study->renewableClusterRename(cluster, name))
+        {
+            OnStudyRenewableClusterRenamed(cluster);
+            // Notify
+            cluster->markAsModified();
+            return true;
+        }
+        return false;
+    }
+
+    // Group
+    if (name == "rn-cluster.group")
+    {
+        wxString vs = value.GetString();
+        String newgroup;
+        wxStringToString(vs, newgroup);
+        Data::RenewableClusterName name; // gp : RenewableClusterName about to be renamed into ClusterName
+
+        if (not newgroup.empty())
+        {
+            long index;
+            if (newgroup.to(index))
+            {
+                if (index < 0 || index > arrayRnClusterGroupCount)
+                {
+                    logs.error() << "The group index is invalid";
+                    return false;
+                }
+                //
+                const wxChar* const wName = arrayRnClusterGroup[index];
+                wxStringToString(wName, name);
+                name.trim(" \r\n\t");
+                if (!name)
+                    return false;
+            }
+            else
+                name = newgroup;
+        }
+        else
+            name = newgroup;
+
+        // TODO RegEx are good sometimes...
+        name.replace('/', '-');
+        name.replace('\\', '-');
+        name.replace(',', '-');
+        name.replace('(', '-');
+        name.replace(')', '-');
+        name.replace('?', '-');
+        name.replace(':', '-');
+
+        typedef Data::Area* AreaType;
+        typedef std::set<AreaType> SetType;
+        SetType set;
+
+        for (; i != end; ++i)
+        {
+            Data::RenewableCluster& cluster = *(*i);
+            if (cluster.group() != name)
+            {
+                cluster.group(name);
+                set.insert(cluster.parentArea);
+            }
+        }
+
+        if (!set.empty())
+        {
+            const SetType::iterator end = set.end();
+            for (SetType::iterator i = set.begin(); i != end; ++i)
+                OnStudyThermalClusterGroupChanged(*i);
+        }
+
+        return true;
+    }
+
+    // unit
+    /*
+    if (name == "rn-cluster.unit")
+    {
+        uint d = static_cast<uint>(value.GetLong());
+        if (d > 100)
+        {
+            logs.error() << "A renewable cluster can not have more than 100 units";
+            for (; i != end; ++i)
+                (*i)->unitCount = 100;
+            Accumulator<PClusterUnitCount>::Apply(pFrame.pPGThClusterUnitCount, data->ThClusters);
+        }
+        else
+        {
+            for (; i != end; ++i)
+                (*i)->unitCount = d;
+        }
+        // refresh the installed capacity
+        if (data)
+            Accumulator<PClusterInstalled, Add>::Apply(pFrame.pPGThClusterInstalled, data->ThClusters);
+
+        // Notify
+        OnStudyThermalClusterCommonSettingsChanged();
+
+        if (d > 100)
+            pFrame.delayApply();
+        return true;
+    }
+    */
+    if (name == "rn-cluster.nominal_capacity")
+    {
+        double d = value.GetDouble();
+        if (d < 0.)
+        {
+            for (; i != end; ++i)
+                (*i)->nominalCapacity = 0.;
+            pFrame.delayApply();
+        }
+        else
+        {
+            for (; i != end; ++i)
+                (*i)->nominalCapacity = d;
+        }
+        // refresh the installed capacity
+        if (data)
+        {
+            Accumulator<PRnClusterNomCapacity>::Apply(pFrame.pPGRnClusterNominalCapacity,
+                data->RnClusters);
+            // AccumulatorCheck<PClusterNomCapacityColor>::ApplyTextColor(
+            //     pFrame.pPGThClusterNominalCapacity, data->ThClusters);
+        }
+        // Notify
+        OnStudyRenewableClusterCommonSettingsChanged();
+        return true;
+    }
+
+    if (name == "rn-cluster.enabled")
+    {
+        const bool d = value.GetBool();
+        for (; i != end; ++i)
+            (*i)->enabled = d;
+        // Notify
+        OnStudyRenewableClusterCommonSettingsChanged();
+        return true;
+    }
+
+    return false;
+}
+
 
 bool InspectorGrid::onPropertyChanging_S(wxPGProperty*,
                                          const PropertyNameType& name,
@@ -1436,6 +1601,9 @@ void InspectorGrid::OnPropertyChanging(wxPropertyGridEvent& event)
     }
     case 'l':
         result = onPropertyChanging_L(property, propName, value);
+        break;
+    case 'r':
+        result = onPropertyChanging_RenewableClusters(propName, value);
         break;
     case 's':
         result = onPropertyChanging_S(property, propName, value);

--- a/src/ui/simulator/windows/renewables/cluster.cpp
+++ b/src/ui/simulator/windows/renewables/cluster.cpp
@@ -26,14 +26,16 @@
 */
 
 #include "cluster.h"
-#include "../../windows/inspector.h"
-#include "../../toolbox/components/datagrid/renderer/area/thermalmodulation.h"
-#include "../../toolbox/components/notebook/notebook.h"
-#include "../../toolbox/components/refresh.h"
-#include <antares/study/parts/thermal/cluster.h>
+// #include "../../windows/inspector.h"
+// #include "../../toolbox/components/datagrid/renderer/area/thermalmodulation.h"
+// #include "../../toolbox/components/notebook/notebook.h"
+// #include "../../toolbox/components/refresh.h"
+// #include <antares/study/parts/thermal/cluster.h>
 #include <wx/sizer.h>
 #include "../../windows/inspector/frame.h"
-#include <ui/common/dispatcher/gui.h>
+// #include <ui/common/dispatcher/gui.h>
+
+#include "../../application/study.h"
 
 using namespace Yuni;
 
@@ -41,10 +43,10 @@ namespace Antares
 {
 namespace Window
 {
-namespace Thermal
+namespace Renewable
 {
 CommonProperties::CommonProperties(wxWindow* parent,
-                                   Toolbox::InputSelector::ThermalCluster* notifier) :
+                                   Toolbox::InputSelector::RenewableCluster* notifier) :
  Component::Panel(parent),
  pMainSizer(nullptr),
  pAggregate(nullptr),
@@ -64,18 +66,18 @@ CommonProperties::CommonProperties(wxWindow* parent,
     sizer->Add(vs, 0, wxALL | wxEXPAND);
     sizer->SetItemMinSize(inspector, 280, 50);
 
-    sizer->Add(
-      new Component::Datagrid::Component(
-        this, new Component::Datagrid::Renderer::ThermalClusterCommonModulation(this, notifier)),
-      1,
-      wxALL | wxEXPAND);
+    // sizer->Add(
+    //   new Component::Datagrid::Component(
+    //     this, new Component::Datagrid::Renderer::RenewableClusterCommonModulation(this, notifier)),
+    //   1,
+    // wxALL | wxEXPAND);
 
     // Connection with the notifier
-    thermalEventConnect();
+    renewableEventConnect();
 
-    OnStudyThermalClusterRenamed.connect(this, &CommonProperties::onStudyThermalClusterRenamed);
-    OnStudyThermalClusterCommonSettingsChanged.connect(this,
-                                                       &CommonProperties::thermalSettingsChanged);
+    OnStudyRenewableClusterRenamed.connect(this, &CommonProperties::onStudyRenewableClusterRenamed);
+    OnStudyRenewableClusterCommonSettingsChanged.connect(this,
+                                                       &CommonProperties::renewableSettingsChanged);
     OnStudyClosed.connect(this, &CommonProperties::onStudyClosed);
 }
 
@@ -85,12 +87,12 @@ CommonProperties::~CommonProperties()
     destroyBoundEvents();
 }
 
-void CommonProperties::onThermalClusterChanged(Data::ThermalCluster* cluster)
+void CommonProperties::onClusterChanged(Data::RenewableCluster* cluster)
 {
     if (cluster)
     {
         auto* data = new Window::Inspector::InspectorData(*Data::Study::Current::Get());
-        data->clusters.insert(cluster);
+        data->RnClusters.insert(cluster);
         pUpdateInfoAboutPlant(data);
     }
     else
@@ -102,7 +104,7 @@ void CommonProperties::onThermalClusterChanged(Data::ThermalCluster* cluster)
 
 void CommonProperties::onStudyClosed()
 {
-    onThermalClusterChanged(nullptr);
+    onClusterChanged(nullptr);
 }
 
 void CommonProperties::onUpdAggregateListDueToGroupChange()
@@ -112,42 +114,42 @@ void CommonProperties::onUpdAggregateListDueToGroupChange()
         pGroupHasChanged = false;
         if (pNotifier)
         {
-            thermalEventDisconnect();
+            renewableEventDisconnect();
             pNotifier->update();
             pNotifier->Refresh();
 
             // (Re) Connection with the notifier
             pNotifier->UpdateWindowUI();
-            thermalEventConnect();
+            renewableEventConnect();
         }
     }
 }
 
-void CommonProperties::thermalEventConnect()
+void CommonProperties::renewableEventConnect()
 {
     if (pNotifier)
-        pNotifier->onThermalClusterChanged.connect(this,
-                                                   &CommonProperties::onThermalClusterChanged);
+        pNotifier->onClusterChanged.connect(this,
+                                                   &CommonProperties::onClusterChanged);
 }
 
-void CommonProperties::thermalEventDisconnect()
+void CommonProperties::renewableEventDisconnect()
 {
     if (pNotifier)
-        pNotifier->onThermalClusterChanged.remove(this);
+        pNotifier->onClusterChanged.remove(this);
 }
 
-void CommonProperties::onStudyThermalClusterRenamed(Data::ThermalCluster* cluster)
+void CommonProperties::onStudyRenewableClusterRenamed(Data::RenewableCluster* cluster)
 {
     if (cluster == pAggregate and cluster)
-        onThermalClusterChanged(cluster);
+        onClusterChanged(cluster);
     Dispatcher::GUI::Refresh(this);
 }
 
-void CommonProperties::thermalSettingsChanged()
+void CommonProperties::renewableSettingsChanged()
 {
     Dispatcher::GUI::Refresh(this);
 }
 
-} // namespace Thermal
+} // namespace Renewable
 } // namespace Window
 } // namespace Antares

--- a/src/ui/simulator/windows/renewables/cluster.h
+++ b/src/ui/simulator/windows/renewables/cluster.h
@@ -24,55 +24,58 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#ifndef __ANTARES_APPLICATION_WINDOW_THERMAL_COMMON_H__
-#define __ANTARES_APPLICATION_WINDOW_THERMAL_COMMON_H__
+#ifndef __ANTARES_APPLICATION_WINDOW_RENEWABLE_COMMON_H__
+#define __ANTARES_APPLICATION_WINDOW_RENEWABLE_COMMON_H__
 
 #include <antares/wx-wrapper.h>
-#include <ui/common/component/panel.h>
-#include "../../toolbox/components/datagrid/component.h"
-#include "../../toolbox/input/thermal-cluster.h"
-#include "../../toolbox/validator.h"
+// #include <ui/common/component/panel.h>
+// #include "../../toolbox/components/datagrid/component.h"
+#include "../../toolbox/input/renewable-cluster.h"
+// #include "../../toolbox/validator.h"
 #include "../../windows/inspector/data.h"
+
+#include "../../toolbox/input/renewable-cluster.h"
 
 namespace Antares
 {
 namespace Window
 {
-namespace Thermal
+namespace Renewable
 {
 class CommonProperties : public Component::Panel, public Yuni::IEventObserver<CommonProperties>
 {
 public:
-    CommonProperties(wxWindow* parent, Toolbox::InputSelector::ThermalCluster* notifier);
+    CommonProperties(wxWindow* parent, Toolbox::InputSelector::RenewableCluster* notifier);
     virtual ~CommonProperties();
 
 private:
-    void onThermalClusterChanged(Data::ThermalCluster* cluster);
+    void onClusterChanged(Data::RenewableCluster* cluster);
 
     void onUpdAggregateListDueToGroupChange();
 
-    void thermalEventConnect();
-    void thermalEventDisconnect();
+    void renewableEventConnect();
+    void renewableEventDisconnect();
 
-    void onStudyThermalClusterRenamed(Data::ThermalCluster* cluster);
 
-    void thermalSettingsChanged();
+    void onStudyRenewableClusterRenamed(Data::RenewableCluster* cluster);
+
+    void renewableSettingsChanged();
 
     void onStudyClosed();
 
 private:
     //! The main sizer
     wxSizer* pMainSizer;
-    Data::ThermalCluster* pAggregate;
-    Toolbox::InputSelector::ThermalCluster* pNotifier;
+    Data::RenewableCluster* pAggregate;
+    Toolbox::InputSelector::RenewableCluster* pNotifier;
     bool pGroupHasChanged;
 
     Yuni::Bind<void(const Window::Inspector::InspectorData::Ptr&)> pUpdateInfoAboutPlant;
 
 }; // class Aggregate
 
-} // namespace Thermal
+} // namespace Renewable
 } // namespace Window
 } // namespace Antares
 
-#endif // __ANTARES_APPLICATION_WINDOW_THERMAL_COMMON_H__
+#endif // __ANTARES_APPLICATION_WINDOW_RENEWABLE_COMMON_H__

--- a/src/ui/simulator/windows/renewables/panel.cpp
+++ b/src/ui/simulator/windows/renewables/panel.cpp
@@ -35,7 +35,7 @@
 // #include "../../toolbox/components/datagrid/renderer/area/timeseries.h"
 #include <wx/stattext.h>
 #include <wx/splitter.h>
-// #include "cluster.h"
+#include "cluster.h"
 
 #include <wx/sizer.h>
 #include "../../toolbox/input/renewable-cluster.h"
@@ -54,7 +54,7 @@ Panel::Panel(Component::Notebook* parent) : Component::Panel(parent)
  ,
  // pageThermalTimeSeries(nullptr),
  // pageThermalPrepro(nullptr),
- // pageThermalCommon(nullptr),
+ pageRenewableCommon(nullptr),
  pNotebookCluster(nullptr),
  pAreaForCommonData(nullptr),
  pAreaSelector(nullptr),
@@ -112,11 +112,11 @@ Panel::Panel(Component::Notebook* parent) : Component::Panel(parent)
         subbook->caption(wxT("Renewable cluster"));
         subbook->theme(Component::Notebook::themeLight);
 
-        /*
         // Common properties of the current thermal cluster
-        pageThermalCommon
-          = subbook->add(new Window::Thermal::CommonProperties(subbook, tag), wxT("Common"));
+        pageRenewableCommon
+          = subbook->add(new Window::Renewable::CommonProperties(subbook, tag), wxT("Common"));
 
+        /*
         // TS-Generator
         pageThermalPrepro = subbook->add(
           new Component::Datagrid::Component(

--- a/src/ui/simulator/windows/renewables/panel.h
+++ b/src/ui/simulator/windows/renewables/panel.h
@@ -63,7 +63,7 @@ public:
     //! The page related to the cluster's ts-generator data
     // Component::Notebook::Page* pageThermalPrepro;
     //! The page related to the cluster's properties
-    // Component::Notebook::Page* pageThermalCommon;
+    Component::Notebook::Page* pageRenewableCommon;
     //! The page related to the cluster list view
     Component::Notebook::Page* pageRenewableClusterList;
 

--- a/src/ui/simulator/windows/thermal/cluster.cpp
+++ b/src/ui/simulator/windows/thermal/cluster.cpp
@@ -90,7 +90,7 @@ void CommonProperties::onThermalClusterChanged(Data::ThermalCluster* cluster)
     if (cluster)
     {
         auto* data = new Window::Inspector::InspectorData(*Data::Study::Current::Get());
-        data->clusters.insert(cluster);
+        data->ThClusters.insert(cluster);
         pUpdateInfoAboutPlant(data);
     }
     else


### PR DESCRIPTION
- Display the renewable cluster property sub-frame
- Change some of the properties of a cluster in the property frame (by clicking first on the cluster in list of clusters frame) :
  A change of **name**, **group** or **enable** status is broadcast to the list of cluster frame.
- This sub-frame is actually a part of the inspector, so a change of cluster property in this frame or in the inspector frame must be broadcat in the other frame.
- Save : changing a cluster property (for instance **name**, **group** or **enable** status) and saving the study is updates the associated **list.ini** on disk