### PR TITLE
CentOS 7: upgrade devtoolset-7 -> devtoolset-9

### DIFF
--- a/.github/workflows/centos7-release.yml
+++ b/.github/workflows/centos7-release.yml
@@ -71,12 +71,12 @@ jobs:
            
     - name: Configure
       run: |
-           source /opt/rh/devtoolset-7/enable
+           source /opt/rh/devtoolset-9/enable
            cmake3 -B _build -S src -DDEPS_INSTALL_DIR=/rte-antares-deps-Release -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON
     
     - name: Build
       run: |
-           source /opt/rh/devtoolset-7/enable
+           source /opt/rh/devtoolset-9/enable
            cmake3 --build _build --config release -j2
     
     - name: Running unit tests

--- a/.github/workflows/centos7-system-deps-build.yml
+++ b/.github/workflows/centos7-system-deps-build.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
            yum install -y epel-release
            yum install -y git redhat-lsb-core gcc gcc-c++ make wget centos-release-scl scl-utils rpm-build
-           yum install -y cmake3 devtoolset-7
+           yum install -y cmake3 devtoolset-9
            yum install -y rh-git227-git
            yum install -y unzip libuuid-devel wxGTK3-devel boost-test boost-devel
                       
@@ -45,14 +45,14 @@ jobs:
 
     - name: Configure
       run: |
-           source /opt/rh/devtoolset-7/enable
+           source /opt/rh/devtoolset-9/enable
            #git 2.x must be enabled for Coin compilation with CMake ExternalProject_Add
            source /opt/rh/rh-git227/enable
            cmake3 -B _build -S src -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DBUILD_ortools=ON
 
     - name: Build
       run: |
-           source /opt/rh/devtoolset-7/enable
+           source /opt/rh/devtoolset-9/enable
            source /opt/rh/rh-git227/enable
            cmake3 --build _build --config release -j2
     

--- a/.github/workflows/centos7-system.yml
+++ b/.github/workflows/centos7-system.yml
@@ -70,12 +70,12 @@ jobs:
 
     - name: Configure
       run: |
-           source /opt/rh/devtoolset-7/enable
+           source /opt/rh/devtoolset-9/enable
            cmake3 -B _build -S src -DDEPS_INSTALL_DIR=/rte-antares-deps-Release -DCMAKE_BUILD_TYPE=release -DBUILD_TESTING=ON -DBUILD_OUTPUT_TEST=ON -DBUILD_not_system=OFF
 
     - name: Build
       run: |
-           source /opt/rh/devtoolset-7/enable
+           source /opt/rh/devtoolset-9/enable
            cmake3 --build _build --config Release -j2
     
     - name: Run unit tests

--- a/docker/centos7-basic-requirements
+++ b/docker/centos7-basic-requirements
@@ -9,8 +9,8 @@ RUN yum update -y
 RUN yum install -y epel-release 
 
 # Install requirements
-RUN yum install -y git redhat-lsb-core gcc gcc-c++ make wget centos-release-scl scl-utils rpm-build &&\
-    yum install -y cmake3 devtoolset-7 &&\
+RUN yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils rpm-build &&\
+    yum install -y cmake3 devtoolset-9 &&\
     yum install -y rh-git227-git
 
 # Install simulator requirements


### PR DESCRIPTION
GCC 9 is compatible with recent C++ features such as std::filesystem, etc.