### PR TITLE
Invalidate link before calling setMatrix(link)

### DIFF
--- a/src/libs/antares/array/matrix.hxx
+++ b/src/libs/antares/array/matrix.hxx
@@ -415,7 +415,7 @@ bool Matrix<T, ReadWriteT>::loadFromCSVFile(const AnyString& filename,
 {
     assert(not filename.empty() and "Matrix<>:: loadFromCSVFile: empty filename");
     // As the loading might be expensive, especially when dealing with
-    // numerous matriceis, we may want to delay this loading (a `lazy` mode)
+    // numerous matrices, we may want to delay this loading (a `lazy` mode)
     return (JIT::enabled and not(options & optImmediate))
              ? internalLoadJITData(filename, minWidth, maxHeight, options)
              // Reading data from file

--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -217,22 +217,10 @@ bool AreaLink::linkLoadTimeSeries_for_version_820_and_later(const AnyString& fol
     String filename;
     bool success = true;
 
-    bool enabledModeIsChanged = false;
-    if (JIT::enabled)
-    {
-        JIT::enabled = false; // Allowing to read the area's daily max power
-        enabledModeIsChanged = true;
-    }
-
     // Read link's parameters times series
     filename.clear() << folder << SEP << with->id << "_parameters.txt";
-    success
-      = parameters.loadFromCSVFile(
-          filename, fhlMax, HOURS_PER_YEAR, Matrix<>::optFixedSize | Matrix<>::optImmediate)
-        && success;
-
-    if (enabledModeIsChanged)
-        JIT::enabled = true; // Back to the previous loading mode.
+    success = parameters.loadFromCSVFile(filename, fhlMax, HOURS_PER_YEAR, Matrix<>::optFixedSize)
+              && success;
 
     // Read link's direct capacities time series
     filename.clear() << capacitiesFolder << SEP << with->id << "_direct.txt";

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/connection.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/connection.cpp
@@ -61,6 +61,11 @@ wxString Connection::rowCaption(int row) const
 
 void Connection::onConnectionChanged(Data::AreaLink* link)
 {
+    if (!link)
+        return;
+
+    link->invalidate(true);
+
     setMatrix(link);
     if (link)
         mUseLoopFlow = link->useLoopFlow;

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/connection.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/connection.cpp
@@ -63,7 +63,7 @@ void Connection::onConnectionChanged(Data::AreaLink* link)
 {
     if (link)
     {
-        link->invalidate(true);
+        link->invalidate(true); // Force the reload of parameters & capacities to avoid a crash.
         setMatrix(link);
         mUseLoopFlow = link->useLoopFlow;
     }

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/connection.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/connection.cpp
@@ -61,12 +61,12 @@ wxString Connection::rowCaption(int row) const
 
 void Connection::onConnectionChanged(Data::AreaLink* link)
 {
-    if (!link)
-        return;
-
-    link->invalidate(true);
-    setMatrix(link);
-    mUseLoopFlow = link->useLoopFlow;
+    if (link)
+    {
+        link->invalidate(true);
+        setMatrix(link);
+        mUseLoopFlow = link->useLoopFlow;
+    }
 
     if (pControl)
     {

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/connection.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/connection.cpp
@@ -65,10 +65,9 @@ void Connection::onConnectionChanged(Data::AreaLink* link)
         return;
 
     link->invalidate(true);
-
     setMatrix(link);
-    if (link)
-        mUseLoopFlow = link->useLoopFlow;
+    mUseLoopFlow = link->useLoopFlow;
+
     if (pControl)
     {
         pControl->InvalidateBestSize();


### PR DESCRIPTION
This forces the data to be loaded, preventing crashes