### PR TITLE
Fix "Save as" freezing main window

### DIFF
--- a/src/ui/simulator/windows/saveas.cpp
+++ b/src/ui/simulator/windows/saveas.cpp
@@ -527,7 +527,7 @@ void SaveAs::onSave(void*)
 
     // Closing the Window
     pResult = svsSaved;
-    Dispatcher::GUI::Close(this);
+    this->Close();
 
     mainFrm.saveStudyAs(path, copyOutput, copyUserData, copyLogs);
 }


### PR DESCRIPTION
Instead of posting a job, execute the action (close window) immediately.