### PR TITLE
[Linux] Fix segfault occurring when an INI file does not exist

### DIFF
--- a/src/libs/antares/inifile/inifile.cpp
+++ b/src/libs/antares/inifile/inifile.cpp
@@ -249,8 +249,8 @@ bool IniFile::open(const AnyString& filename, bool warnings)
 // reading the file
 // So the optimization should be useless
 #ifndef YUNI_OS_WINDOWS
-    if (0 == IO::File::Size(filename))
-        return true;
+    if (!IO::File::Exists(filename))
+        return false;
 #endif
 
     // Load the file

--- a/src/libs/antares/inifile/inifile.cpp
+++ b/src/libs/antares/inifile/inifile.cpp
@@ -245,14 +245,6 @@ bool IniFile::open(const AnyString& filename, bool warnings)
     clear();
     pFilename = filename;
 
-// On Windows, getting the size of the file will be as costly as directly
-// reading the file
-// So the optimization should be useless
-#ifndef YUNI_OS_WINDOWS
-    if (!IO::File::Exists(filename))
-        return false;
-#endif
-
     // Load the file
     IO::File::Stream file;
     if (file.open(filename))


### PR DESCRIPTION
`IO::File::Size` returns 0 if the file does not exist. This causes `IniFile::open` to return `true` when it should return `false`. 

This optimization is only present in Linux, so we remove it.