### PR TITLE
Display commit-id in GUI and CLI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,14 @@ else()
 	set (ANTARES_RC 0)
 endif()
 
+# git SHA-1
+find_package(Git QUIET)
+execute_process(COMMAND
+  "${GIT_EXECUTABLE}" describe --match=NeVeRmAtCh --abbrev=7 --always --dirty
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  OUTPUT_VARIABLE GIT_SHA1_SHORT
+  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 # Build Configuration
 if("${CMAKE_BUILD_TYPE}" STREQUAL "release" OR "${CMAKE_BUILD_TYPE}" STREQUAL "tuning")
 	set(ANTARES_TARGET "${CMAKE_BUILD_TYPE}")

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -38,5 +38,7 @@
 //! git revision (SHA-1)
 #cmakedefine GIT_SHA1_SHORT @GIT_SHA1_SHORT@
 
+#define GIT_SHA1_SHORT_STRING "@GIT_SHA1_SHORT@"
+
 #endif // __ANTARES_CONFIG_H__
 

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -36,8 +36,6 @@
 #cmakedefine ANTARES_RC     @ANTARES_RC@
 
 //! git revision (SHA-1)
-#cmakedefine GIT_SHA1_SHORT @GIT_SHA1_SHORT@
-
 #define GIT_SHA1_SHORT_STRING "@GIT_SHA1_SHORT@"
 
 #endif // __ANTARES_CONFIG_H__

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -35,5 +35,8 @@
 //! RC version
 #cmakedefine ANTARES_RC     @ANTARES_RC@
 
+//! git revision (SHA-1)
+#cmakedefine GIT_SHA1_SHORT @GIT_SHA1_SHORT@
+
 #endif // __ANTARES_CONFIG_H__
 

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -219,7 +219,7 @@ bool GrabOptionsFromCommandLine(int argc,
     if (optVersion)
     {
 #ifdef GIT_SHA1_SHORT_STRING
-        std::cout << ANTARES_VERSION_STR <<  " (revision " <<GIT_SHA1_SHORT_STRING << ")" << std::endl;
+        std::cout << ANTARES_VERSION_STR <<  " (revision " << GIT_SHA1_SHORT_STRING << ")" << std::endl;
 #else
         std::cout << ANTARES_VERSION_STR << std::endl;
 #endif

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -218,7 +218,11 @@ bool GrabOptionsFromCommandLine(int argc,
     // Version
     if (optVersion)
     {
+#ifdef GIT_SHA1_SHORT_STRING
+        std::cout << ANTARES_VERSION_STR <<  " (revision " <<GIT_SHA1_SHORT_STRING << ")" << std::endl;
+#else
         std::cout << ANTARES_VERSION_STR << std::endl;
+#endif
         return false;
     }
 

--- a/src/ui/simulator/windows/about/aboutbox.cpp
+++ b/src/ui/simulator/windows/about/aboutbox.cpp
@@ -944,11 +944,11 @@ AboutBox::AboutBox(wxWindow* parent) :
     version->SetForegroundColour(wxColour(90, 90, 90));
     sv->Add(version, 0, wxALL | wxEXPAND);
 
-#ifdef GIT_SHA1_SHORT
+#ifdef GIT_SHA1_SHORT_STRING
     sv->AddSpacer(1);
     // git sha-1 (short)
     vstr.clear();
-    vstr << wxT("git revision: " STRING(GIT_SHA1_SHORT));
+    vstr << wxT("git revision: " GIT_SHA1_SHORT_STRING);
     wxStaticText* SHA1Text = Component::CreateLabel(this, vstr, false, true);
     SHA1Text->SetBackgroundColour(wxColour(255, 255, 255));
     SHA1Text->SetForegroundColour(wxColour(90, 90, 90));

--- a/src/ui/simulator/windows/about/aboutbox.cpp
+++ b/src/ui/simulator/windows/about/aboutbox.cpp
@@ -944,6 +944,17 @@ AboutBox::AboutBox(wxWindow* parent) :
     version->SetForegroundColour(wxColour(90, 90, 90));
     sv->Add(version, 0, wxALL | wxEXPAND);
 
+#ifdef GIT_SHA1_SHORT
+    sv->AddSpacer(1);
+    // git sha-1 (short)
+    vstr.clear();
+    vstr << wxT("git revision: " STRING(GIT_SHA1_SHORT));
+    wxStaticText* SHA1Text = Component::CreateLabel(this, vstr, false, true);
+    SHA1Text->SetBackgroundColour(wxColour(255, 255, 255));
+    SHA1Text->SetForegroundColour(wxColour(90, 90, 90));
+    sv->Add(SHA1Text, 0, wxALL | wxEXPAND);
+#endif
+
     sv->AddSpacer(20);
 
     // Notebook


### PR DESCRIPTION
### GUI
![image](https://user-images.githubusercontent.com/26088210/144062085-df5f0038-0e57-48ce-b51e-c8bcaef0d6dd.png)
### CLI
```
omnesflo@gm0winl370:~/Antares_Simulator$ antares-8.1-solver --version
[Tue Nov 30 15:05:24 2021][noname][infos] Copyright 2007-2018 RTE  - Authors: The Antares_Simulator Team 

Antares_Simulator is free software : you can redistribute it and / or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation, either version 3 of the License, or
(at your option) any later version.

There are special exceptions to the terms and conditions of the
license as they are applied to this software.View the full text of
the exceptions in file COPYING.txt in the directory of a distribution
of this software in source form.

Antares_Simulator is distributed in the hope that it will be useful, 
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with Antares_Simulator.If not, see <http://www.gnu.org/licenses/>.



8.1.0 (revision 89966ed)
```