### PR TITLE
UI : more specific event for switch renewable

### DIFF
--- a/src/ui/simulator/application/main/main.cpp
+++ b/src/ui/simulator/application/main/main.cpp
@@ -65,6 +65,8 @@
 #include "internal-data.h"
 #include "../wait.h"
 
+#include "../../windows/options/advanced/advanced.h"
+
 using namespace Yuni;
 
 namespace Antares
@@ -533,6 +535,7 @@ void ApplWnd::evtOnUpdateGUIAfterStudyIO(bool opened)
     // Keep informed all other dependencies that something has changed
     OnStudyAreasChanged();
     OnStudySettingsChanged();
+    Window::Options::OnRenewableGenerationModellingChanged();
 
     // Make some components visible
     pAUIManager.GetPane(pBigDaddy).Show(opened);

--- a/src/ui/simulator/windows/options/advanced/advanced.cpp
+++ b/src/ui/simulator/windows/options/advanced/advanced.cpp
@@ -46,6 +46,9 @@ namespace Window
 {
 namespace Options
 {
+
+Yuni::Event<void()> OnRenewableGenerationModellingChanged;
+
 static void Title(wxWindow* parent, wxSizer* sizer, const wxChar* text, bool margintop = true)
 {
     if (margintop)
@@ -1040,7 +1043,7 @@ void AdvancedParameters::onSelectRGMaggregated(wxCommandEvent& evt)
     {
         study.parameters.renewableGeneration.rgModelling = Data::rgAggregated;
         MarkTheStudyAsModified();
-        OnStudyLoaded();
+        OnRenewableGenerationModellingChanged();
         refresh();
     }
 }
@@ -1055,7 +1058,7 @@ void AdvancedParameters::onSelectRGMrenewableClusters(wxCommandEvent& evt)
     {
         study.parameters.renewableGeneration.rgModelling = Data::rgClusters;
         MarkTheStudyAsModified();
-        OnStudyLoaded();
+        OnRenewableGenerationModellingChanged();
         refresh();
     }
 }

--- a/src/ui/simulator/windows/options/advanced/advanced.h
+++ b/src/ui/simulator/windows/options/advanced/advanced.h
@@ -39,6 +39,9 @@ namespace Window
 {
 namespace Options
 {
+
+extern Yuni::Event<void()> OnRenewableGenerationModellingChanged;
+
 /*!
 ** \brief Startup Wizard User Interface
 */

--- a/src/ui/simulator/windows/simulation/panel.cpp
+++ b/src/ui/simulator/windows/simulation/panel.cpp
@@ -33,7 +33,7 @@
 #include "../../toolbox/components/datagrid/renderer/ts-management.h"
 #include "../../toolbox/components/datagrid/renderer/ts-management-clusters-as-renewables.h"
 #include "../../application/main.h"
-#include "../../application/study.h"
+#include "../../windows/options/advanced/advanced.h"
 #include "../../toolbox/validator.h"
 #include "../../toolbox/resources.h"
 #include "../../toolbox/create.h"
@@ -97,7 +97,7 @@ Panel::Panel(wxWindow* parent) : Antares::Component::Panel(parent)
     SetSizer(hz);
 
     // External events
-    OnStudyLoaded.connect(this, &Panel::onStudyLoaded);
+    Options::OnRenewableGenerationModellingChanged.connect(this, &Panel::onRenewableGenerationModellingChanged);
     OnStudyClosed.connect(this, &Panel::onStudyClosed);
     OnStudyUpdatePlaylist.connect(this, &Panel::onUpdatePlaylist);
 }
@@ -115,7 +115,7 @@ Panel::~Panel()
         sizer->Clear(true);
 }
 
-void Panel::onStudyLoaded()
+void Panel::onRenewableGenerationModellingChanged()
 {
     auto study = Data::Study::Current::Get();
     if (!study)

--- a/src/ui/simulator/windows/simulation/panel.h
+++ b/src/ui/simulator/windows/simulation/panel.h
@@ -59,8 +59,8 @@ public:
     //@}
 
 private:
-    //! A study has been loaded
-    void onStudyLoaded();
+    //! In case renewable generation modelling was changed
+    void onRenewableGenerationModellingChanged();
     //! The study has been closed
     void onStudyClosed();
     //! A study has been loaded (delayed)


### PR DESCRIPTION
**Context** : 
When switching of renewable generation modelling parameter, an **event** is broadcasted through UI application and caught only by authorized UI components (typically time series management pane). A method of these components is then run.

**What's was wrong** : 
The event used up to now was not specific enough. It's named **onStudyLoaded** and caught by too much components in the UI.

**What is done here** : 
Defining a specific event (called **OnRenewableGenerationModellingChanged**) broadcasted when a change of RES gen modelling parameters occurs. It is now caught by out time series management pane. 