### PR TITLE
Do not write debug logs after log objects have been destroyed

### DIFF
--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -111,14 +111,11 @@ Study::Study(bool forTheSolver) :
 
 Study::~Study()
 {
-    logs.debug() << "  :: destroying study " << (void*)this;
     clear();
 }
 
 void Study::clear()
 {
-    logs.debug() << "  :: clear study";
-
     // Releasing runtime infos
     FreeAndNil(runtime);
     FreeAndNil(scenarioRules);


### PR DESCRIPTION
Do not try to write data in the logs if they have already been destroyed. Doing so may induce a segfault.