### PR TITLE
Remove everything related to deprecated output file digest.txt

### DIFF
--- a/src/solver/variable/area.h
+++ b/src/solver/variable/area.h
@@ -171,8 +171,6 @@ public:
                                  int precision,
                                  uint numSpace) const;
 
-    void buildDigest(SurveyResults&, int digestLevel, int dataLevel) const;
-
     void beforeYearByYearExport(uint year, uint numSpace);
 
     Yuni::uint64 memoryUsage() const;

--- a/src/solver/variable/area.hxx
+++ b/src/solver/variable/area.hxx
@@ -168,36 +168,6 @@ void Areas<NextT>::buildAnnualSurveyReport(SurveyResults& results,
 }
 
 template<class NextT>
-void Areas<NextT>::buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-{
-    int count_int = count;
-    if (count_int)
-    {
-        if (dataLevel & Category::area)
-        {
-            assert(pAreaCount == results.data.study.areas.size());
-
-            // Reset captions
-            results.data.rowCaptions.clear();
-            results.data.rowCaptions.resize(pAreaCount);
-
-            // For each area
-            // for (uint i = 0; i != results.data.study.areas.byIndex.size(); ++i)
-            for (uint i = 0; i != pAreaCount; ++i)
-            {
-                results.data.area = results.data.study.areas[i];
-                uint index = results.data.area->index;
-                results.data.rowIndex = index;
-                results.data.rowCaptions[index] = results.data.area->id;
-                results.data.columnIndex = 0;
-                results.resetValuesAtLine(i);
-                pAreas[i].buildDigest(results, digestLevel, dataLevel);
-            }
-        }
-    }
-}
-
-template<class NextT>
 template<class PredicateT>
 inline void Areas<NextT>::RetrieveVariableList(PredicateT& predicate)
 {

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -95,7 +95,7 @@ void Areas<NEXTTYPE>::initializeFromStudy(Data::Study& study)
         // From the area
         n.initializeFromArea(&study, currentArea);
         // Does current output variable appears non applicable in areas' output files, not
-        // districts'. Note that digest gather area and district results.
+        // districts'.
         n.broadcastNonApplicability(not currentArea->hydro.reservoirManagement);
 
         // For each current area's variable, getting the print status, that is :

--- a/src/solver/variable/categories.h
+++ b/src/solver/variable/categories.h
@@ -109,21 +109,6 @@ enum ColumnManagement
 };
 
 /*!
-** \brief Digest levels
-*/
-enum Digest
-{
-    //! No digest
-    digestNone = 0,
-    //! Only all years
-    digestAllYears = 1,
-    //! Flow (linear)
-    digestFlowLinear = 2,
-    //! Flow (Quadratic)
-    digestFlowQuad = 4,
-};
-
-/*!
 ** \brief Spatial clusters (bitwise)
 */
 enum SpatialAggregate

--- a/src/solver/variable/commons/join.h
+++ b/src/solver/variable/commons/join.h
@@ -291,16 +291,8 @@ public:
         RightType::buildAnnualSurveyReport(results, dataLevel, fileLevel, precision, numSpace);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Building the digest
-        LeftType ::buildDigest(results, digestLevel, dataLevel);
-        RightType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     void beforeYearByYearExport(uint year, uint numSpace)
     {
-        // Building the digest
         LeftType ::beforeYearByYearExport(year, numSpace);
         RightType::beforeYearByYearExport(year, numSpace);
     }

--- a/src/solver/variable/commons/links/links.cpp.inc.hxx
+++ b/src/solver/variable/commons/links/links.cpp.inc.hxx
@@ -103,26 +103,6 @@ void Links::simulationEnd()
     }
 }
 
-void Links::buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-{
-    int count_int = count;
-    bool linkDataLevel = dataLevel & Category::link;
-    bool areaDataLevel = dataLevel & Category::area;
-    if (count_int && (linkDataLevel || areaDataLevel))
-    {
-        if (not results.data.area->links.empty())
-        {
-            auto end = results.data.area->links.cend();
-            for (auto i = results.data.area->links.cbegin(); i != end; ++i)
-            {
-                results.data.link = i->second;
-                pLinks[results.data.link->indexForArea].buildDigest(
-                  results, digestLevel, Category::link);
-            }
-        }
-    }
-}
-
 void Links::beforeYearByYearExport(uint year, uint numSpace)
 {
     for (uint i = 0; i != pLinkCount; ++i)

--- a/src/solver/variable/commons/links/links.h.inc.hxx
+++ b/src/solver/variable/commons/links/links.h.inc.hxx
@@ -185,8 +185,6 @@ public:
 
     Yuni::uint64 memoryUsage() const;
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const;
-
     template<class I>
     static void provideInformations(I& infos);
 

--- a/src/solver/variable/commons/spatial-aggregate.h
+++ b/src/solver/variable/commons/spatial-aggregate.h
@@ -333,22 +333,6 @@ public:
         NextType::template simulationEndSpatialAggregates(allVars, set);
     }
 
-    inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Generate the Digest for the local results (districts part)
-        if (VCardType::columnCount != 0 && (VCardType::categoryDataLevel & Category::setOfAreas))
-        {
-            // Initializing pointer on variable non applicable and print stati arrays to beginning
-            results.isPrinted = AncestorType::isPrinted;
-            results.isCurrentVarNA = AncestorType::isNonApplicable;
-
-            VariableAccessorType::template BuildDigest<typename VCardType::VCardOrigin>(
-              results, AncestorType::pResults, digestLevel, dataLevel);
-        }
-        // Ask to build the digest to the next variable
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     void localBuildAnnualSurveyReport(SurveyResults& results,
                                       int fileLevel,
                                       int precision,

--- a/src/solver/variable/container.h
+++ b/src/solver/variable/container.h
@@ -224,18 +224,10 @@ public:
                                  unsigned int numSpace) const;
 
     /*!
-    ** \brief Ask to all variables to fullfil additional reports (like the digest for example)
-    **
     ** \tparam GlobalT True to write down the results of the simulation, false
     **   for the results of the current year
     */
     void exportSurveyResults(bool global, const Yuni::String& output, unsigned int numSpace);
-
-    /*!
-    ** \brief Ask to all variables to fullfil the digest
-    */
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const;
-    //@}
 
     //! \name Memory management
     //@{

--- a/src/solver/variable/container.hxx
+++ b/src/solver/variable/container.hxx
@@ -312,20 +312,6 @@ void List<NextT>::buildAnnualSurveyReport(SurveyResults& results,
 }
 
 template<class NextT>
-void List<NextT>::buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-{
-    // Reset
-    results.data.columnIndex = 0;
-    results.data.thermalCluster = nullptr;
-    results.data.area = nullptr;
-    results.data.link = nullptr;
-    results.variableCaption.clear();
-
-    // Building the digest
-    NextType::buildDigest(results, digestLevel, dataLevel);
-}
-
-template<class NextT>
 inline void List<NextT>::EstimateMemoryUsage(Data::StudyMemoryUsage& u)
 {
     u.requiredMemoryForOutput += sizeof(ListType);
@@ -368,11 +354,6 @@ void List<NextT>::exportSurveyResults(bool global,
 
         // Exporting the Grid (information about the study)
         survey->exportGridInfos();
-
-        // Exporting the digest
-        // The digest must be exported after the real report because some values
-        // are computed at this moment.
-        Builder::RunDigest(*this, *survey);
     }
     else
     {

--- a/src/solver/variable/economy/links/congestionFee.h
+++ b/src/solver/variable/economy/links/congestionFee.h
@@ -250,12 +250,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Next
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       uint,
       uint numSpace) const

--- a/src/solver/variable/economy/links/congestionFeeAbs.h
+++ b/src/solver/variable/economy/links/congestionFeeAbs.h
@@ -252,12 +252,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Next
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       uint,
       uint numSpace) const

--- a/src/solver/variable/economy/links/flowLinear.h
+++ b/src/solver/variable/economy/links/flowLinear.h
@@ -243,25 +243,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        if (dataLevel & Category::link)
-        {
-            if (digestLevel & Category::digestFlowLinear)
-            {
-                results.data.matrix
-                  .entry[results.data.link->from->index][results.data.link->with->index]
-                  = AncestorType::pResults.avgdata.allYears;
-                results.data.matrix
-                  .entry[results.data.link->with->index][results.data.link->from->index]
-                  = -AncestorType::pResults.avgdata.allYears;
-            }
-        }
-
-        // Next
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       uint,
       uint numSpace) const

--- a/src/solver/variable/economy/links/flowLinearAbs.h
+++ b/src/solver/variable/economy/links/flowLinearAbs.h
@@ -244,12 +244,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Next
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       uint,
       uint numSpace) const

--- a/src/solver/variable/economy/links/flowQuad.h
+++ b/src/solver/variable/economy/links/flowQuad.h
@@ -234,24 +234,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        if (dataLevel & Category::link)
-        {
-            if (digestLevel & Category::digestFlowQuad)
-            {
-                results.data.matrix
-                  .entry[results.data.link->from->index][results.data.link->with->index]
-                  = AncestorType::pResults.rawdata.allYears;
-                results.data.matrix
-                  .entry[results.data.link->with->index][results.data.link->from->index]
-                  = -AncestorType::pResults.rawdata.allYears;
-            }
-        }
-        // Next
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       uint,
       uint) const

--- a/src/solver/variable/economy/links/hurdleCosts.h
+++ b/src/solver/variable/economy/links/hurdleCosts.h
@@ -294,12 +294,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Next
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       unsigned int,
       unsigned int numSpace) const

--- a/src/solver/variable/economy/links/loopFlow.h
+++ b/src/solver/variable/economy/links/loopFlow.h
@@ -243,12 +243,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Next
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       uint,
       uint) const

--- a/src/solver/variable/economy/links/marginalCost.h
+++ b/src/solver/variable/economy/links/marginalCost.h
@@ -254,12 +254,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Next
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       uint,
       uint numSpace) const

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -378,12 +378,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Ask to build the digest to the next variable
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       unsigned int column,
       unsigned int numSpace) const

--- a/src/solver/variable/economy/productionByRenewablePlant.h
+++ b/src/solver/variable/economy/productionByRenewablePlant.h
@@ -339,12 +339,6 @@ public:
         NextType::hourEnd(state, hourInTheYear);
     }
 
-    inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Ask to build the digest to the next variable
-        NextType::buildDigest(results, digestLevel, dataLevel);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       unsigned int column,
       unsigned int numSpace) const

--- a/src/solver/variable/endoflist.h
+++ b/src/solver/variable/endoflist.h
@@ -240,10 +240,6 @@ public:
     {
     }
 
-    static void buildDigest(SurveyResults&, int, int)
-    {
-    }
-
     static void beforeYearByYearExport(uint /*year*/, uint)
     {
     }

--- a/src/solver/variable/info.h
+++ b/src/solver/variable/info.h
@@ -161,25 +161,6 @@ struct VariableAccessor
         return result;
     }
 
-    template<class VCardT>
-    static void BuildDigest(SurveyResults& results,
-                            const Type& container,
-                            int digestLevel,
-                            int dataLevel)
-    {
-        for (uint i = 0; i != ColumnCountT; ++i)
-        {
-            if (*results.isPrinted)
-            {
-                results.variableCaption = VCardT::Multiple::Caption(i);
-                container[i].template buildDigest<VCardT>(results, digestLevel, dataLevel);
-            }
-            // Shift to the next internal variable's non applicable status and print status
-            results.isCurrentVarNA++;
-            results.isPrinted++;
-        }
-    }
-
     template<class VCardType>
     static void BuildSurveyReport(SurveyResults& results,
                                   const Type& container,
@@ -366,23 +347,6 @@ struct VariableAccessor<ResultsT, Category::dynamicColumns>
         return result;
     }
 
-    template<class VCardT>
-    static void BuildDigest(SurveyResults& results,
-                            const Type& container,
-                            int digestLevel,
-                            int dataLevel)
-    {
-        if (*results.isPrinted)
-        {
-            const Data::PartThermal& thermal = results.data.area->thermal;
-            for (uint i = 0; i != container.size(); ++i)
-            {
-                results.variableCaption = thermal.clusters[i]->name();
-                container[i].template buildDigest<VCardT>(results, digestLevel, dataLevel);
-            }
-        }
-    }
-
     static bool setClusterCaption(SurveyResults& results, int fileLevel, uint idx)
     {
         assert(results.data.area && "Area is NULL");
@@ -562,19 +526,6 @@ struct VariableAccessor<ResultsT, Category::singleColumn /* The default */>
         return container.memoryUsage();
     }
 
-    template<class VCardT>
-    static void BuildDigest(SurveyResults& results,
-                            const Type& container,
-                            int digestLevel,
-                            int dataLevel)
-    {
-        if (*results.isPrinted)
-        {
-            results.variableCaption = VCardT::Caption();
-            container.template buildDigest<VCardT>(results, digestLevel, dataLevel);
-        }
-    }
-
     template<class VCardType>
     static void BuildSurveyReport(SurveyResults& results,
                                   const Type& container,
@@ -690,12 +641,6 @@ struct VariableAccessor<ResultsT, Category::noColumn>
 
     template<class VCardType>
     static void BuildAnnualSurveyReport(SurveyResults&, const Type&, int, int)
-    {
-        // Do nothing
-    }
-
-    template<class VCardT>
-    static void BuildDigest(SurveyResults&, const Type&, int, int)
     {
         // Do nothing
     }

--- a/src/solver/variable/setofareas.h
+++ b/src/solver/variable/setofareas.h
@@ -168,8 +168,6 @@ public:
                                  int precision,
                                  unsigned int numSpace) const;
 
-    void buildDigest(SurveyResults&, int digestLevel, int dataLevel) const;
-
     void beforeYearByYearExport(uint year, uint numSpace);
 
     Yuni::uint64 memoryUsage() const;

--- a/src/solver/variable/setofareas.hxx
+++ b/src/solver/variable/setofareas.hxx
@@ -253,30 +253,6 @@ inline void SetsOfAreas<NextT>::buildAnnualSurveyReport(SurveyResults& results,
 }
 
 template<class NextT>
-void SetsOfAreas<NextT>::buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-{
-    int count_int = count;
-    bool setOfAreasDataLevel = dataLevel & Category::setOfAreas;
-    if (count_int && setOfAreasDataLevel)
-    {
-        // Reset
-        results.data.rowCaptions.clear();
-        results.data.rowCaptions.resize(pSetsOfAreas.size());
-        results.data.area = nullptr;
-        results.data.rowIndex = 0;
-
-        for (auto i = pBegin; i != pEnd; ++i)
-        {
-            results.data.columnIndex = 0;
-            results.data.rowCaptions[results.data.rowIndex].clear()
-              << "@ " << pNames[results.data.rowIndex];
-            (*i)->buildDigest(results, digestLevel, dataLevel);
-            ++results.data.rowIndex;
-        }
-    }
-}
-
-template<class NextT>
 inline Yuni::uint64 SetsOfAreas<NextT>::memoryUsage() const
 {
     Yuni::uint64 result = sizeof(NextType) * pSetsOfAreas.size();

--- a/src/solver/variable/storage/and.h
+++ b/src/solver/variable/storage/and.h
@@ -141,32 +141,6 @@ protected:
           report, results, dataLevel, fileLevel, precision);
     }
 
-    template<class VCardT>
-    void buildDigest(SurveyResults& report, int digestLevel, int dataLevel) const
-    {
-        if (dataLevel & Category::area && digestLevel & Category::digestAllYears)
-        {
-            assert(report.data.columnIndex < report.maxVariables && "Column index out of bounds");
-
-            report.captions[0][report.data.columnIndex] = report.variableCaption;
-            report.captions[1][report.data.columnIndex] = VCardT::Unit();
-            report.captions[2][report.data.columnIndex] = "values";
-
-            // Precision
-            report.precision[report.data.columnIndex]
-              = PrecisionToPrintfFormat<VCardT::decimal>::Value();
-            // Value
-            report.values[report.data.columnIndex][report.data.area->index] = andAllYears;
-            // Non applicability
-            report.digestNonApplicableStatus[report.data.rowIndex][report.data.columnIndex]
-              = *report.isCurrentVarNA;
-
-            ++(report.data.columnIndex);
-        }
-        // Next
-        NextType::template buildDigest<VCardT>(report, digestLevel, dataLevel);
-    }
-
     static void EstimateMemoryUsage(Antares::Data::StudyMemoryUsage& u)
     {
         Antares::Memory::EstimateMemoryUsage(sizeof(double), maxHoursInAYear, u, false);

--- a/src/solver/variable/storage/average.h
+++ b/src/solver/variable/storage/average.h
@@ -139,34 +139,6 @@ protected:
           report, results, dataLevel, fileLevel, precision);
     }
 
-    template<class VCardT>
-    void buildDigest(SurveyResults& report, int digestLevel, int dataLevel) const
-    {
-        if ((dataLevel & Category::area || dataLevel & Category::setOfAreas)
-            && digestLevel & Category::digestAllYears)
-        {
-            assert(report.data.columnIndex < report.maxVariables && "Column index out of bounds");
-
-            report.captions[0][report.data.columnIndex] = report.variableCaption;
-            report.captions[1][report.data.columnIndex] = VCardT::Unit();
-            report.captions[2][report.data.columnIndex]
-              = (report.variableCaption == "LOLP") ? "values" : "EXP";
-
-            // Precision
-            report.precision[report.data.columnIndex]
-              = PrecisionToPrintfFormat<VCardT::decimal>::Value();
-            // Value
-            report.values[report.data.columnIndex][report.data.rowIndex] = avgdata.allYears;
-            // Non applicability
-            report.digestNonApplicableStatus[report.data.rowIndex][report.data.columnIndex]
-              = *report.isCurrentVarNA;
-
-            ++(report.data.columnIndex);
-        }
-        // Next
-        NextType::template buildDigest<VCardT>(report, digestLevel, dataLevel);
-    }
-
     Yuni::uint64 memoryUsage() const
     {
         return avgdata.dynamicMemoryUsage() + NextType::memoryUsage();

--- a/src/solver/variable/storage/empty.h
+++ b/src/solver/variable/storage/empty.h
@@ -70,12 +70,6 @@ protected:
         // Does nothing
     }
 
-    template<class VCardT>
-    static void buildDigest(SurveyResults&, int, int)
-    {
-        // Does nothing
-    }
-
     static Yuni::uint64 memoryUsage()
     {
         return 0;

--- a/src/solver/variable/storage/raw.h
+++ b/src/solver/variable/storage/raw.h
@@ -141,37 +141,6 @@ protected:
           report, results, dataLevel, fileLevel, precision);
     }
 
-    template<class VCardT>
-    void buildDigest(SurveyResults& report, int digestLevel, int dataLevel) const
-    {
-        if ((dataLevel & Category::area || dataLevel & Category::setOfAreas)
-            && digestLevel & Category::digestAllYears)
-        {
-            if (report.data.study.parameters.mode != Antares::Data::stdmAdequacyDraft)
-            {
-                assert(report.data.columnIndex < report.maxVariables
-                       && "Column index out of bounds");
-
-                report.captions[0][report.data.columnIndex] = report.variableCaption;
-                report.captions[1][report.data.columnIndex] = VCardT::Unit();
-                report.captions[2][report.data.columnIndex] = "values";
-
-                // Precision
-                report.precision[report.data.columnIndex]
-                  = PrecisionToPrintfFormat<VCardT::decimal>::Value();
-                // Value
-                report.values[report.data.columnIndex][report.data.rowIndex] = rawdata.allYears;
-                // Non applicability
-                report.digestNonApplicableStatus[report.data.rowIndex][report.data.columnIndex]
-                  = *report.isCurrentVarNA;
-
-                ++(report.data.columnIndex);
-            }
-        }
-        // Next
-        NextType::template buildDigest<VCardT>(report, digestLevel, dataLevel);
-    }
-
     Yuni::uint64 memoryUsage() const
     {
         return

--- a/src/solver/variable/storage/results.h
+++ b/src/solver/variable/storage/results.h
@@ -88,13 +88,6 @@ public:
                            int fileLevel,
                            int precision) const;
 
-    template<class VCardT>
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
-    {
-        // Next
-        DecoratorType::template buildDigest<VCardT>(results, digestLevel, dataLevel);
-    }
-
     Yuni::uint64 memoryUsage() const
     {
         return DecoratorType::memoryUsage();

--- a/src/solver/variable/surveyresults/data.h
+++ b/src/solver/variable/surveyresults/data.h
@@ -60,8 +60,6 @@ public:
 
     void exportGridInfosAreas(const Yuni::String& folder);
 
-    bool createDigestFile();
-
 public:
     //! The current column index
     unsigned int columnIndex;
@@ -97,7 +95,7 @@ public:
     //! Captions for rows
     Yuni::String::Vector rowCaptions;
 
-    //! A multi-purposes matrix (mainly used for the digest)
+    //! A multi-purposes matrix
     Matrix<double, double> matrix;
 
     unsigned int rowIndex;
@@ -105,16 +103,6 @@ public:
     Yuni::Clob fileBuffer;
 
 }; // class SurveyResultsData
-
-/*!
-** \brief Append the data of a matrix (about links variables) to the digest file
-*/
-void InternalExportDigestLinksMatrix(const Data::Study& study,
-                                     const Yuni::String& originalOutput,
-                                     Yuni::String& output,
-                                     const char* title,
-                                     Yuni::Clob& pFileBuffer,
-                                     const Matrix<>& matrix);
 
 void ExportGridInfosAreas(const Data::Study& study, const Yuni::String& folder);
 

--- a/src/solver/variable/surveyresults/reportbuilder.hxx
+++ b/src/solver/variable/surveyresults/reportbuilder.hxx
@@ -227,49 +227,6 @@ public:
         SurveyReportBuilder<GlobalT, NextT, nextDataLevel>::Run(list, results, numSpace);
     }
 
-    static void RunDigest(const ListType& list, SurveyResults& results)
-    {
-        logs.info() << "Exporting digest...";
-        logs.debug() << " . Digest, truncating file";
-        if (results.createDigestFile())
-        {
-            // Digest: Summary for All years
-            logs.debug() << " . Digest, annual";
-
-            // Digest file : areas part
-            list.buildDigest(results, Category::digestAllYears, Category::area);
-            results.exportDigestAllYears();
-
-            // Degest file : districts part
-            list.buildDigest(results, Category::digestAllYears, Category::setOfAreas);
-            results.exportDigestAllYears();
-
-            if (results.data.study.parameters.mode != Data::stdmAdequacyDraft)
-            {
-                // Digest: Flow linear (only if selected by user)
-                if (results.data.study.parameters.variablesPrintInfo.isPrinted("FLOW LIN."))
-                {
-                    logs.debug() << " . Digest, flow linear";
-                    results.data.matrix.fill(std::numeric_limits<double>::quiet_NaN());
-                    list.buildDigest(results, Category::digestFlowLinear, Category::area);
-                    results.exportDigestMatrix("Links (FLOW LIN.)");
-                }
-
-                // Digest: Flow Quad (only if selected by user)
-                if (results.data.study.parameters.variablesPrintInfo.isPrinted("FLOW QUAD."))
-                {
-                    logs.debug() << " . Digest, flow quad";
-                    results.data.matrix.fill(std::numeric_limits<double>::quiet_NaN());
-                    list.buildDigest(results, Category::digestFlowQuad, Category::area);
-                    results.exportDigestMatrix("Links (FLOW QUAD.)");
-                }
-            }
-
-            if (Antares::Memory::swapSupport)
-                Antares::memory.flushAll();
-        }
-    }
-
 private:
     static void RunStandard(const ListType& list, SurveyResults& results, unsigned int numSpace)
     {

--- a/src/solver/variable/surveyresults/surveyresults.h
+++ b/src/solver/variable/surveyresults/surveyresults.h
@@ -89,17 +89,8 @@ public:
     */
     void exportGridInfos();
 
-    bool createDigestFile();
-
     // Reset a line of values to zero.
     void resetValuesAtLine(uint);
-
-    /*!
-    ** \brief Export the digest file
-    */
-    void exportDigestAllYears();
-
-    void exportDigestMatrix(const char* title);
 
 public:
     //! Data (not related to the template parameter)
@@ -123,9 +114,6 @@ public:
 
     //! Non applicable status for each column (in the printf format)
     bool* nonApplicableStatus;
-    // Digest file non applicable status ( dim : nb vars x max(nb areas, nb sets of areas) )
-    uint digestSize; // Useful dimension for digest file non applicable statut management.
-    bool** digestNonApplicableStatus;
 
     //! The total number of variables
     const uint maxVariables;

--- a/src/solver/variable/variable.h
+++ b/src/solver/variable/variable.h
@@ -284,8 +284,6 @@ public:
                                  int precision,
                                  uint numSpace) const;
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const;
-
     /*!
     ** \brief Event triggered before exporting a year-by-year survey report
     */

--- a/src/solver/variable/variable.hxx
+++ b/src/solver/variable/variable.hxx
@@ -77,7 +77,7 @@ inline IVariable<ChildT, NextT, VCardT>::IVariable()
 
     // Allocation
     // Does current output variable appear non applicable in all output reports (of any kind :
-    // area or district reports, annual or over all years reports, digest, ...) ?
+    // area or district reports, annual or over all years reports, ...) ?
     isNonApplicable = new bool[pColumnCount];
     // Does current output variable column(s) appear in all reports ?
     isPrinted = new bool[pColumnCount];
@@ -429,28 +429,6 @@ inline void IVariable<ChildT, NextT, VCardT>::buildAnnualSurveyReport(SurveyResu
 }
 
 template<class ChildT, class NextT, class VCardT>
-inline void IVariable<ChildT, NextT, VCardT>::buildDigest(SurveyResults& results,
-                                                          int digestLevel,
-                                                          int dataLevel) const
-{
-    // Generate the Digest for the local results (areas part)
-    if (VCardType::columnCount != 0
-        && (VCardType::categoryDataLevel & Category::setOfAreas
-            || VCardType::categoryDataLevel & Category::area
-            || VCardType::categoryDataLevel & Category::link))
-    {
-        // Initializing pointer on variable non applicable and print stati arrays to beginning
-        results.isPrinted = isPrinted;
-        results.isCurrentVarNA = isNonApplicable;
-
-        VariableAccessorType::template BuildDigest<VCardT>(
-          results, pResults, digestLevel, dataLevel);
-    }
-    // Ask to build the digest to the next variable
-    NextType::buildDigest(results, digestLevel, dataLevel);
-}
-
-template<class ChildT, class NextT, class VCardT>
 inline void IVariable<ChildT, NextT, VCardT>::beforeYearByYearExport(uint year, uint numspace)
 {
     NextType::beforeYearByYearExport(year, numspace);
@@ -561,7 +539,8 @@ template<class VCardToFindT>
 inline const double* IVariable<ChildT, NextT, VCardT>::retrieveHourlyResultsForCurrentYear(
   uint numSpace) const
 {
-    using AssignT = RetrieveResultsAssignment<Yuni::Static::Type::StrictlyEqual<VCardT, VCardToFindT>::Yes>;
+    using AssignT
+      = RetrieveResultsAssignment<Yuni::Static::Type::StrictlyEqual<VCardT, VCardToFindT>::Yes>;
     return (AssignT::Yes)
              ? nullptr
              : NextType::template retrieveHourlyResultsForCurrentYear<VCardToFindT>(numSpace);
@@ -573,7 +552,8 @@ inline void IVariable<ChildT, NextT, VCardT>::retrieveResultsForArea(
   typename Storage<VCardToFindT>::ResultsType** result,
   const Data::Area* area)
 {
-    using AssignT = RetrieveResultsAssignment<Yuni::Static::Type::StrictlyEqual<VCardT,VCardToFindT>::Yes>;
+    using AssignT
+      = RetrieveResultsAssignment<Yuni::Static::Type::StrictlyEqual<VCardT, VCardToFindT>::Yes>;
     AssignT::Do(pResults, result);
     if (!AssignT::Yes)
         NextType::template retrieveResultsForArea<VCardToFindT>(result, area);
@@ -585,7 +565,8 @@ inline void IVariable<ChildT, NextT, VCardT>::retrieveResultsForThermalCluster(
   typename Storage<VCardToFindT>::ResultsType** result,
   const Data::ThermalCluster* cluster)
 {
-    using AssignT = RetrieveResultsAssignment<Yuni::Static::Type::StrictlyEqual<VCardT, VCardToFindT>::Yes>;
+    using AssignT
+      = RetrieveResultsAssignment<Yuni::Static::Type::StrictlyEqual<VCardT, VCardToFindT>::Yes>;
     AssignT::Do(pResults, result);
     if (!AssignT::Yes)
         NextType::template retrieveResultsForThermalCluster<VCardToFindT>(result, cluster);
@@ -597,7 +578,8 @@ inline void IVariable<ChildT, NextT, VCardT>::retrieveResultsForLink(
   typename Storage<VCardToFindT>::ResultsType** result,
   const Data::AreaLink* link)
 {
-    using AssignT = RetrieveResultsAssignment<Yuni::Static::Type::StrictlyEqual<VCardT, VCardToFindT>::Yes>;
+    using AssignT
+      = RetrieveResultsAssignment<Yuni::Static::Type::StrictlyEqual<VCardT, VCardToFindT>::Yes>;
     AssignT::Do(pResults, result);
     if (!AssignT::Yes)
         NextType::template retrieveResultsForLink<VCardToFindT>(result, link);


### PR DESCRIPTION
Since the digest file is deprecated, and sometimes causes segfaults, we decide to remove it completely.

Hopefully, it will also simplify the output module (**src/solver/variable**) and allow the dev team to work on higher-value topics.