### PR TITLE
Remove swap from code (1st step)

### DIFF
--- a/src/libs/antares/array/matrix.hxx
+++ b/src/libs/antares/array/matrix.hxx
@@ -416,10 +416,15 @@ bool Matrix<T, ReadWriteT>::loadFromCSVFile(const AnyString& filename,
     assert(not filename.empty() and "Matrix<>:: loadFromCSVFile: empty filename");
     // As the loading might be expensive, especially when dealing with
     // numerous matriceis, we may want to delay this loading (a `lazy` mode)
-    return (JIT::enabled and not(options & optImmediate))
-             ? internalLoadJITData(filename, minWidth, maxHeight, options)
-             // Reading data from file
-             : internalLoadCSVFile(filename, minWidth, maxHeight, options, buffer);
+    if (JIT::enabled and not(options & optImmediate))
+    {
+        return internalLoadJITData(filename, minWidth, maxHeight, options);
+    }
+    else
+    {
+        // Reading data from file
+        return internalLoadCSVFile(filename, minWidth, maxHeight, options, buffer);
+    }
 }
 
 template<class T, class ReadWriteT>

--- a/src/libs/antares/memory/memory.cpp
+++ b/src/libs/antares/memory/memory.cpp
@@ -625,43 +625,11 @@ void Memory::EstimateMemoryUsage(size_t bytes,
     size_t total = bytes * count;
     if (duplicateForParallelYears)
         total = total * u.nbYearsParallel;
-    if (u.swappingSupport)
-    {
-        if (total < minimalAllocationSize)
-        {
-            if (u.gatheringInformationsForInput)
-                u.requiredMemoryForInput += total;
-            else
-                u.requiredMemoryForOutput += total;
-        }
-        else
-        {
-            // counting the number of blocks required by the swap file
-            // to store all `bytes`
-            uint nbBlocks = 0;
-            do
-            {
-                total -= (total < (size_t)blockSize) ? total : (size_t)blockSize;
-                ++nbBlocks;
-            } while (total);
 
-            // Disk
-            u.requiredDiskSpaceForSwap += nbBlocks * blockSize;
-
-            // Memory overhead
-            if (u.gatheringInformationsForInput)
-                u.requiredMemoryForInput += (sizeof(Mapping) + sizeof(void*) + sizeof(void*));
-            else
-                u.requiredMemoryForOutput += (sizeof(Mapping) + sizeof(void*) + sizeof(void*));
-        }
-    }
+    if (u.gatheringInformationsForInput)
+        u.requiredMemoryForInput += total;
     else
-    {
-        if (u.gatheringInformationsForInput)
-            u.requiredMemoryForInput += total;
-        else
-            u.requiredMemoryForOutput += total;
-    }
+        u.requiredMemoryForOutput += total;
 }
 
 void Memory::displayInfo() const

--- a/src/libs/antares/solver.cpp
+++ b/src/libs/antares/solver.cpp
@@ -80,18 +80,8 @@ bool FindLocation(String& location, Data::Version /*version*/, Solver::Feature f
         searchpaths.directories.push_back(s.clear() << "/usr/bin/");
     }
 
-    bool success = false;
     s.clear();
-    switch (features)
-    {
-    case Solver::parallel:
-    case Solver::standard:
-        success = searchpaths.find(s, "solver");
-        break;
-    case Solver::withSwapFiles:
-        success = searchpaths.find(s, "solver-swap");
-        break;
-    }
+    bool success = searchpaths.find(s, "solver");
 
     if (success)
     {

--- a/src/libs/antares/solver.h
+++ b/src/libs/antares/solver.h
@@ -38,8 +38,6 @@ enum Feature
 {
     //! The standard solver
     standard = 0,
-    //! With swap files
-    withSwapFiles,
     //! The solver with years computed in parallel
     parallel,
 };

--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -420,12 +420,6 @@ void Area::estimateMemoryUsage(StudyMemoryUsage& u) const
         for (auto i = links.begin(); i != end; ++i)
             (i->second)->estimateMemoryUsage(u);
     }
-
-    if (u.swappingSupport)
-    {
-        // + something
-        u.requiredMemoryForInput += ((/*1.5*/ 15 * 1024 * 1024) / 10);
-    }
 }
 
 bool Area::thermalClustersMinStablePowerValidity(std::vector<YString>& output) const

--- a/src/libs/antares/study/memory-usage.cpp
+++ b/src/libs/antares/study/memory-usage.cpp
@@ -38,13 +38,11 @@ namespace Data
 // gp : voir l'impact de la selection des variables ici
 StudyMemoryUsage::StudyMemoryUsage(const Study& s) :
  mode(s.parameters.mode),
- swappingSupport(false),
  gatheringInformationsForInput(false),
  requiredMemory(),
  requiredMemoryForInput(),
  requiredMemoryForOutput(),
  requiredDiskSpace(),
- requiredDiskSpaceForSwap(),
  requiredDiskSpaceForOutput(),
  study(s),
  years(s.parameters.nbYears),
@@ -101,7 +99,6 @@ StudyMemoryUsage& StudyMemoryUsage::operator+=(const StudyMemoryUsage& rhs)
     requiredMemoryForInput += rhs.requiredMemoryForInput;
     requiredMemoryForOutput += rhs.requiredMemoryForOutput;
     requiredDiskSpace += rhs.requiredDiskSpace;
-    requiredDiskSpaceForSwap += rhs.requiredDiskSpaceForSwap;
     requiredDiskSpaceForOutput += rhs.requiredDiskSpaceForOutput;
     return *this;
 }
@@ -111,20 +108,9 @@ void StudyMemoryUsage::estimate()
     study.estimateMemoryUsageForInput(*this);
     study.estimateMemoryUsageForOutput(*this);
 
-    if (requiredDiskSpaceForSwap != 0)
-    {
-        Yuni::uint64 swap = 0;
-        do
-        {
-            swap += Antares::Memory::swapSize;
-        } while (swap < requiredDiskSpaceForSwap);
-
-        requiredDiskSpaceForSwap = swap + Antares::Memory::swapSize;
-    }
-
     // Post-operations
     requiredMemory = requiredMemoryForInput + requiredMemoryForOutput;
-    requiredDiskSpace = requiredDiskSpaceForSwap + requiredDiskSpaceForOutput;
+    requiredDiskSpace = requiredDiskSpaceForOutput;
 }
 
 void StudyMemoryUsage::takeIntoConsiderationANewTimeserieForDiskOutput(bool withIDs)

--- a/src/libs/antares/study/memory-usage.h
+++ b/src/libs/antares/study/memory-usage.h
@@ -74,8 +74,6 @@ public:
     //@{
     //! Study mode (economy / adequacy / other)
     StudyMode mode;
-    //! Swapping support
-    bool swappingSupport;
     //! For matrices
     bool gatheringInformationsForInput;
     //@}
@@ -91,8 +89,6 @@ public:
 
     //! Total Amount of disk space required for a simulation
     Yuni::uint64 requiredDiskSpace;
-    //! Amount of disk space required by the swap files for a simulation
-    Yuni::uint64 requiredDiskSpaceForSwap;
     //! Amount of disk space required by the output for a simulation
     Yuni::uint64 requiredDiskSpaceForOutput;
     //@}

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -201,17 +201,6 @@ void Application::prepare(int argc, char* argv[])
     WriteHostInfoIntoLogs();
     logs.info();
 
-#ifdef ANTARES_SWAP_SUPPORT
-    // Changing the swap folder
-    if (!pSettings.swap.empty())
-    {
-        logs.info() << "  memory pool: scratch folder:" << pSettings.swap;
-        Antares::memory.cacheFolder(pSettings.swap);
-    }
-    else
-        logs.info() << "  memory pool: scratch folder:" << Antares::memory.cacheFolder();
-#endif
-
     // Initialize the main structures for the simulation
     // Logs
     Resources::WriteRootFolderToLogs();

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -168,18 +168,6 @@ GetOpt::Parser CreateParser(Settings& settings, Antares::Data::StudyLoadOptions&
     // --progress
     parser.addFlag(
       settings.displayProgression, ' ', "progress", "Display the progress of each task");
-    // --swap
-    parser.add(settings.swap,
-               ' ',
-               "swap-folder",
-#ifdef ANTARES_SWAP_SUPPORT
-               String("Folder where the swap files will be written. (default: '")
-                 << Antares::memory.cacheFolder() << "')"
-#else
-               "Folder where the swap files will be written. This option has no effect (swap files "
-               "are only available for 'antares-solver-swap')"
-#endif
-    );
 
     // --pid
     parser.add(settings.PID, 'p', "pid", "Specify the file where to write the process ID");

--- a/src/solver/misc/options.h
+++ b/src/solver/misc/options.h
@@ -59,8 +59,6 @@ public:
     bool noOutput;
     //! Progression
     bool displayProgression;
-    //! Swap folder
-    Yuni::String swap;
 
     Yuni::String PID;
 

--- a/src/tools/batchrun/main.cpp
+++ b/src/tools/batchrun/main.cpp
@@ -85,7 +85,6 @@ int main(int argc, char* argv[])
 
     // options
     String optInput;
-    bool optSwap = false;
     bool optNoTSImport = false;
     bool optIgnoreAllConstraints = false;
     bool optForceExpansion = false;
@@ -144,7 +143,6 @@ int main(int argc, char* argv[])
                     ' ',
                     "force-parallel",
                     "Override the max number of years computed simultaneously");
-        options.addFlag(optSwap, 's', "swap", "Swap mode");
         options.remainingArguments(optInput);
         // Version
         options.addParagraph("\nMisc.");
@@ -186,7 +184,7 @@ int main(int argc, char* argv[])
     String solver;
     if (optSolver.empty())
     {
-        Solver::Feature feature = (not optSwap) ? Solver::standard : Solver::withSwapFiles;
+        Solver::Feature feature = Solver::standard;
         Solver::FindLocation(solver, (Data::Version)Data::versionLatest, feature);
         if (solver.empty())
         {

--- a/src/tools/yby-aggregator/main.cpp
+++ b/src/tools/yby-aggregator/main.cpp
@@ -271,7 +271,6 @@ static void ReadCommandLineOptions(int argc, char** argv)
 {
     String::Vector optOutputs;
     uint optJobs = FindNbProcessors();
-    String optSwap;
     String::Vector optTimes;
     String::Vector optColumns;
     String::Vector optDatum;
@@ -307,17 +306,6 @@ static void ReadCommandLineOptions(int argc, char** argv)
                     "jobs",
                     String() << "The number of jobs to run simultaneously (default: " << optJobs
                              << ", 4 should be a maxmimum due to i/o performance considerations)");
-        // --swap
-        options.add(optSwap,
-                    ' ',
-                    "swap-folder",
-#ifdef ANTARES_SWAP_SUPPORT
-                    String("Folder where the swap files will be written. (default: '")
-                      << Antares::memory.cacheFolder() << "')"
-#else
-                    "Folder where the swap files will be written. This option has no effect"
-#endif
-        );
 
         options.addParagraph("\nMisc.");
 
@@ -371,17 +359,6 @@ static void ReadCommandLineOptions(int argc, char** argv)
             optJobs = 1;
         queueService.maximumThreadCount(optJobs);
     }
-
-#ifdef ANTARES_SWAP_SUPPORT
-    // Changing the swap folder
-    if (not optSwap.empty())
-    {
-        logs.info() << "  memory pool: scratch folder:" << optSwap;
-        Antares::memory.cacheFolder(optSwap);
-    }
-    else
-        logs.info() << "  memory pool: scratch folder:" << Antares::memory.cacheFolder();
-#endif
 
     // Starting !
     {

--- a/src/ui/simulator/windows/memorystatistics/memorystatistics.cpp
+++ b/src/ui/simulator/windows/memorystatistics/memorystatistics.cpp
@@ -503,7 +503,6 @@ void MemoryStatistics::refreshInformation()
 
             {
                 Data::StudyMemoryUsage m(*study);
-                m.swappingSupport = true;
                 m.estimate();
                 s.clear();
 
@@ -513,7 +512,7 @@ void MemoryStatistics::refreshInformation()
                                 << (m.requiredMemoryForInput / (1024 * 1024))
                                 << "Mo, output: " << (m.requiredMemoryForOutput / (1024 * 1024))
                                 << "Mo,   disk: " << (m.requiredDiskSpace / (1024 * 1024))
-                                << "Mo (with swap support)";
+                                << "Mo";
                 }
 
                 s << wxT("~ ") << NormalizeAmountOfMemory(m.requiredMemory) << wxT(" Mo");

--- a/src/ui/simulator/windows/output/panel/panel.cpp
+++ b/src/ui/simulator/windows/output/panel/panel.cpp
@@ -466,19 +466,6 @@ void Panel::executeAggregator()
     // Time interval
     cmd << " -t hourly -t daily -t weekly -t monthly -t annual";
 
-    // Temp folder
-    String cacheFolder = Antares::memory.cacheFolder();
-    if (not cacheFolder.empty())
-    {
-        if (cacheFolder.last() == '\\' || cacheFolder.last() == '/')
-            cacheFolder.removeLast();
-        if (not cacheFolder.empty())
-        {
-            cmd << " --swap-folder=";
-            AppendWithQuotes(cmd, cacheFolder);
-        }
-    }
-
     auto* exec = new Toolbox::Process::Execute();
     exec->title(wxT("Extracting data from the output"));
     exec->subTitle(wxT("Running..."));

--- a/src/ui/simulator/windows/simulation/run.cpp
+++ b/src/ui/simulator/windows/simulation/run.cpp
@@ -69,15 +69,15 @@ namespace Simulation
 {
 enum
 {
-    featuresCount = 3,
+    featuresCount = 2,
     timerInterval = 3500 // ms
 };
 
 static const wxString featuresNames[featuresCount]
-  = {wxT(" Default  "), wxT(" Swap  "), wxT(" Parallel ")};
+  = {wxT(" Default  "), wxT(" Parallel ")};
 
 static const Solver::Feature featuresAlias[featuresCount]
-  = {Solver::standard, Solver::withSwapFiles, Solver::parallel};
+  = {Solver::standard, Solver::parallel};
 
 static wxString TimeSeriesToWxString(uint m)
 {
@@ -489,16 +489,6 @@ void Run::estimateMemoryUsage()
         if (pPreproOnly->GetValue())
             m.years = 0;
 
-        switch (featuresAlias[pFeatureIndex])
-        {
-        case Solver::parallel:
-        case Solver::standard:
-            break;
-        case Solver::withSwapFiles:
-            m.swappingSupport = true;
-            break;
-        }
-
         m.estimate();
 
         uint64 amountNeeded = m.requiredMemory;
@@ -525,13 +515,8 @@ void Run::estimateMemoryUsage()
             BytesToStringW(s, m.requiredDiskSpace);
             break;
         }
-        case Solver::withSwapFiles:
-        {
-            s << wxT(" < ");
-            BytesToStringW(s, m.requiredDiskSpace) << wxT(" [temp: ");
-            BytesToStringW(s, m.requiredDiskSpaceForSwap) << wxT(" included]");
+        default:
             break;
-        }
         }
         UpdateLabel(guiUpdated, pLblDiskEstimation, s);
 
@@ -907,7 +892,7 @@ void Run::onSelectMode(wxCommandEvent& evt)
     if (pFeatureIndex >= featuresCount)
         pFeatureIndex = 0;
 
-    // In case of either default or swap support mode, MC years parallel computation is disabled (nb
+    // In case of either default mode, MC years parallel computation is disabled (nb
     // of cores is set to 1)
 
     // Needed For RAM estimation


### PR DESCRIPTION
The purpose is to remove totally the swap from the sources.
This work is spread over several PR (a PR is based on the previous one in the list) :
* the current one (#900). This PR is a start. It is a try to remove the swap feature as a user entry (in the GUI's run simulation window) or as command line options of standalone programs.  
* PR #906. This PR cleans the cmake files from swap libraries, and pulls changes from current **develop** branch. 
* PR #907. This PR finishes the job.
* PR #916 for removing swap considerations from online documentation.

List of tasks to do (if a task is done, we give the associated PR)   : 
- [x] Removing swap folder option from standalone programs (*.exe ) : solver, yby-aggregator, batchrun. Done in  #900.
- [x] Removing swap mode from GUI (see GUI's **run simulation** window). Done in #900 (cleaning command to run the solver from the GUI is done in #906).
- [x] clean the Antares doc from swap considerations. Done in #916 
- [x] Removing swap considerations from disk memory usage. Done in #900.
- [x] Clean cmake files from swap libraries. Done in #906.
- [x] Clean cpp sources from snippets compiled only if **ANTARES_SWAP_SUPPORT** is enabled. Done in #907.
- [x] Update the current work with **develop** content (merge). Done in #906.
- [x] Solve a CI problem related to a submodule introduced in the previous task. Done in #907.

Class **Memory** has an important part in swap functionalities.
The following is done or will be in PR #907 : 
- [x] Removing use of enum value : **Memory::swapSupport**
- [x] Cleaning class **Memory** from swap (currently on progress)
- [x] Removing all **flush()** functions
- [x] Remove swap in GUI's **main menu > Tools**
