### PR TITLE
Use std::enable_shared_from_this

### DIFF
--- a/src/libs/antares/study/parts/thermal/cluster.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster.cpp
@@ -278,7 +278,7 @@ void Data::ThermalCluster::copyFrom(const ThermalCluster& cluster)
     // Making sure that the data related to the prepro and timeseries are present
     // prepro
     if (not prepro)
-        prepro = new PreproThermal(this);
+        prepro = new PreproThermal(this->shared_from_this());
     if (not series)
         series = new DataSeriesCommon();
 
@@ -513,7 +513,7 @@ void Data::ThermalCluster::reset()
     //   since the interface may still have a pointer to them.
     //   we must simply reset their content.
     if (not prepro)
-        prepro = new PreproThermal(this);
+        prepro = new PreproThermal(this->shared_from_this());
     prepro->reset();
 
     // Links

--- a/src/libs/antares/study/parts/thermal/cluster.h
+++ b/src/libs/antares/study/parts/thermal/cluster.h
@@ -36,6 +36,7 @@
 #include "../../fwd.h"
 #include <set>
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace Antares
@@ -73,7 +74,7 @@ enum class GlobalTSGenerationBehavior
 /*!
 ** \brief A single thermal cluster
 */
-class ThermalCluster final : public Cluster
+class ThermalCluster final : public Cluster, public std::enable_shared_from_this<ThermalCluster>
 {
 public:
     enum ThermalDispatchableGroup

--- a/src/libs/antares/study/parts/thermal/cluster.h
+++ b/src/libs/antares/study/parts/thermal/cluster.h
@@ -119,16 +119,11 @@ public:
     static const char* GroupName(enum ThermalDispatchableGroup grp);
 
 public:
-    //! \name Constructor & Destructor
-    //@{
-    /*!
-    ** \brief Default constructor, with a parent area
-    */
     explicit ThermalCluster(Data::Area* parent);
     explicit ThermalCluster(Data::Area* parent, uint nbParallelYears);
-    //! Destructor
+
+    ThermalCluster() = delete;
     ~ThermalCluster();
-    //@}
 
     /*!
     ** \brief Invalidate all data associated to the thermal cluster

--- a/src/libs/antares/study/parts/thermal/cluster_list.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_list.cpp
@@ -721,7 +721,7 @@ void ThermalClusterList::ensureDataPrepro()
     {
         auto c = it->second;
         if (not c->prepro)
-            c->prepro = new PreproThermal(c.get());
+            c->prepro = new PreproThermal(c);
     }
 }
 

--- a/src/libs/antares/study/parts/thermal/prepro.cpp
+++ b/src/libs/antares/study/parts/thermal/prepro.cpp
@@ -43,12 +43,13 @@ namespace Antares
 {
 namespace Data
 {
-PreproThermal::PreproThermal(ThermalCluster* thermalCluster) : itsThermalCluster(thermalCluster)
+PreproThermal::PreproThermal(std::shared_ptr<const ThermalCluster> cluster) : itsThermalCluster(cluster)
 {
 }
 
 void PreproThermal::copyFrom(const PreproThermal& rhs)
 {
+    itsThermalCluster = rhs.itsThermalCluster;
     data = rhs.data;
     rhs.data.unloadFromMemory();
 }

--- a/src/libs/antares/study/parts/thermal/prepro.cpp
+++ b/src/libs/antares/study/parts/thermal/prepro.cpp
@@ -43,7 +43,8 @@ namespace Antares
 {
 namespace Data
 {
-PreproThermal::PreproThermal(std::shared_ptr<const ThermalCluster> cluster) : itsThermalCluster(cluster)
+PreproThermal::PreproThermal(std::shared_ptr<const ThermalCluster> cluster) :
+ itsThermalCluster(cluster)
 {
 }
 
@@ -96,8 +97,7 @@ static bool LoadPreproThermal350(Study& study, Matrix<>& data, const AnyString& 
     return ret;
 }
 
-bool PreproThermal::loadFromFolder(Study& study,
-                                   const AnyString& folder)
+bool PreproThermal::loadFromFolder(Study& study, const AnyString& folder)
 {
     bool ret = true;
     auto& buffer = study.bufferLoadingTS;

--- a/src/libs/antares/study/parts/thermal/prepro.h
+++ b/src/libs/antares/study/parts/thermal/prepro.h
@@ -116,14 +116,12 @@ public:
     */
     bool normalizeAndCheckNPO();
 
-private:
-    std::shared_ptr<const ThermalCluster> itsThermalCluster = nullptr;
-
-public:
     //! All {FO,PO}{Duration,Rate} annual values
     // max x DAYS_PER_YEAR
     Matrix<> data;
 
+private:
+    std::shared_ptr<const ThermalCluster> itsThermalCluster = nullptr;
 }; // class PreproThermal
 
 } // namespace Data

--- a/src/libs/antares/study/parts/thermal/prepro.h
+++ b/src/libs/antares/study/parts/thermal/prepro.h
@@ -89,8 +89,7 @@ public:
     ** \param folder The source folder
     ** \return A non-zero value if the operation succeeded, 0 otherwise
     */
-    bool loadFromFolder(Study& study,
-                        const AnyString& folder);
+    bool loadFromFolder(Study& study, const AnyString& folder);
 
     /*!
     ** \brief Save settings used by the thermal prepro to a folder
@@ -116,6 +115,7 @@ public:
     ** This method should only be used by the solver
     */
     bool normalizeAndCheckNPO();
+
 private:
     std::shared_ptr<const ThermalCluster> itsThermalCluster = nullptr;
 

--- a/src/libs/antares/study/parts/thermal/prepro.h
+++ b/src/libs/antares/study/parts/thermal/prepro.h
@@ -30,6 +30,7 @@
 #include "../../../array/matrix.h"
 #include "defines.h"
 #include "../../fwd.h"
+#include <memory>
 
 namespace Antares
 {
@@ -65,7 +66,7 @@ public:
     /*!
     ** \brief Default constructor
     */
-    PreproThermal(ThermalCluster* thermalCluster);
+    PreproThermal(std::shared_ptr<const ThermalCluster> cluster);
     //@}
 
     bool invalidate(bool reload) const;
@@ -116,7 +117,7 @@ public:
     */
     bool normalizeAndCheckNPO();
 private:
-    ThermalCluster* itsThermalCluster = nullptr;
+    std::shared_ptr<const ThermalCluster> itsThermalCluster = nullptr;
 
 public:
     //! All {FO,PO}{Duration,Rate} annual values

--- a/src/libs/antares/study/parts/thermal/prepro.h
+++ b/src/libs/antares/study/parts/thermal/prepro.h
@@ -27,6 +27,7 @@
 #ifndef __ANTARES_LIBS_STUDY_PARTS_THERMAL_PREPRO_H__
 #define __ANTARES_LIBS_STUDY_PARTS_THERMAL_PREPRO_H__
 
+#include "cluster.h"
 #include "../../../array/matrix.h"
 #include "defines.h"
 #include "../../fwd.h"
@@ -119,8 +120,7 @@ public:
     //! All {FO,PO}{Duration,Rate} annual values
     // max x DAYS_PER_YEAR
     Matrix<> data;
-
-private:
+    // Parent thermal cluster
     std::shared_ptr<const ThermalCluster> itsThermalCluster = nullptr;
 }; // class PreproThermal
 
@@ -128,6 +128,6 @@ private:
 } // namespace Antares
 
 #include "prepro.hxx"
-#include "cluster.h"
+
 
 #endif // __ANTARES_LIBS_STUDY_PARTS_THERMAL_PREPRO_HXX__

--- a/src/libs/antares/study/parts/thermal/prepro.h
+++ b/src/libs/antares/study/parts/thermal/prepro.h
@@ -66,7 +66,7 @@ public:
     /*!
     ** \brief Default constructor
     */
-    PreproThermal(std::shared_ptr<const ThermalCluster> cluster);
+    explicit PreproThermal(std::shared_ptr<const ThermalCluster> cluster);
     //@}
 
     bool invalidate(bool reload) const;


### PR DESCRIPTION
Relevant example
```cpp
#include <iostream>
#include <memory>

class Resource : public std::enable_shared_from_this<Resource> {
public:
  explicit Resource(const char* msg) {
    std::cout << "Resource(" << msg << ")" << std::endl;
  }
  ~Resource() {
    std::cout << "~Resource()" << std::endl;
  }
};

int main() {
  auto s1 = std::make_shared<Resource>("Hello");
  auto ptr = s1.get();
  auto s2 = ptr->shared_from_this();

  std::cout << s1.use_count() << ' ' << s2.use_count() << std::endl;

  /*  Possible output
  Resource(Hello)
  2 2
  ~Resource()
  */
}
```

See [cppreference.com](https://en.cppreference.com/w/cpp/memory/enable_shared_from_this) about this C++11 feature.