### PR TITLE
Link upper banner : update the banner (or board) when changing of tab

### DIFF
--- a/src/ui/simulator/application/main/create.cpp
+++ b/src/ui/simulator/application/main/create.cpp
@@ -714,15 +714,13 @@ void ApplWnd::createNBInterconnections()
         pNotebook, wxT("interconnections"), wxT("Links"));
 
     // links parameters time series
-    auto* lpg = new_check_allocation<Window::linkParametersGrid>();
-    auto* intercoParam
-      = new_check_allocation<Window::Interconnection>(page.first, page.second, lpg);
+    auto* parametersGrid = new_check_allocation<Window::linkParametersGrid>();
+    auto* intercoParam = new_check_allocation<Window::Interconnection>(page.first, page.second, parametersGrid);
     pageLinksParameters = page.first->add(intercoParam, wxT(" Parameters "));
 
     // links NTC time series
     auto* ntcGrid = new_check_allocation<Window::linkNTCgrid>();
-    auto* intercoGrid
-      = new_check_allocation<Window::Interconnection>(page.first, page.second, ntcGrid);
+    auto* intercoGrid = new_check_allocation<Window::Interconnection>(page.first, page.second, ntcGrid);
     pageLinksNTC = page.first->add(intercoGrid, wxT(" Transmission capacities "));
 
     // Summary

--- a/src/ui/simulator/windows/connection.cpp
+++ b/src/ui/simulator/windows/connection.cpp
@@ -99,10 +99,10 @@ void linkNTCgrid::add(wxBoxSizer* sizer,
 }
 
 // Events to update a link property in all Interconnection objects (upper banner for any link view) 
-Yuni::Event<void(Antares::Data::AreaLink*)> onTransmissionCapacitiesUsageChanges;
-Yuni::Event<void(Antares::Data::AreaLink*)> onHurdleCostsUsageChanges;
-Yuni::Event<void(Antares::Data::AreaLink*)> onAssetTypeChanges;
-Yuni::Event<void(Antares::Data::AreaLink*)> onLinkCaptionChanges;
+Yuni::Event<void(const Antares::Data::AreaLink*)> onTransmissionCapacitiesUsageChanges;
+Yuni::Event<void(const Antares::Data::AreaLink*)> onHurdleCostsUsageChanges;
+Yuni::Event<void(const Antares::Data::AreaLink*)> onAssetTypeChanges;
+Yuni::Event<void(const Antares::Data::AreaLink*)> onLinkCaptionChanges;
 
 
 Interconnection::Interconnection(wxWindow* parent,
@@ -309,7 +309,7 @@ void Interconnection::onConnectionChanged(Data::AreaLink* link)
     this->SetScrollRate(5, 5);
 }
 
-void Interconnection::updatePhaseShifter(Antares::Data::AreaLink* link)
+void Interconnection::updatePhaseShifter(const Data::AreaLink* link)
 {
     if (link->usePST)
     {
@@ -323,7 +323,7 @@ void Interconnection::updatePhaseShifter(Antares::Data::AreaLink* link)
     }
 }
 
-void Interconnection::updateLoopFlowUsage(Antares::Data::AreaLink* link)
+void Interconnection::updateLoopFlowUsage(const Data::AreaLink* link)
 {
     if (link->useLoopFlow)
     {
@@ -337,7 +337,7 @@ void Interconnection::updateLoopFlowUsage(Antares::Data::AreaLink* link)
     }
 }
 
-void Interconnection::updateLinkCaption(Data::AreaLink* link)
+void Interconnection::updateLinkCaption(const Data::AreaLink* link)
 {
     if (link->comments.empty())
     {
@@ -352,7 +352,7 @@ void Interconnection::updateLinkCaption(Data::AreaLink* link)
     }
 }
 
-void Interconnection::updateTransmissionCapacityUsage(Data::AreaLink* link)
+void Interconnection::updateTransmissionCapacityUsage(const Data::AreaLink* link)
 {
     switch (link->transmissionCapacities)
     {
@@ -371,7 +371,7 @@ void Interconnection::updateTransmissionCapacityUsage(Data::AreaLink* link)
     }
 }
 
-void Interconnection::updateHurdleCostsUsage(Data::AreaLink* link)
+void Interconnection::updateHurdleCostsUsage(const Data::AreaLink* link)
 {
     if (link->useHurdlesCost)
     {
@@ -385,7 +385,7 @@ void Interconnection::updateHurdleCostsUsage(Data::AreaLink* link)
     }
 }
 
-void Interconnection::updateAssetType(Antares::Data::AreaLink* link)
+void Interconnection::updateAssetType(const Data::AreaLink* link)
 {
     switch (link->assetType)
     {

--- a/src/ui/simulator/windows/connection.h
+++ b/src/ui/simulator/windows/connection.h
@@ -119,16 +119,16 @@ private:
     void onStudyLinkChanged(Data::AreaLink* link);
 
     // For a given link, update transmission capacity usage 
-    void updateTransmissionCapacityUsage(Data::AreaLink* link);
+    void updateTransmissionCapacityUsage(const Data::AreaLink* link);
     // For a given link, update hurdle costs usage
-    void updateHurdleCostsUsage(Data::AreaLink* link);
+    void updateHurdleCostsUsage(const Data::AreaLink* link);
     // For a given link, update asset type
-    void updateAssetType(Data::AreaLink* link);
+    void updateAssetType(const Data::AreaLink* link);
     // For a given link, update its caption
-    void updateLinkCaption(Data::AreaLink* link);
+    void updateLinkCaption(const Data::AreaLink* link);
 
-    void updateLoopFlowUsage(Antares::Data::AreaLink* link);
-    void updatePhaseShifter(Antares::Data::AreaLink* link);
+    void updateLoopFlowUsage(const Data::AreaLink* link);
+    void updatePhaseShifter(const Data::AreaLink* link);
 
 private:
     //! Pointer to the current link

--- a/src/ui/simulator/windows/connection.h
+++ b/src/ui/simulator/windows/connection.h
@@ -53,8 +53,7 @@ public:
     virtual void add(wxBoxSizer* sizer,
                      wxWindow* parent,
                      Interconnection* intercoWindow,
-                     Toolbox::InputSelector::Connections* notifier)
-      = 0;
+                     Toolbox::InputSelector::Connections* notifier) = 0;
 };
 
 class linkParametersGrid : public linkGrid
@@ -118,6 +117,18 @@ private:
     void onButtonEditCaption(void*);
 
     void onStudyLinkChanged(Data::AreaLink* link);
+
+    // For a given link, update transmission capacity usage 
+    void updateTransmissionCapacityUsage(Data::AreaLink* link);
+    // For a given link, update hurdle costs usage
+    void updateHurdleCostsUsage(Data::AreaLink* link);
+    // For a given link, update asset type
+    void updateAssetType(Data::AreaLink* link);
+    // For a given link, update its caption
+    void updateLinkCaption(Data::AreaLink* link);
+
+    void updateLoopFlowUsage(Antares::Data::AreaLink* link);
+    void updatePhaseShifter(Antares::Data::AreaLink* link);
 
 private:
     //! Pointer to the current link

--- a/src/ui/simulator/windows/connection.h
+++ b/src/ui/simulator/windows/connection.h
@@ -118,6 +118,10 @@ private:
 
     void onStudyLinkChanged(Data::AreaLink* link);
 
+    bool checkLinkView(Data::AreaLink* link);
+    void updateLinkView(Data::AreaLink* link);
+    void finalizeView();
+
     // For a given link, update transmission capacity usage 
     void updateTransmissionCapacityUsage(const Data::AreaLink* link);
     // For a given link, update hurdle costs usage


### PR DESCRIPTION
When we change a link property (transmission capacity usage, hurdle costs usage, ...) in the upper banner, and than
change of tab  (for example from Transmission capacities to Parameters), his upper banner is not properly refreshed.
This is fixed here.

See issue #566 