### PR TITLE
Fix crash related to "delete all clusters", thermal & renewable

### DIFF
--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -421,7 +421,7 @@ void Area::estimateMemoryUsage(StudyMemoryUsage& u) const
 bool Area::thermalClustersMinStablePowerValidity(std::vector<YString>& output) const
 {
     bool noErrorMinStabPow = true;
-    for (uint l = 0; l != thermal.clusterCount; ++l)
+    for (uint l = 0; l != thermal.clusterCount(); ++l)
     {
         auto& cluster = thermal.clusters[l];
         logs.debug() << "cluster : " << cluster->name();

--- a/src/libs/antares/study/parts/renewable/container.cpp
+++ b/src/libs/antares/study/parts/renewable/container.cpp
@@ -38,7 +38,7 @@ namespace Antares
 {
 namespace Data
 {
-PartRenewable::PartRenewable() : list(), clusters()
+PartRenewable::PartRenewable()
 {
 }
 

--- a/src/libs/antares/study/parts/renewable/container.cpp
+++ b/src/libs/antares/study/parts/renewable/container.cpp
@@ -68,10 +68,10 @@ void PartRenewable::prepareAreaWideIndexes()
 {
     // Copy the list with all renewable clusters
     // And init the areaWideIndex (unique index for a given area)
-    if (!clusterCount())
+    if (list.size() == 0)
         return;
 
-    clusters = std::vector<RenewableCluster*>(clusterCount());
+    clusters = std::vector<RenewableCluster*>(list.size());
 
     auto end = list.end();
     uint idx = 0;

--- a/src/libs/antares/study/parts/renewable/container.cpp
+++ b/src/libs/antares/study/parts/renewable/container.cpp
@@ -38,7 +38,7 @@ namespace Antares
 {
 namespace Data
 {
-PartRenewable::PartRenewable() : list(), clusters(nullptr), clusterCount((uint)-1)
+PartRenewable::PartRenewable() : list(), clusters()
 {
 }
 
@@ -62,24 +62,16 @@ void PartRenewable::estimateMemoryUsage(StudyMemoryUsage& u) const
 
 PartRenewable::~PartRenewable()
 {
-    if (clusterCount)
-        delete[] clusters;
 }
 
 void PartRenewable::prepareAreaWideIndexes()
 {
     // Copy the list with all renewable clusters
     // And init the areaWideIndex (unique index for a given area)
-    clusterCount = list.size();
-    delete[] clusters;
-    if (!clusterCount)
-    {
-        clusters = nullptr;
+    if (!clusterCount())
         return;
-    }
 
-    typedef RenewableCluster* RenewableClusterPointer;
-    clusters = new RenewableClusterPointer[clusterCount];
+    clusters = std::vector<RenewableCluster*>(clusterCount());
 
     auto end = list.end();
     uint idx = 0;
@@ -115,10 +107,7 @@ uint PartRenewable::removeDisabledClusters()
 void PartRenewable::reset()
 {
     list.clear();
-
-    // just in case
-    clusterCount = 0;
-    delete[] clusters;
+    clusters.clear();
 }
 
 } // namespace Data

--- a/src/libs/antares/study/parts/renewable/container.h
+++ b/src/libs/antares/study/parts/renewable/container.h
@@ -106,11 +106,13 @@ public:
     ** This list is mainly used to ensure the same order of the
     ** renewable clusters in the outputs.
     */
-    RenewableCluster** clusters;
+    std::vector<RenewableCluster*> clusters;
     //! How many clusters have we got ?
     // Only available from the solver
-    uint clusterCount;
-
+    inline uint clusterCount() const
+    {
+        return clusters.size();
+    }
 }; // class PartRenewable
 
 } // namespace Data

--- a/src/libs/antares/study/parts/renewable/container.h
+++ b/src/libs/antares/study/parts/renewable/container.h
@@ -109,7 +109,7 @@ public:
     std::vector<RenewableCluster*> clusters;
     //! How many clusters have we got ?
     // Only available from the solver
-    inline uint clusterCount() const
+    inline size_t clusterCount() const
     {
         return clusters.size();
     }

--- a/src/libs/antares/study/parts/thermal/container.cpp
+++ b/src/libs/antares/study/parts/thermal/container.cpp
@@ -71,10 +71,10 @@ void PartThermal::prepareAreaWideIndexes()
 {
     // Copy the list with all thermal clusters
     // And init the areaWideIndex (unique index for a given area)
-    if (!clusterCount())
+    if (!list.size())
         return;
 
-    clusters = std::vector<ThermalCluster*>(clusterCount());
+    clusters = std::vector<ThermalCluster*>(list.size());
 
     auto end = list.end();
     uint idx = 0;

--- a/src/libs/antares/study/parts/thermal/container.cpp
+++ b/src/libs/antares/study/parts/thermal/container.cpp
@@ -39,7 +39,7 @@ namespace Antares
 namespace Data
 {
 PartThermal::PartThermal() :
- unsuppliedEnergyCost(0.), spilledEnergyCost(0.), list(), mustrunList(), clusters()
+ unsuppliedEnergyCost(0.), spilledEnergyCost(0.)
 {
 }
 

--- a/src/libs/antares/study/parts/thermal/container.cpp
+++ b/src/libs/antares/study/parts/thermal/container.cpp
@@ -39,12 +39,7 @@ namespace Antares
 namespace Data
 {
 PartThermal::PartThermal() :
- unsuppliedEnergyCost(0.),
- spilledEnergyCost(0.),
- list(),
- mustrunList(),
- clusters(nullptr),
- clusterCount((uint)-1)
+ unsuppliedEnergyCost(0.), spilledEnergyCost(0.), list(), mustrunList(), clusters()
 {
 }
 
@@ -70,24 +65,16 @@ void PartThermal::estimateMemoryUsage(StudyMemoryUsage& u) const
 
 PartThermal::~PartThermal()
 {
-    if (clusterCount)
-        delete[] clusters;
 }
 
 void PartThermal::prepareAreaWideIndexes()
 {
     // Copy the list with all thermal clusters
     // And init the areaWideIndex (unique index for a given area)
-    clusterCount = list.size();
-    delete[] clusters;
-    if (!clusterCount)
-    {
-        clusters = nullptr;
+    if (!clusterCount())
         return;
-    }
 
-    typedef ThermalCluster* ThermalClusterPointer;
-    clusters = new ThermalClusterPointer[clusterCount];
+    clusters = std::vector<ThermalCluster*>(clusterCount());
 
     auto end = list.end();
     uint idx = 0;
@@ -178,11 +165,7 @@ void PartThermal::reset()
 
     mustrunList.clear();
     list.clear();
-
-    // just in case
-    clusterCount = 0;
-    delete[] clusters;
+    clusters.clear();
 }
-
 } // namespace Data
 } // namespace Antares

--- a/src/libs/antares/study/parts/thermal/container.h
+++ b/src/libs/antares/study/parts/thermal/container.h
@@ -127,7 +127,7 @@ public:
     std::vector<ThermalCluster*> clusters;
 
     // Return unit count
-    inline uint clusterCount() const {
+    inline size_t clusterCount() const {
         return clusters.size();
     }
 }; // class PartThermal

--- a/src/libs/antares/study/parts/thermal/container.h
+++ b/src/libs/antares/study/parts/thermal/container.h
@@ -124,11 +124,12 @@ public:
     ** This list is mainly used to ensure the same order of the
     ** thermal clusters in the outputs.
     */
-    ThermalCluster** clusters;
-    //! How many clusters have we got ?
-    // Only available from the solver
-    uint clusterCount;
+    std::vector<ThermalCluster*> clusters;
 
+    // Return unit count
+    inline uint clusterCount() const {
+        return clusters.size();
+    }
 }; // class PartThermal
 
 } // namespace Data

--- a/src/libs/antares/study/runtime/runtime.cpp
+++ b/src/libs/antares/study/runtime/runtime.cpp
@@ -585,8 +585,8 @@ void StudyRuntimeInfos::initializeThermalClustersInMustRunMode(Study& study)
         if (mode != stdmAdequacyDraft)
             count += area.thermal.prepareClustersInMustRunMode();
 
-        if (area.thermal.clusterCount > maxThermalClustersForSingleArea)
-            maxThermalClustersForSingleArea = area.thermal.clusterCount;
+        if (area.thermal.clusterCount() > maxThermalClustersForSingleArea)
+            maxThermalClustersForSingleArea = area.thermal.clusterCount();
     }
 
     switch (count)

--- a/src/libs/antares/study/scenario-builder/TSnumberData.cpp
+++ b/src/libs/antares/study/scenario-builder/TSnumberData.cpp
@@ -411,7 +411,7 @@ void renewableTSNumberData::apply(Study& study)
     Area& area = *(study.areas.byIndex[pArea->index]);
     // The total number of clusters for the area
     // WARNING: We may have some renewable clusters with the `mustrun` option
-    uint clusterCount = area.renewable.clusterCount;
+    uint clusterCount = area.renewable.clusterCount();
 
     const uint tsGenCountRenewable = get_tsGenCount(study);
 
@@ -479,7 +479,7 @@ bool renewableTSNumberData::reset(const Study& study)
     // If an area is available, it can only be an overlay for renewable timeseries
     // WARNING: The total number of clusters may vary if used from the
     //   solver or not.
-    // WARNING: At this point in time, the variable pArea->renewable.clusterCount
+    // WARNING: At this point in time, the variable pArea->renewable.clusterCount()
     //   might not be valid (because not really initialized yet)
     uint clusterCount
       = (study.usedByTheSolver) ? (pArea->renewable.list.size()) : pArea->renewable.list.size();

--- a/src/libs/antares/study/scenario-builder/TSnumberData.cpp
+++ b/src/libs/antares/study/scenario-builder/TSnumberData.cpp
@@ -296,7 +296,7 @@ bool thermalTSNumberData::reset(const Study& study)
     // If an area is available, it can only be an overlay for thermal timeseries
     // WARNING: The total number of clusters may vary if used from the
     //   solver or not.
-    // WARNING: At this point in time, the variable pArea->thermal.clusterCount
+    // WARNING: At this point in time, the variable pArea->thermal.clusterCount()
     //   might not be valid (because not really initialized yet)
     uint clusterCount = (study.usedByTheSolver)
                           ? (pArea->thermal.list.size() + pArea->thermal.mustrunList.size())
@@ -362,7 +362,7 @@ void thermalTSNumberData::apply(Study& study)
     Area& area = *(study.areas.byIndex[pArea->index]);
     // The total number of clusters for the area
     // WARNING: We may have some thermal clusters with the `mustrun` option
-    uint clusterCount = area.thermal.clusterCount;
+    uint clusterCount = area.thermal.clusterCount();
 
     const uint tsGenCountThermal = get_tsGenCount(study);
 

--- a/src/libs/antares/study/ui-runtimeinfos.cpp
+++ b/src/libs/antares/study/ui-runtimeinfos.cpp
@@ -80,7 +80,7 @@ void UIRuntimeInfo::reload()
                     set.insert(i->second);
             }
 
-            for (uint j = 0; j < area->thermal.clusterCount; ++j)
+            for (uint j = 0; j < area->thermal.clusterCount(); ++j)
             {
                 ThermalCluster* cluster = area->thermal.clusters[j];
                 pClusters.push_back(cluster);

--- a/src/solver/main.cpp
+++ b/src/solver/main.cpp
@@ -216,7 +216,7 @@ bool SolverApplication::prepare(int argc, char* argv[])
 
             auto NombreDePaliersThermiques = area.thermal.list.size();
 
-            for (uint l = 0; l != area.thermal.clusterCount; ++l) //
+            for (uint l = 0; l != area.thermal.clusterCount(); ++l) //
             {
                 auto& cluster = *(area.thermal.clusters[l]);
                 auto PmaxDUnGroupeDuPalierThermique = cluster.nominalCapacityWithSpinning;

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -176,7 +176,7 @@ void PrepareDataFromClustersInMustrunMode(Data::Study& study, uint numSpace)
             }
         }
 
-        for (uint j = 0; j != area.thermal.clusterCount; ++j)
+        for (uint j = 0; j != area.thermal.clusterCount(); ++j)
         {
             Data::ThermalCluster* cluster = area.thermal.clusters[j];
             cluster->unitCountLastHour[numSpace] = 0;

--- a/src/solver/simulation/sim_allocation_tableaux.cpp
+++ b/src/solver/simulation/sim_allocation_tableaux.cpp
@@ -142,7 +142,7 @@ void SIM_AllocationTableaux()
             NumeroChroniquesTireesParPays[numSpace][i]->ThermiqueParPalier
               = (int*)MemAlloc(area.thermal.clusterCount() * sizeof(int));
             NumeroChroniquesTireesParPays[numSpace][i]->RenouvelableParPalier
-              = (int*)MemAlloc(area.renewable.clusterCount * sizeof(int));
+              = (int*)MemAlloc(area.renewable.clusterCount() * sizeof(int));
             ValeursGenereesParPays[numSpace][i]->HydrauliqueModulableQuotidien
               = (double*)MemAlloc(study.runtime->nbDaysPerYear * sizeof(double));
             ValeursGenereesParPays[numSpace][i]->AleaCoutDeProductionParPalier

--- a/src/solver/simulation/sim_allocation_tableaux.cpp
+++ b/src/solver/simulation/sim_allocation_tableaux.cpp
@@ -140,13 +140,13 @@ void SIM_AllocationTableaux()
               = (VALEURS_GENEREES_PAR_PAYS*)MemAlloc(sizeof(VALEURS_GENEREES_PAR_PAYS));
 
             NumeroChroniquesTireesParPays[numSpace][i]->ThermiqueParPalier
-              = (int*)MemAlloc(area.thermal.clusterCount * sizeof(int));
+              = (int*)MemAlloc(area.thermal.clusterCount() * sizeof(int));
             NumeroChroniquesTireesParPays[numSpace][i]->RenouvelableParPalier
               = (int*)MemAlloc(area.renewable.clusterCount * sizeof(int));
             ValeursGenereesParPays[numSpace][i]->HydrauliqueModulableQuotidien
               = (double*)MemAlloc(study.runtime->nbDaysPerYear * sizeof(double));
             ValeursGenereesParPays[numSpace][i]->AleaCoutDeProductionParPalier
-              = (double*)MemAlloc(area.thermal.clusterCount * sizeof(double));
+              = (double*)MemAlloc(area.thermal.clusterCount() * sizeof(double));
             if (area.hydro.reservoirManagement)
             {
                 ValeursGenereesParPays[numSpace][i]->NiveauxReservoirsDebutJours

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -476,9 +476,9 @@ void ISimulation<Impl>::estimateMemoryUsage(Antares::Data::StudyMemoryUsage& u)
         auto& area = *areas.byIndex[i];
         tmpAmountMemory += sizeof(NUMERO_CHRONIQUES_TIREES_PAR_PAYS);
         tmpAmountMemory += sizeof(VALEURS_GENEREES_PAR_PAYS);
-        tmpAmountMemory += area.thermal.clusterCount * sizeof(int);
+        tmpAmountMemory += area.thermal.clusterCount() * sizeof(int);
         tmpAmountMemory += 366 * sizeof(double);
-        tmpAmountMemory += area.thermal.clusterCount * sizeof(double);
+        tmpAmountMemory += area.thermal.clusterCount() * sizeof(double);
     }
     u.requiredMemoryForInput += u.nbYearsParallel * tmpAmountMemory;
 

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -175,7 +175,7 @@ static unsigned int CheckMatricesWidth(const Data::Study& study)
         }
         case Data::timeSeriesThermal:
         {
-            unsigned int clusterCount = area.thermal.clusterCount;
+            unsigned int clusterCount = area.thermal.clusterCount();
             for (unsigned int i = 0; i != clusterCount; ++i)
             {
                 auto& cluster = *(area.thermal.clusters[i]);
@@ -260,7 +260,7 @@ static bool GenerateDeratedMode(Data::Study& study)
         area.wind.series->timeseriesNumbers.zero();
         area.hydro.series->timeseriesNumbers.zero();
 
-        for (unsigned int i = 0; i != area.thermal.clusterCount; ++i)
+        for (unsigned int i = 0; i != area.thermal.clusterCount(); ++i)
         {
             auto& cluster = *(area.thermal.clusters[i]);
             cluster.series->timeseriesNumbers.zero();
@@ -416,7 +416,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
 
             if (intermodal[TS_INDEX(Data::timeSeriesThermal)])
             {
-                const unsigned int clusterCount = area.thermal.clusterCount;
+                const unsigned int clusterCount = area.thermal.clusterCount();
                 for (unsigned int j = 0; j != clusterCount; ++j)
                 {
                     auto& cluster = *(area.thermal.clusters[j]);
@@ -466,7 +466,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
                 else if (intermodal[TS_INDEX(Data::timeSeriesHydro)])
                     tsNumbers = &(area.hydro.series->timeseriesNumbers);
                 else if (intermodal[TS_INDEX(Data::timeSeriesThermal)]
-                         && area.thermal.clusterCount > 0)
+                         && area.thermal.clusterCount() > 0)
                     tsNumbers = &(area.thermal.clusters[0]->series->timeseriesNumbers);
                 else if (intermodal[TS_INDEX(Data::timeSeriesRenewable)]
                          && area.renewable.clusterCount > 0)
@@ -497,7 +497,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
 
                 if (intermodal[TS_INDEX(Data::timeSeriesThermal)])
                 {
-                    unsigned int clusterCount = area.thermal.clusterCount;
+                    unsigned int clusterCount = area.thermal.clusterCount();
                     for (unsigned int i = 0; i != clusterCount; ++i)
                     {
                         auto& cluster = *(area.thermal.clusters[i]);

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -192,7 +192,7 @@ static unsigned int CheckMatricesWidth(const Data::Study& study)
         }
         case Data::timeSeriesRenewable:
         {
-            unsigned int clusterCount = area.renewable.clusterCount;
+            unsigned int clusterCount = area.renewable.clusterCount();
             for (unsigned int i = 0; i != clusterCount; ++i)
             {
                 auto& cluster = *(area.renewable.clusters[i]);
@@ -428,7 +428,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
 
             if (intermodal[TS_INDEX(Data::timeSeriesRenewable)])
             {
-                const unsigned int clusterCount = area.renewable.clusterCount;
+                const unsigned int clusterCount = area.renewable.clusterCount();
                 for (unsigned int j = 0; j != clusterCount; ++j)
                 {
                     auto& cluster = *(area.renewable.clusters[j]);
@@ -469,7 +469,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
                          && area.thermal.clusterCount() > 0)
                     tsNumbers = &(area.thermal.clusters[0]->series->timeseriesNumbers);
                 else if (intermodal[TS_INDEX(Data::timeSeriesRenewable)]
-                         && area.renewable.clusterCount > 0)
+                         && area.renewable.clusterCount() > 0)
                     tsNumbers = &(area.renewable.clusters[0]->series->timeseriesNumbers);
             }
             assert(tsNumbers);
@@ -507,7 +507,7 @@ bool TimeSeriesNumbers::Generate(Data::Study& study)
                 }
                 if (intermodal[TS_INDEX(Data::timeSeriesRenewable)])
                 {
-                    unsigned int clusterCount = area.renewable.clusterCount;
+                    unsigned int clusterCount = area.renewable.clusterCount();
                     for (unsigned int i = 0; i != clusterCount; ++i)
                     {
                         auto& cluster = *(area.renewable.clusters[i]);

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -157,7 +157,7 @@ void Areas<NEXTTYPE>::hourForEachArea(State& state, uint numSpace)
         } // for each thermal cluster
 
         // For each renewable cluster
-        for (uint j = 0; j != area.renewable.clusterCount; ++j)
+        for (uint j = 0; j != area.renewable.clusterCount(); ++j)
         {
             // Intitializing the state for the current thermal cluster
             state.initFromRenewableClusterIndex(j, numSpace);
@@ -252,7 +252,7 @@ void Areas<NEXTTYPE>::yearEndBuild(State& state, uint year, uint numSpace)
         } // for each thermal cluster
 
         // For each renewable cluster
-        for (uint j = 0; j != area.renewable.clusterCount; ++j)
+        for (uint j = 0; j != area.renewable.clusterCount(); ++j)
         {
             state.renewableCluster = area.renewable.clusters[j];
             state.yearEndResetRenewable();

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -147,7 +147,7 @@ void Areas<NEXTTYPE>::hourForEachArea(State& state, uint numSpace)
         variablesForArea.hourForEachArea(state, numSpace);
 
         // For each thermal cluster
-        for (uint j = 0; j != area.thermal.clusterCount; ++j)
+        for (uint j = 0; j != area.thermal.clusterCount(); ++j)
         {
             // Intiializing the state for the current thermal cluster
             state.initFromThermalClusterIndex(j, numSpace);
@@ -236,7 +236,7 @@ void Areas<NEXTTYPE>::yearEndBuild(State& state, uint year, uint numSpace)
         auto& variablesForArea = pAreas[area.index];
 
         // For each thermal cluster
-        for (uint j = 0; j != area.thermal.clusterCount; ++j)
+        for (uint j = 0; j != area.thermal.clusterCount(); ++j)
         {
             state.thermalCluster = area.thermal.clusters[j];
             state.yearEndResetThermal();

--- a/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -187,7 +187,7 @@ public:
         pValuesForTheCurrentYear = new VCardType::IntermediateValuesBaseType[pNbYearsParallel];
 
         // Get the area
-        pSize = area->thermal.clusterCount;
+        pSize = area->thermal.clusterCount();
         if (pSize)
         {
             AncestorType::pResults.resize(pSize);

--- a/src/solver/variable/economy/npCostByDispatchablePlant.h
+++ b/src/solver/variable/economy/npCostByDispatchablePlant.h
@@ -190,7 +190,7 @@ public:
         pValuesForTheCurrentYear = new VCardType::IntermediateValuesBaseType[pNbYearsParallel];
 
         // Get the area
-        pSize = area->thermal.clusterCount;
+        pSize = area->thermal.clusterCount();
         if (pSize)
         {
             AncestorType::pResults.resize(pSize);

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -195,7 +195,7 @@ public:
         pminOfTheClusterForYear = new double*[pNbYearsParallel];
 
         // Get the area
-        pSize = area->thermal.clusterCount;
+        pSize = area->thermal.clusterCount();
         if (pSize)
         {
             AncestorType::pResults.resize(pSize);

--- a/src/solver/variable/economy/productionByRenewablePlant.h
+++ b/src/solver/variable/economy/productionByRenewablePlant.h
@@ -185,7 +185,7 @@ public:
         pValuesForTheCurrentYear = new VCardType::IntermediateValuesBaseType[pNbYearsParallel];
 
         // Get the area
-        pSize = area->renewable.clusterCount;
+        pSize = area->renewable.clusterCount();
         if (pSize)
         {
             AncestorType::pResults.resize(pSize);

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -56,7 +56,7 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
 {
     // asserts
     assert(area);
-    assert(clusterAreaWideIndex < area->thermal.clusterCount);
+    assert(clusterAreaWideIndex < area->thermal.clusterCount());
 
     thermalClusterNonProportionalCost = 0.;
 

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -238,7 +238,7 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
 void State::initFromRenewableClusterIndex(const uint clusterAreaWideIndex, uint numSpace)
 {
     assert(area);
-    assert(clusterAreaWideIndex < area->renewable.clusterCount);
+    assert(clusterAreaWideIndex < area->renewable.clusterCount());
 
     // alias to the current renewable cluster
     renewableCluster = area->renewable.clusters[clusterAreaWideIndex];

--- a/src/solver/variable/surveyresults/surveyresults.cpp
+++ b/src/solver/variable/surveyresults/surveyresults.cpp
@@ -163,7 +163,7 @@ void ExportGridInfosAreas(const Data::Study& study, const String& folder)
         }
 
         // Thermal clusters
-        for (uint i = 0; i != area.thermal.clusterCount; ++i)
+        for (uint i = 0; i != area.thermal.clusterCount(); ++i)
         {
             assert(NULL != area.thermal.clusters[i]);
             auto& cluster = *(area.thermal.clusters[i]);

--- a/src/tests/examples/example_test.py
+++ b/src/tests/examples/example_test.py
@@ -82,7 +82,7 @@ def launch_solver(solver_path, study_path, use_ortools = False, ortools_solver =
     output = process.communicate()
 
     # TODO check return value
-    assert "Solver returned error" not in output[0].decode('utf-8')
+    assert "Solver returned error" not in output[0].decode('iso-8859-1')
 
 
 def check_integrity_first_opt(path):

--- a/src/tests/examples/example_test.py
+++ b/src/tests/examples/example_test.py
@@ -82,7 +82,7 @@ def launch_solver(solver_path, study_path, use_ortools = False, ortools_solver =
     output = process.communicate()
 
     # TODO check return value
-    assert "Solver returned error" not in output[0].decode('iso-8859-1')
+    assert "Solver returned error" not in output[0].decode('utf-8')
 
 
 def check_integrity_first_opt(path):


### PR DESCRIPTION
Fix #297 

* `clusterCount` becomes a method
* Use `std::vector` instead of C-style arrays.