### PR TITLE
Write 1 in the ts-numbers when series.width == 1

### DIFF
--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -70,7 +70,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             if (data.series.width == 1)
                 data.timeseriesNumbers[0][year] = 0;
 
-            ptchro.Consommation = (long)data.timeseriesNumbers[0][year];
+            ptchro.Consommation = data.timeseriesNumbers[0][year];
         }
         // Solar
         {
@@ -80,7 +80,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             if (data.series.width == 1)
                 data.timeseriesNumbers[0][year] = 0;
 
-            ptchro.Solar = (long)data.timeseriesNumbers[0][year];
+            ptchro.Solar = data.timeseriesNumbers[0][year];
         }
         // Hydro
         {
@@ -90,7 +90,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             if (data.count == 1)
                 data.timeseriesNumbers[0][year] = 0;
 
-            ptchro.Hydraulique = (long)data.timeseriesNumbers[0][year];
+            ptchro.Hydraulique = data.timeseriesNumbers[0][year];
             // Hydro - mod
             memset(ptvalgen.HydrauliqueModulableQuotidien, 0, nbDaysPerYearDouble);
         }
@@ -102,7 +102,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             if (data.series.width == 1)
                 data.timeseriesNumbers[0][year] = 0;
 
-            ptchro.Eolien = (long)data.timeseriesNumbers[0][year];
+            ptchro.Eolien = data.timeseriesNumbers[0][year];
         }
         // Renewable
         {
@@ -122,7 +122,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
                 if (data.series.width == 1)
                     data.timeseriesNumbers[0][year] = 0;
 
-                ptchro.RenouvelableParPalier[index] = (long)data.timeseriesNumbers[0][year];
+                ptchro.RenouvelableParPalier[index] = data.timeseriesNumbers[0][year];
             }
         }
 
@@ -151,7 +151,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
 
                 // the matrix data.series should be properly initialized at this stage
                 // because the ts-generator has already been launched
-                ptchro.ThermiqueParPalier[index] = (long)data.timeseriesNumbers[0][year];
+                ptchro.ThermiqueParPalier[index] = data.timeseriesNumbers[0][year];
 
                 if (EconomicModeT)
                 {

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -67,19 +67,22 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
         {
             const Data::DataSeriesLoad& data = *area.load.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Consommation = data.timeseriesNumbers[0][year];
+            ptchro.Consommation
+              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
         }
         // Solar
         {
             const Data::DataSeriesSolar& data = *area.solar.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Solar = data.timeseriesNumbers[0][year];
+            ptchro.Solar
+              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
         }
         // Hydro
         {
             const Data::DataSeriesHydro& data = *area.hydro.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Hydraulique = data.timeseriesNumbers[0][year];
+            ptchro.Hydraulique
+              = (data.count != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
             // Hydro - mod
             memset(ptvalgen.HydrauliqueModulableQuotidien, 0, nbDaysPerYearDouble);
         }
@@ -87,7 +90,8 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
         {
             const Data::DataSeriesWind& data = *area.wind.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Eolien = data.timeseriesNumbers[0][year];
+            ptchro.Eolien
+              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
         }
         // Renewable
         {
@@ -104,7 +108,9 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
                 assert(year < data.timeseriesNumbers.height);
                 unsigned int index = cluster->areaWideIndex;
 
-                ptchro.RenouvelableParPalier[index] = data.timeseriesNumbers[0][year];
+                ptchro.RenouvelableParPalier[index] = (data.series.width != 1)
+                                                        ? (long)data.timeseriesNumbers[0][year]
+                                                        : 0; // zero-based
             }
         }
 
@@ -130,7 +136,9 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
 
                 // the matrix data.series should be properly initialized at this stage
                 // because the ts-generator has already been launched
-                ptchro.ThermiqueParPalier[index] = data.timeseriesNumbers[0][year];
+                ptchro.ThermiqueParPalier[index] = (data.series.width != 1)
+                                                     ? (long)data.timeseriesNumbers[0][year]
+                                                     : 0; // zero-based
 
                 if (EconomicModeT)
                 {
@@ -178,7 +186,8 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
         const uint directWidth = link->directCapacities.width;
         const uint indirectWidth = link->indirectCapacities.width;
         assert(directWidth == indirectWidth);
-        ptchro.TransmissionCapacities = link->timeseriesNumbers[0][year];
+        ptchro.TransmissionCapacities
+          = (directWidth != 1) ? link->timeseriesNumbers[0][year] : 0; // zero-based
     }
 }
 

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -65,33 +65,44 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
 
         // Load
         {
-            const Data::DataSeriesLoad& data = *area.load.series;
+            Data::DataSeriesLoad& data = *area.load.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Consommation
-              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
+            if (data.series.width == 1)
+                data.timeseriesNumbers[0][year] = 0;
+
+            ptchro.Consommation = (long)data.timeseriesNumbers[0][year];
         }
         // Solar
         {
-            const Data::DataSeriesSolar& data = *area.solar.series;
+            Data::DataSeriesSolar& data = *area.solar.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Solar
-              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
+
+            if (data.series.width == 1)
+                data.timeseriesNumbers[0][year] = 0;
+
+            ptchro.Solar = (long)data.timeseriesNumbers[0][year];
         }
         // Hydro
         {
-            const Data::DataSeriesHydro& data = *area.hydro.series;
+            Data::DataSeriesHydro& data = *area.hydro.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Hydraulique
-              = (data.count != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
+
+            if (data.count == 1)
+                data.timeseriesNumbers[0][year] = 0;
+
+            ptchro.Hydraulique = (long)data.timeseriesNumbers[0][year];
             // Hydro - mod
             memset(ptvalgen.HydrauliqueModulableQuotidien, 0, nbDaysPerYearDouble);
         }
         // Wind
         {
-            const Data::DataSeriesWind& data = *area.wind.series;
+            Data::DataSeriesWind& data = *area.wind.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Eolien
-              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
+
+            if (data.series.width == 1)
+                data.timeseriesNumbers[0][year] = 0;
+
+            ptchro.Eolien = (long)data.timeseriesNumbers[0][year];
         }
         // Renewable
         {
@@ -104,13 +115,14 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
                     continue;
                 }
 
-                const auto& data = *cluster->series;
+                auto& data = *cluster->series;
                 assert(year < data.timeseriesNumbers.height);
                 unsigned int index = cluster->areaWideIndex;
 
-                ptchro.RenouvelableParPalier[index] = (data.series.width != 1)
-                                                        ? (long)data.timeseriesNumbers[0][year]
-                                                        : 0; // zero-based
+                if (data.series.width == 1)
+                    data.timeseriesNumbers[0][year] = 0;
+
+                ptchro.RenouvelableParPalier[index] = (long)data.timeseriesNumbers[0][year];
             }
         }
 
@@ -130,15 +142,16 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
                     continue;
                 }
 
-                const auto& data = *cluster->series;
+                auto& data = *cluster->series;
                 assert(year < data.timeseriesNumbers.height);
                 unsigned int index = cluster->areaWideIndex;
 
+                if (data.series.width == 1)
+                    data.timeseriesNumbers[0][year] = 0;
+
                 // the matrix data.series should be properly initialized at this stage
                 // because the ts-generator has already been launched
-                ptchro.ThermiqueParPalier[index] = (data.series.width != 1)
-                                                     ? (long)data.timeseriesNumbers[0][year]
-                                                     : 0; // zero-based
+                ptchro.ThermiqueParPalier[index] = (long)data.timeseriesNumbers[0][year];
 
                 if (EconomicModeT)
                 {
@@ -186,8 +199,13 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
         const uint directWidth = link->directCapacities.width;
         const uint indirectWidth = link->indirectCapacities.width;
         assert(directWidth == indirectWidth);
-        ptchro.TransmissionCapacities
-          = (directWidth != 1) ? link->timeseriesNumbers[0][year] : 0; // zero-based
+
+        if (directWidth == 1)
+        {
+            link->timeseriesNumbers[0][year] = 0;
+        }
+
+        ptchro.TransmissionCapacities = link->timeseriesNumbers[0][year];
     }
 }
 

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -70,7 +70,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             if (data.series.width == 1)
                 data.timeseriesNumbers[0][year] = 0;
 
-            ptchro.Consommation = data.timeseriesNumbers[0][year];
+            ptchro.Consommation = (long)data.timeseriesNumbers[0][year];
         }
         // Solar
         {
@@ -80,7 +80,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             if (data.series.width == 1)
                 data.timeseriesNumbers[0][year] = 0;
 
-            ptchro.Solar = data.timeseriesNumbers[0][year];
+            ptchro.Solar = (long)data.timeseriesNumbers[0][year];
         }
         // Hydro
         {
@@ -90,7 +90,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             if (data.count == 1)
                 data.timeseriesNumbers[0][year] = 0;
 
-            ptchro.Hydraulique = data.timeseriesNumbers[0][year];
+            ptchro.Hydraulique = (long)data.timeseriesNumbers[0][year];
             // Hydro - mod
             memset(ptvalgen.HydrauliqueModulableQuotidien, 0, nbDaysPerYearDouble);
         }
@@ -102,7 +102,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
             if (data.series.width == 1)
                 data.timeseriesNumbers[0][year] = 0;
 
-            ptchro.Eolien = data.timeseriesNumbers[0][year];
+            ptchro.Eolien = (long)data.timeseriesNumbers[0][year];
         }
         // Renewable
         {
@@ -122,7 +122,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
                 if (data.series.width == 1)
                     data.timeseriesNumbers[0][year] = 0;
 
-                ptchro.RenouvelableParPalier[index] = data.timeseriesNumbers[0][year];
+                ptchro.RenouvelableParPalier[index] = (long)data.timeseriesNumbers[0][year];
             }
         }
 
@@ -151,7 +151,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
 
                 // the matrix data.series should be properly initialized at this stage
                 // because the ts-generator has already been launched
-                ptchro.ThermiqueParPalier[index] = data.timeseriesNumbers[0][year];
+                ptchro.ThermiqueParPalier[index] = (long)data.timeseriesNumbers[0][year];
 
                 if (EconomicModeT)
                 {

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -67,22 +67,19 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
         {
             const Data::DataSeriesLoad& data = *area.load.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Consommation
-              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
+            ptchro.Consommation = data.timeseriesNumbers[0][year];
         }
         // Solar
         {
             const Data::DataSeriesSolar& data = *area.solar.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Solar
-              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
+            ptchro.Solar = data.timeseriesNumbers[0][year];
         }
         // Hydro
         {
             const Data::DataSeriesHydro& data = *area.hydro.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Hydraulique
-              = (data.count != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
+            ptchro.Hydraulique = data.timeseriesNumbers[0][year];
             // Hydro - mod
             memset(ptvalgen.HydrauliqueModulableQuotidien, 0, nbDaysPerYearDouble);
         }
@@ -90,8 +87,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
         {
             const Data::DataSeriesWind& data = *area.wind.series;
             assert(year < data.timeseriesNumbers.height);
-            ptchro.Eolien
-              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
+            ptchro.Eolien = data.timeseriesNumbers[0][year];
         }
         // Renewable
         {
@@ -108,9 +104,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
                 assert(year < data.timeseriesNumbers.height);
                 unsigned int index = cluster->areaWideIndex;
 
-                ptchro.RenouvelableParPalier[index] = (data.series.width != 1)
-                                                        ? (long)data.timeseriesNumbers[0][year]
-                                                        : 0; // zero-based
+                ptchro.RenouvelableParPalier[index] = data.timeseriesNumbers[0][year];
             }
         }
 
@@ -136,9 +130,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
 
                 // the matrix data.series should be properly initialized at this stage
                 // because the ts-generator has already been launched
-                ptchro.ThermiqueParPalier[index] = (data.series.width != 1)
-                                                     ? (long)data.timeseriesNumbers[0][year]
-                                                     : 0; // zero-based
+                ptchro.ThermiqueParPalier[index] = data.timeseriesNumbers[0][year];
 
                 if (EconomicModeT)
                 {
@@ -186,8 +178,7 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
         const uint directWidth = link->directCapacities.width;
         const uint indirectWidth = link->indirectCapacities.width;
         assert(directWidth == indirectWidth);
-        ptchro.TransmissionCapacities
-          = (directWidth != 1) ? link->timeseriesNumbers[0][year] : 0; // zero-based
+        ptchro.TransmissionCapacities = link->timeseriesNumbers[0][year];
     }
 }
 

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -65,44 +65,33 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
 
         // Load
         {
-            Data::DataSeriesLoad& data = *area.load.series;
+            const Data::DataSeriesLoad& data = *area.load.series;
             assert(year < data.timeseriesNumbers.height);
-            if (data.series.width == 1)
-                data.timeseriesNumbers[0][year] = 0;
-
-            ptchro.Consommation = (long)data.timeseriesNumbers[0][year];
+            ptchro.Consommation
+              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
         }
         // Solar
         {
-            Data::DataSeriesSolar& data = *area.solar.series;
+            const Data::DataSeriesSolar& data = *area.solar.series;
             assert(year < data.timeseriesNumbers.height);
-
-            if (data.series.width == 1)
-                data.timeseriesNumbers[0][year] = 0;
-
-            ptchro.Solar = (long)data.timeseriesNumbers[0][year];
+            ptchro.Solar
+              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
         }
         // Hydro
         {
-            Data::DataSeriesHydro& data = *area.hydro.series;
+            const Data::DataSeriesHydro& data = *area.hydro.series;
             assert(year < data.timeseriesNumbers.height);
-
-            if (data.count == 1)
-                data.timeseriesNumbers[0][year] = 0;
-
-            ptchro.Hydraulique = (long)data.timeseriesNumbers[0][year];
+            ptchro.Hydraulique
+              = (data.count != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
             // Hydro - mod
             memset(ptvalgen.HydrauliqueModulableQuotidien, 0, nbDaysPerYearDouble);
         }
         // Wind
         {
-            Data::DataSeriesWind& data = *area.wind.series;
+            const Data::DataSeriesWind& data = *area.wind.series;
             assert(year < data.timeseriesNumbers.height);
-
-            if (data.series.width == 1)
-                data.timeseriesNumbers[0][year] = 0;
-
-            ptchro.Eolien = (long)data.timeseriesNumbers[0][year];
+            ptchro.Eolien
+              = (data.series.width != 1) ? (long)data.timeseriesNumbers[0][year] : 0; // zero-based
         }
         // Renewable
         {
@@ -115,14 +104,13 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
                     continue;
                 }
 
-                auto& data = *cluster->series;
+                const auto& data = *cluster->series;
                 assert(year < data.timeseriesNumbers.height);
                 unsigned int index = cluster->areaWideIndex;
 
-                if (data.series.width == 1)
-                    data.timeseriesNumbers[0][year] = 0;
-
-                ptchro.RenouvelableParPalier[index] = (long)data.timeseriesNumbers[0][year];
+                ptchro.RenouvelableParPalier[index] = (data.series.width != 1)
+                                                        ? (long)data.timeseriesNumbers[0][year]
+                                                        : 0; // zero-based
             }
         }
 
@@ -142,16 +130,15 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
                     continue;
                 }
 
-                auto& data = *cluster->series;
+                const auto& data = *cluster->series;
                 assert(year < data.timeseriesNumbers.height);
                 unsigned int index = cluster->areaWideIndex;
 
-                if (data.series.width == 1)
-                    data.timeseriesNumbers[0][year] = 0;
-
                 // the matrix data.series should be properly initialized at this stage
                 // because the ts-generator has already been launched
-                ptchro.ThermiqueParPalier[index] = (long)data.timeseriesNumbers[0][year];
+                ptchro.ThermiqueParPalier[index] = (data.series.width != 1)
+                                                     ? (long)data.timeseriesNumbers[0][year]
+                                                     : 0; // zero-based
 
                 if (EconomicModeT)
                 {
@@ -199,13 +186,8 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
         const uint directWidth = link->directCapacities.width;
         const uint indirectWidth = link->indirectCapacities.width;
         assert(directWidth == indirectWidth);
-
-        if (directWidth == 1)
-        {
-            link->timeseriesNumbers[0][year] = 0;
-        }
-
-        ptchro.TransmissionCapacities = link->timeseriesNumbers[0][year];
+        ptchro.TransmissionCapacities
+          = (directWidth != 1) ? link->timeseriesNumbers[0][year] : 0; // zero-based
     }
 }
 

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -361,8 +361,6 @@ void ISimulation<Impl>::run()
         if (parameters.useCustomScenario)
             ApplyCustomScenario(study);
 
-        TimeSeriesNumbers::StoreTimeseriesIntoOuput(study);
-
         // Launching the simulation for all years
         logs.info() << "MC-Years : [" << (study.runtime->rangeLimits.year[Data::rangeBegin] + 1)
                     << " .. " << (1 + study.runtime->rangeLimits.year[Data::rangeEnd])
@@ -387,6 +385,8 @@ void ISimulation<Impl>::run()
         ImplementationType::simulationEnd();
 
         ImplementationType::variables.simulationEnd();
+
+        TimeSeriesNumbers::StoreTimeseriesIntoOuput(study);
 
         // Spatial clusters
         // Notifying all variables to perform the final spatial clusters.

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -386,6 +386,7 @@ void ISimulation<Impl>::run()
 
         ImplementationType::variables.simulationEnd();
 
+        // Export ts-numbers into output
         TimeSeriesNumbers::StoreTimeseriesIntoOuput(study);
 
         // Spatial clusters

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -811,11 +811,13 @@ static void fixTSNumbersWhenWidthIsOne(Study& study,
     study.areas.each([&](Area& area) {
         uint nbTimeSeries;
         int indexTS;
+
         // Load
         indexTS = ts_to_tsIndex.at(timeSeriesLoad);
         nbTimeSeries
           = isTSgenerated[indexTS] ? nbTimeseriesByMode[indexTS] : area.load.series->series.width;
         fixTSNumbersSingleAreaSingleMode(area.load.series->timeseriesNumbers, nbTimeSeries, years);
+
         // Solar
         indexTS = ts_to_tsIndex.at(timeSeriesSolar);
         nbTimeSeries
@@ -847,6 +849,7 @@ static void fixTSNumbersWhenWidthIsOne(Study& study,
                   cluster.series->timeseriesNumbers, nbTimeSeries, years);
             }
         }
+
         // Renewables
         {
             uint clusterCount = (uint)area.renewable.clusterCount();
@@ -858,6 +861,7 @@ static void fixTSNumbersWhenWidthIsOne(Study& study,
                   cluster.series->timeseriesNumbers, nbTimeSeries, years);
             }
         }
+
         // NTC
         indexTS = ts_to_tsIndex.at(timeSeriesTransmissionCapacities);
         for (auto it = area.links.begin(); it != area.links.end(); ++it)

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -808,44 +808,46 @@ static void fixTSNumbersWhenWidthIsOne(Study& study)
 
     study.areas.each([&years](Area& area) {
         // Load
-        fixTSNumbersSingleAreaSingleMode(area.load.series->timeseriesNumbers, area.load.series->series.width, years);
+        fixTSNumbersSingleAreaSingleMode(
+          area.load.series->timeseriesNumbers, area.load.series->series.width, years);
         // Solar
-        fixTSNumbersSingleAreaSingleMode(area.solar.series->timeseriesNumbers, area.solar.series->series.width, years);
+        fixTSNumbersSingleAreaSingleMode(
+          area.solar.series->timeseriesNumbers, area.solar.series->series.width, years);
         // Wind
-        fixTSNumbersSingleAreaSingleMode(area.wind.series->timeseriesNumbers, area.wind.series->series.width, years);
+        fixTSNumbersSingleAreaSingleMode(
+          area.wind.series->timeseriesNumbers, area.wind.series->series.width, years);
         // Hydro
-        fixTSNumbersSingleAreaSingleMode(area.hydro.series->timeseriesNumbers, area.hydro.series->count, years);
+        fixTSNumbersSingleAreaSingleMode(
+          area.hydro.series->timeseriesNumbers, area.hydro.series->count, years);
 
         // Thermal
-        {
-            const auto clusterCount = (uint)area.thermal.clusterCount();
-            for (uint i = 0; i != clusterCount; ++i)
-            {
-                auto& cluster = *(area.thermal.clusters[i]);
-                fixTSNumbersSingleAreaSingleMode(
-                  cluster.series->timeseriesNumbers, cluster.series->series.width, years);
-            }
-        }
+        std::for_each(area.thermal.clusters.cbegin(),
+                      area.thermal.clusters.cend(),
+                      [&years](const Data::ThermalCluster* cluster) {
+                          fixTSNumbersSingleAreaSingleMode(cluster->series->timeseriesNumbers,
+                                                           cluster->series->series.width,
+                                                           years);
+                      });
 
         // Renewables
-        {
-            const auto clusterCount = (uint)area.renewable.clusterCount();
-            for (uint i = 0; i != clusterCount; ++i)
-            {
-                auto& cluster = *(area.renewable.clusters[i]);
-                fixTSNumbersSingleAreaSingleMode(
-                  cluster.series->timeseriesNumbers, cluster.series->series.width, years);
-            }
-        }
+        std::for_each(area.renewable.clusters.cbegin(),
+                      area.renewable.clusters.cend(),
+                      [&years](const Data::RenewableCluster* cluster)
+
+                      {
+                          fixTSNumbersSingleAreaSingleMode(cluster->series->timeseriesNumbers,
+                                                           cluster->series->series.width,
+                                                           years);
+                      });
 
         // NTC
-        std::for_each(
-          area.links.cbegin(),
-          area.links.cend(),
-          [&years](const std::pair<Data::AreaName, Data::AreaLink*>& it) {
-              auto link = it.second;
-              fixTSNumbersSingleAreaSingleMode(link->timeseriesNumbers, link->directCapacities.width, years);
-          });
+        std::for_each(area.links.cbegin(),
+                      area.links.cend(),
+                      [&years](const std::pair<Data::AreaName, Data::AreaLink*>& it) {
+                          auto link = it.second;
+                          fixTSNumbersSingleAreaSingleMode(
+                            link->timeseriesNumbers, link->directCapacities.width, years);
+                      });
     });
 }
 

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -808,7 +808,7 @@ static void fixTSNumbersWhenWidthIsOne(Study& study,
 {
     const uint years = 1 + study.runtime->rangeLimits.year[rangeEnd];
 
-    study.areas.each([&](Area& area) {
+    study.areas.each([&years, &isTSgenerated, &nbTimeseriesByMode](Area& area) {
         uint nbTimeSeries;
         int indexTS;
 
@@ -839,7 +839,7 @@ static void fixTSNumbersWhenWidthIsOne(Study& study,
         // Thermal
         {
             indexTS = ts_to_tsIndex.at(timeSeriesThermal);
-            const uint clusterCount = (uint)area.thermal.clusterCount();
+            const auto clusterCount = (uint)area.thermal.clusterCount();
             for (uint i = 0; i != clusterCount; ++i)
             {
                 auto& cluster = *(area.thermal.clusters[i]);
@@ -852,7 +852,7 @@ static void fixTSNumbersWhenWidthIsOne(Study& study,
 
         // Renewables
         {
-            uint clusterCount = (uint)area.renewable.clusterCount();
+            const auto clusterCount = (uint)area.renewable.clusterCount();
             for (uint i = 0; i != clusterCount; ++i)
             {
                 auto& cluster = *(area.renewable.clusters[i]);
@@ -864,12 +864,14 @@ static void fixTSNumbersWhenWidthIsOne(Study& study,
 
         // NTC
         indexTS = ts_to_tsIndex.at(timeSeriesTransmissionCapacities);
-        for (auto it = area.links.begin(); it != area.links.end(); ++it)
-        {
-            auto link = it->second;
-            nbTimeSeries = link->directCapacities.width;
-            fixTSNumbersSingleAreaSingleMode(link->timeseriesNumbers, nbTimeSeries, years);
-        }
+        std::for_each(
+          area.links.cbegin(),
+          area.links.cend(),
+          [&years, &nbTimeSeries](const std::pair<Data::AreaName, Data::AreaLink*>& it) {
+              auto link = it.second;
+              nbTimeSeries = link->directCapacities.width;
+              fixTSNumbersSingleAreaSingleMode(link->timeseriesNumbers, nbTimeSeries, years);
+          });
     });
 }
 

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -545,7 +545,7 @@ void storeTSnumbersForIntraModal(const array<uint32, timeSeriesCount>& intramoda
             {
                 ThermalClusterList::SharedPtr cluster = i->second;
                 if (cluster->enabled)
-                    cluster->series->timeseriesNumbers.entry[0][year] = intramodal_draws[indexTS];
+                    cluster->series->timeseriesNumbers[0][year] = intramodal_draws[indexTS];
             }
         }
 
@@ -561,7 +561,7 @@ void storeTSnumbersForIntraModal(const array<uint32, timeSeriesCount>& intramoda
             {
                 RenewableClusterList::SharedPtr cluster = j->second;
                 if (cluster->enabled)
-                    cluster->series->timeseriesNumbers.entry[0][year] = intramodal_draws[indexTS];
+                    cluster->series->timeseriesNumbers[0][year] = intramodal_draws[indexTS];
             }
         }
 
@@ -657,7 +657,7 @@ void drawAndStoreTSnumbersForNOTintraModal(const array<bool, timeSeriesCount>& i
                 {
                     uint nbTimeSeries = isTSgenerated[indexTS] ? nbTimeseriesByMode[indexTS]
                                                                : cluster->series->series.width;
-                    cluster->series->timeseriesNumbers.entry[0][year] = (uint32)(
+                    cluster->series->timeseriesNumbers[0][year] = (uint32)(
                       floor(study.runtime->random[seedTimeseriesNumbers].next() * nbTimeSeries));
                 }
             }
@@ -678,8 +678,9 @@ void drawAndStoreTSnumbersForNOTintraModal(const array<bool, timeSeriesCount>& i
             {
                 if (!isTSintramodal[indexTS])
                 {
+                    // There is no TS generation for renewable clusters
                     uint nbTimeSeries = cluster->series->series.width;
-                    cluster->series->timeseriesNumbers.entry[0][year] = (uint32)(
+                    cluster->series->timeseriesNumbers[0][year] = (uint32)(
                       floor(study.runtime->random[seedTimeseriesNumbers].next() * nbTimeSeries));
                 }
             }
@@ -695,8 +696,7 @@ void drawAndStoreTSnumbersForNOTintraModal(const array<bool, timeSeriesCount>& i
             for (auto it = area.links.begin(); it != area.links.end(); ++it)
             {
                 auto& link = *(it->second);
-
-                uint nbTimeSeries = link.directCapacities.width;
+                const uint nbTimeSeries = link.directCapacities.width;
                 if (nbTimeSeries == 1)
                 {
                     // Random generator (mersenne-twister) must not be called here
@@ -753,19 +753,19 @@ void applyMatrixDrawsToInterModalModesInArea(Matrix<uint32>* tsNumbersMtx,
 
         assert(year < area.load.series->timeseriesNumbers.height);
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesLoad)])
-            area.load.series->timeseriesNumbers.entry[0][year] = draw;
+            area.load.series->timeseriesNumbers[0][year] = draw;
 
         assert(year < area.solar.series->timeseriesNumbers.height);
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesSolar)])
-            area.solar.series->timeseriesNumbers.entry[0][year] = draw;
+            area.solar.series->timeseriesNumbers[0][year] = draw;
 
         assert(year < area.wind.series->timeseriesNumbers.height);
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesWind)])
-            area.wind.series->timeseriesNumbers.entry[0][year] = draw;
+            area.wind.series->timeseriesNumbers[0][year] = draw;
 
         assert(year < area.hydro.series->timeseriesNumbers.height);
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesHydro)])
-            area.hydro.series->timeseriesNumbers.entry[0][year] = draw;
+            area.hydro.series->timeseriesNumbers[0][year] = draw;
 
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesThermal)])
         {
@@ -774,7 +774,7 @@ void applyMatrixDrawsToInterModalModesInArea(Matrix<uint32>* tsNumbersMtx,
             {
                 auto& cluster = *(area.thermal.clusters[i]);
                 assert(year < cluster.series->timeseriesNumbers.height);
-                cluster.series->timeseriesNumbers.entry[0][year] = draw;
+                cluster.series->timeseriesNumbers[0][year] = draw;
             }
         }
         if (isTSintermodal[ts_to_tsIndex.at(timeSeriesRenewable)])
@@ -784,7 +784,7 @@ void applyMatrixDrawsToInterModalModesInArea(Matrix<uint32>* tsNumbersMtx,
             {
                 auto& cluster = *(area.renewable.clusters[i]);
                 assert(year < cluster.series->timeseriesNumbers.height);
-                cluster.series->timeseriesNumbers.entry[0][year] = draw;
+                cluster.series->timeseriesNumbers[0][year] = draw;
             }
         }
     }

--- a/src/tests/src/solver/simulation/tests-ts-numbers.cpp
+++ b/src/tests/src/solver/simulation/tests-ts-numbers.cpp
@@ -45,8 +45,7 @@ Area* addAreaToStudy(Study::Ptr study, const std::string& areaName)
 // Add a cluster to an area
 // ===========================
 template<class ClusterType>
-void addClusterToAreaList(Area* area, std::shared_ptr<ClusterType> cluster)
-{}
+void addClusterToAreaList(Area* area, std::shared_ptr<ClusterType> cluster);
 
 template<>
 void addClusterToAreaList(Area* area, std::shared_ptr<ThermalCluster> cluster)
@@ -196,7 +195,7 @@ BOOST_AUTO_TEST_CASE(two_areas_3_thermal_clusters_with_same_number_of_ready_made
 	BOOST_CHECK_EQUAL(thCluster_21->series->timeseriesNumbers[0][year], thCluster_11->series->timeseriesNumbers[0][year]);
 }
 
-BOOST_AUTO_TEST_CASE(two_areas_3_thermal_clusters_with_respectively_4_1_4_ready_made_ts___check_intra_modal_consistency_OK)
+BOOST_AUTO_TEST_CASE(two_areas_2_thermal_clusters_with_respectively_4_4_ready_made_ts___check_intra_modal_consistency_OK)
 {
 	// Creating a study
 	auto study = std::make_shared<Study>();
@@ -212,9 +211,6 @@ BOOST_AUTO_TEST_CASE(two_areas_3_thermal_clusters_with_respectively_4_1_4_ready_
 	// ... Area 1 : thermal cluster 1
 	auto thCluster_11 = addClusterToArea<ThermalCluster>(area_1, "th-cluster-11");
 	thCluster_11->series->series.resize(4, 1);
-	// ... Area 1 : thermal cluster 2
-	auto thCluster_12 = addClusterToArea<ThermalCluster>(area_1, "th-cluster-12");
-	thCluster_12->series->series.resize(1, 1);
 
 	area_1->resizeAllTimeseriesNumbers(1 + study->runtime->rangeLimits.year[rangeEnd]);
 
@@ -315,7 +311,7 @@ BOOST_AUTO_TEST_CASE(two_areas_3_renew_clusters_with_same_number_of_ready_made_t
 }
 
 
-BOOST_AUTO_TEST_CASE(two_areas_3_renew_clusters_with_respectively_4_4_1_ready_made_ts___check_intra_modal_consistency_OK)
+BOOST_AUTO_TEST_CASE(two_areas_2_renew_clusters_with_respectively_4_4_ready_made_ts___check_intra_modal_consistency_OK)
 {
 	// Creating a study
 	auto study = std::make_shared<Study>();
@@ -342,9 +338,6 @@ BOOST_AUTO_TEST_CASE(two_areas_3_renew_clusters_with_respectively_4_4_1_ready_ma
 	// Area 2
 	// =============
 	Area* area_2 = addAreaToStudy(study, "Area 2");
-	// ... Area 2 : renewable cluster 1
-	auto rnCluster_21 = addClusterToArea<RenewableCluster>(area_2, "rn-cluster-21");
-	rnCluster_21->series->series.resize(1, 1);
 
 	area_2->resizeAllTimeseriesNumbers(1 + study->runtime->rangeLimits.year[rangeEnd]);
 

--- a/src/tests/src/solver/simulation/tests-ts-numbers.cpp
+++ b/src/tests/src/solver/simulation/tests-ts-numbers.cpp
@@ -233,7 +233,6 @@ BOOST_AUTO_TEST_CASE(two_areas_3_thermal_clusters_with_respectively_4_1_4_ready_
 
 	// TS number checks
 	uint year = 0;
-	BOOST_CHECK_EQUAL(thCluster_12->series->timeseriesNumbers[0][year], thCluster_11->series->timeseriesNumbers[0][year]);
 	BOOST_CHECK_EQUAL(thCluster_21->series->timeseriesNumbers[0][year], thCluster_11->series->timeseriesNumbers[0][year]);
 }
 
@@ -354,7 +353,6 @@ BOOST_AUTO_TEST_CASE(two_areas_3_renew_clusters_with_respectively_4_4_1_ready_ma
 	// TS number checks
 	uint year = 0;
 	BOOST_CHECK_EQUAL(rnCluster_12->series->timeseriesNumbers[0][year], rnCluster_11->series->timeseriesNumbers[0][year]);
-	BOOST_CHECK_EQUAL(rnCluster_21->series->timeseriesNumbers[0][year], rnCluster_11->series->timeseriesNumbers[0][year]);
 }
 
 BOOST_AUTO_TEST_CASE(two_areas_3_renew_clusters_with_different_number_of_ready_made_ts___check_intra_modal_consistency_KO)


### PR DESCRIPTION
Before that patch, random numbers were drawn, ignored in the simulation, but still written in ts-numbers.