### PR TITLE
Fix compilation warning in file helper

### DIFF
--- a/src/tests/src/libs/antares/study/area/files-helper.cpp
+++ b/src/tests/src/libs/antares/study/area/files-helper.cpp
@@ -12,9 +12,8 @@ namespace fs = std::filesystem;
 
 void remove_files(const vector<string>& filesToRemove)
 {
-	for (int i = 0; i != filesToRemove.size(); i++)
+    for (const auto& fileToRemove : filesToRemove)
 	{
-		fs::path fileToRemove = filesToRemove[i];
 		if (fs::exists(fileToRemove))
 			fs::remove(fileToRemove);
 	}


### PR DESCRIPTION
Use range-based loop instead of signed int.

Warning was caused by comparison of signed/unsigned integers.