### PR TITLE
FLOW QUAD : use batches to compute the average hourly NTC

### DIFF
--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -35,6 +35,7 @@
 #include "common-eco-adq.h"
 #include <antares/logs.h>
 #include <cassert>
+#include <map>
 #include "simulation.h"
 #include "../aleatoire/alea_fonctions.h"
 
@@ -377,14 +378,26 @@ int retrieveAverageNTC(const Data::Study& study,
     const auto width = capacities.width;
     avg.assign(HOURS_PER_YEAR, 0);
 
+    std::map<Yuni::uint32, double> weightOfTS;
+
     for (uint y = 0; y < study.parameters.nbYears; y++)
     {
         if (!yearsFilter[y])
             continue;
-        Yuni::uint32 tsNumber = (width == 1) ? 0 : tsNumbers[0][y];
+
+        Yuni::uint32 tsIndex = (width == 1) ? 0 : tsNumbers[0][y];
+        weightOfTS[tsIndex] += yearsWeight[y];
+    }
+
+    // No need for the year number, only the TS index is required
+    for (const auto& it : weightOfTS)
+    {
+        const Yuni::uint32 tsIndex = it.first;
+        const double weight = it.second;
+
         for (uint h = 0; h < HOURS_PER_YEAR; h++)
         {
-            avg[h] += capacities[tsNumber][h] * yearsWeight[y];
+            avg[h] += capacities[tsIndex][h] * weight;
         }
     }
 

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -369,13 +369,18 @@ int retrieveAverageNTC(const Data::Study& study,
                        const Matrix<Yuni::uint32>& tsNumbers,
                        std::vector<double>& avg)
 {
-    auto yearsWeight = study.parameters.getYearsWeight();
-    auto yearsWeightSum = study.parameters.getYearsWeightSum();
+    const auto& parameters = study.parameters;
+
+    const auto& yearsWeight = parameters.getYearsWeight();
+    const auto& yearsWeightSum = parameters.getYearsWeightSum();
+    const auto& yearsFilter = parameters.yearsFilter;
     const auto width = capacities.width;
     avg.assign(HOURS_PER_YEAR, 0);
 
     for (uint y = 0; y < study.parameters.nbYears; y++)
     {
+        if (!yearsFilter[y])
+            continue;
         Yuni::uint32 tsNumber = (width == 1) ? 0 : tsNumbers[0][y];
         for (uint h = 0; h < HOURS_PER_YEAR; h++)
         {


### PR DESCRIPTION
This PR intends to speed up the computation of FLOW QUAD results.

The archetypal example is the following : N MC years with all the same NTC timeseries, with weight = 1 for all MC years. There is no need to compute `(capa+capa+...+capa)/N`. Instead, we compute `N*capa/N`, which is roughly N times faster.