### PR TITLE
Statistics: use std::mutex / std::atomic<> to prevent concurrent writes

### DIFF
--- a/src/libs/antares/benchmarking/file_content.cpp
+++ b/src/libs/antares/benchmarking/file_content.cpp
@@ -4,31 +4,31 @@ using namespace std;
 
 namespace Benchmarking
 {
-	FileContent::iterator FileContent::firstSection()
-	{
-		return sections_.begin();
-	}
-
-	FileContent::iterator FileContent::endSections()
-	{
-		return sections_.end();
-	}
-
-	void FileContent::addItemToSection(const string& section, const string& key, int value)
-	{
-        std::lock_guard<std::mutex> guard(pMutex);
-		sections_[section][key] = to_string(value);
-	}
-
-	void FileContent::addItemToSection(const string& section, const string& key, const string& value)
-	{
-        std::lock_guard<std::mutex> guard(pMutex);
-		sections_[section][key] = value;
-	}
-
-	void FileContent::addDurationItem(const string& name, unsigned int duration, int nbCalls)
-	{
-		addItemToSection("durations_ms", name, duration);
-		addItemToSection("number_of_calls", name, nbCalls);
-	}
+FileContent::iterator FileContent::begin()
+{
+    return sections_.begin();
 }
+
+FileContent::iterator FileContent::end()
+{
+    return sections_.end();
+}
+
+void FileContent::addItemToSection(const string& section, const string& key, int value)
+{
+    std::lock_guard<std::mutex> guard(pSectionsMutex);
+    sections_[section][key] = to_string(value);
+}
+
+void FileContent::addItemToSection(const string& section, const string& key, const string& value)
+{
+    std::lock_guard<std::mutex> guard(pSectionsMutex);
+    sections_[section][key] = value;
+}
+
+void FileContent::addDurationItem(const string& name, unsigned int duration, int nbCalls)
+{
+    addItemToSection("durations_ms", name, duration);
+    addItemToSection("number_of_calls", name, nbCalls);
+}
+} // namespace Benchmarking

--- a/src/libs/antares/benchmarking/file_content.cpp
+++ b/src/libs/antares/benchmarking/file_content.cpp
@@ -16,11 +16,13 @@ namespace Benchmarking
 
 	void FileContent::addItemToSection(const string& section, const string& key, int value)
 	{
+        std::lock_guard<std::mutex> guard(pMutex);
 		sections_[section][key] = to_string(value);
 	}
 
 	void FileContent::addItemToSection(const string& section, const string& key, const string& value)
 	{
+        std::lock_guard<std::mutex> guard(pMutex);
 		sections_[section][key] = value;
 	}
 

--- a/src/libs/antares/benchmarking/file_content.h
+++ b/src/libs/antares/benchmarking/file_content.h
@@ -6,28 +6,27 @@
 
 namespace Benchmarking
 {
-
 class FileContent
 {
 public:
     FileContent() = default;
 
     using iterator = std::map<std::string, std::map<std::string, std::string>>::iterator;
-    iterator firstSection();
-    iterator endSections();
+    iterator end();
+    iterator begin();
 
     void addItemToSection(const std::string& section, const std::string& key, int value);
-    void addItemToSection(const std::string& section, const std::string& key, const std::string& value);
+    void addItemToSection(const std::string& section,
+                          const std::string& key,
+                          const std::string& value);
     void addDurationItem(const std::string& name, unsigned int duration, int nbCalls);
 
 private:
-    std::mutex pMutex;
+    std::mutex pSectionsMutex;
     // Data of the file content
-    std::map<std::string,                           // Sections as keys
-             std::map<std::string, std::string>>    // Section parameters as name / value
-             sections_;
-
+    std::map<std::string,                        // Sections as keys
+             std::map<std::string, std::string>> // Section parameters as name / value
+      sections_;
 };
 
 } // namespace Benchmarking
-

--- a/src/libs/antares/benchmarking/file_content.h
+++ b/src/libs/antares/benchmarking/file_content.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <mutex>
 #include <map>
 
 namespace Benchmarking
@@ -20,6 +21,7 @@ public:
     void addDurationItem(const std::string& name, unsigned int duration, int nbCalls);
 
 private:
+    std::mutex pMutex;
     // Data of the file content
     std::map<std::string,                           // Sections as keys
              std::map<std::string, std::string>>    // Section parameters as name / value

--- a/src/libs/antares/benchmarking/file_writer.cpp
+++ b/src/libs/antares/benchmarking/file_writer.cpp
@@ -5,26 +5,26 @@ using namespace std;
 
 namespace Benchmarking
 {
-	
-	FileWriter::FileWriter(FileContent& fileContent) : fileContent_(fileContent) {}
-	
-	iniFilewriter::iniFilewriter(Yuni::String& filePath, FileContent& fileContent)
-		: FileWriter(fileContent), filePath_(filePath)
-	{}
-	
-	
-	void iniFilewriter::flush()
-	{
-		Antares::IniFile ini;
-
-		FileContent::iterator it_section = fileContent_.firstSection();
-		for (; it_section != fileContent_.endSections(); it_section++)
-		{
-			auto* section = ini.addSection(it_section->first);
-			for (pair<string, string> line : it_section->second)
-				section->add(line.first, line.second);
-		}
-
-		ini.save(filePath_);
-	}
+FileWriter::FileWriter(FileContent& fileContent) : fileContent_(fileContent)
+{
 }
+
+iniFilewriter::iniFilewriter(Yuni::String& filePath, FileContent& fileContent) :
+ FileWriter(fileContent), filePath_(filePath)
+{
+}
+
+void iniFilewriter::flush()
+{
+    Antares::IniFile ini;
+
+    for (const auto& [section_name, properties] : fileContent_)
+    {
+        auto* section = ini.addSection(section_name);
+        for (pair<string, string> line : properties)
+            section->add(line.first, line.second);
+    }
+
+    ini.save(filePath_);
+}
+} // namespace Benchmarking

--- a/src/solver/utils/optimization_statistics.h
+++ b/src/solver/utils/optimization_statistics.h
@@ -3,15 +3,16 @@
 
 #include <string>
 #include <cmath>
+#include <atomic>
 
 class optimizationStatistics
 {
 private:
-    long long totalSolveTime;
-    unsigned int nbSolve;
+    std::atomic<long long> totalSolveTime;
+    std::atomic<unsigned int> nbSolve;
 
-    long long totalUpdateTime;
-    unsigned int nbUpdate;
+    std::atomic<long long> totalUpdateTime;
+    std::atomic<unsigned int> nbUpdate;
 
 public:
     void reset()


### PR DESCRIPTION
`FileContent` and `optimizationStatistics` objects are shared among threads. Prevent concurrent writes to `int/map` by using `std::atomic/std::mutex`.