### PR TITLE
Remove unnecessary output columns depending on rg modelling

### DIFF
--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -437,11 +437,14 @@ public:
         NumberOfCoresMode ncMode;
     } nbCores;
 
-    struct
+    struct RenewableGeneration
     {
         //! Renewable generation mode
         RenewableGenerationModelling rgModelling;
-    } renewableGeneration;
+        std::vector<std::string> excludedVariables() const;
+    };
+
+    RenewableGeneration renewableGeneration;
 
     struct
     {

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -163,13 +163,21 @@ bool AllVariablesPrintInfo::setPrintStatus(string varname, bool printStatus)
     return false;
 }
 
-void AllVariablesPrintInfo::prepareForSimulation(bool userSelection)
+void AllVariablesPrintInfo::prepareForSimulation(bool userSelection,
+                                                 const std::vector<std::string>& excluded_vars)
 {
     assert(!isEmpty() && "The variable print info list must not be empty at this point");
 
     // Initializing output variables status
     if (!userSelection)
         setAllPrintStatusesTo(true);
+
+    for (const auto& varname : excluded_vars)
+    {
+        const bool res = setPrintStatus(varname, false);
+        if (not res)
+            logs.warning() << "Variable " << varname << " not found. Could not remove it";
+    }
 
     // Computing the max number columns a report of any kind can contain.
     computeMaxColumnsCountInReports();

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -113,7 +113,8 @@ public:
 
     bool setPrintStatus(string varname, bool printStatus);
 
-    void prepareForSimulation(bool userSelection);
+    void prepareForSimulation(bool userSelection,
+                              const std::vector<std::string>& excluded_vars = {});
 
     // Incremental search for the variable, then get the print status.
     bool searchIncrementally_getPrintStatus(string var_name) const;

--- a/src/solver/variable/info.h
+++ b/src/solver/variable/info.h
@@ -388,7 +388,8 @@ struct VariableAccessor<ResultsT, Category::dynamicColumns>
         assert(results.data.area && "Area is NULL");
         const bool thermal_details = fileLevel & Category::de;
         const bool renewable_details = fileLevel & Category::de_res;
-        if (thermal_details && renewable_details) {
+        if (thermal_details && renewable_details)
+        {
             logs.error() << "Inconsistent fileLevel detected";
             return false;
         }
@@ -434,7 +435,6 @@ struct VariableAccessor<ResultsT, Category::dynamicColumns>
                                         int fileLevel,
                                         int precision)
     {
-
         bool res;
         if (*results.isPrinted)
         {


### PR DESCRIPTION
- When the user chooses aggregated production, disable cluster groups
  (wind onshore, etc.);
- When the user chooses cluster production, disable aggregated
  groups (wind and solar).