### PR TITLE
Fix thermal cluster segfault

### DIFF
--- a/src/libs/antares/study/parts/common/cluster_list.cpp
+++ b/src/libs/antares/study/parts/common/cluster_list.cpp
@@ -463,9 +463,6 @@ bool ClusterList<ClusterT>::remove(const Data::ClusterName& id)
     // Invalidating the parent area
     c->parentArea->invalidate();
 
-    // delete the cluster
-    delete c;
-
     // Rebuilding the index
     rebuildIndex();
     return true;

--- a/src/libs/antares/study/parts/common/cluster_list.cpp
+++ b/src/libs/antares/study/parts/common/cluster_list.cpp
@@ -222,7 +222,7 @@ void ClusterList<ClusterT>::rebuildIndex()
 }
 
 template<class ClusterT>
-typename std::shared_ptr<ClusterT> ClusterList<ClusterT>::add(ClusterT* newcluster)
+typename ClusterList<ClusterT>::SharedPtr ClusterList<ClusterT>::add(ClusterT* newcluster)
 {
     if (newcluster)
     {
@@ -230,7 +230,7 @@ typename std::shared_ptr<ClusterT> ClusterList<ClusterT>::add(ClusterT* newclust
             return cluster[newcluster->id()];
 
         newcluster->index = (uint)size();
-        cluster[newcluster->id()] = std::shared_ptr<ClusterT>(newcluster);
+        cluster[newcluster->id()] = SharedPtr(newcluster);
         ++(groupCount[newcluster->groupId()]);
         rebuildIndex();
         return cluster[newcluster->id()];
@@ -378,7 +378,7 @@ bool ClusterList<ClusterT>::rename(Data::ClusterName idToFind, Data::ClusterName
     if (it == cluster.end())
         return true;
 
-    std::shared_ptr<ClusterT> p = it->second;
+    SharedPtr p = it->second;
 
     if (idToFind == newID)
     {

--- a/src/libs/antares/study/parts/common/cluster_list.cpp
+++ b/src/libs/antares/study/parts/common/cluster_list.cpp
@@ -88,7 +88,7 @@ ClusterT* ClusterList<ClusterT>::find(const Data::ClusterName& id)
 template<class ClusterT>
 ClusterT* ClusterList<ClusterT>::detach(iterator i)
 {
-    auto c = i->second;
+    SharedPtr c = i->second;
     cluster.erase(i);
     return c.get();
 }
@@ -456,7 +456,7 @@ bool ClusterList<ClusterT>::remove(const Data::ClusterName& id)
         return false;
 
     // Getting the pointer on the cluster
-    auto c = i->second;
+    SharedPtr c = i->second;
 
     // Removing it from the list
     cluster.erase(i);
@@ -579,9 +579,9 @@ void ClusterList<ClusterT>::ensureDataTimeSeries()
     auto end = cluster.end();
     for (auto it = cluster.begin(); it != end; ++it)
     {
-        auto& cluster = *(it->second);
-        if (not cluster.series)
-            cluster.series = new DataSeriesCommon();
+        SharedPtr cluster = it->second;
+        if (not cluster->series)
+            cluster->series = new DataSeriesCommon();
     }
 }
 

--- a/src/libs/antares/study/parts/common/cluster_list.h
+++ b/src/libs/antares/study/parts/common/cluster_list.h
@@ -84,7 +84,7 @@ public:
     ** \param t The cluster to add
     ** \return True if the cluster has been added, false otherwise
     */
-    typename std::shared_ptr<ClusterT> add(ClusterT* t);
+    SharedPtr add(ClusterT* t);
 
     /*!
     ** \brief Detach a cluster represented by an iterator

--- a/src/libs/antares/study/parts/common/cluster_list.h
+++ b/src/libs/antares/study/parts/common/cluster_list.h
@@ -20,7 +20,10 @@ template<class ClusterT>
 class ClusterList
 {
 public:
-    typedef typename std::map<ClusterName, std::shared_ptr<ClusterT>> Map;
+    // Shared pointer
+    typedef typename std::shared_ptr<ClusterT> SharedPtr;
+    // Map container
+    typedef typename std::map<ClusterName, SharedPtr> Map;
     //! iterator
     typedef typename Map::iterator iterator;
     //! const iterator

--- a/src/libs/antares/study/parts/common/cluster_list.h
+++ b/src/libs/antares/study/parts/common/cluster_list.h
@@ -6,6 +6,7 @@
 #include "../../fwd.h"
 
 #include <vector>
+#include <memory>
 
 namespace Antares
 {
@@ -19,7 +20,7 @@ template<class ClusterT>
 class ClusterList
 {
 public:
-    typedef typename std::map<ClusterName, ClusterT*> Map;
+    typedef typename std::map<ClusterName, std::shared_ptr<ClusterT>> Map;
     //! iterator
     typedef typename Map::iterator iterator;
     //! const iterator
@@ -80,7 +81,7 @@ public:
     ** \param t The cluster to add
     ** \return True if the cluster has been added, false otherwise
     */
-    bool add(ClusterT* t);
+    typename std::shared_ptr<ClusterT> add(ClusterT* t);
 
     /*!
     ** \brief Detach a cluster represented by an iterator

--- a/src/libs/antares/study/parts/renewable/cluster_list.cpp
+++ b/src/libs/antares/study/parts/renewable/cluster_list.cpp
@@ -6,10 +6,6 @@ namespace Data
 {
 RenewableClusterList::~RenewableClusterList()
 {
-    for (auto& it : cluster)
-    {
-        delete it.second;
-    }
 }
 
 RenewableClusterList::RenewableClusterList()

--- a/src/libs/antares/study/parts/renewable/container.cpp
+++ b/src/libs/antares/study/parts/renewable/container.cpp
@@ -85,7 +85,7 @@ void PartRenewable::prepareAreaWideIndexes()
     uint idx = 0;
     for (auto i = list.begin(); i != end; ++i)
     {
-        RenewableCluster* t = i->second;
+        RenewableCluster* t = i->second.get();
         t->areaWideIndex = idx;
         clusters[idx] = t;
         ++idx;

--- a/src/libs/antares/study/parts/thermal/cluster_list.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_list.cpp
@@ -703,7 +703,7 @@ bool ThermalClusterList::remove(const ClusterName& id)
         return false;
 
     // Getting the pointer on the cluster
-    auto c = i->second;
+    SharedPtr c = i->second;
 
     // Removing it from the list
     cluster.erase(i);

--- a/src/libs/antares/study/parts/thermal/cluster_list.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_list.cpp
@@ -26,11 +26,6 @@ ThermalClusterList::ThermalClusterList()
 
 ThermalClusterList::~ThermalClusterList()
 {
-    for (auto& it : mapping)
-    {
-        delete it.second;
-    }
-
     // deleting all thermal clusters
     clear();
 }
@@ -358,7 +353,8 @@ bool ThermalClusterList::loadFromFolder(Study& study, const AnyString& folder, A
                 cluster->integrityCheck();
 
                 // adding the thermal cluster
-                if (not add(cluster))
+                auto added = add(cluster);
+                if (not added)
                 {
                     // This error should never happen
                     logs.error() << "Impossible to add the thermal cluster '" << cluster->name()
@@ -367,7 +363,7 @@ bool ThermalClusterList::loadFromFolder(Study& study, const AnyString& folder, A
                     continue;
                 }
                 // keeping track of the cluster
-                mapping[cluster->id()] = cluster;
+                mapping[cluster->id()] = added;
 
                 cluster->flush();
             }
@@ -707,7 +703,7 @@ bool ThermalClusterList::remove(const ClusterName& id)
         return false;
 
     // Getting the pointer on the cluster
-    auto* c = i->second;
+    auto c = i->second;
 
     // Removing it from the list
     cluster.erase(i);
@@ -722,7 +718,7 @@ bool ThermalClusterList::remove(const ClusterName& id)
         {
             auto* link = *j;
             link->parentArea->invalidate();
-            link->coupling.erase(c);
+            link->coupling.erase(c.get());
         }
     }
 

--- a/src/libs/antares/study/parts/thermal/cluster_list.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_list.cpp
@@ -26,6 +26,11 @@ ThermalClusterList::ThermalClusterList()
 
 ThermalClusterList::~ThermalClusterList()
 {
+    for (auto& it : mapping)
+    {
+        delete it.second;
+    }
+
     // deleting all thermal clusters
     clear();
 }

--- a/src/libs/antares/study/parts/thermal/cluster_list.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_list.cpp
@@ -721,9 +721,6 @@ bool ThermalClusterList::remove(const ClusterName& id)
         }
     }
 
-    // delete the cluster
-    delete c;
-
     // Rebuilding the index
     rebuildIndex();
     return true;

--- a/src/libs/antares/study/parts/thermal/container.cpp
+++ b/src/libs/antares/study/parts/thermal/container.cpp
@@ -93,7 +93,7 @@ void PartThermal::prepareAreaWideIndexes()
     uint idx = 0;
     for (auto i = list.begin(); i != end; ++i)
     {
-        ThermalCluster* t = i->second;
+        ThermalCluster* t = i->second.get();
         t->areaWideIndex = idx;
         clusters[idx] = t;
         ++idx;

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -98,7 +98,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             auto end = area.renewable.list.cluster.end();
             for (auto it = area.renewable.list.cluster.begin(); it != end; ++it)
             {
-                auto cluster = it->second;
+                RenewableClusterList::SharedPtr cluster = it->second;
                 if (!cluster->enabled)
                 {
                     continue;
@@ -120,7 +120,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             auto end = area.thermal.list.mapping.end();
             for (auto it = area.thermal.list.mapping.begin(); it != end; ++it)
             {
-                auto cluster = it->second;
+                ThermalClusterList::SharedPtr cluster = it->second;
                 // Draw a new random number, whatever the cluster is
                 double rnd = thermalNoisesByArea[i][indexCluster];
 

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -98,7 +98,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             auto end = area.renewable.list.cluster.end();
             for (auto it = area.renewable.list.cluster.begin(); it != end; ++it)
             {
-                auto* cluster = it->second;
+                auto cluster = it->second;
                 if (!cluster->enabled)
                 {
                     continue;
@@ -120,7 +120,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             auto end = area.thermal.list.mapping.end();
             for (auto it = area.thermal.list.mapping.begin(); it != end; ++it)
             {
-                auto* cluster = it->second;
+                auto cluster = it->second;
                 // Draw a new random number, whatever the cluster is
                 double rnd = thermalNoisesByArea[i][indexCluster];
 

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -348,7 +348,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
                 auto end = area.thermal.list.mapping.end();
                 for (auto i = area.thermal.list.mapping.begin(); i != end; ++i)
                 {
-                    auto* cluster = i->second;
+                    auto cluster = i->second;
                     if (!cluster->enabled)
                     {
                         study.runtime->random[Data::seedTimeseriesNumbers].next();
@@ -367,7 +367,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
                 auto end = area.renewable.list.cluster.end();
                 for (auto i = area.renewable.list.cluster.begin(); i != end; ++i)
                 {
-                    auto* cluster = i->second;
+                    auto cluster = i->second;
                     if (!cluster->enabled)
                     {
                         study.runtime->random[Data::seedTimeseriesNumbers].next();

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -348,7 +348,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
                 auto end = area.thermal.list.mapping.end();
                 for (auto i = area.thermal.list.mapping.begin(); i != end; ++i)
                 {
-                    auto cluster = i->second;
+                    Data::ThermalClusterList::SharedPtr cluster = i->second;
                     if (!cluster->enabled)
                     {
                         study.runtime->random[Data::seedTimeseriesNumbers].next();
@@ -367,7 +367,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
                 auto end = area.renewable.list.cluster.end();
                 for (auto i = area.renewable.list.cluster.begin(); i != end; ++i)
                 {
-                    auto cluster = i->second;
+                    Data::RenewableClusterList::SharedPtr cluster = i->second;
                     if (!cluster->enabled)
                     {
                         study.runtime->random[Data::seedTimeseriesNumbers].next();

--- a/src/tests/end-to-end/simple-study.cpp
+++ b/src/tests/end-to-end/simple-study.cpp
@@ -128,7 +128,11 @@ ThermalCluster* addCluster(Study::Ptr pStudy, Area* pArea, const std::string& cl
 	
 	pCluster->nominalCapacityWithSpinning = pCluster->nominalCapacity;
 
-	BOOST_CHECK(pArea->add(pCluster));
+    auto added = pArea->thermal.list.add(pCluster);
+
+	BOOST_CHECK(added != nullptr);
+
+    pArea->thermal.list.mapping[pCluster->id()] = added;
 
 	return pCluster;
 }

--- a/src/tests/end-to-end/simple-study.cpp
+++ b/src/tests/end-to-end/simple-study.cpp
@@ -128,9 +128,7 @@ ThermalCluster* addCluster(Study::Ptr pStudy, Area* pArea, const std::string& cl
 	
 	pCluster->nominalCapacityWithSpinning = pCluster->nominalCapacity;
 
-	BOOST_CHECK(pArea->thermal.list.add(pCluster));
-
-	pArea->thermal.list.mapping[pCluster->id()] = pCluster;
+	BOOST_CHECK(pArea->add(pCluster));
 
 	return pCluster;
 }

--- a/src/ui/simulator/toolbox/components/htmllistbox/datasource/thermal-cluster.cpp
+++ b/src/ui/simulator/toolbox/components/htmllistbox/datasource/thermal-cluster.cpp
@@ -75,7 +75,7 @@ void GetThermalClusterMap(Data::Area* area, ThermalClusterMap& l, const wxString
     const Data::ThermalClusterList::iterator end = area->thermal.list.end();
     for (Data::ThermalClusterList::iterator i = area->thermal.list.begin(); i != end; ++i)
     {
-        Data::ThermalCluster* cluster = i->second;
+        Data::ThermalCluster* cluster = i->second.get();
 
         if (search.empty())
         {

--- a/src/ui/simulator/toolbox/components/map/manager.cpp
+++ b/src/ui/simulator/toolbox/components/map/manager.cpp
@@ -768,7 +768,7 @@ void Manager::selectFromBoundingBox(const wxPoint& a, const wxPoint& b, const si
                             for (Data::ThermalClusterList::iterator t = area->thermal.list.begin();
                                  t != tend;
                                  ++t)
-                                clusterlist.push_back(t->second);
+                                clusterlist.push_back(t->second.get());
                         }
                         continue;
                     }

--- a/src/ui/simulator/toolbox/input/thermal-cluster.cpp
+++ b/src/ui/simulator/toolbox/input/thermal-cluster.cpp
@@ -447,8 +447,8 @@ void ThermalCluster::internalAddPlant(void*)
         logs.info() << "adding new thermal cluster " << pArea->id << '.' << sFl;
         cluster->setName(sFl);
         cluster->reset();
-        pArea->thermal.list.add(cluster);
-        pArea->thermal.list.mapping[cluster->id()] = cluster;
+        auto added = pArea->thermal.list.add(cluster);
+        pArea->thermal.list.mapping[cluster->id()] = added;
         pArea->thermal.list.rebuildIndex();
         pArea->thermal.prepareAreaWideIndexes();
 
@@ -527,8 +527,8 @@ void ThermalCluster::internalClonePlant(void*)
         // Reset to default values
         cluster->copyFrom(selectedPlant);
 
-        pArea->thermal.list.add(cluster);
-        pArea->thermal.list.mapping[cluster->id()] = cluster;
+        auto added = pArea->thermal.list.add(cluster);
+        pArea->thermal.list.mapping[cluster->id()] = added;
         pArea->thermal.list.rebuildIndex();
         pArea->thermal.prepareAreaWideIndexes();
 

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -177,7 +177,7 @@ void Frame::onSelectAllPlants(wxCommandEvent&)
             Data::Area& area = *(*i);
             auto end = area.thermal.list.end();
             for (auto i = area.thermal.list.begin(); i != end; ++i)
-                data->clusters.insert(i->second);
+                data->clusters.insert(i->second.get());
         }
         data->areas.clear();
         data->links.clear();
@@ -211,7 +211,7 @@ void Frame::onSelectAllPlantsFromArea(wxCommandEvent& evt)
         data->clusters.clear();
         auto end = area->thermal.list.end();
         for (auto i = area->thermal.list.begin(); i != end; ++i)
-            data->clusters.insert(i->second);
+            data->clusters.insert(i->second.get());
         data->areas.clear();
         data->links.clear();
         data->empty = data->clusters.empty();


### PR DESCRIPTION
Cluster object shouldn't be `operator delete`d when removing disabled
clusters.

They're still used in the `area.thermal.list.mapping` object.

For what it's worth, this is the valgrind trace that lead me to this
conclusion :

```
[Fri Jun 11 20:02:38 2021][solver][infos] Preparing time-series numbers...
==489011== Invalid read of size 1
==489011==    at 0xFDAA39: Antares::Solver::TimeSeriesNumbers::Generate(Antares::Data::Study&)::{lambda(Antares::Data::Area&)#1}::operator()(Antares::Data::Area&) const (timeseries-numbers.cpp:353)
==489011==    by 0xFDCE67: void Antares::Data::AreaList::each<Antares::Solver::TimeSeriesNumbers::Generate(Antares::Data::Study&)::{lambda(Antares::Data::Area&)#1}>(Antares::Solver::TimeSeriesNumbers::Generate(Antares::Data::Study&)::{lambda(Antares::Data::Area&)#1} const&) (area.hxx:131)
==489011==    by 0xFDB316: Antares::Solver::TimeSeriesNumbers::Generate(Antares::Data::Study&) (timeseries-numbers.cpp:329)
==489011==    by 0xD7B08C: Antares::Solver::Simulation::ISimulation<Antares::Solver::Simulation::Economy>::run() (solver.hxx:361)
==489011==    by 0xD79BAC: void SolverApplication::runSimulation<Antares::Solver::Simulation::ISimulation<Antares::Solver::Simulation::Economy> >() (main.hxx:37)
==489011==    by 0xD75C8F: SolverApplication::runSimulationInEconomicMode() (economy.cpp:40)
==489011==    by 0xD5E9AA: SolverApplication::execute() (main.cpp:339)
==489011==    by 0xD5FA09: main (main.cpp:592)
==489011==  Address 0x6011d4c is 12 bytes inside a block of size 768 free'd
==489011==    at 0x483CFBF: operator delete(void*) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==489011==    by 0x1114853: Antares::Data::ThermalClusterList::remove(Yuni::CString<128u, false> const&) (cluster_list.cpp:725)
==489011==    by 0x110A79B: Antares::Data::PartThermal::removeDisabledClusters() (container.cpp:169)
==489011==    by 0x103BCF1: Antares::Data::StudyRuntimeInfos::removeDisabledThermalClustersFromSolverComputations(Antares::Data::Study&)::{lambda(Antares::Data::Area&)#1}::operator()(Antares::Data::Area&) const (runtime.cpp:635)
==489011==    by 0x103D2C8: std::_Function_handler<unsigned int (Antares::Data::Area&), Antares::Data::StudyRuntimeInfos::removeDisabledThermalClustersFromSolverComputations(Antares::Data::Study&)::{lambda(Antares::Data::Area&)#1}>::_M_invoke(std::_Any_data const&, Antares::Data::Area&) (std_function.h:285)
==489011==    by 0x103DB86: std::function<unsigned int (Antares::Data::Area&)>::operator()(Antares::Data::Area&) const (std_function.h:688)
==489011==    by 0x103BB76: Antares::Data::removeDisabledClusters(Antares::Data::Study&, char const*, std::function<unsigned int (Antares::Data::Area&)>) (runtime.cpp:618)
==489011==    by 0x103BD3A: Antares::Data::StudyRuntimeInfos::removeDisabledThermalClustersFromSolverComputations(Antares::Data::Study&) (runtime.cpp:634)
==489011==    by 0x103B33F: Antares::Data::StudyRuntimeInfos::loadFromStudy(Antares::Data::Study&) (runtime.cpp:493)
==489011==    by 0x1045088: Antares::Data::Study::initializeRuntimeInfos() (study.cpp:677)
==489011==    by 0xD5F498: SolverApplication::readDataForTheStudy(Antares::Data::StudyLoadOptions&) (main.cpp:502)
==489011==    by 0xD5D966: SolverApplication::prepare(int, char**) (main.cpp:143)
==489011==  Block was alloc'd at
==489011==    at 0x483BE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==489011==    by 0x1111883: Antares::Data::ThermalClusterList::loadFromFolder(Antares::Data::Study&, Yuni::CString<0u, true> const&, Antares::Data::Area*) (cluster_list.cpp:99)
==489011==    by 0x109AC5E: Antares::Data::AreaList::loadFromFolder(Antares::Data::StudyLoadOptions const&) (list.cpp:1237)
==489011==    by 0x105DCB8: Antares::Data::Study::internalLoadFromFolder(Yuni::CString<128u, true> const&, Antares::Data::StudyLoadOptions const&) (load.cpp:177)
==489011==    by 0x105D640: Antares::Data::Study::loadFromFolder(Yuni::CString<0u, true> const&, Antares::Data::StudyLoadOptions const&) (load.cpp:65)
==489011==    by 0xD5EF30: SolverApplication::readDataForTheStudy(Antares::Data::StudyLoadOptions&) (main.cpp:415)
==489011==    by 0xD5D966: SolverApplication::prepare(int, char**) (main.cpp:143)
==489011==    by 0xD5F9F9: main (main.cpp:591)
==489011==
```