### PR TITLE
Make adequacy patch parameters future-proof

### DIFF
--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1435,10 +1435,9 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
     const auto excluded_vars_rg = renewableGeneration.excludedVariables();
     const auto excluded_vars_adq_patch = adqPatch.excludedVariables();
     std::vector<std::string> excluded_vars;
-    excluded_vars.insert(excluded_vars.end(), excluded_vars_rg.begin(),
-                         excluded_vars_rg.end());
-    excluded_vars.insert(excluded_vars.end(), excluded_vars_adq_patch.begin(),
-                         excluded_vars_adq_patch.end());
+    excluded_vars.insert(excluded_vars.end(), excluded_vars_rg.begin(), excluded_vars_rg.end());
+    excluded_vars.insert(
+      excluded_vars.end(), excluded_vars_adq_patch.begin(), excluded_vars_adq_patch.end());
     variablesPrintInfo.prepareForSimulation(thematicTrimming, excluded_vars);
 
     switch (mode)
@@ -1922,12 +1921,13 @@ std::vector<std::string> Parameters::RenewableGeneration::excludedVariables() co
 
 std::vector<std::string> Parameters::AdequacyPatch::excludedVariables() const
 {
-  switch(include) {
-  case true:
-    return {};
-  default:
-    return {"dens"};
-  }
+    switch (include)
+    {
+    case true:
+        return {};
+    default:
+        return {"dens"};
+    }
 }
 
 bool Parameters::haveToImport(int tsKind) const

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1904,11 +1904,13 @@ void Parameters::RenewableGeneration::addExcludedVariables(std::vector<std::stri
 
     switch (rgModelling)
     {
+    // Using `aggregated` renewable generation, exclude `renewable` variables
     case rgAggregated:
-        out.insert(out.end(), agg.begin(), agg.end());
-        break;
-    case rgClusters:
         out.insert(out.end(), ren.begin(), ren.end());
+        break;
+    // Using `renewable clusters` renewable generation, exclude `aggregated` variables
+    case rgClusters:
+        out.insert(out.end(), agg.begin(), agg.end());
         break;
     default:
         break;

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1432,12 +1432,10 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
     case rgUnknown:
         logs.error() << "Generation should be either `clusters` or `aggregated`";
     }
-    const auto excluded_vars_rg = renewableGeneration.excludedVariables();
-    const auto excluded_vars_adq_patch = adqPatch.excludedVariables();
     std::vector<std::string> excluded_vars;
-    excluded_vars.insert(excluded_vars.end(), excluded_vars_rg.begin(), excluded_vars_rg.end());
-    excluded_vars.insert(
-      excluded_vars.end(), excluded_vars_adq_patch.begin(), excluded_vars_adq_patch.end());
+    renewableGeneration.addExcludedVariables(excluded_vars);
+    adqPatch.addExcludedVariables(excluded_vars);
+
     variablesPrintInfo.prepareForSimulation(thematicTrimming, excluded_vars);
 
     switch (mode)
@@ -1890,44 +1888,37 @@ bool Parameters::saveToFile(const AnyString& filename) const
     return ini.save(filename);
 }
 
-std::vector<std::string> Parameters::RenewableGeneration::excludedVariables() const
+void Parameters::RenewableGeneration::addExcludedVariables(std::vector<std::string>& out) const
 {
+    const static std::vector<std::string> ren = {"wind offshore",
+                                                 "wind onshore",
+                                                 "solar concrt.",
+                                                 "solar pv",
+                                                 "solar rooft",
+                                                 "renw. 1",
+                                                 "renw. 2",
+                                                 "renw. 3",
+                                                 "renw. 4"};
+
+    const static std::vector<std::string> agg = {"wind", "solar"};
+
     switch (rgModelling)
     {
-    /*
-       Order is important because AllVariablesPrintInfo::setPrintStatus
-       does not reset the search pointer.
-
-       Inverting some variable names below may result in some of them not being
-       taken into account.
-    */
     case rgAggregated:
-        return {"wind offshore",
-                "wind onshore",
-                "solar concrt.",
-                "solar pv",
-                "solar rooft",
-                "renw. 1",
-                "renw. 2",
-                "renw. 3",
-                "renw. 4"};
+        out.insert(out.end(), agg.begin(), agg.end());
+        break;
     case rgClusters:
-        return {"wind", "solar"};
-    case rgUnknown:
-        return {};
+        out.insert(out.end(), ren.begin(), ren.end());
+        break;
+    default:
+        break;
     }
-    return {};
 }
 
-std::vector<std::string> Parameters::AdequacyPatch::excludedVariables() const
+void Parameters::AdequacyPatch::addExcludedVariables(std::vector<std::string>& out) const
 {
-    switch (include)
-    {
-    case true:
-        return {};
-    default:
-        return {"dens"};
-    }
+    if (!include)
+        out.emplace_back("dens");
 }
 
 bool Parameters::haveToImport(int tsKind) const

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -204,7 +204,7 @@ void Parameters::resetSeeds()
 
 void Parameters::resetAdqPatchParameters()
 {
-    adqPatch.include = false;
+    adqPatch.enabled = false;
     adqPatch.localMatching.setToZeroOutsideInsideLinks = true;
     adqPatch.localMatching.setToZeroOutsideOutsideLinks = true;
 }
@@ -631,7 +631,7 @@ static bool SGDIntLoadFamily_AdqPatch(Parameters& d,
                                       uint)
 {
     if (key == "include-adq-patch")
-        return value.to<bool>(d.adqPatch.include);
+        return value.to<bool>(d.adqPatch.enabled);
     if (key == "set-to-null-ntc-from-physical-out-to-physical-in-for-first-step")
         return value.to<bool>(d.adqPatch.localMatching.setToZeroOutsideInsideLinks);
     if (key == "set-to-null-ntc-between-physical-out-for-first-step")
@@ -1585,7 +1585,7 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
         logs.info() << "  :: ignoring export mps";
     if (!include.splitExportedMPS)
         logs.info() << "  :: ignoring split exported mps";
-    if (!adqPatch.include)
+    if (!adqPatch.enabled)
         logs.info() << "  :: ignoring adequacy patch";
     if (!include.exportStructure)
         logs.info() << "  :: ignoring export structure";
@@ -1759,7 +1759,7 @@ void Parameters::saveToINI(IniFile& ini) const
     // Adequacy patch
     {
         auto* section = ini.addSection("adequacy patch");
-        section->add("include-adq-patch", adqPatch.include);
+        section->add("include-adq-patch", adqPatch.enabled);
         section->add("set-to-null-ntc-from-physical-out-to-physical-in-for-first-step",
                      adqPatch.localMatching.setToZeroOutsideInsideLinks);
         section->add("set-to-null-ntc-between-physical-out-for-first-step",
@@ -1943,7 +1943,7 @@ std::vector<std::string> Parameters::RenewableGeneration::excludedVariables() co
 
 std::vector<std::string> Parameters::AdequacyPatch::excludedVariables() const
 {
-    switch (include)
+    switch (enabled)
     {
     case true:
         return {};

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -522,7 +522,7 @@ public:
             //! rule.
             bool setToZeroOutsideOutsideLinks = true;
         };
-        bool include;
+        bool enabled;
         LocalMatching localMatching;
         std::vector<std::string> excludedVariables() const;
     };

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -458,7 +458,7 @@ public:
     {
         //! Renewable generation mode
         RenewableGenerationModelling rgModelling;
-        std::vector<std::string> excludedVariables() const;
+        void addExcludedVariables(std::vector<std::string>&) const;
         RenewableGenerationModelling operator()() const;
         void toAggregated();
         void toClusters();
@@ -520,7 +520,7 @@ public:
         };
         bool include;
         LocalMatching localMatching;
-        std::vector<std::string> excludedVariables() const;
+        void addExcludedVariables(std::vector<std::string>&) const;
     };
 
     AdequacyPatch adqPatch;

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -419,9 +419,6 @@ public:
         //! if MPS files are exported, a flag to split them
         bool splitExportedMPS;
 
-        //! a flag to use Adequacy patch
-        bool adequacyPatch;
-
         //! a flag to export structure needed for Antares XPansion
         bool exportStructure;
 
@@ -521,7 +518,9 @@ public:
             //! rule.
             bool setToZeroOutsideOutsideLinks = true;
         };
+        bool include;
         LocalMatching localMatching;
+        std::vector<std::string> excludedVariables() const;
     };
 
     AdequacyPatch adqPatch;

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -138,6 +138,10 @@ public:
     ** \brief Reset to default all seeds
     */
     void resetSeeds();
+    /*!
+    ** \brief Reset to default all adequacy patch values
+    */
+    void resetAdqPatchParameters();
 
     /*!
     ** \brief Try to detect then fix any bad value

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -287,8 +287,8 @@ void Application::prepare(int argc, char* argv[])
 
     checkSimplexRangeHydroHeuristic(pParameters->simplexOptimizationRange, pStudy->areas);
 
-    checkAdqPatchStudyModeEconomyOnly(pParameters->include.adequacyPatch, pParameters->mode);
-    checkAdqPatchContainsAdqPatchArea(pParameters->include.adequacyPatch, pStudy->areas);
+    checkAdqPatchStudyModeEconomyOnly(pParameters->adqPatch.include, pParameters->mode);
+    checkAdqPatchContainsAdqPatchArea(pParameters->adqPatch.include, pStudy->areas);
 
     bool tsGenThermal = (0
                          != (pStudy->parameters.timeSeriesToGenerate

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -287,8 +287,8 @@ void Application::prepare(int argc, char* argv[])
 
     checkSimplexRangeHydroHeuristic(pParameters->simplexOptimizationRange, pStudy->areas);
 
-    checkAdqPatchStudyModeEconomyOnly(pParameters->adqPatch.include, pParameters->mode);
-    checkAdqPatchContainsAdqPatchArea(pParameters->adqPatch.include, pStudy->areas);
+    checkAdqPatchStudyModeEconomyOnly(pParameters->adqPatch.enabled, pParameters->mode);
+    checkAdqPatchContainsAdqPatchArea(pParameters->adqPatch.enabled, pStudy->areas);
 
     bool tsGenThermal = (0
                          != (pStudy->parameters.timeSeriesToGenerate

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -152,7 +152,7 @@ bool Economy::simulationBegin()
         }
 
         weeklyOptProblem
-          = EconomyWeeklyOptimization::create(study.parameters.adqPatch.include);
+          = EconomyWeeklyOptimization::create(study.parameters.adqPatch.enabled);
 
         SIM_InitialisationResultats();
     }

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -152,7 +152,7 @@ bool Economy::simulationBegin()
         }
 
         weeklyOptProblem
-          = EconomyWeeklyOptimization::create(study.parameters.include.adequacyPatch);
+          = EconomyWeeklyOptimization::create(study.parameters.adqPatch.include);
 
         SIM_InitialisationResultats();
     }

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -63,7 +63,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
     problem.hydroHotStart
       = (parameters.initialReservoirLevels.iniLevels == Antares::Data::irlHotStart);
 
-    if (parameters.include.adequacyPatch)
+    if (parameters.adqPatch.include)
     {
         problem.adqPatchParams
           = std::unique_ptr<AdequacyPatchParameters>(new AdequacyPatchParameters());
@@ -75,7 +75,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
           = parameters.adqPatch.localMatching.setToZeroOutsideOutsideLinks;
     }
 
-    if (parameters.include.adequacyPatch)
+    if (parameters.adqPatch.include)
     {
         problem.adequacyPatchRuntimeData.initialize(study);
     }

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -63,7 +63,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
     problem.hydroHotStart
       = (parameters.initialReservoirLevels.iniLevels == Antares::Data::irlHotStart);
 
-    if (parameters.adqPatch.include)
+    if (parameters.adqPatch.enabled)
     {
         problem.adqPatchParams
           = std::unique_ptr<AdequacyPatchParameters>(new AdequacyPatchParameters());
@@ -75,7 +75,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
           = parameters.adqPatch.localMatching.setToZeroOutsideOutsideLinks;
     }
 
-    if (parameters.adqPatch.include)
+    if (parameters.adqPatch.enabled)
     {
         problem.adequacyPatchRuntimeData.initialize(study);
     }

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -393,7 +393,7 @@ Optimization::Optimization(wxWindow* parent) :
         button->menu(true);
         onPopup.bind(this,
                      &Optimization::onPopupMenuSpecify,
-                     PopupInfo(study.parameters.adqPatch.include, wxT("true")));
+                     PopupInfo(study.parameters.adqPatch.enabled, wxT("true")));
         button->onPopupMenu(onPopup);
         s->Add(label, 0, wxRIGHT | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL);
         s->Add(button, 0, wxLEFT | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL);
@@ -518,7 +518,7 @@ void Optimization::onResetToDefault(void*)
             study.parameters.include.reserve.spinning = true;
             study.parameters.include.exportMPS = false;
             study.parameters.include.splitExportedMPS = false;
-            study.parameters.adqPatch.include = false;
+            study.parameters.adqPatch.enabled = false;
             study.parameters.adqPatch.localMatching.setToZeroOutsideInsideLinks = true;
             study.parameters.adqPatch.localMatching.setToZeroOutsideOutsideLinks = true;
             study.parameters.simplexOptimizationRange = Data::sorWeek;
@@ -571,7 +571,7 @@ void Optimization::refresh()
     // Split exported MPS
     ResetButtonSpecify(pBtnSplitExportedMPS, study.parameters.include.splitExportedMPS);
     // Adequacy patch
-    ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.adqPatch.include);
+    ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.adqPatch.enabled);
     // NTC from physical areas outside adequacy patch (area type 1) to physical areas inside
     // adequacy patch (area type 2). Used in the first step of adequacy patch local matching rule.
     ResetButtonAdequacyPatch(pBtnAdqPatchOutsideInside,

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -393,7 +393,7 @@ Optimization::Optimization(wxWindow* parent) :
         button->menu(true);
         onPopup.bind(this,
                      &Optimization::onPopupMenuSpecify,
-                     PopupInfo(study.parameters.include.adequacyPatch, wxT("true")));
+                     PopupInfo(study.parameters.adqPatch.include, wxT("true")));
         button->onPopupMenu(onPopup);
         s->Add(label, 0, wxRIGHT | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL);
         s->Add(button, 0, wxLEFT | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL);
@@ -518,7 +518,7 @@ void Optimization::onResetToDefault(void*)
             study.parameters.include.reserve.spinning = true;
             study.parameters.include.exportMPS = false;
             study.parameters.include.splitExportedMPS = false;
-            study.parameters.include.adequacyPatch = false;
+            study.parameters.adqPatch.include = false;
             study.parameters.adqPatch.localMatching.setToZeroOutsideInsideLinks = true;
             study.parameters.adqPatch.localMatching.setToZeroOutsideOutsideLinks = true;
             study.parameters.simplexOptimizationRange = Data::sorWeek;
@@ -571,7 +571,7 @@ void Optimization::refresh()
     // Split exported MPS
     ResetButtonSpecify(pBtnSplitExportedMPS, study.parameters.include.splitExportedMPS);
     // Adequacy patch
-    ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.include.adequacyPatch);
+    ResetButtonSpecify(pBtnAdequacyPatch, study.parameters.adqPatch.include);
     // NTC from physical areas outside adequacy patch (area type 1) to physical areas inside
     // adequacy patch (area type 2). Used in the first step of adequacy patch local matching rule.
     ResetButtonAdequacyPatch(pBtnAdqPatchOutsideInside,


### PR DESCRIPTION
Move adequacy-patch parameters to section **adequacy patch** (current : **optimization**). This is to match RTE-i's development branch.