### PR TITLE
Linux - fix UI freeze when using "save as"

### DIFF
--- a/src/ui/simulator/windows/saveas.cpp
+++ b/src/ui/simulator/windows/saveas.cpp
@@ -527,7 +527,7 @@ void SaveAs::onSave(void*)
 
     // Closing the Window
     pResult = svsSaved;
-    Dispatcher::GUI::Close(this);
+    this->Close();
 
     mainFrm.saveStudyAs(path, copyOutput, copyUserData, copyLogs);
 }


### PR DESCRIPTION
This is a re-open of #585, which was merged by accident (don't push to develop, even if you're confident...).

### Description of the bug

Linux only.

1. Create a new study containing for example 1 area
2. Save it using "save as"
3. The GUI becomes party frozen. One can still add new areas, links, but it becomes impossible to open new windows. In particular, it's impossible to "save as" once again.

### Description of the fix
Instead of posting an action ("close a `wxDialog`") in an event queue, immediately close said `wxDialog`.

### Tests

- Ubuntu 20.04 : fixes the incorrect behavior.
- Win10 : nominal behavior.