### PR TITLE
Save output to .zip archive

### DIFF
--- a/.github/workflows/centos7-system-deps-build.yml
+++ b/.github/workflows/centos7-system-deps-build.yml
@@ -26,7 +26,7 @@ jobs:
            yum install -y git redhat-lsb-core gcc gcc-c++ make wget centos-release-scl scl-utils rpm-build
            yum install -y cmake3 devtoolset-9
            yum install -y rh-git227-git
-           yum install -y unzip libuuid-devel wxGTK3-devel boost-test boost-devel
+           yum install -y unzip libuuid-devel wxGTK3-devel boost-test boost-devel libzip-devel
                       
     
     - uses: nelonoel/branch-name@v1.0.1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
              sudo apt-get update
              sudo apt-get install uuid-dev libwxgtk3.0-gtk3-dev
-             sudo apt-get install libboost-test-dev
+             sudo apt-get install libboost-test-dev libzip-dev
 
       - name: Read antares-deps version
         id: antares-deps-version

--- a/.github/workflows/ubuntu-release.yml
+++ b/.github/workflows/ubuntu-release.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
            sudo apt-get update
            sudo apt-get install uuid-dev libwxgtk3.0-gtk3-dev
-           sudo apt-get install libboost-test-dev
+           sudo apt-get install libboost-test-dev libzip-dev
 
     - name: Read antares-deps version
       id: antares-deps-version

--- a/.github/workflows/ubuntu-system-deps-build.yml
+++ b/.github/workflows/ubuntu-system-deps-build.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
            sudo apt-get update
            sudo apt-get install uuid-dev libwxgtk3.0-gtk3-dev
-           sudo apt-get install libboost-test-dev
+           sudo apt-get install libboost-test-dev libzip-dev
            
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/ubuntu-system.yml
+++ b/.github/workflows/ubuntu-system.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
            sudo apt-get update
            sudo apt-get install uuid-dev libwxgtk3.0-gtk3-dev
-           sudo apt-get install libboost-test-dev
+           sudo apt-get install libboost-test-dev libzip-dev
 
     # antares-deps
     - name: Read antares-deps version

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-            vcpkgPackages: wxwidgets boost-test
+            vcpkgPackages: wxwidgets boost-test libzip
             test-platform: windows-2022
     env:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-            vcpkgPackages: wxwidgets boost-test
+            vcpkgPackages: wxwidgets boost-test libzip
             test-platform: windows-2022
     env:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.

--- a/docker/centos7-basic-requirements
+++ b/docker/centos7-basic-requirements
@@ -14,7 +14,7 @@ RUN yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils rp
     yum install -y rh-git227-git
 
 # Install simulator requirements
-RUN yum install -y unzip libuuid-devel wxGTK3-devel boost-test boost-devel
+RUN yum install -y unzip libuuid-devel wxGTK3-devel boost-test boost-devel libzip-devel
     
 # Add python and pip installation
 RUN yum install -y python3-pip &&\

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,9 @@ message(STATUS "Build antares solver with swap support: ${BUILD_SWAP}")
 option(BUILD_ORTOOLS "Build OR-Tools" OFF)
 message(STATUS "Build OR-Tools ${BUILD_ORTOOLS}")
 
+option(BUILD_LIBZIPPP "Build libzippp" ON)
+message(STATUS "Build libzippp ${BUILD_LIBZIPPP}")
+
 #Define install directory
 if (NOT DEPS_INSTALL_DIR)
     SET(DEPS_INSTALL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../rte-antares-deps-${CMAKE_BUILD_TYPE})
@@ -270,6 +273,14 @@ message(STATUS "OR-Tools tag ${ORTOOLS_TAG}")
   set(BUILD_SHARED_LIBS "OFF" CACHE INTERNAL "")
 
   FetchContent_MakeAvailable(ortools)
+endif()
+
+find_package(libzippp QUIET)
+if(NOT libzippp_FOUND OR BUILD_LIBZIPPP)
+  FetchContent_Declare(libzippp
+    GIT_REPOSITORY "https://github.com/ctabin/libzippp"
+    GIT_TAG "libzippp-v5.1-1.8.0")
+  FetchContent_MakeAvailable(libzippp)
 endif()
 
 #wxWidget not needed for all library find is done in ui CMakeLists.txt

--- a/src/libs/antares/CMakeLists.txt
+++ b/src/libs/antares/CMakeLists.txt
@@ -578,6 +578,7 @@ macro(ADD_ANTARES_CORE name)
 			yuni-static-uuid
 			libantares-core-calendar
 			libantares-solver-variable-info${name}
+            libzippp::libzippp
 		)
 endmacro()
 

--- a/src/libs/antares/study/mps.cpp
+++ b/src/libs/antares/study/mps.cpp
@@ -37,10 +37,12 @@ namespace Antares
 {
 namespace Data
 {
-FILE* Study::createFileIntoOutputWithExtension(const YString& prefix,
-                                               const YString& extension,
-                                               uint numSpace) const
+std::string Study::createFileIntoOutputWithExtension(const YString& prefix,
+                                                     const YString& extension,
+                                                     uint numSpace) const
 {
+    auto archive = this->pZipArchive;
+
     static std::map<YString, int> count;
 
     // Empty log entry
@@ -63,15 +65,11 @@ FILE* Study::createFileIntoOutputWithExtension(const YString& prefix,
     outputFile << (runtime->currentYear[numSpace] + 1) << "-"
                << (runtime->weekInTheYear[numSpace] + 1);
 
-    buffer.clear() << this->folderOutput << SEP << outputFile;
-
     // test if file already exists
-    FILE* fd_test = FileOpen(buffer.c_str(), "rb");
-    if (fd_test)
+    if (archive->hasEntry(outputFile.c_str()))
     {
         count[prefix]++;
         outputFile << "-" << count[prefix] << "." << extension;
-        fclose(fd_test);
     }
     else
     {
@@ -79,20 +77,8 @@ FILE* Study::createFileIntoOutputWithExtension(const YString& prefix,
         outputFile << "." << extension;
     }
 
-    buffer.clear() << this->folderOutput << SEP << outputFile;
-
-    logs.info() << "Solver output File: `" << buffer << "'";
-
-    FILE* fd = FileOpen(buffer.c_str(), "wb");
-    if (!fd)
-    {
-        logs.error() << "I/O Error: Impossible to write `" << buffer << "'";
-        logs.info() << "Aborting now.";
-        importLogsToOutputFolder();
-        return nullptr;
-    }
-    logs.info();
-    return fd;
+    logs.info() << "Solver output File: `" << outputFile << "'";
+    return outputFile.c_str();
 }
 
 } // namespace Data

--- a/src/libs/antares/study/save.cpp
+++ b/src/libs/antares/study/save.cpp
@@ -209,7 +209,7 @@ bool Study::saveToFolder(const AnyString& newfolder)
     buffer.clear() << folder << SEP << "settings" << SEP << "simulations";
     ret = IO::Directory::Create(buffer) and ret;
     buffer.clear() << folder << SEP << "settings";
-    ret = simulation.saveToFolder(buffer) and ret;
+    ret = simulation.saveToFolder(pZipArchive) and ret;
     buffer.clear() << folder << SEP << "settings" << SEP << "generaldata.ini";
     ret = parameters.saveToFile(buffer) and ret;
 

--- a/src/libs/antares/study/simulation.cpp
+++ b/src/libs/antares/study/simulation.cpp
@@ -46,26 +46,18 @@ Simulation::Simulation(Study& study) : pStudy(study)
 {
 }
 
-bool Simulation::saveToFolder(const AnyString& folder) const
+bool Simulation::saveToFolder(libzippp::ZipArchive* archive) const
 {
-    String b;
-    b.reserve(folder.size() + 20);
-    b = folder;
-
-    // Ensure that the folder has been created
-    if (!IO::Directory::Create(b))
+    if (archive)
     {
-        logs.error() << "I/O: impossible to create the directory " << b;
+        logs.notice() << comments;
+        return archive->addData("comments.txt", comments.c_str(), comments.size());
+    }
+    else
+    {
+        logs.error() << "Couldn't write comments.txt";
         return false;
     }
-
-    // Save the comments
-    b = folder;
-    b << SEP << "comments.txt";
-    if (IO::File::SetContent(b, comments))
-        return true;
-    logs.error() << "I/O: impossible to write " << b;
-    return false;
 }
 
 bool Simulation::loadFromFolder(const StudyLoadOptions& options)

--- a/src/libs/antares/study/simulation.h
+++ b/src/libs/antares/study/simulation.h
@@ -28,6 +28,7 @@
 #define __ANTARES_LIBS_STUDY_SIMULATION_H__
 
 #include <yuni/yuni.h>
+#include <libzippp.h>
 #include "fwd.h"
 
 namespace Antares
@@ -62,7 +63,7 @@ public:
     /*!
     ** \brief Save settings to the appropriate folder
     */
-    bool saveToFolder(const AnyString& folder) const;
+    bool saveToFolder(libzippp::ZipArchive* archive) const;
 
     //! Get (in bytes) the amount of memory used by the class
     Yuni::uint64 memoryUsage() const;

--- a/src/libs/antares/study/study.h
+++ b/src/libs/antares/study/study.h
@@ -47,6 +47,7 @@
 #include "progression/progression.h"
 #include "load-options.h"
 #include "../date.h"
+#include <libzippp.h>
 
 #include <memory>
 
@@ -767,6 +768,7 @@ public:
     */
     const bool usedByTheSolver;
 
+    libzippp::ZipArchive* pZipArchive = nullptr;
 protected:
     //! \name Loading
     //@{

--- a/src/libs/antares/study/study.h
+++ b/src/libs/antares/study/study.h
@@ -501,9 +501,9 @@ public:
     **
     ** \return a FILE structure (which may be null if any error occured)
     */
-    FILE* createFileIntoOutputWithExtension(const YString& prefix,
-                                            const YString& extension,
-                                            uint numSpace) const;
+    std::string createFileIntoOutputWithExtension(const YString& prefix,
+                                                  const YString& extension,
+                                                  uint numSpace) const;
 
     //! \name
     //@{

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -109,7 +109,9 @@ macro(solver_app name swap)
 
 	target_link_libraries(${exec_name}
 			PRIVATE
-				${ANTARES_SOLVER_LIBS}
+			${ANTARES_SOLVER_LIBS}
+            PUBLIC
+            libzippp::libzippp
 			)
 
 	import_std_libs(${exec_name})

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -390,26 +390,4 @@ void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(void* Prob,
                                                     uint numSpace,
                                                     int NumeroDeLIntervalle)
 {
-    FILE* Flot;
-    double CoutOptimalDeLaSolution;
-    PROBLEME_HEBDO* Probleme;
-
-    Probleme = (PROBLEME_HEBDO*)Prob;
-
-    CoutOptimalDeLaSolution = 0.;
-    if (Probleme->numeroOptimisation[NumeroDeLIntervalle] == PREMIERE_OPTIMISATION)
-        CoutOptimalDeLaSolution = Probleme->coutOptimalSolution1[NumeroDeLIntervalle];
-    else
-        CoutOptimalDeLaSolution = Probleme->coutOptimalSolution2[NumeroDeLIntervalle];
-
-    auto study = Data::Study::Current::Get();
-    Flot = study->createFileIntoOutputWithExtension("criterion", "txt", numSpace);
-    if (!Flot)
-        AntaresSolverEmergencyShutdown(2);
-
-    fprintf(Flot, "* Optimal criterion value :   %11.10e\n", CoutOptimalDeLaSolution);
-
-    fclose(Flot);
-
-    return;
 }

--- a/src/solver/optimisation/opt_export_structure.cpp
+++ b/src/solver/optimisation/opt_export_structure.cpp
@@ -66,36 +66,14 @@ void OPT_ExportInterco(const Antares::Data::Study& study,
                        PROBLEME_HEBDO* ProblemeHebdo,
                        uint numSpace)
 {
-    // Interco are exported only once for first year
-    if (ProblemeHebdo->firstWeekOfSimulation)
-    {
-        FILE* Flot = study.createFileIntoOutputWithExtension("interco", "txt", numSpace);
-        for (int i(0); i < ProblemeHebdo->NombreDInterconnexions; ++i)
-        {
-            fprintf(Flot,
-                    "%d %d %d\n",
-                    i,
-                    ProblemeHebdo->PaysOrigineDeLInterconnexion[i],
-                    ProblemeHebdo->PaysExtremiteDeLInterconnexion[i]);
-        }
-        fclose(Flot);
-    }
+  // TODO
 }
 
 void OPT_ExportAreaName(const Antares::Data::Study& study,
                         PROBLEME_HEBDO* ProblemeHebdo,
                         uint numSpace)
 {
-    // Area name are exported only once for first year
-    if (ProblemeHebdo->firstWeekOfSimulation)
-    {
-        FILE* Flot = study.createFileIntoOutputWithExtension("area", "txt", numSpace);
-        for (uint i = 0; i < study.areas.size(); ++i)
-        {
-            fprintf(Flot, "%s\n", study.areas[i]->name.c_str());
-        }
-        fclose(Flot);
-    }
+  // TODO
 }
 
 void OPT_Export_add_variable(std::vector<std::string>& varname,
@@ -140,10 +118,5 @@ void OPT_ExportVariables(const Antares::Data::Study& study,
                          const std::string& fileExtension,
                          uint numSpace)
 {
-    FILE* Flot = study.createFileIntoOutputWithExtension(fileName, fileExtension, numSpace);
-    for (auto const& line : varname)
-    {
-        fprintf(Flot, "%s\n", line.c_str());
-    }
-    fclose(Flot);
+  // TODO
 }

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -435,8 +435,7 @@ void ISimulation<Impl>::writeResults(bool synthesis, uint year, uint numSpace)
 
         // The target folder
         String newPath;
-        newPath << study.folderOutput << IO::Separator << ImplementationType::Name()
-                << IO::Separator;
+        newPath << ImplementationType::Name() << IO::Separator;
         if (synthesis)
             newPath << "mc-all";
         else

--- a/src/solver/variable/container.hxx
+++ b/src/solver/variable/container.hxx
@@ -265,7 +265,6 @@ void List<NextT>::buildSurveyReport(SurveyResults& results,
 
     // The new filename
     results.data.filename.clear();
-    results.data.filename << results.data.output << '/';
     Category::FileLevelToStream(results.data.filename, fileLevel);
     results.data.filename << '-';
     Category::PrecisionLevelToStream(results.data.filename, precision);

--- a/src/solver/variable/container.hxx
+++ b/src/solver/variable/container.hxx
@@ -265,6 +265,7 @@ void List<NextT>::buildSurveyReport(SurveyResults& results,
 
     // The new filename
     results.data.filename.clear();
+    results.data.filename << results.data.output << '/';
     Category::FileLevelToStream(results.data.filename, fileLevel);
     results.data.filename << '-';
     Category::PrecisionLevelToStream(results.data.filename, precision);


### PR DESCRIPTION
Save output to one single .zip file
### TODO
- [ ] Include all files to this archive
- [ ] Create a new option : save as .zip (new), or as files (legacy)
- [ ] Make sure scripts (R, python) can read files easily when they're in a zip archive
- [ ] Also discuss this with the Xpansion team : save all MPS files in one archive. This is an easy test-case, and useful in the short-term since it would may allow to solve the disk usage issue.
- [ ] Create a generic interface allowing other output formats : SQL, HDF5, etc. and to avoid introducing those dependencies deep into our codebase
- [ ] Check technical limitations (RAM consumption, does libzip write when calling `close` or whenever data is added ?, etc.)
- [ ] Check licensing issues : is ZIP free to use ? Can we use all underlying components (libzippp, libzip, etc.) ?
- [ ] Assess performance : is it shorter to write a .zip than multiple files then zip them all ?
```cpp
// We don't want this everywhere in our code
switch (outputType) {
case file:
   result.saveAsFile();
   break;
case archive:
   result.saveAsZip();
   break;
case sql:
   sqlDB->connect();
   result.saveAsSQLTable(sqlDB);
   break;
}

// We want this
result.write(output);
```