### PR TITLE
UI : hide or show tabs depending on renewable modeling parameter value

### DIFF
--- a/src/ui/simulator/application/main/create.cpp
+++ b/src/ui/simulator/application/main/create.cpp
@@ -36,11 +36,11 @@
 #include <wx/richtext/richtexthtml.h>
 
 #include <antares/logs.h>
-#include "../../toolbox/resources.h"
-#include "../../toolbox/locales.h"
+#include "toolbox/resources.h"
+#include "toolbox/locales.h"
 #include "internal-data.h"
-#include "../../windows/version.h"
-#include "../../config.h"
+#include "windows/version.h"
+#include "config.h"
 #include "drag-drop.hxx"
 
 // Antares study
@@ -48,47 +48,48 @@
 #include <antares/sys/appdata.h>
 
 // Create toolbox
-#include "../../toolbox/create.h"
+#include "toolbox/create.h"
 // Panel
 #include <ui/common/component/panel.h>
 // Map
-#include "../../toolbox/components/map/component.h"
+#include "toolbox/components/map/component.h"
 // WIP Panel
-#include "../../toolbox/components/wip-panel.h"
+#include "toolbox/components/wip-panel.h"
 // Datagrid
-#include "../../toolbox/components/datagrid/component.h"
-#include "../../toolbox/components/datagrid/gridhelper.h"
-#include "../../toolbox/components/datagrid/renderer/connection.h"
-#include "../../toolbox/components/datagrid/renderer/area/dsm.h"
-#include "../../toolbox/components/datagrid/renderer/area/misc.h"
-#include "../../toolbox/components/datagrid/renderer/area/timeseries.h"
-#include "../../toolbox/components/datagrid/renderer/links/summary.h"
-#include "../../toolbox/components/datagrid/renderer/layers.h"
-#include "../../toolbox/input/area.h"
-#include "../../toolbox/input/connection.h"
-#include "../../toolbox/input/bindingconstraint.h"
+#include "toolbox/components/datagrid/component.h"
+#include "toolbox/components/datagrid/gridhelper.h"
+#include "toolbox/components/datagrid/renderer/connection.h"
+#include "toolbox/components/datagrid/renderer/area/dsm.h"
+#include "toolbox/components/datagrid/renderer/area/misc.h"
+#include "toolbox/components/datagrid/renderer/area/timeseries.h"
+#include "toolbox/components/datagrid/renderer/links/summary.h"
+#include "toolbox/components/datagrid/renderer/layers.h"
+#include "toolbox/input/area.h"
+#include "toolbox/input/connection.h"
+#include "toolbox/input/bindingconstraint.h"
 // MainPanel
-#include "../../toolbox/components/mainpanel.h"
+#include "toolbox/components/mainpanel.h"
 
 // Windows
-#include "../../windows/connection.h"
-#include "../../windows/simulation/panel.h"
-#include "../../windows/thermal/panel.h"
-#include "../../windows/renewables/panel.h"
-#include "../../windows/correlation/correlation.h"
-#include "../../windows/bindingconstraint/bindingconstraint.h"
-#include "../../windows/analyzer/analyzer.h"
-#include "../../windows/inspector/inspector.h"
+#include "windows/connection.h"
+#include "windows/simulation/panel.h"
+#include "windows/thermal/panel.h"
+#include "windows/renewables/panel.h"
+#include "windows/correlation/correlation.h"
+#include "windows/bindingconstraint/bindingconstraint.h"
+#include "windows/analyzer/analyzer.h"
+#include "windows/inspector/inspector.h"
+#include "windows/options/advanced/advanced.h"
 
 // Standard page
 #include "build/standard-page.hxx"
 // Wait
 #include "../wait.h"
 // startup wizard
-#include "../../windows/startupwizard.h"
-#include "../../toolbox/dispatcher/study.h"
+#include "windows/startupwizard.h"
+#include "toolbox/dispatcher/study.h"
 // license
-#include "../../windows/message.h"
+#include "windows/message.h"
 
 using namespace Yuni;
 
@@ -459,6 +460,8 @@ void ApplWnd::internalInitialize()
     OnStudyEndUpdate.connect(&MemoryFlushEndUpdate);
     // System parameter
     OnStudySettingsChanged.connect(this, &ApplWnd::onSystemParametersChanged);
+    // Advanced parameters
+    Window::Options::OnRenewableGenerationModellingChanged.connect(this, &ApplWnd::onRenewableGenerationModellingChanged);
 
     // Update the status bar
     resetDefaultStatusBarText();

--- a/src/ui/simulator/application/main/main.cpp
+++ b/src/ui/simulator/application/main/main.cpp
@@ -781,15 +781,27 @@ void ApplWnd::onRenewableGenerationModellingChanged()
 
     if (study->parameters.renewableGeneration.rgModelling == Antares::Data::rgAggregated)
     {
+        // Main window
         pNotebook->show_page(wxString("wind"));
         pNotebook->show_page(wxString("solar"));
         pNotebook->hide_page(wxString("renewable"));
+
+        // Scenario builder pane
+        pScenarioBuilderNotebook->show_page(wxString("wind"));
+        pScenarioBuilderNotebook->show_page(wxString("solar"));
+        pScenarioBuilderNotebook->hide_page(wxString("renewable"));
     }
     else
     {
+        // Main window
         pNotebook->hide_page(wxString("wind"));
         pNotebook->hide_page(wxString("solar"));
         pNotebook->show_page(wxString("renewable"));
+
+        // Scenario builder pane
+        pScenarioBuilderNotebook->hide_page(wxString("wind"));
+        pScenarioBuilderNotebook->hide_page(wxString("solar"));
+        pScenarioBuilderNotebook->show_page(wxString("renewable"));
     }
 }
 

--- a/src/ui/simulator/application/main/main.cpp
+++ b/src/ui/simulator/application/main/main.cpp
@@ -773,6 +773,26 @@ void ApplWnd::onSystemParametersChanged()
     // Do nothing
 }
 
+void ApplWnd::onRenewableGenerationModellingChanged()
+{
+    auto study = Data::Study::Current::Get();
+    if (!study)
+        return;
+
+    if (study->parameters.renewableGeneration.rgModelling == Antares::Data::rgAggregated)
+    {
+        pNotebook->show_page(wxString("wind"));
+        pNotebook->show_page(wxString("solar"));
+        pNotebook->hide_page(wxString("renewable"));
+    }
+    else
+    {
+        pNotebook->hide_page(wxString("wind"));
+        pNotebook->hide_page(wxString("solar"));
+        pNotebook->show_page(wxString("renewable"));
+    }
+}
+
 void ApplWnd::gridOperatorSelectedCells(Component::Datagrid::Selection::IOperator* v)
 {
     delete pGridSelectionOperator;

--- a/src/ui/simulator/application/main/main.cpp
+++ b/src/ui/simulator/application/main/main.cpp
@@ -535,7 +535,7 @@ void ApplWnd::evtOnUpdateGUIAfterStudyIO(bool opened)
     // Keep informed all other dependencies that something has changed
     OnStudyAreasChanged();
     OnStudySettingsChanged();
-    Window::Options::OnRenewableGenerationModellingChanged();
+    Window::Options::OnRenewableGenerationModellingChanged(true);
 
     // Make some components visible
     pAUIManager.GetPane(pBigDaddy).Show(opened);
@@ -773,7 +773,7 @@ void ApplWnd::onSystemParametersChanged()
     // Do nothing
 }
 
-void ApplWnd::onRenewableGenerationModellingChanged()
+void ApplWnd::onRenewableGenerationModellingChanged(bool init)
 {
     auto study = Data::Study::Current::Get();
     if (!study)
@@ -793,6 +793,15 @@ void ApplWnd::onRenewableGenerationModellingChanged()
 
     // Scenario builder pane
     pScenarioBuilderNotebook->set_page_visibility(wxString("renewable"), not aggregated);
+    if (!init)
+    {
+      if (aggregated)
+        pNotebook->select(wxT("wind"));
+      else
+        pNotebook->select(wxT("renewable"));
+
+      pNotebook->forceRefresh();
+    }
 }
 
 void ApplWnd::gridOperatorSelectedCells(Component::Datagrid::Selection::IOperator* v)

--- a/src/ui/simulator/application/main/main.cpp
+++ b/src/ui/simulator/application/main/main.cpp
@@ -779,30 +779,20 @@ void ApplWnd::onRenewableGenerationModellingChanged()
     if (!study)
         return;
 
-    if (study->parameters.renewableGeneration.rgModelling == Antares::Data::rgAggregated)
-    {
-        // Main window
-        pNotebook->show_page(wxString("wind"));
-        pNotebook->show_page(wxString("solar"));
-        pNotebook->hide_page(wxString("renewable"));
+    const bool aggregated = study->parameters.renewableGeneration.rgModelling == Antares::Data::rgAggregated;
 
-        // Scenario builder pane
-        pScenarioBuilderNotebook->show_page(wxString("wind"));
-        pScenarioBuilderNotebook->show_page(wxString("solar"));
-        pScenarioBuilderNotebook->hide_page(wxString("renewable"));
+    for (auto s : {"wind", "solar"}) {
+      // Main window
+      pNotebook->set_page_visibility(wxString(s), aggregated);
+      // Scenario builder pane
+      pScenarioBuilderNotebook->set_page_visibility(wxString(s), aggregated);
     }
-    else
-    {
-        // Main window
-        pNotebook->hide_page(wxString("wind"));
-        pNotebook->hide_page(wxString("solar"));
-        pNotebook->show_page(wxString("renewable"));
 
-        // Scenario builder pane
-        pScenarioBuilderNotebook->hide_page(wxString("wind"));
-        pScenarioBuilderNotebook->hide_page(wxString("solar"));
-        pScenarioBuilderNotebook->show_page(wxString("renewable"));
-    }
+    // Main window
+    pNotebook->set_page_visibility(wxString("renewable"), not aggregated);
+
+    // Scenario builder pane
+    pScenarioBuilderNotebook->set_page_visibility(wxString("renewable"), not aggregated);
 }
 
 void ApplWnd::gridOperatorSelectedCells(Component::Datagrid::Selection::IOperator* v)

--- a/src/ui/simulator/application/main/main.h
+++ b/src/ui/simulator/application/main/main.h
@@ -619,6 +619,9 @@ private:
     //!! The system parameters have changed, some pages have to be hidden
     void onSystemParametersChanged();
 
+    // Renewable generation modelling changed, some pages have to be hidden
+    void onRenewableGenerationModellingChanged();
+
     //! Update the Interface after loaded a study
     void evtOnUpdateInterfaceAfterLoadedStudy(wxCommandEvent& evt);
 

--- a/src/ui/simulator/application/main/main.h
+++ b/src/ui/simulator/application/main/main.h
@@ -620,7 +620,7 @@ private:
     void onSystemParametersChanged();
 
     // Renewable generation modelling changed, some pages have to be hidden
-    void onRenewableGenerationModellingChanged();
+    void onRenewableGenerationModellingChanged(bool init);
 
     //! Update the Interface after loaded a study
     void evtOnUpdateInterfaceAfterLoadedStudy(wxCommandEvent& evt);

--- a/src/ui/simulator/toolbox/components/notebook/notebook.cpp
+++ b/src/ui/simulator/toolbox/components/notebook/notebook.cpp
@@ -1023,16 +1023,12 @@ Notebook::Page* Notebook::find(const wxString& name, bool warn)
     return nullptr;
 }
 
-void Notebook::hide_page(const wxString& name)
+void Notebook::set_page_visibility(const wxString& name, bool visibility)
 {
     Page* page = find(name);
-    page->visible(false);
-}
-
-void Notebook::show_page(const wxString& name)
-{
-    Page* page = find(name);
-    page->visible(true);
+    if (page == nullptr)
+        return;
+    page->visible(visibility);
 }
 
 void Notebook::caption(const wxString& s)

--- a/src/ui/simulator/toolbox/components/notebook/notebook.cpp
+++ b/src/ui/simulator/toolbox/components/notebook/notebook.cpp
@@ -1023,6 +1023,18 @@ Notebook::Page* Notebook::find(const wxString& name, bool warn)
     return nullptr;
 }
 
+void Notebook::hide_page(const wxString& name)
+{
+    Page* page = find(name);
+    page->visible(false);
+}
+
+void Notebook::show_page(const wxString& name)
+{
+    Page* page = find(name);
+    page->visible(true);
+}
+
 void Notebook::caption(const wxString& s)
 {
     pCaption = s;

--- a/src/ui/simulator/toolbox/components/notebook/notebook.h
+++ b/src/ui/simulator/toolbox/components/notebook/notebook.h
@@ -278,6 +278,9 @@ public:
     */
     Page* find(const wxString& name, bool warn = true);
 
+    void hide_page(const wxString& name);
+    void show_page(const wxString& name);
+
     //! \name Theme
     //@{
     /*!

--- a/src/ui/simulator/toolbox/components/notebook/notebook.h
+++ b/src/ui/simulator/toolbox/components/notebook/notebook.h
@@ -278,8 +278,7 @@ public:
     */
     Page* find(const wxString& name, bool warn = true);
 
-    void hide_page(const wxString& name);
-    void show_page(const wxString& name);
+    void set_page_visibility(const wxString& name, bool visible);
 
     //! \name Theme
     //@{

--- a/src/ui/simulator/windows/options/advanced/advanced.cpp
+++ b/src/ui/simulator/windows/options/advanced/advanced.cpp
@@ -47,7 +47,7 @@ namespace Window
 namespace Options
 {
 
-Yuni::Event<void()> OnRenewableGenerationModellingChanged;
+Yuni::Event<void(bool)> OnRenewableGenerationModellingChanged;
 
 static void Title(wxWindow* parent, wxSizer* sizer, const wxChar* text, bool margintop = true)
 {
@@ -1043,7 +1043,7 @@ void AdvancedParameters::onSelectRGMaggregated(wxCommandEvent& evt)
     {
         study.parameters.renewableGeneration.rgModelling = Data::rgAggregated;
         MarkTheStudyAsModified();
-        OnRenewableGenerationModellingChanged();
+        OnRenewableGenerationModellingChanged(false);
         refresh();
     }
 }
@@ -1058,7 +1058,7 @@ void AdvancedParameters::onSelectRGMrenewableClusters(wxCommandEvent& evt)
     {
         study.parameters.renewableGeneration.rgModelling = Data::rgClusters;
         MarkTheStudyAsModified();
-        OnRenewableGenerationModellingChanged();
+        OnRenewableGenerationModellingChanged(false);
         refresh();
     }
 }

--- a/src/ui/simulator/windows/options/advanced/advanced.h
+++ b/src/ui/simulator/windows/options/advanced/advanced.h
@@ -40,7 +40,7 @@ namespace Window
 namespace Options
 {
 
-extern Yuni::Event<void()> OnRenewableGenerationModellingChanged;
+extern Yuni::Event<void(bool)> OnRenewableGenerationModellingChanged;
 
 /*!
 ** \brief Startup Wizard User Interface

--- a/src/ui/simulator/windows/simulation/panel.cpp
+++ b/src/ui/simulator/windows/simulation/panel.cpp
@@ -115,7 +115,7 @@ Panel::~Panel()
         sizer->Clear(true);
 }
 
-void Panel::onRenewableGenerationModellingChanged()
+void Panel::onRenewableGenerationModellingChanged(bool)
 {
     auto study = Data::Study::Current::Get();
     if (!study)

--- a/src/ui/simulator/windows/simulation/panel.h
+++ b/src/ui/simulator/windows/simulation/panel.h
@@ -60,7 +60,7 @@ public:
 
 private:
     //! In case renewable generation modelling was changed
-    void onRenewableGenerationModellingChanged();
+    void onRenewableGenerationModellingChanged(bool);
     //! The study has been closed
     void onStudyClosed();
     //! A study has been loaded (delayed)


### PR DESCRIPTION
- On the left part of main window, Wind and Solar tabs must be hidden if we use renewable clusters.
Conversely, Renewable tab must be hidden if we use Wind and Solar as renewables.
- Same thing regarding the sceanrio builder pane