### PR TITLE
Remove optImmediate from links' timeseries

### DIFF
--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -227,13 +227,13 @@ bool AreaLink::linkLoadTimeSeries_for_version_820_and_later(const AnyString& fol
 
     // Read link's direct capacities time series
     filename.clear() << capacitiesFolder << SEP << with->id << "_direct.txt";
-    success = directCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR, Matrix<>::optImmediate)
+    success = directCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR)
               && success;
 
     // Read link's indirect capacities time series
     filename.clear() << capacitiesFolder << SEP << with->id << "_indirect.txt";
     success
-      = indirectCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR, Matrix<>::optImmediate)
+      = indirectCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR)
         && success;
 
     return success;


### PR DESCRIPTION
Fix #485 