### PR TITLE
Fix build when BUILD_SWAP=OFF

### DIFF
--- a/src/libs/antares/memory/memory.cpp
+++ b/src/libs/antares/memory/memory.cpp
@@ -596,7 +596,7 @@ void* Memory::acquireMapping(Handle handle, volatile void* pointer)
     return nullptr;
 }
 
-void Memory::flushAll()
+void Memory::flushAll() const
 {
 #ifdef ANTARES_SWAP_SUPPORT
     Yuni::MutexLocker locker(gMutex);

--- a/src/libs/antares/memory/memory.cpp
+++ b/src/libs/antares/memory/memory.cpp
@@ -596,15 +596,15 @@ void* Memory::acquireMapping(Handle handle, volatile void* pointer)
     return nullptr;
 }
 
-#ifdef ANTARES_SWAP_SUPPORT
 void Memory::flushAll()
 {
+#ifdef ANTARES_SWAP_SUPPORT
     Yuni::MutexLocker locker(gMutex);
     const MappingMap::iterator end = pMapping.end();
     for (MappingMap::iterator i = pMapping.begin(); i != end; ++i)
         FlushMappingWL(*(i->second));
-}
 #endif
+}
 
 void Memory::flush(Handle handle)
 {

--- a/src/libs/antares/memory/memory.h
+++ b/src/libs/antares/memory/memory.h
@@ -416,7 +416,7 @@ public:
     /*!
     ** \brief Flush all memory into swap files
     */
-    void flushAll();
+    void flushAll() const;
 
     /*!
     ** \brief Get the amount of memory currently used

--- a/src/libs/antares/memory/memory.hxx
+++ b/src/libs/antares/memory/memory.hxx
@@ -152,13 +152,11 @@ inline bool Memory::Array<T>::needFlush() const
 #endif
 }
 
-#ifndef ANTARES_SWAP_SUPPORT
-// If the support is not available, we define an empty method
 inline void Memory::flushAll()
 {
     // Do nothing
 }
-#endif
+
 
 template<class T>
 inline void Memory::Array<T>::flush() const

--- a/src/libs/antares/memory/memory.hxx
+++ b/src/libs/antares/memory/memory.hxx
@@ -152,12 +152,6 @@ inline bool Memory::Array<T>::needFlush() const
 #endif
 }
 
-inline void Memory::flushAll()
-{
-    // Do nothing
-}
-
-
 template<class T>
 inline void Memory::Array<T>::flush() const
 {

--- a/src/ui/simulator/CMakeLists.txt
+++ b/src/ui/simulator/CMakeLists.txt
@@ -143,12 +143,12 @@ set(ANTARES_LIBS
 		libantares-ui-dispatcher
 		libantares-ui-common
 		libantares-solver-constraints-builder
-		libantares-solver-variable-info-swap
-		libantares-core-swap #TODO : why no libantares-core ?
+		libantares-solver-variable-info
+		libantares-core
 		libantares-core-calendar
 		yuni-static-core
 		yuni-static-uuid
-		libmodel_antares-swap #TODO : why no libmodel_antares ? link librairies added for ortools_utils.h
+		libmodel_antares
 	)
 
 	target_link_libraries(${execname}

--- a/src/ui/simulator/cmake/application.cmake
+++ b/src/ui/simulator/cmake/application.cmake
@@ -73,5 +73,6 @@ target_link_libraries(libantares-ui-application
 						PRIVATE
 							${wxWidgets_LIBRARIES}
 							libantares-ui-common
+                            libantares-core
 )
 


### PR DESCRIPTION
Previously, linking would fail because libmodel_antares-swap didn't exist