### PR TITLE
Do not try to de-allocate global arrays if they were not allocated

### DIFF
--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -69,7 +69,7 @@ macro(solver_app name swap)
 		mps/mps_extern_global.h
 		mps/mps_global.c
 		${SRCS}
-		main.h main.hxx main.cpp
+		main.h exceptions.h main.hxx main.cpp
 	)
 	
 	set(ANTARES_SOLVER_LIBS		

--- a/src/solver/exceptions.h
+++ b/src/solver/exceptions.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <stdexcept>
+
+namespace Error
+{
+class ReadingStudy : public std::runtime_error
+{
+public:
+    explicit ReadingStudy() : std::runtime_error("Got a fatal error reading the study.")
+    {
+    }
+};
+
+class NoAreas : public std::runtime_error
+{
+public:
+    explicit NoAreas() :
+     std::runtime_error("No area found. A valid study contains contains at least one.")
+    {
+    }
+};
+
+class InvalidFileName : public std::runtime_error
+{
+public:
+    explicit InvalidFileName() : std::runtime_error("Invalid file names detected.")
+    {
+    }
+};
+
+class RuntimeInfoInitialization : public std::runtime_error
+{
+public:
+    explicit RuntimeInfoInitialization() : std::runtime_error("Error initializing runtime infos.")
+    {
+    }
+};
+} // namespace Error

--- a/src/solver/main.cpp
+++ b/src/solver/main.cpp
@@ -214,8 +214,6 @@ bool SolverApplication::prepare(int argc, char* argv[])
             // Alias de la zone courant
             auto& area = *(pStudy->areas.byIndex[i]);
 
-            auto NombreDePaliersThermiques = area.thermal.list.size();
-
             for (uint l = 0; l != area.thermal.clusterCount(); ++l) //
             {
                 auto& cluster = *(area.thermal.clusters[l]);

--- a/src/solver/main.cpp
+++ b/src/solver/main.cpp
@@ -30,12 +30,12 @@
 #include <yuni/core/system/suspend.h>
 #include <stdarg.h>
 #include <new>
-#include <stdexcept>
 
 #include "config.h"
 #include <antares/study/study.h>
 #include <antares/logs.h>
 #include "main.h"
+#include "exceptions.h"
 #include "../ui/common/winmain.hxx"
 
 #include <time.h>
@@ -419,11 +419,11 @@ void SolverApplication::readDataForTheStudy(Data::StudyLoadOptions& options)
     }
 
     if (study.gotFatalError)
-        throw std::runtime_error("Got a fatal error reading the study.");
+        throw Error::ReadingStudy();
 
     if (study.areas.empty())
     {
-        throw std::runtime_error("No area found. A valid study contains contains at least one.");
+        throw Error::NoAreas();
     }
 
     // no output ?
@@ -474,7 +474,7 @@ void SolverApplication::readDataForTheStudy(Data::StudyLoadOptions& options)
     if (not pSettings.noOutput)
     {
         if (not study.checkForFilenameLimits(true))
-            throw std::runtime_error("Invalid file names detected");
+            throw Error::InvalidFileName();
 
         // comments
         {
@@ -499,7 +499,7 @@ void SolverApplication::readDataForTheStudy(Data::StudyLoadOptions& options)
 
     // Runtime data dedicated for the solver
     if (not study.initializeRuntimeInfos())
-        throw std::runtime_error("Error initializing runtime infos");
+        throw Error::RuntimeInfoInitialization();
 
     // Apply transformations needed by the solver only (and not the interface for example)
     study.performTransformationsBeforeLaunchingSimulation();
@@ -585,7 +585,8 @@ int main(int argc, char** argv)
     int ret = EXIT_FAILURE;
 
     auto* application = new SolverApplication();
-    try {
+    try
+    {
         application->prepare(argc, argv);
     }
     catch (const std::runtime_error& e)

--- a/src/solver/main.h
+++ b/src/solver/main.h
@@ -117,7 +117,7 @@ private:
     /*!
      * \brief Load data of the study from a local or remote folder
      */
-    bool readDataForTheStudy(Antares::Data::StudyLoadOptions& options);
+    void readDataForTheStudy(Antares::Data::StudyLoadOptions& options);
 
     void runSimulationInAdequacyMode();
     void runSimulationInAdequacyDraftMode();


### PR DESCRIPTION
In some cases, when loading the study fails, `SIM_AllocationTableaux` is not called, but `SIM_DesallocationTableaux` is called. Trying to free address `0x0` triggers a segfault.

The goal of this PR is to make sure this doesn't happen.