### PR TITLE
Fix wxWidgets error message when opening "Advanced parameters"

### DIFF
--- a/src/ui/simulator/windows/options/advanced/advanced.cpp
+++ b/src/ui/simulator/windows/options/advanced/advanced.cpp
@@ -93,7 +93,7 @@ AdvancedParameters::AdvancedParameters(wxWindow* parent) :
     hz->AddSpacer(6);
     hz->Add(Resources::StaticBitmapLoadFromFile(this, wxID_ANY, "images/64x64/advanced.png"),
             0,
-            wxALL | wxALIGN_TOP | wxALIGN_CENTER_HORIZONTAL);
+            wxALL | wxALIGN_TOP);
     hz->AddSpacer(35);
 
     auto* s = new wxFlexGridSizer(0, 2, 1, 10);


### PR DESCRIPTION
Fix this error

ASSERT INFO:
/home/omnesflo/Antares_Simulator/build/antares-deps/cmake/dependencies/wxWidgets/source/src/common/sizer.cpp(2099): assert "!(flags & wxALIGN_CENTRE_HORIZONTAL)" failed in DoInsert(): Horizontal alignment flags are ignored in horizontal sizers

BACKTRACE:
[1] wxBoxSizer::DoInsert(unsigned long, wxSizerItem*)
[2] Antares::Window::Options::AdvancedParameters::AdvancedParameters(wxWindow*)
[3] Antares::Dispatcher::Internal::ExecuteQueueDispatcher()
[4] wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&)
[5] wxEventHashTable::HandleEvent(wxEvent&, wxEvtHandler*)
[6] wxEvtHandler::TryHereOnly(wxEvent&)
[7] wxEvtHandler::DoTryChain(wxEvent&)
[8] wxEvtHandler::ProcessEvent(wxEvent&)
[9] wxEvtHandler::ProcessPendingEvents()
[10] wxAppConsoleBase::ProcessPendingEvents()
[11] wxApp::DoIdle()
[12] g_main_context_dispatch
[13] g_main_loop_run
[14] gtk_main
[15] wxGUIEventLoop::DoRun()
[16] wxEventLoopBase::Run()
[17] wxAppConsoleBase::OnRun()
[18] wxEntry(int&, wchar_t**)
[19] main
[20] __libc_start_main
[21] _start