### PR TITLE
Fix/run vcpkg

### DIFF
--- a/.github/workflows/linux-system.yml
+++ b/.github/workflows/linux-system.yml
@@ -20,7 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+    
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
+      
     - name: Install libraries
       run: |
            sudo apt-get update
@@ -49,7 +52,7 @@ jobs:
 
     - name: Configure
       run: |
-           cmake -B _build -S src -DDEPS_INSTALL_DIR=./rte-antares-deps-Release -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DBUILD_OUTPUT_TEST=ON
+           cmake -B _build -S src -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DDEPS_INSTALL_DIR=./rte-antares-deps-Release -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DBUILD_OUTPUT_TEST=ON
            
     - name: Build
       run: |

--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-            vcpkgPackages: wxwidgets boost-test boost-process boost-filesystem boost-dll boost-regex
+            vcpkgPackages: wxwidgets boost-test
     env:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg

--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -63,9 +63,7 @@ jobs:
           cd vcpkg
           ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
-          rm -rf buildtrees
-          rm -rf packages
-          rm -rf downloads
+          rm -rf buildtrees packages downloads
       shell: bash
             
     - name: Download pre-compiled librairies

--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -63,6 +63,9 @@ jobs:
           cd vcpkg
           ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
+          rm -rf buildtrees
+          rm -rf packages
+          rm -rf downloads
       shell: bash
             
     - name: Download pre-compiled librairies

--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -29,13 +29,6 @@ jobs:
     - name: Get release
       id: get_release
       uses: bruceadams/get-release@v1.2.0
-            
-    - name: Download pre-compiled librairies
-      run: |
-           choco install wget
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
-           Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip -DestinationPath .
-           rm rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
            
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -75,6 +68,13 @@ jobs:
           ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
       shell: bash
+            
+    - name: Download pre-compiled librairies
+      run: |
+           choco install wget
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
+           Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip -DestinationPath .
+           rm rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
       
     - name: Configure with VCPKG
       run: |

--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -56,14 +56,10 @@ jobs:
       run: |
           python -m pip install --upgrade pip
           pip3 install -r src/tests/examples/requirements.txt
-           
-    - name: Init submodule
-      run: |
-           git submodule update --init --recursive src
-           git submodule update --init vcpkg
-           
+          
     - name : Install deps with VCPKG
       run: |
+          git submodule update --init vcpkg
           cd vcpkg
           ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
@@ -75,6 +71,10 @@ jobs:
            wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
            Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip -DestinationPath .
            rm rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
+           
+    - name: Init submodule
+      run: |
+           git submodule update --init --recursive src
       
     - name: Configure with VCPKG
       run: |

--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -15,39 +15,49 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        architecture: [x64]
         include:
           - os: windows-latest
-            vcpkgCommitId: 'ee17a685087a6886e5681e355d36cd784f0dd2c8'
-            vcpkgPackages: openssl curl wxwidgets boost-test
-
+            triplet: x64-windows
+            vcpkgPackages: wxwidgets boost-test boost-process boost-filesystem boost-dll boost-regex
+    env:
+      # Indicates the location of the vcpkg as a Git submodule of the project repository.
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      
     steps:
     - uses: actions/checkout@v2 
     
     - name: Get release
       id: get_release
       uses: bruceadams/get-release@v1.2.0
-    
-    - name : Install deps with VCPKG
-      uses: lukka/run-vcpkg@v4
-      id: runvcpkg
-      with:
-        vcpkgArguments: '${{ matrix.vcpkgPackages }}'
-        vcpkgTriplet: '${{ matrix.architecture }}-windows'
-        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: '${{ matrix.vcpkgCommitId }}'
-        
+            
     - name: Download pre-compiled librairies
       run: |
            choco install wget
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-${{matrix.architecture}}-Release-solver.zip
-           Expand-Archive ./rte-antares-deps-${{matrix.os}}-${{matrix.architecture}}-Release-solver.zip -DestinationPath .
-           rm rte-antares-deps-${{matrix.os}}-${{matrix.architecture}}-Release-solver.zip
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
+           Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip -DestinationPath .
+           rm rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
            
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
+        
+    # Restore both vcpkg and its artifacts from the GitHub cache service.
+    - name: Restore vcpkg and its artifacts.
+      uses: actions/cache@v2
+      with:
+        # The first path is the location of vcpkg (it contains the vcpkg executable and data files).
+        # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
+        path: |
+          ${{ env.VCPKG_ROOT }}
+          !${{ env.VCPKG_ROOT }}/buildtrees
+          !${{ env.VCPKG_ROOT }}/packages
+          !${{ env.VCPKG_ROOT }}/downloads
+        # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg's Git commit id changes, or the list of packages changes. In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
+        # The key includes: hash of the vcpkg.json file, the hash of the vcpkg Git commit id, and the used vcpkg's triplet. The vcpkg's commit id would suffice, but computing an hash out it does not harm.
+        # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
+        key: |
+          ${{ hashFiles( 'vcpkg_manifest/vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
           
     - name: Install dependencies
       run: |
@@ -57,10 +67,18 @@ jobs:
     - name: Init submodule
       run: |
            git submodule update --init --recursive src
-        
+           git submodule update --init vcpkg
+           
+    - name : Install deps with VCPKG
+      run: |
+          ./bootstrap-vcpkg.sh
+          cd vcpkg
+          vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
+      shell: bash
+      
     - name: Configure with VCPKG
       run: |
-           cmake -B _build -S src -DDEPS_INSTALL_DIR=rte-antares-deps-Release -DVCPKG_ROOT=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }} -DVCPKG_TARGET_TRIPLET=${{ matrix.architecture }}-windows -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DBUILD_OUTPUT_TEST=ON
+           cmake -B _build -S src -DDEPS_INSTALL_DIR=rte-antares-deps-Release -DVCPKG_ROOT=${{env.VCPKG_ROOT}} -DVCPKG_TARGET_TRIPLET=${{matrix.triplet}} -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DBUILD_OUTPUT_TEST=ON
            
     - name: Build
       run: |

--- a/.github/workflows/releasesWindows.yml
+++ b/.github/workflows/releasesWindows.yml
@@ -71,8 +71,8 @@ jobs:
            
     - name : Install deps with VCPKG
       run: |
-          ./bootstrap-vcpkg.sh
           cd vcpkg
+          ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
       shell: bash
       

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -62,9 +62,7 @@ jobs:
           cd vcpkg
           ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
-          rm -rf buildtrees
-          rm -rf packages
-          rm -rf downloads
+          rm -rf buildtrees packages downloads
       shell: bash
         
     - name: Download pre-compiled librairies

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -21,20 +21,13 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-            vcpkgCommitId: 'ee17a685087a6886e5681e355d36cd784f0dd2c8'
-            vcpkgPackages: openssl curl wxwidgets boost-test boost-process boost-filesystem boost-dll boost-regex
-
+            vcpkgPackages: wxwidgets boost-test boost-process boost-filesystem boost-dll boost-regex
+    env:
+      # Indicates the location of the vcpkg as a Git submodule of the project repository.
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      
     steps:
-    - uses: actions/checkout@v2 
-
-    - name : Install deps with VCPKG
-      uses: lukka/run-vcpkg@v4
-      id: runvcpkg
-      with:
-        vcpkgArguments: '${{ matrix.vcpkgPackages }}'
-        vcpkgTriplet: '${{ matrix.triplet }}'
-        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: '${{ matrix.vcpkgCommitId }}'
+    - uses: actions/checkout@v2
         
     - name: Download pre-compiled librairies
       run: |
@@ -47,6 +40,23 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
+        
+    # Restore both vcpkg and its artifacts from the GitHub cache service.
+    - name: Restore vcpkg and its artifacts.
+      uses: actions/cache@v2
+      with:
+        # The first path is the location of vcpkg (it contains the vcpkg executable and data files).
+        # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
+        path: |
+          ${{ env.VCPKG_ROOT }}
+          !${{ env.VCPKG_ROOT }}/buildtrees
+          !${{ env.VCPKG_ROOT }}/packages
+          !${{ env.VCPKG_ROOT }}/downloads
+        # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg's Git commit id changes, or the list of packages changes. In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
+        # The key includes: hash of the vcpkg.json file, the hash of the vcpkg Git commit id, and the used vcpkg's triplet. The vcpkg's commit id would suffice, but computing an hash out it does not harm.
+        # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
+        key: |
+          ${{ hashFiles( 'vcpkg_manifest/vcpkg.json' ) }}-${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}-${{ matrix.triplet }}-invalidate
           
     - name: Install dependencies
       run: |
@@ -56,10 +66,18 @@ jobs:
     - name: Init submodule
       run: |
            git submodule update --init --recursive src
-        
+           git submodule update --init vcpkg
+           
+    - name : Install deps with VCPKG
+      run: |
+          ./bootstrap-vcpkg.sh
+          cd vcpkg
+          vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
+      shell: bash
+      
     - name: Configure
       run: |
-           cmake -B _build -S src -DDEPS_INSTALL_DIR=rte-antares-deps-Release -DVCPKG_ROOT=${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }} -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON  -DBUILD_OUTPUT_TEST=ON
+           cmake -B _build -S src -DDEPS_INSTALL_DIR=rte-antares-deps-Release -DVCPKG_ROOT=${{env.VCPKG_ROOT}} -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON  -DBUILD_OUTPUT_TEST=ON
 
     - name: Build
       run: |

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -70,8 +70,8 @@ jobs:
            
     - name : Install deps with VCPKG
       run: |
-          ./bootstrap-vcpkg.sh
           cd vcpkg
+          ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
       shell: bash
       

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -28,14 +28,7 @@ jobs:
       
     steps:
     - uses: actions/checkout@v2
-        
-    - name: Download pre-compiled librairies
-      run: |
-           choco install wget
-           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
-           Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip -DestinationPath .
-           rm rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
-           
+
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
@@ -74,7 +67,14 @@ jobs:
           ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
       shell: bash
-      
+        
+    - name: Download pre-compiled librairies
+      run: |
+           choco install wget
+           wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
+           Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip -DestinationPath .
+           rm rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
+           
     - name: Configure
       run: |
            cmake -B _build -S src -DDEPS_INSTALL_DIR=rte-antares-deps-Release -DVCPKG_ROOT=${{env.VCPKG_ROOT}} -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON  -DBUILD_OUTPUT_TEST=ON

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -55,14 +55,10 @@ jobs:
       run: |
           python -m pip install --upgrade pip
           pip3 install -r src/tests/examples/requirements.txt
-           
-    - name: Init submodule
-      run: |
-           git submodule update --init --recursive src
-           git submodule update --init vcpkg
-           
+          
     - name : Install deps with VCPKG
       run: |
+          git submodule update --init vcpkg
           cd vcpkg
           ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
@@ -74,6 +70,10 @@ jobs:
            wget https://github.com/AntaresSimulatorTeam/antares-deps/releases/download/v1.0.1/rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
            Expand-Archive ./rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip -DestinationPath .
            rm rte-antares-deps-${{matrix.os}}-x64-Release-solver.zip
+           
+    - name: Init submodule
+      run: |
+           git submodule update --init --recursive src
            
     - name: Configure
       run: |

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -62,6 +62,9 @@ jobs:
           cd vcpkg
           ./bootstrap-vcpkg.sh
           vcpkg install ${{matrix.vcpkgPackages}} --triplet ${{matrix.triplet}}
+          rm -rf buildtrees
+          rm -rf packages
+          rm -rf downloads
       shell: bash
         
     - name: Download pre-compiled librairies

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-            vcpkgPackages: wxwidgets boost-test boost-process boost-filesystem boost-dll boost-regex
+            vcpkgPackages: wxwidgets boost-test
     env:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "src/tests/resources/Antares_Simulator_Tests"]
 	path = src/tests/resources/Antares_Simulator_Tests
 	url = https://github.com/AntaresSimulatorTeam/Antares_Simulator_Tests.git
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg.git

--- a/vcpkg_manifest/vcpkg.json
+++ b/vcpkg_manifest/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "antares-simulator",
+  "version-string": "8.2.0",
+  "dependencies": [
+    "wxwidgets",
+    "boost-test"
+  ]
+}


### PR DESCRIPTION
- use of vcpkg as submodule instead of github action run-vcpkg
- use of github action to cache vcpkg installed package
- test of ccache use to speed up compilation on ubuntu