### PR TITLE
UI - fix a bug on map layers

### DIFF
--- a/src/ui/simulator/toolbox/components/map/control.cpp
+++ b/src/ui/simulator/toolbox/components/map/control.cpp
@@ -107,7 +107,7 @@ Control::Control(wxWindow* parent, Component& component, size_t uID) :
  pCurrentMousePositionGraph(INT_MAX, INT_MAX),
  pCurrentClientSize(0, 0),
  pLastMousePosition(INT_MAX, INT_MAX),
- uid(newUID++)
+ uid(uID)
 {
     while (newUID <= uID)
         newUID++;


### PR DESCRIPTION
Before this fix :
- impossible to create a layer correctly :
    + either the new layer has a wrong name (for instance "Map 6" as though there only All and "Map 1" already exist)
    + either it's not possible to set areas as visible or not in the layer
- After a simulation is run, Antares GUI never gives back the control to user : GUI must be killed.

This PR fixes #721