### PR TITLE
Add "view results" button and function

### DIFF
--- a/src/ui/simulator/application/main/main.h
+++ b/src/ui/simulator/application/main/main.h
@@ -777,7 +777,7 @@ private:
     uint pCurrentEquipmentPage;
 
     // Pointer to latest output
-    Data::Output::Ptr latestOutput;
+    Data::Output::Ptr latestOutput = nullptr;
 
     // friends
     template<class WindowT>

--- a/src/ui/simulator/application/main/main.h
+++ b/src/ui/simulator/application/main/main.h
@@ -39,6 +39,7 @@
 #include "config.h"
 #include <ui/common/component/frame/local-frame.h>
 #include <antares/study.h>
+#include <antares/study/output.h>
 
 namespace Antares
 {
@@ -361,6 +362,7 @@ public:
     //! Retrieve the internal data (const)
     const MainFormData* data() const;
     //@}
+    void viewLatestOutput();
 
 public:
     //! Event: The application is about to quit
@@ -773,6 +775,9 @@ private:
 
     //! Current Equipment page
     uint pCurrentEquipmentPage;
+
+    // Pointer to latest output
+    Data::Output::Ptr latestOutput;
 
     // friends
     template<class WindowT>

--- a/src/ui/simulator/application/main/menu.cpp
+++ b/src/ui/simulator/application/main/menu.cpp
@@ -675,8 +675,11 @@ void ApplWnd::evtOnViewOutput(wxCommandEvent& evt)
 
 void ApplWnd::viewLatestOutput()
 {
-    OnStudyUpdateOutputInfo(ListOfOutputsForTheCurrentStudy, latestOutput);
-    pSectionNotebook->select(wxT("output"), true);
+    if (latestOutput)
+    {
+        OnStudyUpdateOutputInfo(ListOfOutputsForTheCurrentStudy, latestOutput);
+        pSectionNotebook->select(wxT("output"), true);
+    }
 }
 
 void ApplWnd::evtOnViewSystem(wxCommandEvent&)

--- a/src/ui/simulator/application/main/menu.cpp
+++ b/src/ui/simulator/application/main/menu.cpp
@@ -673,6 +673,12 @@ void ApplWnd::evtOnViewOutput(wxCommandEvent& evt)
     }
 }
 
+void ApplWnd::viewLatestOutput()
+{
+    OnStudyUpdateOutputInfo(ListOfOutputsForTheCurrentStudy, latestOutput);
+    pSectionNotebook->select(wxT("output"), true);
+}
+
 void ApplWnd::evtOnViewSystem(wxCommandEvent&)
 {
     pSectionNotebook->select(wxT("input"));

--- a/src/ui/simulator/application/main/refresh.cpp
+++ b/src/ui/simulator/application/main/refresh.cpp
@@ -129,7 +129,6 @@ void ApplWnd::refreshMenuOutput()
     // Informations about the outputs
     Map map;
     TemporalMap orderByTime;
-    Data::Output::Ptr last;
     uint lastTimestamp = 0;
     wxMenuItem* item;
 
@@ -143,7 +142,7 @@ void ApplWnd::refreshMenuOutput()
             if ((*i)->timestamp > lastTimestamp)
             {
                 lastTimestamp = (*i)->timestamp;
-                last = *i;
+                latestOutput = *i;
             }
         }
     }

--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -139,14 +139,6 @@ inline static void ResetLastOpenedFilepath()
 #endif
 }
 
-static void viewResults()
-{
-    auto* mainFrm = Forms::ApplWnd::Instance();
-    if (!mainFrm)
-        return;
-    mainFrm->viewLatestOutput();
-}
-
 static void TheSimulationIsComplete(const wxString& duration)
 {
     if (IsGUIAboutToQuit() or not Data::Study::Current::Valid())
@@ -161,16 +153,9 @@ static void TheSimulationIsComplete(const wxString& duration)
                                   << wxT("Time to complete the simulation : ") << duration);
         message.add(Window::Message::btnContinue);
         message.add(Window::Message::btnViewResults);
-        switch (message.showModal())
-        {
-        case Window::Message::btnViewResults:
-            viewResults();
-            break;
-        case Window::Message::btnContinue:
-        default:
-            // Do nothing
-            break;
-        }
+        const uint userChoice = message.showModal();
+        if (userChoice == Window::Message::btnViewResults)
+            mainFrm->viewLatestOutput();
     }
 }
 

--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -139,6 +139,14 @@ inline static void ResetLastOpenedFilepath()
 #endif
 }
 
+static void viewResults()
+{
+    auto* mainFrm = Forms::ApplWnd::Instance();
+    if (!mainFrm)
+        return;
+    mainFrm->viewLatestOutput();
+}
+
 static void TheSimulationIsComplete(const wxString& duration)
 {
     if (IsGUIAboutToQuit() or not Data::Study::Current::Valid())
@@ -152,7 +160,17 @@ static void TheSimulationIsComplete(const wxString& duration)
                                 wxString()
                                   << wxT("Time to complete the simulation : ") << duration);
         message.add(Window::Message::btnContinue);
-        message.showModal();
+        message.add(Window::Message::btnViewResults);
+        switch (message.showModal())
+        {
+        case Window::Message::btnViewResults:
+            viewResults();
+            break;
+        case Window::Message::btnContinue:
+        default:
+            // Do nothing
+            break;
+        }
     }
 }
 

--- a/src/ui/simulator/toolbox/create.h
+++ b/src/ui/simulator/toolbox/create.h
@@ -44,12 +44,12 @@ namespace Component
 ** \param object  A popinter to the object which will receive the onClick event
 ** \param method  The method to bind for the onClick event
 */
-template<class T, class StringT>
+template<class T, class StringT, class UserDataT = void*>
 wxButton* CreateButton(wxWindow* parent,
                        const StringT& caption,
                        T* object = NULL,
-                       void (T::*method)(void*) = NULL,
-                       void* userdata = NULL);
+                       void (T::*method)(UserDataT) = NULL,
+                       UserDataT userdata = NULL);
 
 /*!
 ** \brief Create a standard label

--- a/src/ui/simulator/toolbox/create.hxx
+++ b/src/ui/simulator/toolbox/create.hxx
@@ -64,12 +64,12 @@ namespace Antares
 {
 namespace Component
 {
-template<class T, class StringT>
+template<class T, class StringT, class UserDataT = void*>
 wxButton* CreateButton(wxWindow* parent,
                        const StringT& caption,
                        T* object,
-                       void (T::*method)(void*),
-                       void* userdata)
+                       void (T::*method)(UserDataT),
+                       UserDataT userdata)
 {
     // type alias
     typedef ::Antares::Private::Component::CustomWxButton ButtonType;
@@ -83,7 +83,7 @@ wxButton* CreateButton(wxWindow* parent,
     // Event
     if (object)
     {
-        typedef void (T::*MemberType)(void*);
+        typedef void (T::*MemberType)(UserDataT);
         button->onUserClick.bind(
           const_cast<T*>(object), reinterpret_cast<MemberType>(method), userdata);
     }

--- a/src/ui/simulator/windows/message.cpp
+++ b/src/ui/simulator/windows/message.cpp
@@ -94,7 +94,7 @@ Message::Message(wxWindow* parent,
                  const char* icon) :
  wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxDefaultSize),
  pSpotlight(nullptr),
- pReturnStatus(-1),
+ pReturnStatus(btnStartID),
  pRecommendedWidth(0)
 {
     // Informations about the study
@@ -191,11 +191,11 @@ Message::~Message()
         sizer->Clear(true);
 }
 
-void Message::add(const wxString& caption, uint value, bool defaultButton, int space)
+void Message::add(const wxString& caption, DefaultButtonType value, bool defaultButton, int space)
 {
     // We will use the userdata (a pointer) as a container for an int (value)
     auto* btn = Component::CreateButton(
-      pPanel, caption, this, &Message::onButtonClick, reinterpret_cast<void*>(value));
+      pPanel, caption, this, &Message::onButtonClick, value);
 
     if (defaultButton)
     {
@@ -208,9 +208,9 @@ void Message::add(const wxString& caption, uint value, bool defaultButton, int s
     pPanelSizer->AddSpacer(space);
 }
 
-void Message::onButtonClick(void* userdata)
+void Message::onButtonClick(DefaultButtonType userdata)
 {
-    pReturnStatus = (uint)((size_t)(userdata));
+    pReturnStatus = userdata;
     Dispatcher::GUI::Close(this);
 }
 

--- a/src/ui/simulator/windows/message.h
+++ b/src/ui/simulator/windows/message.h
@@ -92,6 +92,8 @@ public:
         btnUpgrade,
         //! Standard button: continue
         btnContinue,
+        //! Standard button: view simulation results
+        btnViewResults,
         //! Standard button: quit
         btnQuit
     };

--- a/src/ui/simulator/windows/message.h
+++ b/src/ui/simulator/windows/message.h
@@ -126,7 +126,7 @@ public:
     ** \param defaultButton True to make it the default result
     ** \param space The space to add after before this button
     */
-    void add(const wxString& caption, uint value, bool defaultButton = false, int space = 3);
+    void add(const wxString& caption, DefaultButtonType value, bool defaultButton = false, int space = 3);
 
     /*!
     ** \brief Add a predefined button
@@ -183,7 +183,7 @@ public:
 
 private:
     //! Event: A button has been clicked
-    void onButtonClick(void* userdata);
+    void onButtonClick(DefaultButtonType userdata);
     //
     void prepareShowModal();
 
@@ -199,7 +199,7 @@ private:
     //! Sizer where the spotlight component will be found
     wxSizer* pListSizer;
     //! The return status code
-    uint pReturnStatus;
+    DefaultButtonType pReturnStatus;
     //! Recommended width
     uint pRecommendedWidth;
     //! Empty panel

--- a/src/ui/simulator/windows/message.hxx
+++ b/src/ui/simulator/windows/message.hxx
@@ -68,6 +68,9 @@ inline void Message::add(DefaultButtonType btn, bool defaultButton, int space)
     case btnContinue:
         add(wxT("Continue"), btn, defaultButton, space);
         break;
+    case btnViewResults:
+        add(wxT("View results"), btn, defaultButton, space);
+        break;
     case btnQuit:
         add(wxT("Quit the program"), btn, defaultButton, space);
         break;


### PR DESCRIPTION
Add a "view results" button in the "Simulation" modal. Clicking this button, the user opens the output for that run.

This should save the user a few clicks.

![image](https://user-images.githubusercontent.com/26088210/149372385-263ea340-1201-41bd-a37a-747c3c01b89a.png)
