### PR TITLE
Disable DENS output variable if adq-patch is disabled

### DIFF
--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1435,10 +1435,9 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
     const auto excluded_vars_rg = renewableGeneration.excludedVariables();
     const auto excluded_vars_adq_patch = adqPatch.excludedVariables();
     std::vector<std::string> excluded_vars;
-    excluded_vars.insert(excluded_vars.end(), excluded_vars_rg.begin(),
-                         excluded_vars_rg.end());
-    excluded_vars.insert(excluded_vars.end(), excluded_vars_adq_patch.begin(),
-                         excluded_vars_adq_patch.end());
+    excluded_vars.insert(excluded_vars.end(), excluded_vars_rg.begin(), excluded_vars_rg.end());
+    excluded_vars.insert(
+      excluded_vars.end(), excluded_vars_adq_patch.begin(), excluded_vars_adq_patch.end());
     variablesPrintInfo.prepareForSimulation(thematicTrimming, excluded_vars);
 
     switch (mode)
@@ -1922,12 +1921,13 @@ std::vector<std::string> Parameters::RenewableGeneration::excludedVariables() co
 
 std::vector<std::string> Parameters::AdequacyPatch::excludedVariables() const
 {
-  switch(include) {
-  case true:
-    return {};
-  default:
-    return {"dens"};
-  }
+    switch (include)
+    {
+    case true:
+        return {};
+    default:
+        return {"dens"};
+    }
 }
 
 bool Parameters::haveToImport(int tsKind) const

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1904,11 +1904,13 @@ void Parameters::RenewableGeneration::addExcludedVariables(std::vector<std::stri
 
     switch (rgModelling)
     {
+    // Using `aggregated` renewable generation, exclude `renewable` variables
     case rgAggregated:
-        out.insert(out.end(), agg.begin(), agg.end());
-        break;
-    case rgClusters:
         out.insert(out.end(), ren.begin(), ren.end());
+        break;
+    // Using `renewable clusters` renewable generation, exclude `aggregated` variables
+    case rgClusters:
+        out.insert(out.end(), agg.begin(), agg.end());
         break;
     default:
         break;

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1432,12 +1432,10 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
     case rgUnknown:
         logs.error() << "Generation should be either `clusters` or `aggregated`";
     }
-    const auto excluded_vars_rg = renewableGeneration.excludedVariables();
-    const auto excluded_vars_adq_patch = adqPatch.excludedVariables();
     std::vector<std::string> excluded_vars;
-    excluded_vars.insert(excluded_vars.end(), excluded_vars_rg.begin(), excluded_vars_rg.end());
-    excluded_vars.insert(
-      excluded_vars.end(), excluded_vars_adq_patch.begin(), excluded_vars_adq_patch.end());
+    renewableGeneration.addExcludedVariables(excluded_vars);
+    adqPatch.addExcludedVariables(excluded_vars);
+
     variablesPrintInfo.prepareForSimulation(thematicTrimming, excluded_vars);
 
     switch (mode)
@@ -1890,44 +1888,37 @@ bool Parameters::saveToFile(const AnyString& filename) const
     return ini.save(filename);
 }
 
-std::vector<std::string> Parameters::RenewableGeneration::excludedVariables() const
+void Parameters::RenewableGeneration::addExcludedVariables(std::vector<std::string>& out) const
 {
+    const static std::vector<std::string> ren = {"wind offshore",
+                                                 "wind onshore",
+                                                 "solar concrt.",
+                                                 "solar pv",
+                                                 "solar rooft",
+                                                 "renw. 1",
+                                                 "renw. 2",
+                                                 "renw. 3",
+                                                 "renw. 4"};
+
+    const static std::vector<std::string> agg = {"wind", "solar"};
+
     switch (rgModelling)
     {
-    /*
-       Order is important because AllVariablesPrintInfo::setPrintStatus
-       does not reset the search pointer.
-
-       Inverting some variable names below may result in some of them not being
-       taken into account.
-    */
     case rgAggregated:
-        return {"wind offshore",
-                "wind onshore",
-                "solar concrt.",
-                "solar pv",
-                "solar rooft",
-                "renw. 1",
-                "renw. 2",
-                "renw. 3",
-                "renw. 4"};
+        out.insert(out.end(), agg.begin(), agg.end());
+        break;
     case rgClusters:
-        return {"wind", "solar"};
-    case rgUnknown:
-        return {};
+        out.insert(out.end(), ren.begin(), ren.end());
+        break;
+    default:
+        break;
     }
-    return {};
 }
 
-std::vector<std::string> Parameters::AdequacyPatch::excludedVariables() const
+void Parameters::AdequacyPatch::addExcludedVariables(std::vector<std::string>& out) const
 {
-    switch (include)
-    {
-    case true:
-        return {};
-    default:
-        return {"dens"};
-    }
+    if (!include)
+        out.emplace_back("dens");
 }
 
 bool Parameters::haveToImport(int tsKind) const

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -458,7 +458,7 @@ public:
     {
         //! Renewable generation mode
         RenewableGenerationModelling rgModelling;
-        std::vector<std::string> excludedVariables() const;
+        void addExcludedVariables(std::vector<std::string>&) const;
         RenewableGenerationModelling operator()() const;
         void toAggregated();
         void toClusters();
@@ -520,7 +520,7 @@ public:
         };
         bool include;
         LocalMatching localMatching;
-        std::vector<std::string> excludedVariables() const;
+        void addExcludedVariables(std::vector<std::string>&) const;
     };
 
     AdequacyPatch adqPatch;

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -419,9 +419,6 @@ public:
         //! if MPS files are exported, a flag to split them
         bool splitExportedMPS;
 
-        //! a flag to use Adequacy patch
-        bool adequacyPatch;
-
         //! a flag to export structure needed for Antares XPansion
         bool exportStructure;
 
@@ -521,7 +518,9 @@ public:
             //! rule.
             bool setToZeroOutsideOutsideLinks = true;
         };
+        bool include;
         LocalMatching localMatching;
+        std::vector<std::string> excludedVariables() const;
     };
 
     AdequacyPatch adqPatch;

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -287,8 +287,8 @@ void Application::prepare(int argc, char* argv[])
 
     checkSimplexRangeHydroHeuristic(pParameters->simplexOptimizationRange, pStudy->areas);
 
-    checkAdqPatchStudyModeEconomyOnly(pParameters->include.adequacyPatch, pParameters->mode);
-    checkAdqPatchContainsAdqPatchArea(pParameters->include.adequacyPatch, pStudy->areas);
+    checkAdqPatchStudyModeEconomyOnly(pParameters->adqPatch.include, pParameters->mode);
+    checkAdqPatchContainsAdqPatchArea(pParameters->adqPatch.include, pStudy->areas);
 
     bool tsGenThermal = (0
                          != (pStudy->parameters.timeSeriesToGenerate

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -152,7 +152,7 @@ bool Economy::simulationBegin()
         }
 
         weeklyOptProblem
-          = EconomyWeeklyOptimization::create(study.parameters.include.adequacyPatch);
+          = EconomyWeeklyOptimization::create(study.parameters.adqPatch.include);
 
         SIM_InitialisationResultats();
     }

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -63,7 +63,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
     problem.hydroHotStart
       = (parameters.initialReservoirLevels.iniLevels == Antares::Data::irlHotStart);
 
-    if (parameters.include.adequacyPatch)
+    if (parameters.adqPatch.include)
     {
         problem.adqPatchParams
           = std::unique_ptr<AdequacyPatchParameters>(new AdequacyPatchParameters());
@@ -75,7 +75,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
           = parameters.adqPatch.localMatching.setToZeroOutsideOutsideLinks;
     }
 
-    if (parameters.include.adequacyPatch)
+    if (parameters.adqPatch.include)
     {
         problem.adequacyPatchRuntimeData.initialize(study);
     }

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -393,7 +393,7 @@ Optimization::Optimization(wxWindow* parent) :
         button->menu(true);
         onPopup.bind(this,
                      &Optimization::onPopupMenuSpecify,
-                     PopupInfo(study.parameters.include.adequacyPatch, wxT("true")));
+                     PopupInfo(study.parameters.adqPatch.include, wxT("true")));
         button->onPopupMenu(onPopup);
         s->Add(label, 0, wxRIGHT | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL);
         s->Add(button, 0, wxLEFT | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL);
@@ -518,7 +518,7 @@ void Optimization::onResetToDefault(void*)
             study.parameters.include.reserve.spinning = true;
             study.parameters.include.exportMPS = false;
             study.parameters.include.splitExportedMPS = false;
-            study.parameters.include.adequacyPatch = false;
+            study.parameters.adqPatch.include = false;
             study.parameters.adqPatch.localMatching.setToZeroOutsideInsideLinks = true;
             study.parameters.adqPatch.localMatching.setToZeroOutsideOutsideLinks = true;
             study.parameters.simplexOptimizationRange = Data::sorWeek;
@@ -571,7 +571,7 @@ void Optimization::refresh()
     // Split exported MPS
     ResetButtonSpecify(pBtnSplitExportedMPS, study.parameters.include.splitExportedMPS);
     // Adequacy patch
-    ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.include.adequacyPatch);
+    ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.adqPatch.include);
     // NTC from physical areas outside adequacy patch (area type 1) to physical areas inside
     // adequacy patch (area type 2). Used in the first step of adequacy patch local matching rule.
     ResetButtonAdequacyPatch(pBtnAdqPatchOutsideInside,


### PR DESCRIPTION
- Move `include.adequacyPatch` to `adqPatch.include`
- Add `Parameters::AdequacyPatch::excludedVariables`
- Exclude "DENS" if adequacy patch is disabled