### PR TITLE
Remove references to BUILD_not_system

### DIFF
--- a/docs/build/2-Dependencies-install.md
+++ b/docs/build/2-Dependencies-install.md
@@ -65,8 +65,6 @@ The install procedure can be done
 
 ALL dependency can be built at configure time using the option `-DBUILD_ALL=ON` (`OFF` by default). For a list of available option see [Antares dependencies compilation repository](https://github.com/AntaresSimulatorTeam/antares-deps).
 
-Some dependencies can't be installed with a package manager. They can be built at configure step with a cmake option  : `-DBUILD_not_system=ON` (`ON` by default):
-
 ### Defining dependency install directory
 When using multiple directories for antares development with multiple branches it can be useful to have a common dependency install directory.
 

--- a/docs/build/3-Build.md
+++ b/docs/build/3-Build.md
@@ -36,7 +36,6 @@ Here is a list of available CMake configure option :
 |:-------|-------|
 |`CMAKE_BUILD_TYPE` | Define build type. Available values are `release` and `debug`  |
 |`BUILD_UI`|Enable or disable Antares Simulator UI compilation (default `ON`)|
-|`BUILD_not_system`|Enable build of external libraries not available on system package manager (default `ON`)|
 |`BUILD_ALL`|Enable build of ALL external libraries (default `OFF`)|
 |`DEPS_INSTALL_DIR`|Define dependencies libraries install directory|
 |`USE_PRECOMPILED_EXT`| This option must be set if you use wxWidget as precompiled external library (default `OFF`)|


### PR DESCRIPTION
This option has been moved to antares-deps. It no longer exists in Antares_Simulator.