### PR TITLE
Set 'Dataset > Resize columns to' in first position

### DIFF
--- a/src/ui/simulator/toolbox/components/datagrid/modifiers.hxx
+++ b/src/ui/simulator/toolbox/components/datagrid/modifiers.hxx
@@ -254,8 +254,8 @@ struct ModifierOperatorsData<modifierDataset>
 {
     enum Operator
     {
-        opShiftRows,
         opResizeColumns,
+        opShiftRows,
         opMax
     };
 


### PR DESCRIPTION
This feature is use more often than 'Shift rows until', it should be the default.

![image](https://user-images.githubusercontent.com/26088210/159022909-abecf15f-acf2-4098-aae3-4635926383c0.png)
