### PR TITLE
Clarify execution-info.ini file

### DIFF
--- a/src/libs/antares/benchmarking/file_content.cpp
+++ b/src/libs/antares/benchmarking/file_content.cpp
@@ -26,7 +26,7 @@ namespace Benchmarking
 
 	void FileContent::addDurationItem(const string& name, unsigned int duration, int nbCalls)
 	{
-		addItemToSection("Durations", name + "_duration", duration);
-		addItemToSection("Durations", name + "_nb_calls", nbCalls);
+		addItemToSection("durations_ms", name, duration);
+		addItemToSection("number_of_calls", name, nbCalls);
 	}
 }


### PR DESCRIPTION
### Before (truncated)
```ini
[Durations]
hydro_ventilation_duration = 2
hydro_ventilation_nb_calls = 1
mc_years_duration = 135
mc_years_nb_calls = 1
post_processing_duration = 0
post_processing_nb_calls = 1
study_loading_duration = 25
study_loading_nb_calls = 1
synthesis_export_duration = 460
synthesis_export_nb_calls = 1
total_duration = 663
total_nb_calls = 1
yby_export_duration = 52
yby_export_nb_calls = 1
```

### After (truncated)
```ini
[durations_ms]
hydro_ventilation = 2
mc_years = 143
post_processing = 0
study_loading = 23
synthesis_export = 492
total = 701
yby_export = 63

[number_of_calls]
hydro_ventilation = 1
mc_years = 1
post_processing = 1
study_loading = 1
synthesis_export = 1
total = 1
yby_export = 1
```