### PR TITLE
Fix logging of performed years

### DIFF
--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -1123,7 +1123,6 @@ uint ISimulation<Impl>::buildSetsOfParallelYears(
         else
         {
             set->isYearPerformed[y] = false;
-            set->isFirstPerformedYearOfASet[y] = false;
         }
 
         // Do we build a new set at next iteration (for years to be executed or not) ?
@@ -1502,7 +1501,6 @@ void ISimulation<Impl>::loopThroughYears(uint firstYear,
         computeRandomNumbers(randomForParallelYears, set_it->yearsIndices, set_it->isYearPerformed);
 
         std::vector<unsigned int>::iterator year_it;
-        std::vector<unsigned int> yearsIndicesCopy(set_it->yearsIndices);
 
 #if HYDRO_HOT_START != 0
         // Printing on columns the years chained by final levels

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -1442,6 +1442,8 @@ void ISimulation<Impl>::computeAnnualCostsStatistics(
 
 static void logPerformedYearsInAset(setOfParallelYears& set)
 {
+    logs.info() << "parallel batch size : " << set.nbYears << " (" << set.nbPerformedYears << " perfomed)";
+    
     std::string performedYearsToLog = "";
     std::for_each(std::begin(set.yearsIndices), std::end(set.yearsIndices), [&](uint const& y) {
         if (set.isYearPerformed[y])
@@ -1491,10 +1493,6 @@ void ISimulation<Impl>::loopThroughYears(uint firstYear,
     std::vector<setOfParallelYears>::iterator set_it;
     for (set_it = setsOfParallelYears.begin(); set_it != setsOfParallelYears.end(); ++set_it)
     {
-        logs.info() << "parallel batch size : " << set_it->nbYears << " (" << set_it->nbPerformedYears << " perfomed)";
-
-        logPerformedYearsInAset(*set_it);
-
         // 1 - We may want to regenerate the time-series this year.
         // This is the case when the preprocessors are enabled from the
         // interface and/or the refresh is enabled.
@@ -1568,6 +1566,8 @@ void ISimulation<Impl>::loopThroughYears(uint firstYear,
                                                    pYearByYear));
 
         } // End loop over years of the current set of parallel years
+
+        logPerformedYearsInAset(*set_it);
 
         qs.start();
 


### PR DESCRIPTION
Logging years can be misleading under some circumstances : when there are skipped years in the playlist.
Some skipped years can be embedded among years being performed in the progression bar and in the log file.
In case of sequential execution, it lets user think that several years are run in parallel, although only one is actually performed and the others are actually skipped.
This PR intends to make logging more clear on that matter.
May fix #678 