### PR TITLE
Make absence of areas/<area>/adequacy_patch.ini non-fatal

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -1070,7 +1070,7 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
     }
 
     // Adequacy patch
-    if (study.header.version >= 820)
+    if (study.header.version >= 820 && study.parameters.include.adequacyPatch)
     {
         buffer.clear() << study.folderInput << SEP << "areas" << SEP << area.id << SEP
                        << "adequacy_patch.ini";


### PR DESCRIPTION
If the adequacy patch is disabled and the study version is >=820, when any area has no `adequacy_patch.ini` file, a warning is issued. In most cases, this warning is fatal _ie_ it stops the simulation from running.

This is a problem since for most 820 studies, these files do not exist. Yet, if the adq-patch is disabled (it is by default), it doesn't make much sense to expect them.