### PR TITLE
Binding constraints : filtering each constraint results

### DIFF
--- a/src/libs/antares/study/constraint/constraint.cpp
+++ b/src/libs/antares/study/constraint/constraint.cpp
@@ -564,6 +564,16 @@ bool BindingConstraint::loadFromEnv(BindingConstraint::EnvForLoading& env)
                 pOperator = BindingConstraint::StringToOperator(p->value);
                 continue;
             }
+            if (p->key == "filter-year-by-year")
+            {
+                pFilterYearByYear = stringIntoDatePrecision(p->value);
+                continue;
+            }
+            if (p->key == "filter-synthesis")
+            {
+                pFilterSynthesis = stringIntoDatePrecision(p->value);
+                continue;
+            }
             if (p->key == "comments")
             {
                 pComments = p->value;
@@ -818,6 +828,8 @@ bool BindingConstraint::saveToEnv(BindingConstraint::EnvForSaving& env)
     env.section->add("enabled", pEnabled);
     env.section->add("type", TypeToCString(pType));
     env.section->add("operator", OperatorToCString(pOperator));
+    env.section->add("filter-year-by-year", datePrecisionIntoString(pFilterYearByYear));
+    env.section->add("filter-synthesis", datePrecisionIntoString(pFilterSynthesis));
 
     if (not pComments.empty())
         env.section->add("comments", pComments);
@@ -1300,6 +1312,16 @@ void BindingConstraint::enabled(bool v)
 void BindingConstraint::operatorType(BindingConstraint::Operator o)
 {
     pOperator = o;
+}
+
+uint BindingConstraint::yearByYearFilter() const
+{
+    return pFilterYearByYear;
+}
+
+uint BindingConstraint::synthesisFilter() const
+{
+    return pFilterSynthesis;
 }
 
 bool BindingConstraint::hasAllWeightedLinksOnLayer(size_t layerID)

--- a/src/libs/antares/study/constraint/constraint.h
+++ b/src/libs/antares/study/constraint/constraint.h
@@ -36,6 +36,7 @@
 #include "../parts/thermal/cluster.h"
 #include "../../array/matrix.h"
 #include "../../inifile/inifile.h"
+#include "antares/study/filter.h"
 #include <vector>
 #include <set>
 
@@ -383,6 +384,9 @@ public:
     void operatorType(Operator o);
     //@}
 
+    uint yearByYearFilter() const;
+    uint synthesisFilter() const;
+
     //! \name Enabled / Disabled
     //@{
     //! Get if the binding constraint is enabled
@@ -499,6 +503,10 @@ private:
     Type pType;
     //! Operator
     Operator pOperator;
+    //! Print binding constraint's marginal prices of any year for which time step granularity ?
+    uint pFilterYearByYear = filterAll;
+    //! Print binding constraint's marginal prices synthesis for which time step granularity ?
+    uint pFilterSynthesis = filterAll;
     //! Enabled / Disabled
     bool pEnabled;
     //! Comments

--- a/src/libs/antares/study/runtime/runtime.cpp
+++ b/src/libs/antares/study/runtime/runtime.cpp
@@ -179,6 +179,8 @@ static void CopyBCData(BindingConstraintRTI& rti, const BindingConstraint& b)
     }
     logs.debug() << "copying constraint " << rti.operatorType << ' ' << b.name();
     rti.name = b.name().c_str();
+    rti.filterYearByYear_ = b.yearByYearFilter();
+    rti.filterSynthesis_ = b.synthesisFilter();
     rti.linkCount = b.linkCount();
     rti.clusterCount = b.enabledClusterCount();
     assert(rti.linkCount < 50000000 and "Seems a bit large...");    // arbitrary value

--- a/src/libs/antares/study/runtime/runtime.h
+++ b/src/libs/antares/study/runtime/runtime.h
@@ -83,6 +83,8 @@ public:
     Matrix<double> bounds;
     BindingConstraint::Type type;
     char operatorType;
+    uint filterYearByYear_ = filterAll;
+    uint filterSynthesis_ = filterAll;
 
     uint linkCount;
     double* linkWeight;

--- a/src/solver/variable/economy/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/economy/bindingConstraintsMarginalCost.h
@@ -311,6 +311,9 @@ public:
       int precision /* printed results : hourly, daily, weekly, ...*/,
       unsigned int numSpace) const
     {
+        if (!(precision & associatedBC_->filterYearByYear_))
+            return;
+        
         // Initializing external pointer on current variable non applicable status
         results.isCurrentVarNA[0] = isCurrentOutputNonApplicable(precision);
 
@@ -330,6 +333,8 @@ public:
     {
         // Building syntheses results
         // ------------------------------
+        if (!(precision & associatedBC_->filterSynthesis_))
+            return;
 
         // And only if we match the current data level _and_ precision level
         if ((dataLevel & VCardType::categoryDataLevel) && (fileLevel & VCardType::categoryFileLevel)


### PR DESCRIPTION
Filtering results of marginal price related each binding constraints, depending on parameters in **input\bindingconstraints\bindingconstraints.ini**

For each binding constraint, we add 2 parameters (**filter-year-by-year** and **filter-synthesis**).

Example : 
```ini
[0]
name = my-first-bind-const
...
filter-year-by-year = hourly, daily, annual
filter-synthesis = daily, weekly, monthly
...

[1]
name = my-second-bind-const
...
```