### PR TITLE
Hydro hot start : relaxing error message in case reservoir management is OFF

### DIFF
--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -603,16 +603,6 @@ void Study::getNumberOfCores(const bool forceParallel, const uint nbYearsParalle
 
 bool Study::checkHydroHotStart()
 {
-    // Error messages possibly used in this method.
-    std::string parallelParametersErrMsg1
-      = "Hot Start Hydro option : conflict with parallelization parameters.";
-    std::string parallelParametersErrMsg2
-      = "Please update relevant simulation parameters or use Cold Start option.    ";
-
-    std::string calendarErrMsg1
-      = "Hot Start Hydro option : conflict with Hydro Local Data and/or Simulation Calendar.    ";
-    std::string calendarErrMsg2 = "Please update data or use Cold Start option.";
-
     bool hydroHotStart = (parameters.initialReservoirLevels.iniLevels == irlHotStart);
 
     // No need to check further if hydro hot start is not required
@@ -623,8 +613,8 @@ bool Study::checkHydroHotStart()
     // run, do all sets of parallel years have the same size ?
     if (maxNbYearsInParallel != 1 && !parameters.allSetsHaveSameSize)
     {
-        logs.error() << parallelParametersErrMsg1;
-        logs.error() << parallelParametersErrMsg2;
+        logs.error() << "Hot Start Hydro option : conflict with parallelization parameters.";
+        logs.error() << "Please update relevant simulation parameters or use Cold Start option.    ";
         return false;
     }
 
@@ -633,8 +623,8 @@ bool Study::checkHydroHotStart()
     uint nbDaysInSimulation = parameters.simulationDays.end - parameters.simulationDays.first + 1;
     if (nbDaysInSimulation < 364)
     {
-        logs.error() << calendarErrMsg1;
-        logs.error() << calendarErrMsg2;
+        logs.error() << "Hot Start Hydro option : simulation calendar must cover one complete year.    ";
+        logs.error() << "Please update data or use Cold Start option.";
         return false;
     }
 
@@ -646,6 +636,11 @@ bool Study::checkHydroHotStart()
     {
         // Reference to the area
         Area* area = i->second;
+
+        // No need to make a check on level initialization when reservoir management 
+        // is not activated for the current area
+        if (!area->hydro.reservoirManagement)
+            continue;
 
         // Month the reservoir level is initialized according to.
         // This month number is given in the civil calendar, from january to december (0 is
@@ -661,8 +656,9 @@ bool Study::checkHydroHotStart()
         // Check the day of level initialization is the first day of simulation
         if (initLevelOnSimDay != parameters.simulationDays.first)
         {
-            logs.error() << calendarErrMsg1;
-            logs.error() << calendarErrMsg2;
+            logs.error() << "Hot Start Hydro option : area '" << area->name 
+                         << "' - hydro level must be initialized on the first simulation month.    ";
+            logs.error() << "Please update data or use Cold Start option.";
             return false;
         }
     } // End loop over areas


### PR DESCRIPTION
When hydro hot start is ON, and reservoir management is OFF for a given area, no need to make a check on hydro level initialization on the area. 
This check would lead to an undesirable error message and simulation stop.
This PR fixes the issue #615.

We take advantage of this fix to make error messages more explicit.