### PR TITLE
Pass typeVar instead of &Probleme, remove unused function argument

### DIFF
--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -126,8 +126,7 @@ RESOLUTION:
                                           ProblemeAResoudre->Xmin,
                                           ProblemeAResoudre->Xmax,
                                           ProblemeAResoudre->TypeDeVariable,
-                                          ProblemeAResoudre->NombreDeVariables,
-                                          &Probleme);
+                                          ProblemeAResoudre->NombreDeVariables);
             }
             else
             {

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -20,8 +20,8 @@ void change_MPSolver_rhs(MPSolver* solver, double* rhs, char* sens, int nbRow);
 void change_MPSolver_variables_bounds(MPSolver* solver,
                                       double* bMin,
                                       double* bMax,
-                                      int nbVar,
-                                      PROBLEME_SIMPLEXE* problemeSimplexe);
+                                      int* typeVar,
+                                      int nbVar);
 
 void transferVariables(MPSolver* solver, double* bMin, double* bMax, double* costs, int nbVar)
 {
@@ -207,22 +207,20 @@ void change_MPSolver_objective(MPSolver* solver, double* costs, int nbVar)
 void change_MPSolver_variables_bounds(MPSolver* solver,
                                       double* bMin,
                                       double* bMax,
-                                      int nbVar,
-                                      PROBLEME_SIMPLEXE* problemeSimplexe)
+                                      int* typeVar,
+                                      int nbVar)
 {
     auto& variables = solver->variables();
     for (int idxVar = 0; idxVar < nbVar; ++idxVar)
     {
-        double min_l
-          = ((problemeSimplexe->TypeDeVariable[idxVar] == VARIABLE_NON_BORNEE)
-                 || (problemeSimplexe->TypeDeVariable[idxVar] == VARIABLE_BORNEE_SUPERIEUREMENT)
-               ? -MPSolver::infinity()
-               : bMin[idxVar]);
-        double max_l
-          = ((problemeSimplexe->TypeDeVariable[idxVar] == VARIABLE_NON_BORNEE)
-                 || (problemeSimplexe->TypeDeVariable[idxVar] == VARIABLE_BORNEE_INFERIEUREMENT)
-               ? MPSolver::infinity()
-               : bMax[idxVar]);
+        double min_l = ((typeVar[idxVar] == VARIABLE_NON_BORNEE)
+                            || (typeVar[idxVar] == VARIABLE_BORNEE_SUPERIEUREMENT)
+                          ? -MPSolver::infinity()
+                          : bMin[idxVar]);
+        double max_l = ((typeVar[idxVar] == VARIABLE_NON_BORNEE)
+                            || (typeVar[idxVar] == VARIABLE_BORNEE_INFERIEUREMENT)
+                          ? MPSolver::infinity()
+                          : bMax[idxVar]);
         auto& var = variables[idxVar];
         var->SetBounds(min_l, max_l);
     }
@@ -354,11 +352,9 @@ extern "C"
                                    double* bMin,
                                    double* bMax,
                                    int* typeVar,
-                                   int nbVar,
-                                   PROBLEME_SIMPLEXE* Probleme)
+                                   int nbVar)
     {
-        Probleme->TypeDeVariable = typeVar;
-        change_MPSolver_variables_bounds(solver, bMin, bMax, nbVar, Probleme);
+        change_MPSolver_variables_bounds(solver, bMin, bMax, typeVar, nbVar);
     }
 
     void ORTOOLS_LibererProbleme(MPSolver* solver)

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -17,11 +17,6 @@ void extract_from_MPSolver(MPSolver* solver, PROBLEME_A_RESOUDRE* problemeSimple
 
 void change_MPSolver_objective(MPSolver* solver, double* costs, int nbVar);
 void change_MPSolver_rhs(MPSolver* solver, double* rhs, char* sens, int nbRow);
-void change_MPSolver_variables_bounds(MPSolver* solver,
-                                      double* bMin,
-                                      double* bMax,
-                                      int* typeVar,
-                                      int nbVar);
 
 void transferVariables(MPSolver* solver, double* bMin, double* bMax, double* costs, int nbVar)
 {
@@ -204,28 +199,6 @@ void change_MPSolver_objective(MPSolver* solver, double* costs, int nbVar)
     }
 }
 
-void change_MPSolver_variables_bounds(MPSolver* solver,
-                                      double* bMin,
-                                      double* bMax,
-                                      int* typeVar,
-                                      int nbVar)
-{
-    auto& variables = solver->variables();
-    for (int idxVar = 0; idxVar < nbVar; ++idxVar)
-    {
-        double min_l = ((typeVar[idxVar] == VARIABLE_NON_BORNEE)
-                            || (typeVar[idxVar] == VARIABLE_BORNEE_SUPERIEUREMENT)
-                          ? -MPSolver::infinity()
-                          : bMin[idxVar]);
-        double max_l = ((typeVar[idxVar] == VARIABLE_NON_BORNEE)
-                            || (typeVar[idxVar] == VARIABLE_BORNEE_INFERIEUREMENT)
-                          ? MPSolver::infinity()
-                          : bMax[idxVar]);
-        auto& var = variables[idxVar];
-        var->SetBounds(min_l, max_l);
-    }
-}
-
 void change_MPSolver_rhs(MPSolver* solver, double* rhs, char* sens, int nbRow)
 {
     auto& constraints = solver->constraints();
@@ -354,7 +327,20 @@ extern "C"
                                    int* typeVar,
                                    int nbVar)
     {
-        change_MPSolver_variables_bounds(solver, bMin, bMax, typeVar, nbVar);
+        auto& variables = solver->variables();
+        for (int idxVar = 0; idxVar < nbVar; ++idxVar)
+        {
+            double min_l = ((typeVar[idxVar] == VARIABLE_NON_BORNEE)
+                                || (typeVar[idxVar] == VARIABLE_BORNEE_SUPERIEUREMENT)
+                              ? -MPSolver::infinity()
+                              : bMin[idxVar]);
+            double max_l = ((typeVar[idxVar] == VARIABLE_NON_BORNEE)
+                                || (typeVar[idxVar] == VARIABLE_BORNEE_INFERIEUREMENT)
+                              ? MPSolver::infinity()
+                              : bMax[idxVar]);
+            auto& var = variables[idxVar];
+            var->SetBounds(min_l, max_l);
+        }
     }
 
     void ORTOOLS_LibererProbleme(MPSolver* solver)

--- a/src/solver/utils/ortools_wrapper.h
+++ b/src/solver/utils/ortools_wrapper.h
@@ -19,8 +19,7 @@ void ORTOOLS_CorrigerLesBornes(MPSolver* ProbSpx,
                                double* bMin,
                                double* bMax,
                                int* typeVar,
-                               int nbVar,
-                               PROBLEME_SIMPLEXE* Probleme);
+                               int nbVar);
 void ORTOOLS_LibererProbleme(MPSolver* ProbSpx);
 
 #endif


### PR DESCRIPTION
* change_MPSolver_variables_bounds doesn't need PROBLEME_SIMPLEXE*
  problemeSimplexe, only its member TypeDeVariable. Pass it directly.

* ORTOOLS_CorrigerLesBornes no longer needs argument Probleme, remove it