### PR TITLE
Fix study updater for v8.1

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -1049,6 +1049,7 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
     }
 
     // Renewable cluster list
+    if (study.header.version >= 810)
     {
         buffer.clear() << study.folderInput << SEP << "renewables" << SEP << "series";
         ret = area.renewable.list.loadDataSeriesFromFolder(study, options, buffer, false) and ret;
@@ -1211,6 +1212,7 @@ bool AreaList::loadFromFolder(const StudyLoadOptions& options)
     }
 
     // Renewable data, specific to areas
+    if (pStudy.header.version >= 810)
     {
         // The cluster list must be loaded before the method
         // Study::ensureDataAreInitializedAccordingParameters() is called


### PR DESCRIPTION
If study version is < 810, global load function still tries to load renewable clusters stuffs.
It does not find any of them and returns false.
We fix this by calling renewable clusters load function only if study version is >= 810.