### PR TITLE
Disable JIT for link parameters

### DIFF
--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -217,6 +217,13 @@ bool AreaLink::linkLoadTimeSeries_for_version_820_and_later(const AnyString& fol
     String filename;
     bool success = true;
 
+    bool enabledModeIsChanged = false;
+    if (JIT::enabled)
+    {
+        JIT::enabled = false; // Allowing to read the area's daily max power
+        enabledModeIsChanged = true;
+    }
+
     // Read link's parameters times series
     filename.clear() << folder << SEP << with->id << "_parameters.txt";
     const uint matrixWidth = 6;
@@ -235,6 +242,9 @@ bool AreaLink::linkLoadTimeSeries_for_version_820_and_later(const AnyString& fol
     success
       = indirectCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR)
         && success;
+
+    if (enabledModeIsChanged)
+        JIT::enabled = true; // Back to the previous loading mode.
 
     return success;
 }

--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -231,6 +231,9 @@ bool AreaLink::linkLoadTimeSeries_for_version_820_and_later(const AnyString& fol
           filename, fhlMax, HOURS_PER_YEAR, Matrix<>::optFixedSize | Matrix<>::optImmediate)
         && success;
 
+    if (enabledModeIsChanged)
+        JIT::enabled = true; // Back to the previous loading mode.
+
     // Read link's direct capacities time series
     filename.clear() << capacitiesFolder << SEP << with->id << "_direct.txt";
     success = directCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR)
@@ -241,9 +244,6 @@ bool AreaLink::linkLoadTimeSeries_for_version_820_and_later(const AnyString& fol
     success
       = indirectCapacities.loadFromCSVFile(filename, 1, HOURS_PER_YEAR)
         && success;
-
-    if (enabledModeIsChanged)
-        JIT::enabled = true; // Back to the previous loading mode.
 
     return success;
 }

--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -226,10 +226,9 @@ bool AreaLink::linkLoadTimeSeries_for_version_820_and_later(const AnyString& fol
 
     // Read link's parameters times series
     filename.clear() << folder << SEP << with->id << "_parameters.txt";
-    const uint matrixWidth = 6;
     success
       = parameters.loadFromCSVFile(
-          filename, matrixWidth, HOURS_PER_YEAR, Matrix<>::optFixedSize | Matrix<>::optImmediate)
+          filename, fhlMax, HOURS_PER_YEAR, Matrix<>::optFixedSize | Matrix<>::optImmediate)
         && success;
 
     // Read link's direct capacities time series


### PR DESCRIPTION
Keeping it enabled may cause some issues when all coefficients are 0.