### PR TITLE
Add renewable detail to output

### DIFF
--- a/src/ui/simulator/windows/output/output.cpp
+++ b/src/ui/simulator/windows/output/output.cpp
@@ -348,31 +348,20 @@ void Component::createAllControlsIfNeeded()
                   = Resources::StaticBitmapLoadFromFile(grp, wxID_ANY, "images/16x16/default.png");
                 grp->leftSizer->Add(sbmp, 0, wxALIGN_CENTER);
 
-                btn = new Button(grp->subpanel,
-                                 wxT("General values"),
-                                 nullptr,
-                                 this,
-                                 &Component::onSelectDataLevel);
-                btn->pushed(true);
-                btn->pushedColor(grp);
-                btn->userdata(btn);
-                pBtnValues = btn;
-                hz->Add(btn, 0, wxALL | wxEXPAND);
-                btn = new Button(grp->subpanel,
-                                 wxT("Thermal plants"),
-                                 nullptr,
-                                 this,
-                                 &Component::onSelectDataLevel);
-                btn->pushedColor(grp);
-                btn->userdata(btn);
-                pBtnDetails = btn;
-                hz->Add(btn, 0, wxALL | wxEXPAND);
-                btn = new Button(
-                  grp->subpanel, wxT("Record years"), nullptr, this, &Component::onSelectDataLevel);
-                btn->pushedColor(grp);
-                btn->userdata(btn);
-                hz->Add(btn, 0, wxALL | wxEXPAND);
-                pBtnID = btn;
+                auto addButton = [&](const wxString& caption) -> Button* {
+                    btn = new Button(
+                      grp->subpanel, caption, nullptr, this, &Component::onSelectDataLevel);
+                    btn->pushedColor(grp);
+                    btn->userdata(btn);
+                    hz->Add(btn, 0, wxALL | wxEXPAND);
+                    return btn;
+                };
+
+                pBtnValues = addButton(wxT("General values"));
+                pBtnValues->pushed(true);
+
+                pBtnDetails = addButton(wxT("Thermal plants"));
+                pBtnID = addButton(wxT("Record years"));
             }
 
             hzori->AddSpacer(5);

--- a/src/ui/simulator/windows/output/output.cpp
+++ b/src/ui/simulator/windows/output/output.cpp
@@ -116,6 +116,7 @@ Component::Component(wxWindow* parent, bool parentIsStandaloneWindow) :
  pLabelItemName(nullptr),
  pBtnValues(nullptr),
  pBtnDetails(nullptr),
+ pBtnDetailsRes(nullptr),
  pBtnID(nullptr),
  pBtnHourly(nullptr),
  pBtnDaily(nullptr),
@@ -361,6 +362,7 @@ void Component::createAllControlsIfNeeded()
                 pBtnValues->pushed(true);
 
                 pBtnDetails = addButton(wxT("Thermal plants"));
+                pBtnDetailsRes = addButton(wxT("Ren. clusters"));
                 pBtnID = addButton(wxT("Record years"));
             }
 
@@ -628,6 +630,7 @@ void Component::clear()
 
     pBtnValues = nullptr;
     pBtnDetails = nullptr;
+    pBtnDetailsRes = nullptr;
     pBtnID = nullptr;
 
     pBtnHourly = nullptr;
@@ -1342,6 +1345,7 @@ void Component::copyFrom(const Component& source)
     // Data level
     pBtnValues->pushed(source.pBtnValues->pushed());
     pBtnDetails->pushed(source.pBtnDetails->pushed());
+    pBtnDetailsRes->pushed(source.pBtnDetailsRes->pushed());
     pBtnID->pushed(source.pBtnID->pushed());
     // Time level
     pBtnHourly->pushed(source.pBtnHourly->pushed());
@@ -1596,6 +1600,7 @@ void Component::onSelectDataLevel(void* userdata)
 
     pBtnValues->pushed((userdata == pBtnValues));
     pBtnDetails->pushed((userdata == pBtnDetails));
+    pBtnDetailsRes->pushed((userdata == pBtnDetailsRes));
     pBtnID->pushed((userdata == pBtnID));
     // refresh
     refreshAllPanels();

--- a/src/ui/simulator/windows/output/output.h
+++ b/src/ui/simulator/windows/output/output.h
@@ -356,6 +356,8 @@ private:
     Button* pBtnValues;
     //! Data level: details
     Button* pBtnDetails;
+    //! Data level: details-res
+    Button* pBtnDetailsRes;
     //! Data level: id
     Button* pBtnID;
 

--- a/src/ui/simulator/windows/output/panel/area-link.cpp
+++ b/src/ui/simulator/windows/output/panel/area-link.cpp
@@ -727,6 +727,8 @@ void Panel::loadDataFromFile()
         filename << "values";
     else if (pComponent->pBtnDetails->pushed())
         filename << "details";
+    else if (pComponent->pBtnDetailsRes->pushed())
+        filename << "details-res";
     else if (pComponent->pBtnID->pushed())
         filename << "id";
 


### PR DESCRIPTION
Add a "Ren. clusters" button to the output panel. It allows to display the production for each cluster.

- Individual production for mc-ind
- Average production for mc-all

![image](https://user-images.githubusercontent.com/26088210/125967218-5ae9a533-0b84-4b3a-9728-cd344e314462.png)
