### PR TITLE
Remove build option BUILD_OUTPUT_TEST

### DIFF
--- a/docs/build/3-Build.md
+++ b/docs/build/3-Build.md
@@ -41,7 +41,6 @@ Here is a list of available CMake configure option :
 |`DEPS_INSTALL_DIR`|Define dependencies libraries install directory|
 |`USE_PRECOMPILED_EXT`| This option must be set if you use wxWidget as precompiled external library (default `OFF`)|
 |`BUILD_TESTING`| Enable test build (default `OFF`)|
-|`BUILD_OUTPUT_TEST`| Enable test with output compare build (default `OFF`)|
 
 Additionnal options for windows
 

--- a/docs/build/4-Tests.md
+++ b/docs/build/4-Tests.md
@@ -8,8 +8,6 @@ After build, tests can be run with ``ctest`` :
 cd _build
 ctest -C Release --output-on-failure
 ```
-Note:
-> Tests with output comparison must be enabled using the option `-DBUILD_OUTPUT_TEST=ON` (`OFF` by default)
 
 All tests are associated to a label and multiple labels can be defined. You can choose which tests will be executed at ctest run.
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -17,8 +17,6 @@ if(Boost_VERSION VERSION_GREATER 106000)
     add_subdirectory(end-to-end)
 endif()
 
-option(BUILD_OUTPUT_TEST "Activates output values comparison test building" OFF)
-
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
 
@@ -98,7 +96,7 @@ if(Python3_Interpreter_FOUND)
         
         endmacro()
         
-        macro(run_output_tests use_ortools ortools_solver)
+        macro(add_output_tests use_ortools ortools_solver)
         
             if(${use_ortools})
                 SET(SHORT_NAME short-output-ortools-${ortools_solver})                
@@ -127,9 +125,7 @@ if(Python3_Interpreter_FOUND)
         run_examples_tests(true "sirius")
         run_examples_tests(true "coin")
         
-        if (BUILD_OUTPUT_TEST)
-            run_output_tests(false, "sirius")
-        endif()
+        add_output_tests(false, "sirius")
         
         # Specific tests
         add_test(


### PR DESCRIPTION
This option isn't very useful. It only toggles the generation of tests, not their execution.

It costs nothing to generate the CMake test, so we might as well generate it always (BUILD_OUTPUT_TEST=ON).