### PR TITLE
[WIP] Problem reset pProblemes hebdo

### DIFF
--- a/docs/reference-guide/1-reference-guide.md
+++ b/docs/reference-guide/1-reference-guide.md
@@ -384,6 +384,7 @@ given back their regular capacities (infinite for those being set on "set to inf
     - _Strategic reserve (include / ignore)_
     - _Spinning reserve (include / ignore)_
     - _Export mps (false/true)_
+    - _Adequacy patch (false/true)_
     - _Simplex optimization range # 4_ _(day / week)_
     - _Unfeasible problems behavior (Error Dry/ Error Verbose/ Warning Dry/ Warning Verbose_
 

--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -53,7 +53,7 @@ void Area::internalInitialize()
 Area::Area() :
  index((uint)(-1)),
  enabled(true),
- adequacyPatchMode(Data::adqmNotUsed),
+ adequacyPatchMode(Data::adqmVirtualArea),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),
@@ -71,7 +71,7 @@ Area::Area() :
 
 Area::Area(const AnyString& name, uint nbParallelYears) :
  index((uint)(-1)),
- adequacyPatchMode(Data::adqmNotUsed),
+ adequacyPatchMode(Data::adqmVirtualArea),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),
@@ -91,7 +91,7 @@ Area::Area(const AnyString& name, uint nbParallelYears) :
 
 Area::Area(const AnyString& name, const AnyString& id, uint nbParallelYears, uint indx) :
  index(indx),
- adequacyPatchMode(Data::adqmNotUsed),
+ adequacyPatchMode(Data::adqmVirtualArea),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),

--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -53,7 +53,7 @@ void Area::internalInitialize()
 Area::Area() :
  index((uint)(-1)),
  enabled(true),
- bUseAdequacyPatch(false),
+ adequacyPatchMode(Data::adqmNotUsed),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),
@@ -71,7 +71,7 @@ Area::Area() :
 
 Area::Area(const AnyString& name, uint nbParallelYears) :
  index((uint)(-1)),
- bUseAdequacyPatch(false),
+ adequacyPatchMode(Data::adqmNotUsed),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),
@@ -91,7 +91,7 @@ Area::Area(const AnyString& name, uint nbParallelYears) :
 
 Area::Area(const AnyString& name, const AnyString& id, uint nbParallelYears, uint indx) :
  index(indx),
- bUseAdequacyPatch(false),
+ adequacyPatchMode(Data::adqmNotUsed),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),

--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -53,7 +53,7 @@ void Area::internalInitialize()
 Area::Area() :
  index((uint)(-1)),
  enabled(true),
- adequacyPatchMode(Data::adqmVirtualArea),
+ adequacyPatchMode(Data::adqmPhysicalAreaOutsideAdqPatch),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),
@@ -71,7 +71,7 @@ Area::Area() :
 
 Area::Area(const AnyString& name, uint nbParallelYears) :
  index((uint)(-1)),
- adequacyPatchMode(Data::adqmVirtualArea),
+ adequacyPatchMode(Data::adqmPhysicalAreaOutsideAdqPatch),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),
@@ -91,7 +91,7 @@ Area::Area(const AnyString& name, uint nbParallelYears) :
 
 Area::Area(const AnyString& name, const AnyString& id, uint nbParallelYears, uint indx) :
  index(indx),
- adequacyPatchMode(Data::adqmVirtualArea),
+ adequacyPatchMode(Data::adqmPhysicalAreaOutsideAdqPatch),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),

--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -53,6 +53,7 @@ void Area::internalInitialize()
 Area::Area() :
  index((uint)(-1)),
  enabled(true),
+ bUseAdequacyPatch(false),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),
@@ -70,6 +71,7 @@ Area::Area() :
 
 Area::Area(const AnyString& name, uint nbParallelYears) :
  index((uint)(-1)),
+ bUseAdequacyPatch(false),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),
@@ -89,6 +91,7 @@ Area::Area(const AnyString& name, uint nbParallelYears) :
 
 Area::Area(const AnyString& name, const AnyString& id, uint nbParallelYears, uint indx) :
  index(indx),
+ bUseAdequacyPatch(false),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
  nodalOptimization(anoAll),

--- a/src/libs/antares/study/area/area.h
+++ b/src/libs/antares/study/area/area.h
@@ -226,7 +226,7 @@ public:
     //! Enabled
     bool enabled;
     //! Use adequacy patch for this area
-    bool bUseAdequacyPatch;
+    Data::AdequacyPatchMode adequacyPatchMode;
     /*@}*/
 
     //! \name Associate data */

--- a/src/libs/antares/study/area/area.h
+++ b/src/libs/antares/study/area/area.h
@@ -225,6 +225,8 @@ public:
     uint index;
     //! Enabled
     bool enabled;
+    //! Use adequacy patch for this area
+    bool bUseAdequacyPatch;
     /*@}*/
 
     //! \name Associate data */

--- a/src/libs/antares/study/area/area.h
+++ b/src/libs/antares/study/area/area.h
@@ -347,7 +347,7 @@ private:
 
 bool saveAreaOptimisationIniFile(const Area& area, const Yuni::Clob& buffer);
 
-bool saveAreaAdequancyPatchIniFile(const Area& area, const Yuni::Clob& buffer);
+bool saveAreaAdequacyPatchIniFile(const Area& area, const Yuni::Clob& buffer);
 
 /*!
 ** \brief A list of areas

--- a/src/libs/antares/study/area/area.h
+++ b/src/libs/antares/study/area/area.h
@@ -347,6 +347,8 @@ private:
 
 bool saveAreaOptimisationIniFile(const Area& area, const Yuni::Clob& buffer);
 
+bool saveAreaAdequancyPatchIniFile(const Area& area, const Yuni::Clob& buffer);
+
 /*!
 ** \brief A list of areas
 **

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -348,7 +348,7 @@ bool saveAreaAdequacyPatchIniFile(const Area& area, const Clob& buffer)
         value = 2;
         break;
     default:
-        value = 0;
+        value = 1; //default adqmPhysicalAreaOutsideAdqPatch
         break;
     }
     section->add("adequacy-patch-mode", value);
@@ -1098,7 +1098,7 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
                         area.adequacyPatchMode = Data::adqmPhysicalAreaInsideAdqPatch;
                         break;
                     default:
-                        area.adequacyPatchMode = Data::adqmVirtualArea;
+                        area.adequacyPatchMode = Data::adqmPhysicalAreaOutsideAdqPatch;
                         break;
                     }
                     continue;

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -203,7 +203,7 @@ static bool AreaListSaveToFolderSingleArea(const Area& area, Clob& buffer, const
                    << "optimization.ini";
     ret = saveAreaOptimisationIniFile(area, buffer) and ret;
 
-    //Adequacy ini
+    // Adequacy ini
     buffer.clear() << folder << SEP << "input" << SEP << "areas" << SEP << area.id << SEP
                    << "adequacy_patch.ini";
     ret = saveAreaAdequacyPatchIniFile(area, buffer) and ret;
@@ -315,9 +315,12 @@ bool saveAreaOptimisationIniFile(const Area& area, const Clob& buffer)
     IniFile ini;
     IniFile::Section* section = ini.addSection("nodal optimization");
 
-    section->add("non-dispatchable-power", static_cast<bool>(area.nodalOptimization & anoNonDispatchPower));
-    section->add("dispatchable-hydro-power", static_cast<bool>(area.nodalOptimization & anoDispatchHydroPower));
-    section->add("other-dispatchable-power", static_cast<bool>(area.nodalOptimization & anoOtherDispatchPower));
+    section->add("non-dispatchable-power",
+                 static_cast<bool>(area.nodalOptimization & anoNonDispatchPower));
+    section->add("dispatchable-hydro-power",
+                 static_cast<bool>(area.nodalOptimization & anoDispatchHydroPower));
+    section->add("other-dispatchable-power",
+                 static_cast<bool>(area.nodalOptimization & anoOtherDispatchPower));
     section->add("spread-unsupplied-energy-cost", area.spreadUnsuppliedEnergyCost);
     section->add("spread-spilled-energy-cost", area.spreadSpilledEnergyCost);
 
@@ -332,8 +335,9 @@ bool saveAreaAdequacyPatchIniFile(const Area& area, const Clob& buffer)
 {
     IniFile ini;
     IniFile::Section* section = ini.addSection("adequacy-patch");
-    bool bUseAdequacyPatch = false; //adq: this should be later replaced with area.bUseAdequacyPatch
-    section->add("use-adequacy-patch", static_cast<bool>(bUseAdequacyPatch));
+    bool bUseAdequacyPatch = false; // adq: this should be later replaced with
+                                    // area.bUseAdequacyPatch
+    section->add("use-adequacy-patch", bUseAdequacyPatch));
     return ini.save(buffer);
 }
 
@@ -1531,7 +1535,7 @@ bool AreaList::renameArea(const AreaName& oldid, const AreaName& newid, const Ar
         assert(oldCount == a.links.size() and "We must have the same number of items in the list");
 #endif
     });
-    
+
     area->buildLinksIndexes();
 
     return true;

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -336,18 +336,18 @@ bool saveAreaAdequacyPatchIniFile(const Area& area, const Clob& buffer)
     IniFile ini;
     IniFile::Section* section = ini.addSection("adequacy-patch");
     int value;
-    switch(area.adequacyPatchMode)
+    switch (area.adequacyPatchMode)
     {
-    case Data::adqmNotUsed: 
+    case Data::adqmNotUsed:
         value = 0;
         break;
-    case Data::adqmUsedAsPhysicalArea: 
+    case Data::adqmUsedAsPhysicalArea:
         value = 1;
         break;
-    case Data::adqmUsedAsVirtualArea: 
+    case Data::adqmUsedAsVirtualArea:
         value = 2;
         break;
-    default: 
+    default:
         value = 0;
         break;
     }
@@ -1086,18 +1086,18 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
                 if (tmp == "adequacy-patch-mode")
                 {
                     auto value = p->value.to<int>();
-                    switch(value)
+                    switch (value)
                     {
-                        case 0: 
+                    case 0:
                         area.adequacyPatchMode = Data::adqmNotUsed;
                         break;
-                        case 1: 
+                    case 1:
                         area.adequacyPatchMode = Data::adqmUsedAsPhysicalArea;
                         break;
-                        case 2: 
+                    case 2:
                         area.adequacyPatchMode = Data::adqmUsedAsVirtualArea;
                         break;
-                        default: 
+                    default:
                         area.adequacyPatchMode = Data::adqmNotUsed;
                         break;
                     }

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -335,7 +335,23 @@ bool saveAreaAdequacyPatchIniFile(const Area& area, const Clob& buffer)
 {
     IniFile ini;
     IniFile::Section* section = ini.addSection("adequacy-patch");
-    section->add("use-adequacy-patch", area.bUseAdequacyPatch);
+    int value;
+    switch(area.adequacyPatchMode)
+    {
+    case Data::adqmNotUsed: 
+        value = 0;
+        break;
+    case Data::adqmUsedAsPhysicalArea: 
+        value = 1;
+        break;
+    case Data::adqmUsedAsVirtualArea: 
+        value = 2;
+        break;
+    default: 
+        value = 0;
+        break;
+    }
+    section->add("adequacy-patch-mode", value);
     return ini.save(buffer);
 }
 
@@ -1064,13 +1080,27 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
             auto* section = ini.find("adequacy-patch");
             for (auto* p = section->firstProperty; p; p = p->next)
             {
-                bool value = p->value.to<bool>();
                 CString<30, false> tmp;
                 tmp = p->key;
                 tmp.toLower();
-                if (tmp == "use-adequacy-patch")
+                if (tmp == "adequacy-patch-mode")
                 {
-                    area.bUseAdequacyPatch = value;
+                    auto value = p->value.to<int>();
+                    switch(value)
+                    {
+                        case 0: 
+                        area.adequacyPatchMode = Data::adqmNotUsed;
+                        break;
+                        case 1: 
+                        area.adequacyPatchMode = Data::adqmUsedAsPhysicalArea;
+                        break;
+                        case 2: 
+                        area.adequacyPatchMode = Data::adqmUsedAsVirtualArea;
+                        break;
+                        default: 
+                        area.adequacyPatchMode = Data::adqmNotUsed;
+                        break;
+                    }
                     continue;
                 }
             }

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -203,10 +203,10 @@ static bool AreaListSaveToFolderSingleArea(const Area& area, Clob& buffer, const
                    << "optimization.ini";
     ret = saveAreaOptimisationIniFile(area, buffer) and ret;
 
-    //Adequancy ini
+    //Adequacy ini
     buffer.clear() << folder << SEP << "input" << SEP << "areas" << SEP << area.id << SEP
-                   << "adequancy_patch.ini";
-    ret = saveAreaAdequancyPatchIniFile(area, buffer) and ret;
+                   << "adequacy_patch.ini";
+    ret = saveAreaAdequacyPatchIniFile(area, buffer) and ret;
 
     // Reserves: primary, strategic, dsm, d-1...
     buffer.clear() << folder << SEP << "input" << SEP << "reserves" << SEP << area.id << ".txt";
@@ -328,12 +328,12 @@ bool saveAreaOptimisationIniFile(const Area& area, const Clob& buffer)
     return ini.save(buffer);
 }
 
-bool saveAreaAdequancyPatchIniFile(const Area& area, const Clob& buffer)
+bool saveAreaAdequacyPatchIniFile(const Area& area, const Clob& buffer)
 {
     IniFile ini;
-    IniFile::Section* section = ini.addSection("adequancy-patch");
-    bool bUseAdequancyPatch = false; //adq: this should be later replaced with area.bUseAdequancyPatch
-    section->add("use-adequancy-patch", static_cast<bool>(bUseAdequancyPatch));
+    IniFile::Section* section = ini.addSection("adequacy-patch");
+    bool bUseAdequacyPatch = false; //adq: this should be later replaced with area.bUseAdequacyPatch
+    section->add("use-adequacy-patch", static_cast<bool>(bUseAdequacyPatch));
     return ini.save(buffer);
 }
 

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -338,13 +338,13 @@ bool saveAreaAdequacyPatchIniFile(const Area& area, const Clob& buffer)
     int value;
     switch (area.adequacyPatchMode)
     {
-    case Data::adqmNotUsed:
+    case Data::adqmVirtualArea:
         value = 0;
         break;
-    case Data::adqmUsedAsPhysicalArea:
+    case Data::adqmPhysicalAreaOutsideAdqPatch:
         value = 1;
         break;
-    case Data::adqmUsedAsVirtualArea:
+    case Data::adqmPhysicalAreaInsideAdqPatch:
         value = 2;
         break;
     default:
@@ -1089,16 +1089,16 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
                     switch (value)
                     {
                     case 0:
-                        area.adequacyPatchMode = Data::adqmNotUsed;
+                        area.adequacyPatchMode = Data::adqmVirtualArea;
                         break;
                     case 1:
-                        area.adequacyPatchMode = Data::adqmUsedAsPhysicalArea;
+                        area.adequacyPatchMode = Data::adqmPhysicalAreaOutsideAdqPatch;
                         break;
                     case 2:
-                        area.adequacyPatchMode = Data::adqmUsedAsVirtualArea;
+                        area.adequacyPatchMode = Data::adqmPhysicalAreaInsideAdqPatch;
                         break;
                     default:
-                        area.adequacyPatchMode = Data::adqmNotUsed;
+                        area.adequacyPatchMode = Data::adqmVirtualArea;
                         break;
                     }
                     continue;

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -203,6 +203,11 @@ static bool AreaListSaveToFolderSingleArea(const Area& area, Clob& buffer, const
                    << "optimization.ini";
     ret = saveAreaOptimisationIniFile(area, buffer) and ret;
 
+    //Adequancy ini
+    buffer.clear() << folder << SEP << "input" << SEP << "areas" << SEP << area.id << SEP
+                   << "adequancy_patch.ini";
+    ret = saveAreaAdequancyPatchIniFile(area, buffer) and ret;
+
     // Reserves: primary, strategic, dsm, d-1...
     buffer.clear() << folder << SEP << "input" << SEP << "reserves" << SEP << area.id << ".txt";
     ret = area.reserves.saveToCSVFile(buffer) and ret;
@@ -320,6 +325,15 @@ bool saveAreaOptimisationIniFile(const Area& area, const Clob& buffer)
     section->add("filter-synthesis", datePrecisionIntoString(area.filterSynthesis));
     section->add("filter-year-by-year", datePrecisionIntoString(area.filterYearByYear));
 
+    return ini.save(buffer);
+}
+
+bool saveAreaAdequancyPatchIniFile(const Area& area, const Clob& buffer)
+{
+    IniFile ini;
+    IniFile::Section* section = ini.addSection("adequancy-patch");
+    bool bUseAdequancyPatch = false; //adq: this should be later replaced with area.bUseAdequancyPatch
+    section->add("use-adequancy-patch", static_cast<bool>(bUseAdequancyPatch));
     return ini.save(buffer);
 }
 

--- a/src/libs/antares/study/cleaner/cleaner-v20.cpp
+++ b/src/libs/antares/study/cleaner/cleaner-v20.cpp
@@ -195,7 +195,7 @@ static void PreflightVersion20_area(PathList& e, PathList& p, const Area* area, 
     e.add(buffer);
     buffer.clear() << "input/areas/" << id << "/optimization.ini";
     e.add(buffer);
-    buffer.clear() << "input/areas/" << id << "/adequancy_patch.ini";
+    buffer.clear() << "input/areas/" << id << "/adequacy_patch.ini";
     e.add(buffer);
 
     // Interconnections

--- a/src/libs/antares/study/cleaner/cleaner-v20.cpp
+++ b/src/libs/antares/study/cleaner/cleaner-v20.cpp
@@ -215,14 +215,20 @@ static void PreflightVersion20_interco(PathList& p, const Area* area, StringT& b
     {
         auto& link = *(i->second);
         // Parameters
-        buffer.clear() << "input" << SEP << "links" << SEP << link.from->id << SEP << link.with->id << "_parameters" << ".txt";
+        buffer.clear() << "input" << SEP << "links" << SEP << link.from->id << SEP << link.with->id
+                       << "_parameters"
+                       << ".txt";
         p.add(buffer);
 
         // Indirect capacities
-        buffer.clear() << "input" << SEP << "links" << SEP << link.from->id << SEP << "capacities" << SEP << link.with->id << "_direct" << ".txt";
+        buffer.clear() << "input" << SEP << "links" << SEP << link.from->id << SEP << "capacities"
+                       << SEP << link.with->id << "_direct"
+                       << ".txt";
         p.add(buffer);
         // Direct capacities
-        buffer.clear() << "input" << SEP << "links" << SEP << link.from->id << SEP << "capacities" << SEP << link.with->id << "_indirect" << ".txt";
+        buffer.clear() << "input" << SEP << "links" << SEP << link.from->id << SEP << "capacities"
+                       << SEP << link.with->id << "_indirect"
+                       << ".txt";
         p.add(buffer);
     }
 }

--- a/src/libs/antares/study/cleaner/cleaner-v20.cpp
+++ b/src/libs/antares/study/cleaner/cleaner-v20.cpp
@@ -195,6 +195,8 @@ static void PreflightVersion20_area(PathList& e, PathList& p, const Area* area, 
     e.add(buffer);
     buffer.clear() << "input/areas/" << id << "/optimization.ini";
     e.add(buffer);
+    buffer.clear() << "input/areas/" << id << "/adequancy_patch.ini";
+    e.add(buffer);
 
     // Interconnections
     buffer.clear() << "input/links/" << id;

--- a/src/libs/antares/study/fwd.h
+++ b/src/libs/antares/study/fwd.h
@@ -121,12 +121,12 @@ enum StudyMode
 */
 enum AdequacyPatchMode
 {
-    //! Area out of the adq-patch (area does not use adq-patch)
-    adqmNotUsed = 0,
-    //! Physical Area in the adq-patch (physical area use adq-patch)
-    adqmUsedAsPhysicalArea,
-    //! Virtual Area in the adq-patch (virtual area use adq-patch)
-    adqmUsedAsVirtualArea
+    //! Virtual area in adq patch
+    adqmVirtualArea = 0,
+    //! Physical Area outside the adq-patch
+    adqmPhysicalAreaOutsideAdqPatch,
+    //! Physical Area inside the adq-patch
+    adqmPhysicalAreaInsideAdqPatch
 
 }; // enum AdequacyPatchMode
 

--- a/src/libs/antares/study/fwd.h
+++ b/src/libs/antares/study/fwd.h
@@ -116,6 +116,21 @@ enum StudyMode
 
 }; // enum StudyMode
 
+
+/*!
+** \brief Types of Adequacy patch mode
+*/
+enum AdequacyPatchMode
+{
+    //! Area out of the adq-patch (area does not use adq-patch)
+    adqmNotUsed = 0,
+    //! Physical Area in the adq-patch (physical area use adq-patch)
+    adqmUsedAsPhysicalArea,
+    //! Virtual Area in the adq-patch (virtual area use adq-patch)
+    adqmUsedAsVirtualArea
+
+}; // enum AdequacyPatchMode
+
 /*
 ** \brief Simplex optimizations
 */

--- a/src/libs/antares/study/fwd.h
+++ b/src/libs/antares/study/fwd.h
@@ -116,7 +116,6 @@ enum StudyMode
 
 }; // enum StudyMode
 
-
 /*!
 ** \brief Types of Adequacy patch mode
 */
@@ -519,12 +518,12 @@ const char* NumberOfCoresModeToCString(NumberOfCoresMode ncores);
 NumberOfCoresMode StringToNumberOfCoresMode(const AnyString& text);
 
 /*
-* Renewable generation modelling
-*/
+ * Renewable generation modelling
+ */
 enum RenewableGenerationModelling
 {
     rgAggregated = 0, // Default
-    rgClusters, // Using renewable clusters
+    rgClusters,       // Using renewable clusters
     rgUnknown,
 };
 

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -304,6 +304,7 @@ void Parameters::reset()
     simplexOptimizationRange = sorWeek;
 
     include.exportMPS = false;
+    include.adequacyPatch = false; // parameter-reset method
     include.exportStructure = false;
 
     include.unfeasibleProblemBehavior = UnfeasibleProblemBehavior::ERROR_MPS;
@@ -548,6 +549,8 @@ static bool SGDIntLoadFamily_Optimization(Parameters& d,
         return value.to<bool>(d.include.reserve.primary);
     if (key == "include-exportmps")
         return value.to<bool>(d.include.exportMPS);
+    if (key == "include-adequacypatch")
+        return value.to<bool>(d.include.adequacyPatch);
     if (key == "include-exportstructure")
         return value.to<bool>(d.include.exportStructure);
     if (key == "include-unfeasible-problem-behavior")
@@ -1541,6 +1544,8 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
         logs.info() << "  :: ignoring min up/down time for thermal clusters";
     if (!include.exportMPS)
         logs.info() << "  :: ignoring export mps";
+    if (!include.adequacyPatch) // Windows-LogViewer
+        logs.info() << "  :: ignoring adequacy patch";
     if (!include.exportStructure)
         logs.info() << "  :: ignoring export structure";
     if (!include.hurdleCosts)
@@ -1700,6 +1705,7 @@ void Parameters::saveToINI(IniFile& ini) const
         section->add("include-primaryreserve", include.reserve.primary);
 
         section->add("include-exportmps", include.exportMPS);
+        section->add("include-adequacypatch", include.adequacyPatch); // generaldata.ini, parameters.ini file
         section->add("include-exportstructure", include.exportStructure);
 
         // Unfeasible problem behavior

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -304,7 +304,7 @@ void Parameters::reset()
     simplexOptimizationRange = sorWeek;
 
     include.exportMPS = false;
-    include.adequacyPatch = false; // parameter-reset method
+    include.adequacyPatch = false;
     include.exportStructure = false;
 
     include.unfeasibleProblemBehavior = UnfeasibleProblemBehavior::ERROR_MPS;
@@ -1544,7 +1544,7 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
         logs.info() << "  :: ignoring min up/down time for thermal clusters";
     if (!include.exportMPS)
         logs.info() << "  :: ignoring export mps";
-    if (!include.adequacyPatch) // Windows-LogViewer
+    if (!include.adequacyPatch)
         logs.info() << "  :: ignoring adequacy patch";
     if (!include.exportStructure)
         logs.info() << "  :: ignoring export structure";
@@ -1705,7 +1705,7 @@ void Parameters::saveToINI(IniFile& ini) const
         section->add("include-primaryreserve", include.reserve.primary);
 
         section->add("include-exportmps", include.exportMPS);
-        section->add("include-adequacypatch", include.adequacyPatch); // generaldata.ini, parameters.ini file
+        section->add("include-adequacypatch", include.adequacyPatch); 
         section->add("include-exportstructure", include.exportStructure);
 
         // Unfeasible problem behavior

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -87,7 +87,8 @@ static bool ConvertCStrToListTimeSeries(const String& value, uint& v)
     return true;
 }
 
-static bool ConvertStringToRenewableGenerationModelling(const AnyString& text, RenewableGenerationModelling & out)
+static bool ConvertStringToRenewableGenerationModelling(const AnyString& text,
+                                                        RenewableGenerationModelling& out)
 {
     CString<24, false> s = text;
     s.trim();
@@ -734,7 +735,8 @@ static bool SGDIntLoadFamily_OtherPreferences(Parameters& d,
     }
     // Renewable generation modelling
     if (key == "renewable-generation-modelling")
-        return ConvertStringToRenewableGenerationModelling(value, d.renewableGeneration.rgModelling);
+        return ConvertStringToRenewableGenerationModelling(value,
+                                                           d.renewableGeneration.rgModelling);
 
     return false;
 }
@@ -1705,7 +1707,7 @@ void Parameters::saveToINI(IniFile& ini) const
         section->add("include-primaryreserve", include.reserve.primary);
 
         section->add("include-exportmps", include.exportMPS);
-        section->add("include-adequacypatch", include.adequacyPatch); 
+        section->add("include-adequacypatch", include.adequacyPatch);
         section->add("include-exportstructure", include.exportStructure);
 
         // Unfeasible problem behavior

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -416,6 +416,9 @@ public:
         //! a flag to export all mps files
         bool exportMPS;
 
+        //! a flag to use Adequacy patch
+        bool adequacyPatch;
+
         //! a flag to export structure needed for Antares XPansion
         bool exportStructure;
 

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -146,7 +146,7 @@ public:
 
     /*!
     ** \brief Try to detect then fix refresh intervals
-    */    
+    */
     void fixRefreshIntervals();
 
     /*!

--- a/src/solver/cmake/variable.cmake
+++ b/src/solver/cmake/variable.cmake
@@ -129,7 +129,7 @@ set(SRC_VARIABLE_ECONOMY
 		variable/economy/waterValue.h
 		variable/economy/hydroCost.h
 		variable/economy/unsupliedEnergy.h
-		variable/economy/domesticUnsupliedEnergy.h
+		variable/economy/domesticUnsuppliedEnergy.h
 		variable/economy/spilledEnergy.h
 		variable/economy/dispatchableGeneration.h
 		variable/economy/productionByDispatchablePlant.h

--- a/src/solver/cmake/variable.cmake
+++ b/src/solver/cmake/variable.cmake
@@ -129,6 +129,7 @@ set(SRC_VARIABLE_ECONOMY
 		variable/economy/waterValue.h
 		variable/economy/hydroCost.h
 		variable/economy/unsupliedEnergy.h
+		variable/economy/domesticUnsupliedEnergy.h
 		variable/economy/spilledEnergy.h
 		variable/economy/dispatchableGeneration.h
 		variable/economy/productionByDispatchablePlant.h

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -146,13 +146,47 @@ bool Economy::year(Progression::Task& progression,
 
         try
         {
-            /*
-            if (pProblemesHebdo[numSpace].AdequacyFirstStep){
+            if (pProblemesHebdo[numSpace]->AdequacyFirstStep){
+                logs.debug() << "### AdequacyFirstStep";
+                // Solve once
                 OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace], numSpace);
-                pProblemesHebdo[numSpace].AdequacyFirstStep = false;
+                pProblemesHebdo[numSpace]->AdequacyFirstStep = false;
+                pProblemesHebdo[numSpace]->optimizationStatistics_object.reset(); // Do we need to reset statistics of pProblemesHebdo[numSpace] ?
+
+                // Reset pProblemeHebdo
+                // We identified that AT LEAST
+                // CntEnergieH2OParIntervalleOptimise
+                // CntEnergieH2OParIntervalleOptimiseRef
+                // and InflowForTimeInterval
+                // are modified during the OPT_OptimisationHebdomadaire and need to be reset to prior values or else the next solver execution crashes
+
+                // Solution 1
+                // We isolate the lines 823-870 + 990-993 of the sim_calcul_economique.cpp file, make them in a function and use it here,
+                // Here's a placeholder, to simulate what it ends up doing in our test case :
+                double CntEnergieH2OParIntervalleOptimise = 4800;
+                double CntEnergieH2OParIntervalleOptimiseRef = 4800;
+                double InflowForTimeInterval = 4800;
+                for (uint j = 0; j < 7; ++j)
+                {
+                    pProblemesHebdo[numSpace]->CaracteristiquesHydrauliques[0]->CntEnergieH2OParIntervalleOptimise[j] = CntEnergieH2OParIntervalleOptimise;
+                    pProblemesHebdo[numSpace]->CaracteristiquesHydrauliques[0]->CntEnergieH2OParIntervalleOptimiseRef[j] = CntEnergieH2OParIntervalleOptimiseRef;
+                    pProblemesHebdo[numSpace]->CaracteristiquesHydrauliques[0]->InflowForTimeInterval[j] = InflowForTimeInterval;
+                }
+
+                // Solution 2
+                ::SIM_RenseignementProblemeHebdo(*pProblemesHebdo[numSpace], state, numSpace, hourInTheYear); // does it not touch too much stuff ? Should we try to focus only the hydro stuff ?
+
+                // Solution 3
+                // we thought of using
+                // OPT_RestaurerLesDonnees(pProblemesHebdo[numSpace]); //-> Ne fonctionne pas car la reference a aussi ete changee par le calcul
+
+                // Second solve that gives error if hydro param of pProblemeHebdo are not reset
+                OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace], numSpace);
             }
-            */
-            OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace], numSpace);
+            else {
+                //this is normal routine without adq patch
+                OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace], numSpace);
+            }
             DispatchableMarginForAllAreas(
               study, *pProblemesHebdo[numSpace], numSpace, hourInTheYear, nbHoursInAWeek);
 

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -146,6 +146,12 @@ bool Economy::year(Progression::Task& progression,
 
         try
         {
+            /*
+            if (pProblemesHebdo[numSpace].AdequacyFirstStep){
+                OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace], numSpace);
+                pProblemesHebdo[numSpace].AdequacyFirstStep = false;
+            }
+            */
             OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace], numSpace);
             DispatchableMarginForAllAreas(
               study, *pProblemesHebdo[numSpace], numSpace, hourInTheYear, nbHoursInAWeek);

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -63,6 +63,8 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
     problem.hydroHotStart
       = (parameters.initialReservoirLevels.iniLevels == Antares::Data::irlHotStart);
 
+    problem.AdequacyFirstStep = parameters.include.adequacyPatch;
+
     problem.WaterValueAccurate
       = (study.parameters.hydroPricing.hpMode == Antares::Data::HydroPricingMode::hpMILP)
           ? OUI_ANTARES

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -572,6 +572,9 @@ struct PROBLEME_HEBDO
     double* previousYearFinalLevels;
     ALL_MUST_RUN_GENERATION** AllMustRunGeneration;
 
+    /* Adequacy Patch */
+    bool AdequacyFirstStep;
+
     optimizationStatistics optimizationStatistics_object;
     /* Hydro management */
     double* CoefficientEcretementPMaxHydraulique;

--- a/src/solver/variable/adequacy/all.h
+++ b/src/solver/variable/adequacy/all.h
@@ -57,7 +57,6 @@
 #include "../economy/waterValue.h"
 #include "../economy/hydroCost.h"
 #include "../economy/unsupliedEnergy.h"
-#include "../economy/domesticUnsupliedEnergy.h"
 #include "../adequacy/spilledEnergy.h"
 #include "../economy/productionByDispatchablePlant.h"
 #include "../economy/productionByRenewablePlant.h"
@@ -136,7 +135,6 @@ typedef                             // Prices
                       <Variable::Economy::WaterValue        // Water values
                        <Variable::Economy::HydroCost        // Hydro costs
                         <Variable::Economy::UnsupliedEnergy // Unsuplied Energy
-                        <Variable::Economy::DomesticUnsupliedEnergy // Domestic Unsuplied Energy
                          <Variable::Adequacy::SpilledEnergy // Spilled Energy
                           <Variable::Economy::LOLD          // LOLD
                            <Variable::Economy::LOLP         // LOLP
@@ -145,7 +143,7 @@ typedef                             // Prices
                                 Variable::Economy::Marge // OP. MRG
                                 // Links
                                 <Variable::Adequacy::Links // All links
-                                 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+                                 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     VariablesPerArea;
 
 /*!
@@ -202,8 +200,6 @@ typedef // Prices
                                             Common::SpatialAggregate<
                                               Variable::Economy::UnsupliedEnergy,
                                               Common::SpatialAggregate<
-                                              Variable::Economy::DomesticUnsupliedEnergy,
-                                              Common::SpatialAggregate<
                                                 Variable::Adequacy::SpilledEnergy,
                                                 // LOLD
                                                 Common::SpatialAggregate<
@@ -217,7 +213,7 @@ typedef // Prices
                                                         Variable::Economy::DispatchableGenMargin,
                                                         Common::SpatialAggregate<
                                                           Variable::Economy::
-                                                            Marge>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+                                                            Marge>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     VariablesPerSetOfAreas;
 
 typedef Variable::Join<

--- a/src/solver/variable/adequacy/all.h
+++ b/src/solver/variable/adequacy/all.h
@@ -57,6 +57,7 @@
 #include "../economy/waterValue.h"
 #include "../economy/hydroCost.h"
 #include "../economy/unsupliedEnergy.h"
+#include "../economy/domesticUnsupliedEnergy.h"
 #include "../adequacy/spilledEnergy.h"
 #include "../economy/productionByDispatchablePlant.h"
 #include "../economy/productionByRenewablePlant.h"
@@ -135,6 +136,7 @@ typedef                             // Prices
                       <Variable::Economy::WaterValue        // Water values
                        <Variable::Economy::HydroCost        // Hydro costs
                         <Variable::Economy::UnsupliedEnergy // Unsuplied Energy
+                        <Variable::Economy::DomesticUnsupliedEnergy // Domestic Unsuplied Energy
                          <Variable::Adequacy::SpilledEnergy // Spilled Energy
                           <Variable::Economy::LOLD          // LOLD
                            <Variable::Economy::LOLP         // LOLP
@@ -199,6 +201,8 @@ typedef // Prices
                                             Variable::Economy::HydroCost,
                                             Common::SpatialAggregate<
                                               Variable::Economy::UnsupliedEnergy,
+                                              Common::SpatialAggregate<
+                                              Variable::Economy::DomesticUnsupliedEnergy,
                                               Common::SpatialAggregate<
                                                 Variable::Adequacy::SpilledEnergy,
                                                 // LOLD

--- a/src/solver/variable/adequacy/all.h
+++ b/src/solver/variable/adequacy/all.h
@@ -145,7 +145,7 @@ typedef                             // Prices
                                 Variable::Economy::Marge // OP. MRG
                                 // Links
                                 <Variable::Adequacy::Links // All links
-                                 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+                                 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     VariablesPerArea;
 
 /*!
@@ -217,7 +217,7 @@ typedef // Prices
                                                         Variable::Economy::DispatchableGenMargin,
                                                         Common::SpatialAggregate<
                                                           Variable::Economy::
-                                                            Marge>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+                                                            Marge>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     VariablesPerSetOfAreas;
 
 typedef Variable::Join<

--- a/src/solver/variable/economy/all.h
+++ b/src/solver/variable/economy/all.h
@@ -59,7 +59,7 @@
 #include "waterValue.h"
 #include "hydroCost.h"
 #include "unsupliedEnergy.h"
-#include "domesticUnsupliedEnergy.h"
+#include "domesticUnsuppliedEnergy.h"
 #include "spilledEnergy.h"
 
 #include "lold.h"
@@ -145,7 +145,7 @@ typedef          // Prices
                       <WaterValue        // Water values
                        <HydroCost        // Hydro costs
                         <UnsupliedEnergy // Unsuplied Energy
-                         <DomesticUnsupliedEnergy // Domestic Unsuplied Energy
+                         <DomesticUnsuppliedEnergy // Domestic Unsuplied Energy
                           <SpilledEnergy          // Spilled Energy
                            <LOLD                  // LOLD
                             <LOLP                 // LOLP
@@ -216,7 +216,7 @@ typedef // Prices
                                           Common::SpatialAggregate<
                                             UnsupliedEnergy,
                                             Common::SpatialAggregate<
-                                              DomesticUnsupliedEnergy,
+                                              DomesticUnsuppliedEnergy,
                                               Common::SpatialAggregate<
                                                 SpilledEnergy,
                                                 // LOLD

--- a/src/solver/variable/economy/all.h
+++ b/src/solver/variable/economy/all.h
@@ -161,7 +161,7 @@ typedef          // Prices
                                                             // MBO 25/02/2016 - refs: #55
                                  // Links
                                  <Variable::Economy::Links // All links
-                                  >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+                                  >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     VariablesPerArea;
 
 /*!
@@ -241,7 +241,7 @@ typedef // Prices
                                                           Common::SpatialAggregate<
                                                             NbOfDispatchedUnits // MBO 25/02/2016 -
                                                                                 // refs: #55
-                                                            >>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+                                                            >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     VariablesPerSetOfAreas;
 
 typedef Variable::Join<

--- a/src/solver/variable/economy/all.h
+++ b/src/solver/variable/economy/all.h
@@ -59,6 +59,7 @@
 #include "waterValue.h"
 #include "hydroCost.h"
 #include "unsupliedEnergy.h"
+#include "domesticUnsupliedEnergy.h"
 #include "spilledEnergy.h"
 
 #include "lold.h"
@@ -144,6 +145,7 @@ typedef          // Prices
                       <WaterValue        // Water values
                        <HydroCost        // Hydro costs
                         <UnsupliedEnergy // Unsuplied Energy
+                        <DomesticUnsupliedEnergy // Domestic Unsuplied Energy
                          <SpilledEnergy  // Spilled Energy
                           <LOLD          // LOLD
                            <LOLP         // LOLP
@@ -213,6 +215,8 @@ typedef // Prices
                                           HydroCost,
                                           Common::SpatialAggregate<
                                             UnsupliedEnergy,
+                                            Common::SpatialAggregate<
+                                            DomesticUnsupliedEnergy,
                                             Common::SpatialAggregate<
                                               SpilledEnergy,
                                               // LOLD

--- a/src/solver/variable/economy/all.h
+++ b/src/solver/variable/economy/all.h
@@ -145,23 +145,23 @@ typedef          // Prices
                       <WaterValue        // Water values
                        <HydroCost        // Hydro costs
                         <UnsupliedEnergy // Unsuplied Energy
-                        <DomesticUnsupliedEnergy // Domestic Unsuplied Energy
-                         <SpilledEnergy  // Spilled Energy
-                          <LOLD          // LOLD
-                           <LOLP         // LOLP
-                            <AvailableDispatchGen<DispatchableGenMargin<Marge<
-                              NonProportionalCost // Startup cost + Fixed cost - MBO 13/05/2014 -
-                                                  // refs: #21
-                              <NonProportionalCostByDispatchablePlant // Startup cost + Fixed cost
-                                                                      // per thermal plant detail-
-                                                                      // MBO 13/05/2014 - refs: #21
-                               <NbOfDispatchedUnits // Number of Units Dispatched - MBO 25/02/2016 -
-                                                    // refs: #55
-                                <NbOfDispatchedUnitsByPlant // Number of Units Dispatched by plant-
-                                                            // MBO 25/02/2016 - refs: #55
-                                 // Links
-                                 <Variable::Economy::Links // All links
-                                  >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+                         <DomesticUnsupliedEnergy // Domestic Unsuplied Energy
+                          <SpilledEnergy          // Spilled Energy
+                           <LOLD                  // LOLD
+                            <LOLP                 // LOLP
+                             <AvailableDispatchGen<DispatchableGenMargin<Marge<
+                               NonProportionalCost // Startup cost + Fixed cost - MBO 13/05/2014 -
+                                                   // refs: #21
+                               <NonProportionalCostByDispatchablePlant // Startup cost + Fixed cost
+                                                                       // per thermal plant detail-
+                                                                       // MBO 13/05/2014 - refs: #21
+                                <NbOfDispatchedUnits // Number of Units Dispatched - MBO 25/02/2016
+                                                     // - refs: #55
+                                 <NbOfDispatchedUnitsByPlant // Number of Units Dispatched by plant-
+                                                             // MBO 25/02/2016 - refs: #55
+                                  // Links
+                                  <Variable::Economy::Links // All links
+                                   >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     VariablesPerArea;
 
 /*!
@@ -216,32 +216,32 @@ typedef // Prices
                                           Common::SpatialAggregate<
                                             UnsupliedEnergy,
                                             Common::SpatialAggregate<
-                                            DomesticUnsupliedEnergy,
-                                            Common::SpatialAggregate<
-                                              SpilledEnergy,
-                                              // LOLD
+                                              DomesticUnsupliedEnergy,
                                               Common::SpatialAggregate<
-                                                LOLD,
+                                                SpilledEnergy,
+                                                // LOLD
                                                 Common::SpatialAggregate<
-                                                  LOLP,
-
+                                                  LOLD,
                                                   Common::SpatialAggregate<
-                                                    AvailableDispatchGen,
+                                                    LOLP,
+
                                                     Common::SpatialAggregate<
-                                                      DispatchableGenMargin,
+                                                      AvailableDispatchGen,
                                                       Common::SpatialAggregate<
-                                                        Marge,
-
-                                                        // Detail Prices
+                                                        DispatchableGenMargin,
                                                         Common::SpatialAggregate<
-                                                          NonProportionalCost, // MBO 13/05/2014 -
-                                                                               // refs: #21
+                                                          Marge,
 
-                                                          // Number Of Dispatched Units
+                                                          // Detail Prices
                                                           Common::SpatialAggregate<
-                                                            NbOfDispatchedUnits // MBO 25/02/2016 -
-                                                                                // refs: #55
-                                                            >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+                                                            NonProportionalCost, // MBO 13/05/2014 -
+                                                                                 // refs: #21
+
+                                                            // Number Of Dispatched Units
+                                                            Common::SpatialAggregate<
+                                                              NbOfDispatchedUnits // MBO 25/02/2016
+                                                                                  // - refs: #55
+                                                              >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     VariablesPerSetOfAreas;
 
 typedef Variable::Join<

--- a/src/solver/variable/economy/all.h
+++ b/src/solver/variable/economy/all.h
@@ -145,7 +145,7 @@ typedef          // Prices
                       <WaterValue        // Water values
                        <HydroCost        // Hydro costs
                         <UnsupliedEnergy // Unsuplied Energy
-                         <DomesticUnsuppliedEnergy // Domestic Unsuplied Energy
+                         <DomesticUnsuppliedEnergy // Domestic Unsupplied Energy
                           <SpilledEnergy          // Spilled Energy
                            <LOLD                  // LOLD
                             <LOLP                 // LOLP

--- a/src/solver/variable/economy/domesticUnsupliedEnergy.h
+++ b/src/solver/variable/economy/domesticUnsupliedEnergy.h
@@ -24,8 +24,8 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#ifndef __SOLVER_VARIABLE_ECONOMY_UnsupliedEnergy_H__
-#define __SOLVER_VARIABLE_ECONOMY_UnsupliedEnergy_H__
+#ifndef __SOLVER_VARIABLE_ECONOMY_DomesticUnsupliedEnergy_H__
+#define __SOLVER_VARIABLE_ECONOMY_DomesticUnsupliedEnergy_H__
 
 #include "../variable.h"
 
@@ -37,12 +37,12 @@ namespace Variable
 {
 namespace Economy
 {
-struct VCardUnsupliedEnergy
+struct VCardDomesticUnsupliedEnergy
 {
     //! Caption
     static const char* Caption()
     {
-        return "UNSP. ENRG";
+        return "DENS";
     }
     //! Unit
     static const char* Unit()
@@ -52,7 +52,7 @@ struct VCardUnsupliedEnergy
     //! The short description of the variable
     static const char* Description()
     {
-        return "Unsuplied Energy (demand that cannot be satisfied)";
+        return "Domestic Energy Not Served (demand that cannot be satisfied before exchange)";
     }
 
     //! The expecte results
@@ -64,7 +64,7 @@ struct VCardUnsupliedEnergy
       ResultsType;
 
     //! The VCard to look for for calculating spatial aggregates
-    typedef VCardUnsupliedEnergy VCardForSpatialAggregate;
+    typedef VCardDomesticUnsupliedEnergy VCardForSpatialAggregate; 
 
     enum
     {
@@ -102,16 +102,16 @@ struct VCardUnsupliedEnergy
 **   the thermal dispatchable clusters
 */
 template<class NextT = Container::EndOfList>
-class UnsupliedEnergy
- : public Variable::IVariable<UnsupliedEnergy<NextT>, NextT, VCardUnsupliedEnergy>
+class DomesticUnsupliedEnergy
+ : public Variable::IVariable<DomesticUnsupliedEnergy<NextT>, NextT, VCardDomesticUnsupliedEnergy>
 {
 public:
     //! Type of the next static variable
     typedef NextT NextType;
     //! VCard
-    typedef VCardUnsupliedEnergy VCardType;
+    typedef VCardDomesticUnsupliedEnergy VCardType;
     //! Ancestor
-    typedef Variable::IVariable<UnsupliedEnergy<NextT>, NextT, VCardType> AncestorType;
+    typedef Variable::IVariable<DomesticUnsupliedEnergy<NextT>, NextT, VCardType> AncestorType;
 
     //! List of expected results
     typedef typename VCardType::ResultsType ResultsType;
@@ -138,7 +138,7 @@ public:
     };
 
 public:
-    ~UnsupliedEnergy()
+    ~DomesticUnsupliedEnergy()
     {
         delete[] pValuesForTheCurrentYear;
     }
@@ -279,11 +279,11 @@ private:
     typename VCardType::IntermediateValuesType pValuesForTheCurrentYear;
     unsigned int pNbYearsParallel;
 
-}; // class UnsupliedEnergy
+}; // class DomesticUnsupliedEnergy
 
 } // namespace Economy
 } // namespace Variable
 } // namespace Solver
 } // namespace Antares
 
-#endif // __SOLVER_VARIABLE_ECONOMY_UnsupliedEnergy_H__
+#endif // __SOLVER_VARIABLE_ECONOMY_DomesticUnsupliedEnergy_H__

--- a/src/solver/variable/economy/domesticUnsupliedEnergy.h
+++ b/src/solver/variable/economy/domesticUnsupliedEnergy.h
@@ -98,7 +98,7 @@ struct VCardDomesticUnsupliedEnergy
 }; // class VCard
 
 /*!
-** \brief C02 Average value of the overrall UnsupliedEnergy emissions expected from all
+** \brief C02 Average value of the overrall DomesticUnsupliedEnergy emissions expected from all
 **   the thermal dispatchable clusters
 */
 template<class NextT = Container::EndOfList>
@@ -235,10 +235,10 @@ public:
 
     void hourForEachArea(State& state, unsigned int numSpace)
     {
-        // Total UnsupliedEnergy emissions
-        pValuesForTheCurrentYear[numSpace][state.hourInTheYear] =
-          // Current Hydro Storage generation
-          state.hourlyResults->ValeursHorairesDeDefaillancePositive[state.hourInTheWeek];
+        // Total DomesticUnsupliedEnergy emissions
+        pValuesForTheCurrentYear[numSpace][state.hourInTheYear]
+          = 123; // Connect to DENS values in the similar manner like below
+        // state.hourlyResults->ValeursHorairesDeDefaillancePositive[state.hourInTheWeek];
 
         // Next variable
         NextType::hourForEachArea(state, numSpace);

--- a/src/solver/variable/economy/domesticUnsupliedEnergy.h
+++ b/src/solver/variable/economy/domesticUnsupliedEnergy.h
@@ -64,7 +64,7 @@ struct VCardDomesticUnsupliedEnergy
       ResultsType;
 
     //! The VCard to look for for calculating spatial aggregates
-    typedef VCardDomesticUnsupliedEnergy VCardForSpatialAggregate; 
+    typedef VCardDomesticUnsupliedEnergy VCardForSpatialAggregate;
 
     enum
     {

--- a/src/solver/variable/economy/domesticUnsupliedEnergy.h
+++ b/src/solver/variable/economy/domesticUnsupliedEnergy.h
@@ -1,0 +1,289 @@
+/*
+** Copyright 2007-2018 RTE
+** Authors: Antares_Simulator Team
+**
+** This file is part of Antares_Simulator.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** There are special exceptions to the terms and conditions of the
+** license as they are applied to this software. View the full text of
+** the exceptions in file COPYING.txt in the directory of this software
+** distribution
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Antares_Simulator. If not, see <http://www.gnu.org/licenses/>.
+**
+** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
+*/
+#ifndef __SOLVER_VARIABLE_ECONOMY_UnsupliedEnergy_H__
+#define __SOLVER_VARIABLE_ECONOMY_UnsupliedEnergy_H__
+
+#include "../variable.h"
+
+namespace Antares
+{
+namespace Solver
+{
+namespace Variable
+{
+namespace Economy
+{
+struct VCardUnsupliedEnergy
+{
+    //! Caption
+    static const char* Caption()
+    {
+        return "UNSP. ENRG";
+    }
+    //! Unit
+    static const char* Unit()
+    {
+        return "MWh";
+    }
+    //! The short description of the variable
+    static const char* Description()
+    {
+        return "Unsuplied Energy (demand that cannot be satisfied)";
+    }
+
+    //! The expecte results
+    typedef Results<R::AllYears::Average< // The average values throughout all years
+      R::AllYears::StdDeviation<          // The standard deviation values throughout all years
+        R::AllYears::Min<                 // The minimum values throughout all years
+          R::AllYears::Max<               // The maximum values throughout all years
+            >>>>>
+      ResultsType;
+
+    //! The VCard to look for for calculating spatial aggregates
+    typedef VCardUnsupliedEnergy VCardForSpatialAggregate;
+
+    enum
+    {
+        //! Data Level
+        categoryDataLevel = Category::area,
+        //! File level (provided by the type of the results)
+        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        //! Precision (views)
+        precision = Category::all,
+        //! Indentation (GUI)
+        nodeDepthForGUI = +0,
+        //! Decimal precision
+        decimal = 0,
+        //! Number of columns used by the variable (One ResultsType per column)
+        columnCount = 1,
+        //! The Spatial aggregation
+        spatialAggregate = Category::spatialAggregateSum,
+        spatialAggregateMode = Category::spatialAggregateEachYear,
+        spatialAggregatePostProcessing = 0,
+        //! Intermediate values
+        hasIntermediateValues = 1,
+        //! Can this variable be non applicable (0 : no, 1 : yes)
+        isPossiblyNonApplicable = 0,
+    };
+
+    typedef IntermediateValues IntermediateValuesBaseType;
+    typedef IntermediateValues* IntermediateValuesType;
+
+    typedef IntermediateValuesBaseType* IntermediateValuesTypeForSpatialAg;
+
+}; // class VCard
+
+/*!
+** \brief C02 Average value of the overrall UnsupliedEnergy emissions expected from all
+**   the thermal dispatchable clusters
+*/
+template<class NextT = Container::EndOfList>
+class UnsupliedEnergy
+ : public Variable::IVariable<UnsupliedEnergy<NextT>, NextT, VCardUnsupliedEnergy>
+{
+public:
+    //! Type of the next static variable
+    typedef NextT NextType;
+    //! VCard
+    typedef VCardUnsupliedEnergy VCardType;
+    //! Ancestor
+    typedef Variable::IVariable<UnsupliedEnergy<NextT>, NextT, VCardType> AncestorType;
+
+    //! List of expected results
+    typedef typename VCardType::ResultsType ResultsType;
+
+    typedef VariableAccessor<ResultsType, VCardType::columnCount> VariableAccessorType;
+
+    enum
+    {
+        //! How many items have we got
+        count = 1 + NextT::count,
+    };
+
+    template<int CDataLevel, int CFile>
+    struct Statistics
+    {
+        enum
+        {
+            count
+            = ((VCardType::categoryDataLevel & CDataLevel && VCardType::categoryFileLevel & CFile)
+                 ? (NextType::template Statistics<CDataLevel, CFile>::count
+                    + VCardType::columnCount * ResultsType::count)
+                 : NextType::template Statistics<CDataLevel, CFile>::count),
+        };
+    };
+
+public:
+    ~UnsupliedEnergy()
+    {
+        delete[] pValuesForTheCurrentYear;
+    }
+
+    void initializeFromStudy(Data::Study& study)
+    {
+        pNbYearsParallel = study.maxNbYearsInParallel;
+
+        // Intermediate values
+        InitializeResultsFromStudy(AncestorType::pResults, study);
+
+        pValuesForTheCurrentYear = new VCardType::IntermediateValuesBaseType[pNbYearsParallel];
+        for (unsigned int numSpace = 0; numSpace < pNbYearsParallel; numSpace++)
+            pValuesForTheCurrentYear[numSpace].initializeFromStudy(study);
+
+        // Next
+        NextType::initializeFromStudy(study);
+    }
+
+    template<class R>
+    static void InitializeResultsFromStudy(R& results, Data::Study& study)
+    {
+        VariableAccessorType::InitializeAndReset(results, study);
+    }
+
+    void initializeFromArea(Data::Study* study, Data::Area* area)
+    {
+        // Next
+        NextType::initializeFromArea(study, area);
+    }
+
+    void initializeFromLink(Data::Study* study, Data::AreaLink* link)
+    {
+        // Next
+        NextType::initializeFromAreaLink(study, link);
+    }
+
+    void simulationBegin()
+    {
+        for (unsigned int numSpace = 0; numSpace < pNbYearsParallel; numSpace++)
+            pValuesForTheCurrentYear[numSpace].reset();
+        // Next
+        NextType::simulationBegin();
+    }
+
+    void simulationEnd()
+    {
+        NextType::simulationEnd();
+    }
+
+    void yearBegin(unsigned int year, unsigned int numSpace)
+    {
+        // Reset the values for the current year
+        pValuesForTheCurrentYear[numSpace].reset();
+
+        // Next variable
+        NextType::yearBegin(year, numSpace);
+    }
+
+    void yearEndBuild(State& state, unsigned int year)
+    {
+        // Next variable
+        NextType::yearEndBuild(state, year);
+    }
+
+    void yearEnd(unsigned int year, unsigned int numSpace)
+    {
+        // Compute all statistics for the current year (daily,weekly,monthly)
+        pValuesForTheCurrentYear[numSpace].computeStatisticsForTheCurrentYear();
+
+        // Next variable
+        NextType::yearEnd(year, numSpace);
+    }
+
+    void computeSummary(std::map<unsigned int, unsigned int>& numSpaceToYear,
+                        unsigned int nbYearsForCurrentSummary)
+    {
+        for (unsigned int numSpace = 0; numSpace < nbYearsForCurrentSummary; ++numSpace)
+        {
+            // Merge all those values with the global results
+            AncestorType::pResults.merge(numSpaceToYear[numSpace] /*year*/,
+                                         pValuesForTheCurrentYear[numSpace]);
+        }
+
+        // Next variable
+        NextType::computeSummary(numSpaceToYear, nbYearsForCurrentSummary);
+    }
+
+    void hourBegin(unsigned int hourInTheYear)
+    {
+        // Next variable
+        NextType::hourBegin(hourInTheYear);
+    }
+
+    void hourForEachArea(State& state, unsigned int numSpace)
+    {
+        // Total UnsupliedEnergy emissions
+        pValuesForTheCurrentYear[numSpace][state.hourInTheYear] =
+          // Current Hydro Storage generation
+          state.hourlyResults->ValeursHorairesDeDefaillancePositive[state.hourInTheWeek];
+
+        // Next variable
+        NextType::hourForEachArea(state, numSpace);
+    }
+
+    void hourEnd(State& state, unsigned int hourInTheYear)
+    {
+        // Next variable
+        NextType::hourEnd(state, hourInTheYear);
+    }
+
+    Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
+      unsigned int,
+      unsigned int numSpace) const
+    {
+        return pValuesForTheCurrentYear[numSpace].hour;
+    }
+
+    void localBuildAnnualSurveyReport(SurveyResults& results,
+                                      int fileLevel,
+                                      int precision,
+                                      unsigned int numSpace) const
+    {
+        // Initializing external pointer on current variable non applicable status
+        results.isCurrentVarNA = AncestorType::isNonApplicable;
+
+        if (AncestorType::isPrinted[0])
+        {
+            // Write the data for the current year
+            results.variableCaption = VCardType::Caption();
+            pValuesForTheCurrentYear[numSpace].template buildAnnualSurveyReport<VCardType>(
+              results, fileLevel, precision);
+        }
+    }
+
+private:
+    //! Intermediate values for each year
+    typename VCardType::IntermediateValuesType pValuesForTheCurrentYear;
+    unsigned int pNbYearsParallel;
+
+}; // class UnsupliedEnergy
+
+} // namespace Economy
+} // namespace Variable
+} // namespace Solver
+} // namespace Antares
+
+#endif // __SOLVER_VARIABLE_ECONOMY_UnsupliedEnergy_H__

--- a/src/solver/variable/economy/domesticUnsuppliedEnergy.h
+++ b/src/solver/variable/economy/domesticUnsuppliedEnergy.h
@@ -24,8 +24,8 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#ifndef __SOLVER_VARIABLE_ECONOMY_DomesticUnsupliedEnergy_H__
-#define __SOLVER_VARIABLE_ECONOMY_DomesticUnsupliedEnergy_H__
+#ifndef __SOLVER_VARIABLE_ECONOMY_DomesticUnsuppliedEnergy_H__
+#define __SOLVER_VARIABLE_ECONOMY_DomesticUnsuppliedEnergy_H__
 
 #include "../variable.h"
 
@@ -37,7 +37,7 @@ namespace Variable
 {
 namespace Economy
 {
-struct VCardDomesticUnsupliedEnergy
+struct VCardDomesticUnsuppliedEnergy
 {
     //! Caption
     static const char* Caption()
@@ -64,7 +64,7 @@ struct VCardDomesticUnsupliedEnergy
       ResultsType;
 
     //! The VCard to look for for calculating spatial aggregates
-    typedef VCardDomesticUnsupliedEnergy VCardForSpatialAggregate;
+    typedef VCardDomesticUnsuppliedEnergy VCardForSpatialAggregate;
 
     enum
     {
@@ -98,20 +98,20 @@ struct VCardDomesticUnsupliedEnergy
 }; // class VCard
 
 /*!
-** \brief C02 Average value of the overrall DomesticUnsupliedEnergy emissions expected from all
+** \brief C02 Average value of the overrall DomesticUnsuppliedEnergy emissions expected from all
 **   the thermal dispatchable clusters
 */
 template<class NextT = Container::EndOfList>
-class DomesticUnsupliedEnergy
- : public Variable::IVariable<DomesticUnsupliedEnergy<NextT>, NextT, VCardDomesticUnsupliedEnergy>
+class DomesticUnsuppliedEnergy
+ : public Variable::IVariable<DomesticUnsuppliedEnergy<NextT>, NextT, VCardDomesticUnsuppliedEnergy>
 {
 public:
     //! Type of the next static variable
     typedef NextT NextType;
     //! VCard
-    typedef VCardDomesticUnsupliedEnergy VCardType;
+    typedef VCardDomesticUnsuppliedEnergy VCardType;
     //! Ancestor
-    typedef Variable::IVariable<DomesticUnsupliedEnergy<NextT>, NextT, VCardType> AncestorType;
+    typedef Variable::IVariable<DomesticUnsuppliedEnergy<NextT>, NextT, VCardType> AncestorType;
 
     //! List of expected results
     typedef typename VCardType::ResultsType ResultsType;
@@ -138,7 +138,7 @@ public:
     };
 
 public:
-    ~DomesticUnsupliedEnergy()
+    ~DomesticUnsuppliedEnergy()
     {
         delete[] pValuesForTheCurrentYear;
     }
@@ -235,7 +235,7 @@ public:
 
     void hourForEachArea(State& state, unsigned int numSpace)
     {
-        // Total DomesticUnsupliedEnergy emissions
+        // Total DomesticUnsuppliedEnergy emissions
         pValuesForTheCurrentYear[numSpace][state.hourInTheYear]
           = 123; // Connect to DENS values in the similar manner like below
         // state.hourlyResults->ValeursHorairesDeDefaillancePositive[state.hourInTheWeek];
@@ -279,11 +279,11 @@ private:
     typename VCardType::IntermediateValuesType pValuesForTheCurrentYear;
     unsigned int pNbYearsParallel;
 
-}; // class DomesticUnsupliedEnergy
+}; // class DomesticUnsuppliedEnergy
 
 } // namespace Economy
 } // namespace Variable
 } // namespace Solver
 } // namespace Antares
 
-#endif // __SOLVER_VARIABLE_ECONOMY_DomesticUnsupliedEnergy_H__
+#endif // __SOLVER_VARIABLE_ECONOMY_DomesticUnsuppliedEnergy_H__

--- a/src/solver/variable/economy/domesticUnsuppliedEnergy.h
+++ b/src/solver/variable/economy/domesticUnsuppliedEnergy.h
@@ -42,7 +42,7 @@ struct VCardDomesticUnsuppliedEnergy
     //! Caption
     static const char* Caption()
     {
-        return "DENS";
+        return "LOCAL UNSP. ENRG";
     }
     //! Unit
     static const char* Unit()

--- a/src/solver/variable/economy/domesticUnsuppliedEnergy.h
+++ b/src/solver/variable/economy/domesticUnsuppliedEnergy.h
@@ -237,7 +237,7 @@ public:
     {
         // Total DomesticUnsuppliedEnergy emissions
         pValuesForTheCurrentYear[numSpace][state.hourInTheYear]
-          = 123; // Connect to DENS values in the similar manner like below
+          = 0; // Connect to DENS values in the similar manner like below
         // state.hourlyResults->ValeursHorairesDeDefaillancePositive[state.hourInTheWeek];
 
         // Next variable

--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -90,6 +90,7 @@ Event<void(Data::AreaLink*)> OnStudyLinkDelete;
 
 Event<void()> OnStudySimulationSettingsChanged;
 Event<void()> OnStudyNodalOptimizationChanged;
+Event<void()> OnStudyAreaUseAdequacyPatchChanged;
 
 Event<void()> OnStudyThermalClusterCommonSettingsChanged;
 Event<void(Data::ThermalCluster*)> OnStudyThermalClusterRenamed;

--- a/src/ui/simulator/application/study.h
+++ b/src/ui/simulator/application/study.h
@@ -267,6 +267,11 @@ extern Yuni::Event<void(Data::BindingConstraint*)> OnStudyConstraintModified;
 extern Yuni::Event<void()> OnStudyNodalOptimizationChanged;
 
 /*!
+** \brief Event: The area use adequacy patch settings have been changed
+*/
+extern Yuni::Event<void()> OnStudyAreaUseAdequacyPatchChanged;
+
+/*!
 ** \brief Event: The simulation settings have been changed
 */
 extern Yuni::Event<void()> OnStudySimulationSettingsChanged;

--- a/src/ui/simulator/windows/inspector/accumulator.hxx
+++ b/src/ui/simulator/windows/inspector/accumulator.hxx
@@ -322,11 +322,8 @@ static const wxChar* studyMode[] = {wxT("Economy"),
 #endif
                                     nullptr};
 
-
-static const wxChar* adequacyPatchMode[] = {wxT("Not used"),
-                                    wxT("Physical area"),
-                                    wxT("Virtual area"),
-                                    nullptr}; 
+static const wxChar* adequacyPatchMode[]
+  = {wxT("Not used"), wxT("Physical area"), wxT("Virtual area"), nullptr};
 
 struct Unique
 {
@@ -912,7 +909,6 @@ struct PAreaUnsuppliedEnergyCost
     }
 };
 
-
 struct PAdequacyPatchMode
 {
     typedef Data::AdequacyPatchMode Type;
@@ -934,7 +930,6 @@ struct PAdequacyPatchMode
         return wxEmptyString;
     }
 };
-
 
 template<enum Data::AreaNodalOptimization O>
 struct PAreaResortStatus

--- a/src/ui/simulator/windows/inspector/accumulator.hxx
+++ b/src/ui/simulator/windows/inspector/accumulator.hxx
@@ -906,6 +906,19 @@ struct PAreaUnsuppliedEnergyCost
     }
 };
 
+struct PAreaAdequacyPatch
+{
+    typedef bool Type;
+    static Type Value(const Data::Area* area)
+    {
+        return area->bUseAdequacyPatch;
+    }
+    static wxString ConvertToString(const Type v)
+    {
+        return v ? wxT("True") : wxT("False");
+    }
+};
+
 template<enum Data::AreaNodalOptimization O>
 struct PAreaResortStatus
 {

--- a/src/ui/simulator/windows/inspector/accumulator.hxx
+++ b/src/ui/simulator/windows/inspector/accumulator.hxx
@@ -323,7 +323,7 @@ static const wxChar* studyMode[] = {wxT("Economy"),
                                     nullptr};
 
 static const wxChar* adequacyPatchMode[]
-  = {wxT("Not used"), wxT("Physical area"), wxT("Virtual area"), nullptr};
+  = {wxT("virtual area"), wxT("physical area outside patch"), wxT("physical area inside patch"), nullptr};
 
 struct Unique
 {
@@ -920,12 +920,12 @@ struct PAdequacyPatchMode
     {
         switch (v)
         {
-        case Data::adqmNotUsed:
-            return wxT("Not used");
-        case Data::adqmUsedAsPhysicalArea:
-            return wxT("Physical area");
-        case Data::adqmUsedAsVirtualArea:
-            return wxT("Virtual area");
+        case Data::adqmVirtualArea:
+            return wxT("virtual area");
+        case Data::adqmPhysicalAreaOutsideAdqPatch:
+            return wxT("physical area outside patch");
+        case Data::adqmPhysicalAreaInsideAdqPatch:
+            return wxT("physical area inside patch");
         }
         return wxEmptyString;
     }

--- a/src/ui/simulator/windows/inspector/accumulator.hxx
+++ b/src/ui/simulator/windows/inspector/accumulator.hxx
@@ -322,6 +322,12 @@ static const wxChar* studyMode[] = {wxT("Economy"),
 #endif
                                     nullptr};
 
+
+static const wxChar* adequacyPatchMode[] = {wxT("Not used"),
+                                    wxT("Physical area"),
+                                    wxT("Virtual area"),
+                                    nullptr}; 
+
 struct Unique
 {
     template<class T>
@@ -906,18 +912,29 @@ struct PAreaUnsuppliedEnergyCost
     }
 };
 
-struct PAreaAdequacyPatch
+
+struct PAdequacyPatchMode
 {
-    typedef bool Type;
+    typedef Data::AdequacyPatchMode Type;
     static Type Value(const Data::Area* area)
     {
-        return area->bUseAdequacyPatch;
+        return area->adequacyPatchMode;
     }
     static wxString ConvertToString(const Type v)
     {
-        return v ? wxT("True") : wxT("False");
+        switch (v)
+        {
+        case Data::adqmNotUsed:
+            return wxT("Not used");
+        case Data::adqmUsedAsPhysicalArea:
+            return wxT("Physical area");
+        case Data::adqmUsedAsVirtualArea:
+            return wxT("Virtual area");
+        }
+        return wxEmptyString;
     }
 };
+
 
 template<enum Data::AreaNodalOptimization O>
 struct PAreaResortStatus

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -397,8 +397,10 @@ Frame::Frame(wxWindow* parent, bool allowAnyObject) :
       pPGAreaResort,
       new wxBoolProperty(wxT("other dispatch. power"), wxT("area.other_dispatch_power"), false));
 
-    pPGAreaAdequacyPatchTitle = Category(pg, wxT("Adequacy Patch"), wxT("area.adequacy_patch_title"));
-    pPGAreaAUsedequacyPatch = page->Append(new wxBoolProperty(wxT("use adequacy patch"), wxT("area.use_adequacy_patch"), false));
+    pPGAreaAdequacyPatchTitle
+      = Category(pg, wxT("Adequacy Patch"), wxT("area.adequacy_patch_title"));
+    pPGAreaAUsedequacyPatch = page->Append(
+      new wxBoolProperty(wxT("use adequacy patch"), wxT("area.use_adequacy_patch"), false));
 
     pPGAreaLocalization = Category(pg, wxT("Localization"), wxT("area.localization"));
     P_INT("x", "area.x");
@@ -534,11 +536,11 @@ Frame::Frame(wxWindow* parent, bool allowAnyObject) :
     pPGThClusterReliabilityModel
       = Category(pg, wxT("Timeseries generation"), wxT("cluster.reliabilitymodel"));
     pPGThClusterDoGenerateTS = P_ENUM("Generate timeseries", "cluster.gen-ts", localGenTS.data())
-    pPGThClusterVolatilityForced = P_FLOAT("Volatility (forced)", "cluster.forcedVolatility");
+      pPGThClusterVolatilityForced
+      = P_FLOAT("Volatility (forced)", "cluster.forcedVolatility");
     pPGThClusterVolatilityPlanned = P_FLOAT("Volatility (planned)", "cluster.plannedVolatility");
     pPGThClusterLawForced = P_ENUM("Law (forced)", "cluster.forcedlaw", thermalLaws);
     pPGThClusterLawPlanned = P_ENUM("Law (planned)", "cluster.plannedlaw", thermalLaws);
-
 
     // --- RENEWABLE CLUSTERS ---
     pPGRnClusterSeparator = Group(pg, wxEmptyString, wxEmptyString);
@@ -550,7 +552,7 @@ Frame::Frame(wxWindow* parent, bool allowAnyObject) :
     for (uint i = 0; i != arrayRnClusterGroupCount; ++i)
         RnGroupChoices.Add(arrayRnClusterGroup[i], i);
     pPGRnClusterGroup = page->Append(
-        new wxEditEnumProperty(wxT("group"), wxT("rn-cluster.group"), RnGroupChoices, wxEmptyString));
+      new wxEditEnumProperty(wxT("group"), wxT("rn-cluster.group"), RnGroupChoices, wxEmptyString));
 
     pPGRnClusterArea = P_STRING("area", "rn-cluster.area");
     pg->DisableProperty(pPGRnClusterArea);
@@ -947,8 +949,10 @@ void Frame::apply(const InspectorData::Ptr& data)
         // CO2
         Accumulator<PClusterCO2>::Apply(pPGThClusterCO2, data->ThClusters);
         // Volatility
-        Accumulator<PClusterVolatilityPlanned>::Apply(pPGThClusterVolatilityPlanned, data->ThClusters);
-        Accumulator<PClusterVolatilityForced>::Apply(pPGThClusterVolatilityForced, data->ThClusters);
+        Accumulator<PClusterVolatilityPlanned>::Apply(pPGThClusterVolatilityPlanned,
+                                                      data->ThClusters);
+        Accumulator<PClusterVolatilityForced>::Apply(pPGThClusterVolatilityForced,
+                                                     data->ThClusters);
         // Laws
         Accumulator<PClusterLawPlanned>::Apply(pPGThClusterLawPlanned, data->ThClusters);
         Accumulator<PClusterLawForced>::Apply(pPGThClusterLawForced, data->ThClusters);
@@ -968,7 +972,8 @@ void Frame::apply(const InspectorData::Ptr& data)
         AccumulatorCheck<PClusterMinStablePowerColor>::ApplyTextColor(pPGThClusterMinStablePower,
                                                                       data->ThClusters);
         // check Min. Stable Power with thermal modulation
-        AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pPGThClusterSpinning, data->ThClusters);
+        AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pPGThClusterSpinning,
+                                                                data->ThClusters);
     }
 
     pPGThClusterParams->Hide(hide);
@@ -991,7 +996,7 @@ void Frame::apply(const InspectorData::Ptr& data)
         {
             p->SetLabel(wxT("RENEWABLE CLUSTER"));
             pPGRnClusterName->SetValueFromString(
-                wxStringFromUTF8((*(data->RnClusters.begin()))->name()));
+              wxStringFromUTF8((*(data->RnClusters.begin()))->name()));
         }
         else
             p->SetLabel(wxString() << data->RnClusters.size() << wxT(" RENEWABLE CLUSTERS"));

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -399,7 +399,8 @@ Frame::Frame(wxWindow* parent, bool allowAnyObject) :
 
     pPGAreaAdequacyPatchTitle
       = Category(pg, wxT("Adequacy Patch"), wxT("area.adequacy_patch_title"));
-    pPGAreaAdequacyPatchMode = page->Append(new wxEnumProperty(wxT("adequacy patch mode"), wxT("area.adequacy_patch_mode"), adequacyPatchMode));
+    pPGAreaAdequacyPatchMode = page->Append(new wxEnumProperty(
+      wxT("adequacy patch mode"), wxT("area.adequacy_patch_mode"), adequacyPatchMode));
 
     pPGAreaLocalization = Category(pg, wxT("Localization"), wxT("area.localization"));
     P_INT("x", "area.x");

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -399,8 +399,7 @@ Frame::Frame(wxWindow* parent, bool allowAnyObject) :
 
     pPGAreaAdequacyPatchTitle
       = Category(pg, wxT("Adequacy Patch"), wxT("area.adequacy_patch_title"));
-    pPGAreaAUsedequacyPatch = page->Append(
-      new wxBoolProperty(wxT("use adequacy patch"), wxT("area.use_adequacy_patch"), false));
+    pPGAreaAdequacyPatchMode = page->Append(new wxEnumProperty(wxT("adequacy patch mode"), wxT("area.adequacy_patch_mode"), adequacyPatchMode));
 
     pPGAreaLocalization = Category(pg, wxT("Localization"), wxT("area.localization"));
     P_INT("x", "area.x");
@@ -792,7 +791,7 @@ void Frame::apply(const InspectorData::Ptr& data)
         Accumulator<PAreaColor>::Apply(pPGAreaColor, data->areas);
         // Adequacy patch
         if (!multiple)
-            Accumulator<PAreaAdequacyPatch>::Apply(pPGAreaAUsedequacyPatch, data->areas);
+            Accumulator<PAdequacyPatchMode>::Apply(pPGAreaAdequacyPatchMode, data->areas);
         // Area position
         if (!multiple)
         {

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -397,6 +397,9 @@ Frame::Frame(wxWindow* parent, bool allowAnyObject) :
       pPGAreaResort,
       new wxBoolProperty(wxT("other dispatch. power"), wxT("area.other_dispatch_power"), false));
 
+    pPGAreaAdequacyPatchTitle = Category(pg, wxT("Adequacy Patch"), wxT("area.adequacy_patch_title"));
+    pPGAreaAUsedequacyPatch = page->Append(new wxBoolProperty(wxT("use adequacy patch"), wxT("area.use_adequacy_patch"), false));
+
     pPGAreaLocalization = Category(pg, wxT("Localization"), wxT("area.localization"));
     P_INT("x", "area.x");
     P_INT("y", "area.y");
@@ -785,6 +788,9 @@ void Frame::apply(const InspectorData::Ptr& data)
             pPGAreaName->SetValueFromString(wxStringFromUTF8((*(data->areas.begin()))->name));
         // Area color
         Accumulator<PAreaColor>::Apply(pPGAreaColor, data->areas);
+        // Adequacy patch
+        if (!multiple)
+            Accumulator<PAreaAdequacyPatch>::Apply(pPGAreaAUsedequacyPatch, data->areas);
         // Area position
         if (!multiple)
         {
@@ -835,6 +841,7 @@ void Frame::apply(const InspectorData::Ptr& data)
     }
     pPGAreaOptimization->Hide(hide);
     pPGAreaResort->Hide(hide);
+    pPGAreaAdequacyPatchTitle->Hide(hide);
     pPGAreaLocalization->Hide(hide || multiple);
     pPGAreaDeps->Hide(hide);
 

--- a/src/ui/simulator/windows/inspector/frame.h
+++ b/src/ui/simulator/windows/inspector/frame.h
@@ -185,7 +185,7 @@ private:
     wxPGProperty* pPGSpilled;
     wxPGProperty* pPGAreaName;
     wxPGProperty* pPGAreaAdequacyPatchTitle;
-    wxPGProperty* pPGAreaAUsedequacyPatch;
+    wxPGProperty* pPGAreaAdequacyPatchMode;
     wxPGProperty* pPGAreaColor;
     wxPGProperty* pPGAreaLinks;
     wxPGProperty* pPGAreaPlants;

--- a/src/ui/simulator/windows/inspector/frame.h
+++ b/src/ui/simulator/windows/inspector/frame.h
@@ -184,6 +184,8 @@ private:
     wxPGProperty* pPGUnsupplied;
     wxPGProperty* pPGSpilled;
     wxPGProperty* pPGAreaName;
+    wxPGProperty* pPGAreaAdequacyPatchTitle;
+    wxPGProperty* pPGAreaAUsedequacyPatch;
     wxPGProperty* pPGAreaColor;
     wxPGProperty* pPGAreaLinks;
     wxPGProperty* pPGAreaPlants;

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -172,6 +172,17 @@ bool InspectorGrid::onPropertyChanging_A(wxPGProperty*,
         OnStudyNodalOptimizationChanged();
         return true;
     }
+    if (name == "area.use_adequacy_patch")
+    {
+        auto* area = *i;
+        if (area)
+        {
+            area->bUseAdequacyPatch = value.GetBool();
+            OnStudyAreaUseAdequacyPatchChanged();
+            return true;
+        }
+        return false;
+    }
     if (name == "area.links_count")
         return false;
     if (name == "area.cluster_count")

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -172,12 +172,23 @@ bool InspectorGrid::onPropertyChanging_A(wxPGProperty*,
         OnStudyNodalOptimizationChanged();
         return true;
     }
-    if (name == "area.use_adequacy_patch")
+    if (name == "area.adequacy_patch_mode")
     {
         auto* area = *i;
         if (area)
         {
-            area->bUseAdequacyPatch = value.GetBool();
+            String s;
+            wxStringToString(value.GetString(), s);
+            s.toLower();
+            s.trim();
+
+            if (s == "not used" || s == "0")
+                area->adequacyPatchMode = Data::adqmNotUsed;
+            else if (s == "physical area" || s == "1")
+                area->adequacyPatchMode = Data::adqmUsedAsPhysicalArea;
+            else if (s == "virtual area" || s == "2")
+                area->adequacyPatchMode = Data::adqmUsedAsVirtualArea;
+
             OnStudyAreaUseAdequacyPatchChanged();
             return true;
         }

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -937,7 +937,8 @@ bool InspectorGrid::onPropertyChanging_ThermalCluster(wxPGProperty*,
     {
         long index = value.GetLong();
 
-        Data::LocalTSGenerationBehavior behavior = Data::LocalTSGenerationBehavior::useGlobalParameter;
+        Data::LocalTSGenerationBehavior behavior
+          = Data::LocalTSGenerationBehavior::useGlobalParameter;
 
         switch (index)
         {

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -182,12 +182,12 @@ bool InspectorGrid::onPropertyChanging_A(wxPGProperty*,
             s.toLower();
             s.trim();
 
-            if (s == "not used" || s == "0")
-                area->adequacyPatchMode = Data::adqmNotUsed;
-            else if (s == "physical area" || s == "1")
-                area->adequacyPatchMode = Data::adqmUsedAsPhysicalArea;
-            else if (s == "virtual area" || s == "2")
-                area->adequacyPatchMode = Data::adqmUsedAsVirtualArea;
+            if (s == "virtual area" || s == "0")
+                area->adequacyPatchMode = Data::adqmVirtualArea;
+            else if (s == "physical area outside patch" || s == "1")
+                area->adequacyPatchMode = Data::adqmPhysicalAreaOutsideAdqPatch;
+            else if (s == "physical area inside patch" || s == "2")
+                area->adequacyPatchMode = Data::adqmPhysicalAreaInsideAdqPatch;
 
             OnStudyAreaUseAdequacyPatchChanged();
             return true;

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -491,7 +491,7 @@ void Optimization::refresh()
     ResetButton(pBtnSpinningReserve, study.parameters.include.reserve.spinning);
     // Export mps
     ResetButtonSpecify(pBtnExportMPS, study.parameters.include.exportMPS);
-    // Export adequacy patch
+    // Adequacy patch
     ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.include.adequacyPatch);
 
 

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -323,7 +323,6 @@ Optimization::Optimization(wxWindow* parent) :
         pBtnAdequacyPatch = button;
     }
 
-
     // Unfeasible problem behavior
     {
         label = Component::CreateLabel(this, wxT("Unfeasible problem behavior"));
@@ -493,7 +492,6 @@ void Optimization::refresh()
     ResetButtonSpecify(pBtnExportMPS, study.parameters.include.exportMPS);
     // Adequacy patch
     ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.include.adequacyPatch);
-
 
     // Unfeasible problem behavior
     pBtnUnfeasibleProblemBehavior->image(

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -308,6 +308,22 @@ Optimization::Optimization(wxWindow* parent) :
         pBtnExportMPS = button;
     }
 
+    // Adequacy patch
+    {
+        label = Component::CreateLabel(this, wxT("Adequacy patch"));
+        button = new Component::Button(this, wxT("true"), "images/16x16/light_green.png");
+        button->SetBackgroundColour(bgColor);
+        button->menu(true);
+        onPopup.bind(this,
+                     &Optimization::onPopupMenuSpecify,
+                     PopupInfo(study.parameters.include.adequacyPatch, wxT("true")));
+        button->onPopupMenu(onPopup);
+        s->Add(label, 0, wxRIGHT | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL);
+        s->Add(button, 0, wxLEFT | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL);
+        pBtnAdequacyPatch = button;
+    }
+
+
     // Unfeasible problem behavior
     {
         label = Component::CreateLabel(this, wxT("Unfeasible problem behavior"));
@@ -427,6 +443,7 @@ void Optimization::onResetToDefault(void*)
             study.parameters.include.reserve.primary = true;
             study.parameters.include.reserve.spinning = true;
             study.parameters.include.exportMPS = false;
+            study.parameters.include.adequacyPatch = false;
             study.parameters.simplexOptimizationRange = Data::sorWeek;
 
             study.parameters.include.unfeasibleProblemBehavior
@@ -474,6 +491,9 @@ void Optimization::refresh()
     ResetButton(pBtnSpinningReserve, study.parameters.include.reserve.spinning);
     // Export mps
     ResetButtonSpecify(pBtnExportMPS, study.parameters.include.exportMPS);
+    // Export adequacy patch
+    ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.include.adequacyPatch);
+
 
     // Unfeasible problem behavior
     pBtnUnfeasibleProblemBehavior->image(

--- a/src/ui/simulator/windows/options/optimization/optimization.h
+++ b/src/ui/simulator/windows/options/optimization/optimization.h
@@ -115,6 +115,7 @@ private:
     Component::Button* pBtnSimplexOptimizationRange;
 
     Component::Button* pBtnExportMPS;
+    Component::Button* pBtnAdequacyPatch;
     Component::Button* pBtnUnfeasibleProblemBehavior;
     bool* pTargetRef;
 


### PR DESCRIPTION
Hello Florian,

We encountered a small roadblock in the implementation of the AdequacyPatch and wanted to have your input before pursuing. We are unsure of the best way to reset the **pProblemesHebdo** in the _economy.cpp_ file, after the first **OPT_OptimisationHebdomadaire** was run. I include the small test file we have been playing with: [t3-2.zip](https://github.com/AntaresSimulatorTeam/Antares_Simulator/files/8091916/t3-2.zip).

The way we see it, there are two options:
1.  _using the **SIM_RenseignementProblemeHebdo** method._ The problem we have with that is we don't know the whole behavior of that function and are unsure if it is safe to use again.
2. _extracting only the required parts of **SIM_RenseignementProblemeHebdo** in a smaller function and use it in economy.cpp_
The problem with that second solution is that we are not entirely sure of ALL the parameters that need resetting inside of the **pProblemesHebdo**.

Inside of economy.cpp I left comments to test the two solutions. Let me know of your view on this, and if it is safe to use **SIM_RenseignementProblemeHebdo**.

Thanks in advance !