### PR TITLE
Display commit-id in the solver logs, if available

### DIFF
--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -198,7 +198,11 @@ void Application::prepare(int argc, char* argv[])
     resetLogFilename();
 
     // Starting !
+#ifdef GIT_SHA1_SHORT_STRING
+    logs.checkpoint() << "Antares Solver v" << ANTARES_VERSION_PUB_STR << " (" << GIT_SHA1_SHORT_STRING << ")";
+#else
     logs.checkpoint() << "Antares Solver v" << ANTARES_VERSION_PUB_STR;
+#endif
     WriteHostInfoIntoLogs();
     logs.info();
 


### PR DESCRIPTION
To help identify what version of Antares was used to produce results, display the commit-id in the logs (file simulation.log).