### PR TITLE
[UI] Search solver in the build directory first

### DIFF
--- a/src/libs/antares/solver.cpp
+++ b/src/libs/antares/solver.cpp
@@ -74,10 +74,10 @@ bool FindLocation(String& location, Data::Version /*version*/, Solver::Feature f
     }
     else
     {
-        searchpaths.directories.push_back(s.clear() << "/usr/local/bin/");
-        searchpaths.directories.push_back(s.clear() << "/usr/bin/");
         searchpaths.directories.push_back((s = root) << "/../../solver");
         searchpaths.directories.push_back(root); // TGZ package
+        searchpaths.directories.push_back(s.clear() << "/usr/local/bin/");
+        searchpaths.directories.push_back(s.clear() << "/usr/bin/");
     }
 
     bool success = false;


### PR DESCRIPTION
Do not prioritize the system directory in 2 cases:
- Hand-made build
- Github-generated .tar.gz archive

Instead, prefer the solver from the build/archive.