### PR TITLE
UI : fix assertion failures in debug mode

### DIFF
--- a/src/ui/simulator/windows/constraints-builder/constraintsbuilder.cpp
+++ b/src/ui/simulator/windows/constraints-builder/constraintsbuilder.cpp
@@ -258,7 +258,7 @@ ConstraintsBuilderWizard::ConstraintsBuilderWizard(wxFrame* parent) :
         vS = new wxBoxSizer(wxVERTICAL);
 
         vS->AddSpacer(15);
-        vS->Add(Antares::Component::CreateLabel(panelGrid, wxT(" to "), true), 0, wxALIGN_BOTTOM);
+        vS->Add(Antares::Component::CreateLabel(panelGrid, wxT(" to "), true), 0, wxALIGN_NOT);
         hS->Add(vS, 0, wxALIGN_LEFT);
 
         hS->AddSpacer(5);

--- a/src/ui/simulator/windows/memorystatistics/memorystatistics.cpp
+++ b/src/ui/simulator/windows/memorystatistics/memorystatistics.cpp
@@ -345,7 +345,7 @@ MemoryStatistics::MemoryStatistics(wxWindow* parent) :
     auto* hz = new wxBoxSizer(wxHORIZONTAL);
     hz->Add(Resources::StaticBitmapLoadFromFile(this, wxID_ANY, "images/64x64/cpu.png"),
             0,
-            wxALL | wxALIGN_TOP | wxALIGN_CENTER_HORIZONTAL);
+            wxALL | wxALIGN_TOP | wxALIGN_CENTER);
     hz->Add(gridSizer, 1, wxALL | wxEXPAND);
     sizer->Add(hz, 1, wxALL | wxEXPAND, 20);
 

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -140,7 +140,7 @@ Optimization::Optimization(wxWindow* parent) :
     hz->AddSpacer(6);
     hz->Add(Resources::StaticBitmapLoadFromFile(this, wxID_ANY, "images/64x64/db.png"),
             0,
-            wxALL | wxALIGN_TOP | wxALIGN_CENTER_HORIZONTAL);
+            wxALL | wxALIGN_TOP | wxALIGN_CENTER);
     hz->AddSpacer(35);
 
     auto* s = new wxFlexGridSizer(0, 2, 1, 10);

--- a/src/ui/simulator/windows/studylogs.cpp
+++ b/src/ui/simulator/windows/studylogs.cpp
@@ -754,7 +754,7 @@ StudyLogs::StudyLogs(wxFrame* parent) :
         pBtnLogFilenameRefresh->bold(true);
         pBtnLogFilenameRefresh->caption(wxT("Please select a log file"));
         infosizer->AddSpacer(5);
-        infosizer->Add(pBtnLogFilenameRefresh, 0, wxALL | wxALIGN_CENTER_VERTICAL);
+        infosizer->Add(pBtnLogFilenameRefresh, 0, wxALL | wxALIGN_CENTER);
         infosizer->AddSpacer(1);
 
         auto* pathsizer = new wxBoxSizer(wxHORIZONTAL);


### PR DESCRIPTION
Fix assertion failures in
- Study logs viewer
- Resource monitor
- Optimization preferences
- Kirchoff constraint builder

wxWidgets complains because in a vertical sizer there is no need to center vertically (resp. horizontal, horizontally).