### PR TITLE
Remove duplicate bool StudyLoadOptions::useOrtools

### DIFF
--- a/src/libs/antares/study/load-options.h
+++ b/src/libs/antares/study/load-options.h
@@ -111,8 +111,6 @@ public:
     YString studyFolder;
     YString simulationName;
     std::string ortoolsSolver;
-
-    bool useOrtools = false;
 }; // class StudyLoadOptions
 
 } // namespace Data

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -103,7 +103,7 @@ GetOpt::Parser CreateParser(Settings& settings, Antares::Data::StudyLoadOptions&
 
     // add option for ortools use
     // --use-ortools
-    parser.addFlag(options.useOrtools, ' ', "use-ortools", "Use ortools library to launch solver");
+    parser.addFlag(options.ortoolsUsed, ' ', "use-ortools", "Use ortools library to launch solver");
 
     //--ortools-solver
     parser.add(options.ortoolsSolver,
@@ -259,7 +259,7 @@ void checkAndCorrectSettingsAndOptions(Settings& settings, Data::StudyLoadOption
 void checkOrtoolsSolver(Data::StudyLoadOptions& options)
 {
     // ortools solver
-    if (options.useOrtools)
+    if (options.ortoolsUsed)
     {
         const std::list<std::string> availableSolverList
           = OrtoolsUtils().getAvailableOrtoolsSolverName();


### PR DESCRIPTION
* Having 2 attributes results in OR-Tools not being used even if the flag `--use-ortools` is present.
* `ortoolsUsed` is read in file **parameters.cpp**.
* This is a regression introduced by #521 