### PR TITLE
Fix when loading links NTC time series from files

### DIFF
--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -220,15 +220,16 @@ bool AreaLink::linkLoadTimeSeries_for_version_820_and_later(const AnyString& fol
 
     // Read link's parameters times series
     filename.clear() << folder << SEP << with->id << "_parameters.txt";
-    success = parameters.loadFromCSVFile(filename) && success;
+    const uint matrixWidth = 6;
+    success = parameters.loadFromCSVFile(filename, matrixWidth, HOURS_PER_YEAR, Matrix<>::optFixedSize | Matrix<>::optImmediate) && success;
 
     // Read link's direct capacities time series
     filename.clear() << capacitiesFolder << SEP << with->id << "_direct.txt";
-    success = directCapacities.loadFromCSVFile(filename) && success;
+    success = directCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR, Matrix<>::optImmediate) && success;
 
     // Read link's indirect capacities time series
     filename.clear() << capacitiesFolder << SEP << with->id << "_indirect.txt";
-    success = indirectCapacities.loadFromCSVFile(filename) && success;
+    success = indirectCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR, Matrix<>::optImmediate) && success;
 
     return success;
 }

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -180,7 +180,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
     for (unsigned int i = 0; i < runtime.interconnectionsCount; ++i)
     {
         AreaLink* link = runtime.areaLink[i];
-        assert(year < link->timeseriesNumbers.width);
+        assert(year < link->timeseriesNumbers.height);
         NUMERO_CHRONIQUES_TIREES_PAR_INTERCONNEXION& ptchro
           = NumeroChroniquesTireesParInterconnexion[numSpace][i];
         const uint directWidth = link->directCapacities.width;


### PR DESCRIPTION
- bug found when making manual tests : when loading NTC time series from an empty file, a crash occurs because associated matrix is empty after read.
- The condition of an assertion is wrong  