### PR TITLE
Restore results for non-regression tests

### DIFF
--- a/src/libs/antares/study/action/context.cpp
+++ b/src/libs/antares/study/action/context.cpp
@@ -33,10 +33,9 @@ namespace Antares
 {
 namespace Action
 {
-Context::Context(Data::Study& targetStudy, const size_t layer) :
+Context::Context(Data::Study::Ptr targetStudy, const size_t layer) :
  study(targetStudy),
  extStudy(nullptr),
- shouldDestroyExtStudy(false),
  layerID(layer),
  area(nullptr),
  cluster(nullptr),
@@ -44,15 +43,6 @@ Context::Context(Data::Study& targetStudy, const size_t layer) :
  originalPlant(nullptr),
  constraint(nullptr)
 {
-}
-
-Context::~Context()
-{
-    if (extStudy && shouldDestroyExtStudy)
-    {
-        delete extStudy;
-        extStudy = nullptr;
-    }
 }
 
 void Context::reset()

--- a/src/libs/antares/study/action/context.h
+++ b/src/libs/antares/study/action/context.h
@@ -57,9 +57,9 @@ public:
 public:
     //! \name Constructor & Destructor
     //@{
-    explicit Context(Data::Study& targetStudy, const size_t layer = 0);
+    explicit Context(Data::Study::Ptr targetStudy, const size_t layer = 0);
     //! Destructor
-    ~Context();
+    ~Context() = default;
     //@}
 
     /*!
@@ -69,12 +69,9 @@ public:
 
 public:
     //! The target study
-    // TODO : use smart ptr here
-    Data::Study& study;
+    Data::Study::Ptr study;
     //! An optional external study, which will be destroyed with this class
-    // TODO : use smart ptr here
-    Data::Study* extStudy;
-    bool shouldDestroyExtStudy;
+    Data::Study::Ptr extStudy;
 
     // The current Layer
     const size_t layerID;

--- a/src/libs/antares/study/action/handler/antares-study/area/allocation-hydro-post.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/area/allocation-hydro-post.cpp
@@ -68,11 +68,11 @@ bool AllocationHydroPost::performWL(Context& ctx)
             Data::AreaName targetID;
             TransformNameIntoID(ctx.areaNameMapping[pOriginalAreaName], targetID);
 
-            auto* targetArea = ctx.study.areas.find(targetID);
+            auto* targetArea = ctx.study->areas.find(targetID);
             if (targetArea && targetArea != source)
             {
                 targetArea->hydro.allocation.copyFrom(
-                  source->hydro.allocation, *ctx.extStudy, ctx.areaNameMapping, ctx.study);
+                  source->hydro.allocation, *ctx.extStudy, ctx.areaNameMapping, *ctx.study);
             }
             return true;
         }

--- a/src/libs/antares/study/action/handler/antares-study/area/correlation-post.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/area/correlation-post.cpp
@@ -66,32 +66,32 @@ bool CorrelationPost::performWL(Context& ctx)
             switch (pType)
             {
             case Data::timeSeriesLoad:
-                ctx.study.preproLoadCorrelation.copyFrom(ctx.extStudy->preproLoadCorrelation,
-                                                         *ctx.extStudy,
-                                                         pOriginalAreaName,
-                                                         ctx.areaNameMapping,
-                                                         ctx.study);
+                ctx.study->preproLoadCorrelation.copyFrom(ctx.extStudy->preproLoadCorrelation,
+                                                          *ctx.extStudy,
+                                                          pOriginalAreaName,
+                                                          ctx.areaNameMapping,
+                                                          *ctx.study);
                 break;
             case Data::timeSeriesSolar:
-                ctx.study.preproSolarCorrelation.copyFrom(ctx.extStudy->preproSolarCorrelation,
-                                                          *ctx.extStudy,
-                                                          pOriginalAreaName,
-                                                          ctx.areaNameMapping,
-                                                          ctx.study);
+                ctx.study->preproSolarCorrelation.copyFrom(ctx.extStudy->preproSolarCorrelation,
+                                                           *ctx.extStudy,
+                                                           pOriginalAreaName,
+                                                           ctx.areaNameMapping,
+                                                           *ctx.study);
                 break;
             case Data::timeSeriesWind:
-                ctx.study.preproWindCorrelation.copyFrom(ctx.extStudy->preproWindCorrelation,
-                                                         *ctx.extStudy,
-                                                         pOriginalAreaName,
-                                                         ctx.areaNameMapping,
-                                                         ctx.study);
-                break;
-            case Data::timeSeriesHydro:
-                ctx.study.preproHydroCorrelation.copyFrom(ctx.extStudy->preproHydroCorrelation,
+                ctx.study->preproWindCorrelation.copyFrom(ctx.extStudy->preproWindCorrelation,
                                                           *ctx.extStudy,
                                                           pOriginalAreaName,
                                                           ctx.areaNameMapping,
-                                                          ctx.study);
+                                                          *ctx.study);
+                break;
+            case Data::timeSeriesHydro:
+                ctx.study->preproHydroCorrelation.copyFrom(ctx.extStudy->preproHydroCorrelation,
+                                                           *ctx.extStudy,
+                                                           pOriginalAreaName,
+                                                           ctx.areaNameMapping,
+                                                           *ctx.study);
                 break;
             default:
                 break;

--- a/src/libs/antares/study/action/handler/antares-study/area/create.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/area/create.cpp
@@ -126,7 +126,7 @@ bool Create::prepareWL(Context& ctx)
         if (suffix == "<auto>" || !explicitTarget)
         {
             TransformNameIntoID(pFuturAreaName, id);
-            areaFound = ctx.study.areas.find(id);
+            areaFound = ctx.study->areas.find(id);
             if (areaFound)
             {
                 Data::AreaName::Size sepPos = id.find_last_of('-');
@@ -147,7 +147,7 @@ bool Create::prepareWL(Context& ctx)
                     pFuturAreaName.clear() << pTargetAreaName << "-" << indx;
                     id.clear();
                     TransformNameIntoID(pFuturAreaName, id);
-                    areaFound = ctx.study.areas.find(id);
+                    areaFound = ctx.study->areas.find(id);
                 } while (areaFound);
             }
         }
@@ -155,13 +155,13 @@ bool Create::prepareWL(Context& ctx)
         {
             pFuturAreaName += suffix;
             TransformNameIntoID(pFuturAreaName, id);
-            areaFound = ctx.study.areas.find(id);
+            areaFound = ctx.study->areas.find(id);
         }
     }
     else
     {
         TransformNameIntoID(pFuturAreaName, id);
-        areaFound = ctx.study.areas.find(id);
+        areaFound = ctx.study->areas.find(id);
     }
 
     // area mapping
@@ -214,13 +214,13 @@ bool Create::performWL(Context& ctx)
 
     Data::AreaName id;
     TransformNameIntoID(pFuturAreaName, id);
-    ctx.area = ctx.study.areas.find(id);
+    ctx.area = ctx.study->areas.find(id);
 
     // The area
     if (not ctx.area)
     {
         // create the area
-        ctx.area = ctx.study.areaAdd(pFuturAreaName);
+        ctx.area = ctx.study->areaAdd(pFuturAreaName);
         logs.debug() << "[study-action] The area " << pFuturAreaName << " has been created";
     }
     else

--- a/src/libs/antares/study/action/handler/antares-study/constraint/create.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/constraint/create.cpp
@@ -98,7 +98,7 @@ bool Create::prepareWL(Context& ctx)
         if (suffix == "<auto>" || !explicitTarget)
         {
             TransformNameIntoID(pFuturConstraintName, id);
-            constraintFound = ctx.study.bindingConstraints.find(id);
+            constraintFound = ctx.study->bindingConstraints.find(id);
             if (constraintFound)
             {
                 Antares::Data::ConstraintName::Size sepPos = id.find_last_of('-');
@@ -119,7 +119,7 @@ bool Create::prepareWL(Context& ctx)
                     pFuturConstraintName.clear() << pTargetConstraintName << "-" << indx;
                     id.clear();
                     TransformNameIntoID(pFuturConstraintName, id);
-                    constraintFound = ctx.study.bindingConstraints.find(id);
+                    constraintFound = ctx.study->bindingConstraints.find(id);
                 } while (constraintFound);
             }
         }
@@ -127,13 +127,13 @@ bool Create::prepareWL(Context& ctx)
         {
             pFuturConstraintName += suffix;
             TransformNameIntoID(pFuturConstraintName, id);
-            constraintFound = ctx.study.bindingConstraints.find(id);
+            constraintFound = ctx.study->bindingConstraints.find(id);
         }
     }
     else
     {
         TransformNameIntoID(pFuturConstraintName, id);
-        constraintFound = ctx.study.bindingConstraints.find(id);
+        constraintFound = ctx.study->bindingConstraints.find(id);
     }
 
     pInfos.caption.clear() << "Constraint " << pFuturConstraintName;
@@ -178,13 +178,13 @@ bool Create::performWL(Context& ctx)
 
     String id;
     TransformNameIntoID(pFuturConstraintName, id);
-    ctx.constraint = ctx.study.bindingConstraints.find(id);
+    ctx.constraint = ctx.study->bindingConstraints.find(id);
 
     // The area
     if (!ctx.constraint)
     {
         // create the area
-        ctx.constraint = ctx.study.bindingConstraints.add(pFuturConstraintName);
+        ctx.constraint = ctx.study->bindingConstraints.add(pFuturConstraintName);
         ctx.constraint->clearAndReset(pFuturConstraintName, pType, pOperator);
         logs.debug() << "[study-action] The constraint " << pFuturConstraintName
                      << " has been created";

--- a/src/libs/antares/study/action/handler/antares-study/constraint/offsets.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/constraint/offsets.cpp
@@ -112,7 +112,7 @@ bool Offsets::performWL(Context& ctx)
             {
                 tr.bind(this, &Offsets::translate);
             }
-            ctx.constraint->copyOffsets(ctx.study, *source, true, tr);
+            ctx.constraint->copyOffsets(*ctx.study, *source, true, tr);
             pCurrentContext = nullptr;
             return true;
         }

--- a/src/libs/antares/study/action/handler/antares-study/constraint/weights.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/constraint/weights.cpp
@@ -112,7 +112,7 @@ bool Weights::performWL(Context& ctx)
             {
                 tr.bind(this, &Weights::translate);
             }
-            ctx.constraint->copyWeights(ctx.study, *source, true, tr);
+            ctx.constraint->copyWeights(*ctx.study, *source, true, tr);
             pCurrentContext = nullptr;
             return true;
         }

--- a/src/libs/antares/study/action/handler/antares-study/link/create.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/link/create.cpp
@@ -104,10 +104,10 @@ bool Create::prepareWL(Context& ctx)
     Antares::Data::Area* areaTo;
     Data::AreaName id;
     TransformNameIntoID(from, id);
-    areaFrom = ctx.study.areas.find(id);
+    areaFrom = ctx.study->areas.find(id);
     id.clear();
     TransformNameIntoID(to, id);
-    areaTo = ctx.study.areas.find(id);
+    areaTo = ctx.study->areas.find(id);
 
     if (areaFrom && areaTo)
     {
@@ -152,10 +152,10 @@ bool Create::performWL(Context& ctx)
     Antares::Data::Area* areaTo;
     Data::AreaName id;
     TransformNameIntoID(from, id);
-    areaFrom = ctx.study.areas.find(id);
+    areaFrom = ctx.study->areas.find(id);
     id.clear();
     TransformNameIntoID(to, id);
-    areaTo = ctx.study.areas.find(id);
+    areaTo = ctx.study->areas.find(id);
 
     if (areaFrom && areaTo)
     {
@@ -167,7 +167,7 @@ bool Create::performWL(Context& ctx)
             logs.debug() << "[study-action] The link " << areaFrom->id << " - " << areaTo->id
                          << " has been created";
             ctx.link = AreaListAddLink(
-              &(ctx.study.areas), areaFrom->id.c_str(), areaTo->id.c_str(), false);
+              &(ctx.study->areas), areaFrom->id.c_str(), areaTo->id.c_str(), false);
             ctx.link->resetToDefaultValues();
             ctx.autoselectLinks.push_back(ctx.link);
             return true;

--- a/src/libs/antares/study/action/handler/antares-study/thermal-cluster/create.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/thermal-cluster/create.cpp
@@ -73,7 +73,7 @@ bool Create::prepareWL(Context& ctx)
 
     // finding the final area
     const Data::AreaName& areaMapping = ctx.areaNameMapping[pOriginalAreaName];
-    const Data::Area* area = ctx.study.areas.findFromName(areaMapping);
+    const Data::Area* area = ctx.study->areas.findFromName(areaMapping);
     bool forceAreaCreate = ctx.areaForceCreate[pOriginalAreaName];
     bool forcePlantCreate = ctx.clusterForceCreate[pOriginalAreaName];
 

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -651,9 +651,9 @@ static bool SGDIntLoadFamily_OtherPreferences(Parameters& d,
             d.hydroPricing.hpMode = hpricing;
             return true;
         }
-        logs.warning() << "parameters: invalid unit commitment mode. Got '" << value
+        logs.warning() << "parameters: invalid hydro pricing mode. Got '" << value
                        << "'. reset to fast mode";
-        d.unitCommitment.ucMode = ucHeuristic;
+        d.hydroPricing.hpMode = hpHeuristic;
         return false;
     }
     if (key == "initial-reservoir-levels")

--- a/src/libs/antares/study/parts/renewable/container.cpp
+++ b/src/libs/antares/study/parts/renewable/container.cpp
@@ -104,7 +104,11 @@ uint PartRenewable::removeDisabledClusters()
     for (auto& cluster : disabledClusters)
         list.remove(cluster);
 
-    return disabledClusters.size();
+    const auto count = disabledClusters.size();
+    if (count)
+        list.rebuildIndex();
+
+    return count;
 }
 
 void PartRenewable::reset()

--- a/src/libs/antares/study/parts/thermal/container.cpp
+++ b/src/libs/antares/study/parts/thermal/container.cpp
@@ -161,7 +161,11 @@ uint PartThermal::removeDisabledClusters()
     for (const auto& cluster : disabledClusters)
         list.remove(cluster);
 
-    return disabledClusters.size();
+    const auto count = disabledClusters.size();
+    if (count)
+        list.rebuildIndex();
+
+    return count;
 }
 
 void PartThermal::reset()

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -161,21 +161,26 @@ void HydroManagement::prepareNetDemand(uint numSpace)
             auto realmonth = study.calendar.months[month].realmonth;
             auto dayYear = study.calendar.hours[hour].dayYear;
 
-            double netdemand
-              = +scratchpad.ts.load[ptchro.Consommation][hour] - scratchpad.miscGenSum[hour]
-                - ror[hour]
-                - ((ModeT != Data::stdmAdequacy) ? scratchpad.mustrunSum[hour]
-                                                 : scratchpad.originalMustrunSum[hour]);
+            double netdemand = 0;
 
             // Aggregated renewable production: wind & solar
             if (parameters.renewableGeneration.isAggregated())
             {
-                netdemand -= scratchpad.ts.solar[ptchro.Solar][hour]
-                             + scratchpad.ts.wind[ptchro.Eolien][hour];
+                netdemand = +scratchpad.ts.load[ptchro.Consommation][hour]
+                            - scratchpad.ts.wind[ptchro.Eolien][hour] - scratchpad.miscGenSum[hour]
+                            - scratchpad.ts.solar[ptchro.Solar][hour] - ror[hour]
+                            - ((ModeT != Data::stdmAdequacy) ? scratchpad.mustrunSum[hour]
+                                                             : scratchpad.originalMustrunSum[hour]);
             }
+
             // Renewable clusters, if enabled
             else if (parameters.renewableGeneration.isClusters())
             {
+                netdemand = scratchpad.ts.load[ptchro.Consommation][hour]
+                            - scratchpad.miscGenSum[hour] - ror[hour]
+                            - ((ModeT != Data::stdmAdequacy) ? scratchpad.mustrunSum[hour]
+                                                             : scratchpad.originalMustrunSum[hour]);
+
                 area.renewable.list.each([&](const Antares::Data::RenewableCluster& cluster) {
                     assert(cluster.series->series.jit == NULL && "No JIT data from the solver");
                     netdemand -= cluster.valueAtTimeStep(

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -598,7 +598,7 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem,
 
             uint tsFatalIndex = (uint)tsIndex.Hydraulique < ror.width ? tsIndex.Hydraulique : 0;
             double& mustRunGen = problem.AllMustRunGeneration[j]->AllMustRunGenerationOfArea[k];
-            if (parameters.renewableGeneration() == rgAggregated)
+            if (parameters.renewableGeneration.isAggregated())
             {
                 mustRunGen = scratchpad.ts.wind[tsIndex.Eolien][indx]
                              + scratchpad.ts.solar[tsIndex.Solar][indx]

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -597,23 +597,25 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem,
             }
 
             uint tsFatalIndex = (uint)tsIndex.Hydraulique < ror.width ? tsIndex.Hydraulique : 0;
-            double& mrgen = problem.AllMustRunGeneration[j]->AllMustRunGenerationOfArea[k];
+            double& mustRunGen = problem.AllMustRunGeneration[j]->AllMustRunGenerationOfArea[k];
             if (parameters.renewableGeneration() == rgAggregated)
             {
-                mrgen = scratchpad.ts.wind[tsIndex.Eolien][indx]
-                        + scratchpad.ts.solar[tsIndex.Solar][indx] + scratchpad.miscGenSum[indx]
-                        + ror[tsFatalIndex][indx] + scratchpad.mustrunSum[indx];
+                mustRunGen = scratchpad.ts.wind[tsIndex.Eolien][indx]
+                             + scratchpad.ts.solar[tsIndex.Solar][indx]
+                             + scratchpad.miscGenSum[indx] + ror[tsFatalIndex][indx]
+                             + scratchpad.mustrunSum[indx];
             }
 
             // Renewable
             if (parameters.renewableGeneration.isClusters())
             {
+                mustRunGen = scratchpad.miscGenSum[indx] + ror[tsFatalIndex][indx]
+                             + scratchpad.mustrunSum[indx];
+
                 area.renewable.list.each([&](const RenewableCluster& cluster) {
                     assert(cluster.series->series.jit == NULL && "No JIT data from the solver");
-                    mrgen = scratchpad.miscGenSum[indx] + ror[tsFatalIndex][indx]
-                            + scratchpad.mustrunSum[indx]
-                            + cluster.valueAtTimeStep(
-                              tsIndex.RenouvelableParPalier[cluster.areaWideIndex], (uint)indx);
+                    mustRunGen += cluster.valueAtTimeStep(
+                      tsIndex.RenouvelableParPalier[cluster.areaWideIndex], (uint)indx);
                 });
             }
 

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -597,14 +597,12 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem,
             }
 
             uint tsFatalIndex = (uint)tsIndex.Hydraulique < ror.width ? tsIndex.Hydraulique : 0;
-            problem.AllMustRunGeneration[j]->AllMustRunGenerationOfArea[k]
-              = scratchpad.miscGenSum[indx] + ror[tsFatalIndex][indx] + scratchpad.mustrunSum[indx];
-
-            if (parameters.renewableGeneration.isAggregated())
+            double& mrgen = problem.AllMustRunGeneration[j]->AllMustRunGenerationOfArea[k];
+            if (parameters.renewableGeneration() == rgAggregated)
             {
-                problem.AllMustRunGeneration[j]->AllMustRunGenerationOfArea[k]
-                  += scratchpad.ts.wind[tsIndex.Eolien][indx]
-                     + scratchpad.ts.solar[tsIndex.Solar][indx];
+                mrgen = scratchpad.ts.wind[tsIndex.Eolien][indx]
+                        + scratchpad.ts.solar[tsIndex.Solar][indx] + scratchpad.miscGenSum[indx]
+                        + ror[tsFatalIndex][indx] + scratchpad.mustrunSum[indx];
             }
 
             // Renewable
@@ -612,9 +610,10 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem,
             {
                 area.renewable.list.each([&](const RenewableCluster& cluster) {
                     assert(cluster.series->series.jit == NULL && "No JIT data from the solver");
-                    problem.AllMustRunGeneration[j]->AllMustRunGenerationOfArea[k]
-                      += cluster.valueAtTimeStep(
-                        tsIndex.RenouvelableParPalier[cluster.areaWideIndex], (uint)indx);
+                    mrgen = scratchpad.miscGenSum[indx] + ror[tsFatalIndex][indx]
+                            + scratchpad.mustrunSum[indx]
+                            + cluster.valueAtTimeStep(
+                              tsIndex.RenouvelableParPalier[cluster.areaWideIndex], (uint)indx);
                 });
             }
 

--- a/src/ui/simulator/application/main/paste-from-clipboard.cpp
+++ b/src/ui/simulator/application/main/paste-from-clipboard.cpp
@@ -143,7 +143,7 @@ void PreparePasteFromClipboard(const String& text, bool forceDialog)
     {
         auto study = Data::Study::Current::Get();
         if (!(!study))
-            Antares::ExtSource::Handler::AntaresStudy(*study, text, line + 1, map, forceDialog);
+            Antares::ExtSource::Handler::AntaresStudy(study, text, line + 1, map, forceDialog);
         return;
     }
 }

--- a/src/ui/simulator/toolbox/ext-source/handler/com.rte-france.antares.study.cpp
+++ b/src/ui/simulator/toolbox/ext-source/handler/com.rte-france.antares.study.cpp
@@ -249,7 +249,7 @@ static void PreparePasteOperations(Antares::Action::Context::Ptr context,
         begin = end + 1;
     } while (!stop);
 
-    if (context->extStudy->header.version != context->study.header.version)
+    if (context->extStudy->header.version != context->study->header.version)
     {
         logs.error() << "Impossible to paste data from a study with a different version number.";
         return;
@@ -264,20 +264,11 @@ static void PreparePasteOperations(Antares::Action::Context::Ptr context,
     if (not checkLinkSupportingElementsIntegrity(context, &ctx))
         return;
 
-    if (ctx.modifiedWhenCopied && context->shouldDestroyExtStudy)
-    {
-        // We have to check that the study was not modified when copied
-        // since we are re-loading the whole study, the data may not be up-to-date
-        logs.error()
-          << "Impossible to paste data from another instance. Please save the changes before.";
-        return;
-    }
-
     bool copyPosition = !ctx.shouldOverwriteArea;
 
     // Build the tree
     // Checking if the study comes from another folder
-    if (context->extStudy->folder != context->study.folder)
+    if (context->extStudy->folder != context->study->folder)
     {
         ctx.shouldOverwriteArea = true;
         copyPosition = true;
@@ -433,7 +424,7 @@ public:
                         wxT("Gathering informations about the study"),
                         "images/32x32/open.png"),
      pFolder(folder),
-     pStudy(NULL)
+     pStudy(nullptr)
     {
     }
     //! Destructor
@@ -446,7 +437,7 @@ public:
         pFolder = f;
     }
 
-    Data::Study* study() const
+    Data::Study::Ptr study() const
     {
         return pStudy;
     }
@@ -462,7 +453,7 @@ protected:
         wxStringToString(pFolder, sFl);
 
         {
-            auto* study = new Data::Study(); // new study
+            auto study = std::make_shared<Data::Study>(); // new study
 
             // Load all data
             Data::StudyLoadOptions options;
@@ -490,13 +481,13 @@ private:
     //! The folder where the study is located
     wxString pFolder;
     //! Our study
-    Data::Study* pStudy;
+    Data::Study::Ptr pStudy;
 
 }; // class JobOpenStudy
 
 } // anonymous namespace
 
-void AntaresStudy(Data::Study& target,
+void AntaresStudy(Data::Study::Ptr target,
                   const String& content,
                   uint offset,
                   PropertyMap& map,
@@ -511,7 +502,7 @@ void AntaresStudy(Data::Study& target,
     auto& path = map["path"];
 
     // update area name id set
-    target.areas.updateNameIDSet();
+    target->areas.updateNameIDSet();
 
     Map::Component* mainMap = Antares::Forms::ApplWnd::Instance()->map();
     size_t targetLayerID = 0;
@@ -523,10 +514,9 @@ void AntaresStudy(Data::Study& target,
 
     // If the path of the study where items should be extracted is the same than the current opened
     // study, we can directly use it
-    if (!path || path == target.folder)
+    if (!path || path == target->folder)
     {
-        context->extStudy = &target;
-        context->shouldDestroyExtStudy = false;
+        context->extStudy = target;
 
         PreparePasteOperations(context, content, offset, forceDialog);
     }
@@ -541,7 +531,6 @@ void AntaresStudy(Data::Study& target,
             return;
         }
         context->extStudy = job->study();
-        context->shouldDestroyExtStudy = true;
 
         job->Destroy();
 

--- a/src/ui/simulator/toolbox/ext-source/handler/handler.h
+++ b/src/ui/simulator/toolbox/ext-source/handler/handler.h
@@ -49,7 +49,7 @@ typedef std::map<Key, Value> PropertyMap;
 /*!
 ** \brief Paste from the clipboard items from an Antares Study
 */
-void AntaresStudy(Data::Study& target,
+void AntaresStudy(Data::Study::Ptr target,
                   const Yuni::String& content,
                   uint offset,
                   PropertyMap& map,

--- a/src/ui/simulator/toolbox/ext-source/performer.cpp
+++ b/src/ui/simulator/toolbox/ext-source/performer.cpp
@@ -434,14 +434,13 @@ void PerformerDialog::closeWindow()
             // Unselect from the inspector
             Antares::Window::Inspector::Unselect();
             // ReAdjust all interconnections
-            study.areas.fixOrientationForAllInterconnections(study.bindingConstraints);
+            study->areas.fixOrientationForAllInterconnections(study->bindingConstraints);
             // reload the UI infos
-            study.uiinfo->reloadAll();
+            study->uiinfo->reloadAll();
             // Mark the study as modified
             MarkTheStudyAsModified();
 
             // updating the map
-            // There is no good reason to have a nullptr pointer here but just in case...
             auto* map = mainFrm.map();
             if (map)
             {
@@ -451,8 +450,7 @@ void PerformerDialog::closeWindow()
 
             // Reload runtime data
             auto currentStudy = Data::Study::Current::Get();
-            if (currentStudy
-                != Data::Study::Ptr(&study)) // TODO use smartptr for Action::Context::study
+            if (currentStudy != study)
                 currentStudy->uiinfo->reloadAll();
         }
     }


### PR DESCRIPTION
In this PR, we change the code so as to remove **pathological differences**. Specifically, we partially revert
- aa186d0c Re-implement removeDisabledClusters()
- d170afc1 Take renewableGeneration into account for must run prod
- c36b913d Fix hydro heuristic (#375)

Please note that the two following PRs introduce **legitimate differences** :
- Fix hydro level discontinuities (#491)
- Fix weekly->daily interpolation for min/max reservoir level (#425)

We may still need to re-generate results for non-regression tests to include those legitimate differences.