### PR TITLE
Add gen. modulation interpretation for renewable TS

### DIFF
--- a/src/libs/antares/study/parts/renewable/cluster.cpp
+++ b/src/libs/antares/study/parts/renewable/cluster.cpp
@@ -242,7 +242,7 @@ bool Data::RenewableCluster::setTimeSeriesModeFromString(const YString& value)
     return false;
 }
 
-const YString& Data::RenewableCluster::getTimeSeriesModeAsString() const
+YString Data::RenewableCluster::getTimeSeriesModeAsString() const
 {
     switch (tsMode)
     {

--- a/src/libs/antares/study/parts/renewable/cluster.h
+++ b/src/libs/antares/study/parts/renewable/cluster.h
@@ -178,7 +178,7 @@ public:
 
     bool setTimeSeriesModeFromString(const YString& value);
 
-    const YString& getTimeSeriesModeAsString() const;
+    YString getTimeSeriesModeAsString() const;
 
     /* !
     ** Get production value at time-step ts


### PR DESCRIPTION
The main part is this :
```cpp
// for each renewable cluster, for each time-step...
problem.AllMustRunGeneration[j]->AllMustRunGenerationOfArea[k]
   += cluster.valueAtTimeStep(tsIndex.RenouvelableParPalier[cluster.areaWideIndex], (uint)indx);
```