### PR TITLE
fix TS number distribution for inter-modal

### DIFF
--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -684,29 +684,64 @@ Matrix<uint32>* getFirstTSnumberInterModalMatrixFoundInArea(
 void applyMatrixDrawsToInterModalModesInArea(Matrix<uint32>* tsNumbersMtx,
                                              Area& area,
                                              const array<bool, timeSeriesCount>& isTSintermodal,
-                                             const uint years)
+                                             const array<bool, timeSeriesCount>& isTSgenerated,
+                                             const uint years,
+                                             Study& study)
 {
+    Parameters& parameters = study.parameters;
+
     for (uint year = 0; year < years; ++year)
     {
         const uint draw = tsNumbersMtx->entry[0][year];
         assert(draw < 100000);
 
+        // --------------
+        // Load ...
+        // --------------
         assert(year < area.load.series->timeseriesNumbers.height);
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesLoad)])
-            area.load.series->timeseriesNumbers.entry[0][year] = draw;
+        {
+            uint nbTSload = isTSgenerated[ts_to_tsIndex.at(timeSeriesLoad)] ? parameters.nbTimeSeriesLoad 
+                                                                            : area.load.series->series.width;
+            area.load.series->timeseriesNumbers.entry[0][year] = (nbTSload == 1) ? 0 : draw;
+        }
 
+        // --------------
+        // Solar ...
+        // --------------
         assert(year < area.solar.series->timeseriesNumbers.height);
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesSolar)])
-            area.solar.series->timeseriesNumbers.entry[0][year] = draw;
+        {
+            uint nbTSsolar = isTSgenerated[ts_to_tsIndex.at(timeSeriesSolar)] ? parameters.nbTimeSeriesSolar
+                                                                              : area.solar.series->series.width;
+            area.solar.series->timeseriesNumbers.entry[0][year] = (nbTSsolar == 1) ? 0 : draw;
+        }
 
+        // --------------
+        // Wind ...
+        // --------------
         assert(year < area.wind.series->timeseriesNumbers.height);
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesWind)])
-            area.wind.series->timeseriesNumbers.entry[0][year] = draw;
+        {
+            uint nbTSwind = isTSgenerated[ts_to_tsIndex.at(timeSeriesWind)] ? parameters.nbTimeSeriesWind
+                                                                            : area.wind.series->series.width;
+            area.wind.series->timeseriesNumbers.entry[0][year] = (nbTSwind == 1) ? 0 : draw;
+        }
 
+        // --------------
+        // Hydro ...
+        // --------------
         assert(year < area.hydro.series->timeseriesNumbers.height);
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesHydro)])
-            area.hydro.series->timeseriesNumbers.entry[0][year] = draw;
+        {
+            uint nbTShydro = isTSgenerated[ts_to_tsIndex.at(timeSeriesHydro)] ? parameters.nbTimeSeriesHydro
+                                                                              : area.hydro.series->count;
+            area.hydro.series->timeseriesNumbers.entry[0][year] = (nbTShydro == 1) ? 0 : draw;
+        }
 
+        // -------------------------
+        // Thermal clusters ...
+        // -------------------------
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesThermal)])
         {
             uint clusterCount = (uint)area.thermal.clusterCount();
@@ -714,9 +749,15 @@ void applyMatrixDrawsToInterModalModesInArea(Matrix<uint32>* tsNumbersMtx,
             {
                 auto& cluster = *(area.thermal.clusters[i]);
                 assert(year < cluster.series->timeseriesNumbers.height);
-                cluster.series->timeseriesNumbers.entry[0][year] = draw;
+                uint nbTSthermalCluster = isTSgenerated[ts_to_tsIndex.at(timeSeriesThermal)] ? parameters.nbTimeSeriesThermal
+                                                                                             : cluster.series->series.width;
+                cluster.series->timeseriesNumbers.entry[0][year] = (nbTSthermalCluster == 1) ? 0 : draw;
             }
         }
+
+        // -------------------------
+        // Renewable clusters ...
+        // -------------------------
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesRenewable)])
         {
             uint clusterCount = (uint)area.renewable.clusterCount();
@@ -724,7 +765,8 @@ void applyMatrixDrawsToInterModalModesInArea(Matrix<uint32>* tsNumbersMtx,
             {
                 auto& cluster = *(area.renewable.clusters[i]);
                 assert(year < cluster.series->timeseriesNumbers.height);
-                cluster.series->timeseriesNumbers.entry[0][year] = draw;
+                uint nbTSrenewableCluster = cluster.series->series.width;
+                cluster.series->timeseriesNumbers.entry[0][year] = (nbTSrenewableCluster == 1) ? 0 : draw;
             }
         }
     }
@@ -812,7 +854,7 @@ bool TimeSeriesNumbers::Generate(Study& study)
             Matrix<uint32>* tsNumbersMtx
               = getFirstTSnumberInterModalMatrixFoundInArea(area, isTSintermodal);
 
-            applyMatrixDrawsToInterModalModesInArea(tsNumbersMtx, area, isTSintermodal, years);
+            applyMatrixDrawsToInterModalModesInArea(tsNumbersMtx, area, isTSintermodal, isTSgenerated, years, study);
         }
     }
 

--- a/src/tests/src/solver/simulation/tests-ts-numbers.cpp
+++ b/src/tests/src/solver/simulation/tests-ts-numbers.cpp
@@ -357,10 +357,89 @@ BOOST_AUTO_TEST_CASE(one_area__load_wind_thermal_are_turned_to_inter_modal__same
 
 	// TS number checks
 	uint year = 0;
+	BOOST_CHECK_EQUAL(area->load.series->timeseriesNumbers[0][year], 0);
+
+	uint drawnTsNbForWind = area->wind.series->timeseriesNumbers[0][year];
+	BOOST_CHECK_EQUAL(thCluster_1->series->timeseriesNumbers[0][year], drawnTsNbForWind);
+	BOOST_CHECK_EQUAL(thCluster_2->series->timeseriesNumbers[0][year], drawnTsNbForWind);
+}
+
+
+BOOST_AUTO_TEST_CASE(one_area__load_wind_thermal_are_turned_to_inter_modal__same_nb_of_ts_except_1_for_wind_check_inter_modal_consistency_OK)
+{
+	// Creating a study
+	Study::Ptr study = new Study();
+	initializeStudy(study);
+
+	study->parameters.interModal |= timeSeriesLoad;
+	study->parameters.interModal |= timeSeriesWind;
+	study->parameters.interModal |= timeSeriesThermal;
+
+	// Area
+	Area* area = addAreaToStudy(study, "Area");
+
+	// ... Load
+	area->load.series->series.resize(100, 1); // Ready made TS for load
+
+	// ... Wind
+	area->wind.series->series.resize(1, 1);	// Ready made TS for wind
+
+	// ... Thermal
+	study->parameters.timeSeriesToRefresh |= timeSeriesThermal; // Generated TS for thermal
+	study->parameters.nbTimeSeriesThermal = 100;
+	// ... ... clusters
+	auto thCluster_1 = addClusterToArea<ThermalCluster>(area, "th-cluster-1");
+	auto thCluster_2 = addClusterToArea<ThermalCluster>(area, "th-cluster-2");
+
+	area->resizeAllTimeseriesNumbers(1 + study->runtime->rangeLimits.year[rangeEnd]);
+
+	BOOST_CHECK(Generate(*study));
+
+	// TS number checks
+	uint year = 0;
+	BOOST_CHECK_EQUAL(area->wind.series->timeseriesNumbers[0][year], 0);
+
+	uint drawnTsNbForLoad = area->load.series->timeseriesNumbers[0][year];
+	BOOST_CHECK_EQUAL(thCluster_1->series->timeseriesNumbers[0][year], drawnTsNbForLoad);
+	BOOST_CHECK_EQUAL(thCluster_2->series->timeseriesNumbers[0][year], drawnTsNbForLoad);
+}
+
+BOOST_AUTO_TEST_CASE(one_area__load_wind_thermal_are_turned_to_inter_modal__10_TS_for_everyone_except_thermal_cluster_has_1_TS__check_inter_modal_consistency_OK)
+{
+	// Creating a study
+	Study::Ptr study = new Study();
+	initializeStudy(study);
+
+	study->parameters.interModal |= timeSeriesLoad;
+	study->parameters.interModal |= timeSeriesWind;
+	study->parameters.interModal |= timeSeriesThermal;
+
+	// Area
+	Area* area = addAreaToStudy(study, "Area");
+
+	// ... Load
+	area->load.series->series.resize(10, 1); // Ready made TS for load
+
+	// ... Wind
+	area->wind.series->series.resize(10, 1);	// Ready made TS for wind
+
+	// ... Thermal
+	// ... ... clusters
+	auto thCluster_1 = addClusterToArea<ThermalCluster>(area, "th-cluster-1");
+	auto thCluster_2 = addClusterToArea<ThermalCluster>(area, "th-cluster-2");
+	thCluster_1->series->series.resize(10, 1);
+	thCluster_2->series->series.resize(1, 1); // Only 1 TS for this thermal cluster
+
+	area->resizeAllTimeseriesNumbers(1 + study->runtime->rangeLimits.year[rangeEnd]);
+
+	BOOST_CHECK(Generate(*study));
+
+	// TS number checks
+	uint year = 0;
 	uint drawnTsNbForLoad = area->load.series->timeseriesNumbers[0][year];
 	BOOST_CHECK_EQUAL(area->wind.series->timeseriesNumbers[0][year], drawnTsNbForLoad);
 	BOOST_CHECK_EQUAL(thCluster_1->series->timeseriesNumbers[0][year], drawnTsNbForLoad);
-	BOOST_CHECK_EQUAL(thCluster_2->series->timeseriesNumbers[0][year], drawnTsNbForLoad);
+	BOOST_CHECK_EQUAL(thCluster_2->series->timeseriesNumbers[0][year], 0);
 }
 
 BOOST_AUTO_TEST_CASE(one_area__load_wind_thermal_are_turned_to_inter_modal__different_nb_of_ts____check_inter_modal_consistency_KO)


### PR DESCRIPTION
An inter-modal production/load gets 0 as time-series number if it owns only 1 time-series