### PR TITLE
Do not export BC results by default

### DIFF
--- a/.github/workflows/run-tests/action.yml
+++ b/.github/workflows/run-tests/action.yml
@@ -23,12 +23,15 @@ runs:
            rm batch.zip
 
   - name: Run tests
-    shell: bash
+    # Disable "fail fast" behavior
+    shell: bash {0}
     run: |
            cd _build
            ctest -C Release --output-on-failure -R json
+           echo "RET_CODE=$?" >> GITTHUB_ENV
 
   - name: Clean batches
     shell: bash
     run: |
            rm -rf src/tests/resources/batches/*
+           (exit ${{env.RET_CODE}})

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -137,6 +137,10 @@ jobs:
       shell: bash
       run: rm -rf ${{ github.workspace }}/src/tests/resources/Antares_Simulator_Tests
 
+    - name: Remove _deps to free some disk space
+      shell: bash
+      run: rm -rf ${{ github.workspace }}/src/_build/_deps
+
     # simtest
     - name: Read simtest version
       id: simtest-version

--- a/src/libs/antares/study/constraint/constraint.h
+++ b/src/libs/antares/study/constraint/constraint.h
@@ -504,9 +504,11 @@ private:
     //! Operator
     Operator pOperator;
     //! Print binding constraint's marginal prices of any year for which time step granularity ?
-    uint pFilterYearByYear = filterAll;
+    // By default, print nothing
+    uint pFilterYearByYear = filterNone;
     //! Print binding constraint's marginal prices synthesis for which time step granularity ?
-    uint pFilterSynthesis = filterAll;
+    // By default, print nothing
+    uint pFilterSynthesis = filterNone;
     //! Enabled / Disabled
     bool pEnabled;
     //! Comments


### PR DESCRIPTION
In existing studies, keys `filter-synthesis` and `filter-year-by-year` do not exist. However, by default we don't want to create all outputs because it would take a lot of space, and most of the time the user isn't interested in this output.
### TODO
- [ ] Re-generate reference results, excluding BC results