### PR TITLE
Output variables: remove useless methods for renewable clusters

### DIFF
--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -236,16 +236,6 @@ void Areas<NEXTTYPE>::yearEndBuild(State& state, uint year, uint numSpace)
             // Variables
             variablesForArea.yearEndBuildForEachThermalCluster(state, year, numSpace);
         } // for each thermal cluster
-
-        // For each renewable cluster
-        for (uint j = 0; j != area.renewable.clusterCount(); ++j)
-        {
-            state.renewableCluster = area.renewable.clusters[j];
-            state.yearEndResetRenewable();
-
-            // Variables
-            variablesForArea.yearEndBuildPrepareDataForEachRenewableCluster(state, year, numSpace);
-        } // for each renewable cluster
     });   // for each area
 }
 

--- a/src/solver/variable/commons/links/links.h.inc.hxx
+++ b/src/solver/variable/commons/links/links.h.inc.hxx
@@ -147,7 +147,6 @@ public:
     void yearBegin(uint year, unsigned int numSpace);
 
     void yearEndBuildPrepareDataForEachThermalCluster(State& state, uint year, uint numSpace);
-    void yearEndBuildPrepareDataForEachRenewableCluster(State& state, uint year, uint numSpace);
     void yearEndBuildForEachThermalCluster(State& state, uint year, uint numSpace);
 
     void yearEndBuild(State& state, uint year);

--- a/src/solver/variable/commons/links/links.hxx.inc.hxx
+++ b/src/solver/variable/commons/links/links.hxx.inc.hxx
@@ -104,21 +104,6 @@ inline void Links::yearEndBuildPrepareDataForEachThermalCluster(State& state,
     }
 }
 
-inline void Links::yearEndBuildPrepareDataForEachRenewableCluster(State& state,
-                                                                  uint year,
-                                                                  unsigned int numSpace)
-{
-    for (uint i = 0; i != pLinkCount; ++i)
-    {
-        pLinks[i].yearEndBuildPrepareDataForEachRenewableCluster(state, year, numSpace);
-
-        // Flush all memory into the swap files
-        // (only if the support is available)
-        if (Antares::Memory::swapSupport)
-            Antares::memory.flushAll();
-    }
-}
-
 inline void Links::yearEndBuildForEachThermalCluster(State& state, uint year, unsigned int numSpace)
 {
     for (uint i = 0; i != pLinkCount; ++i)

--- a/src/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/economy/renewableGeneration.h
@@ -287,20 +287,6 @@ public:
         return pValuesForTheCurrentYear[numSpace][column].hour;
     }
 
-    void yearEndBuildPrepareDataForEachRenewableCluster(State& state,
-                                                        uint year,
-                                                        unsigned int numSpace)
-    {
-        for (unsigned int i = 0; i <= state.study.runtime->rangeLimits.hour[Data::rangeEnd]; ++i)
-        {
-            state.renewableClusterProductionForYear[i]
-              += pValuesForTheCurrentYear[numSpace][state.renewableCluster->areaWideIndex].hour[i];
-        }
-
-        // Next variable
-        NextType::yearEndBuildPrepareDataForEachRenewableCluster(state, year, numSpace);
-    }
-
     void localBuildAnnualSurveyReport(SurveyResults& results,
                                       int fileLevel,
                                       int precision,

--- a/src/solver/variable/endoflist.h
+++ b/src/solver/variable/endoflist.h
@@ -136,15 +136,6 @@ public:
         UNUSED_VARIABLE(numSpace);
     }
 
-    static void yearEndBuildPrepareDataForEachRenewableCluster(State& state,
-                                                               uint year,
-                                                               uint numSpace)
-    {
-        UNUSED_VARIABLE(state);
-        UNUSED_VARIABLE(year);
-        UNUSED_VARIABLE(numSpace);
-    }
-
     static void yearEndBuildForEachThermalCluster(State& state, uint year, uint numSpace)
     {
         UNUSED_VARIABLE(state);

--- a/src/solver/variable/state.h
+++ b/src/solver/variable/state.h
@@ -104,11 +104,6 @@ public:
     */
     void yearEndResetThermal();
 
-    /*!
-    ** \brief Reset renewable internal data for end of year calculations
-    */
-    void yearEndResetRenewable();
-
 public:
     //! Current year
     unsigned int year;
@@ -187,7 +182,6 @@ public:
     double thermalClusterPMinOfTheClusterForYear[Variable::maxHoursInAYear];
 
     double renewableClusterProduction;
-    double renewableClusterProductionForYear[Variable::maxHoursInAYear];
 
     //! Dispatchable margin for the current area (valid only from weekForEachArea)
     const double* dispatchableMargin;

--- a/src/solver/variable/state.hxx
+++ b/src/solver/variable/state.hxx
@@ -47,8 +47,6 @@ inline void State::startANewYear()
            0,
            sizeof(thermalClusterDispatchedUnitsCountForYear));
 
-    memset(renewableClusterProductionForYear, 0, sizeof(renewableClusterProductionForYear));
-
     // Re-initializing annual costs (to be printed in output into separate files)
     annualSystemCost = 0.;
     optimalSolutionCost1 = 0.;
@@ -67,11 +65,6 @@ inline void State::yearEndResetThermal()
     memset(thermalClusterDispatchedUnitsCountForYear,
            0,
            sizeof(thermalClusterDispatchedUnitsCountForYear));
-}
-
-inline void State::yearEndResetRenewable()
-{
-    memset(renewableClusterProductionForYear, 0, sizeof(renewableClusterProductionForYear));
 }
 
 inline void State::initFromAreaIndex(const unsigned int areaIndex, uint numSpace)

--- a/src/solver/variable/variable.h
+++ b/src/solver/variable/variable.h
@@ -218,8 +218,6 @@ public:
     */
     void yearEndBuildForEachThermalCluster(State& state, uint year, uint numSpace);
 
-    void yearEndBuildPrepareDataForEachRenewableCluster(State& state, uint year, uint numSpace);
-
     /*!
     ** \brief Notify to all variables that the year is now over
     **

--- a/src/solver/variable/variable.hxx
+++ b/src/solver/variable/variable.hxx
@@ -266,16 +266,6 @@ inline void IVariable<ChildT, NextT, VCardT>::yearEndBuildPrepareDataForEachTher
 }
 
 template<class ChildT, class NextT, class VCardT>
-inline void IVariable<ChildT, NextT, VCardT>::yearEndBuildPrepareDataForEachRenewableCluster(
-  State& state,
-  uint year,
-  uint numSpace)
-{
-    // Next variable
-    NextType::yearEndBuildPrepareDataForEachRenewableCluster(state, year, numSpace);
-}
-
-template<class ChildT, class NextT, class VCardT>
 template<class V>
 inline void IVariable<ChildT, NextT, VCardT>::simulationEndSpatialAggregates(V& allVars)
 {


### PR DESCRIPTION
Methods

- yearEndBuildPrepareDataForEachRenewableCluster
- yearEndResetRenewable

These methods do not produce any result, and sometimes produce segfaults.