### PR TITLE
BC's marginal prices output correction

### DIFF
--- a/src/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -263,13 +263,10 @@ public:
 
             pValuesForTheCurrentYear[yearMemorySpace_].week[weekInTheYear] = weeklyValue;
 
-            // Even if not printed for weekly BC, we need daily values as : (weekly values) / 7
-            double dailyValue = weeklyValue / 7;
-
             int dayInTheYear = state.weekInTheYear * 7;
             for (int dayInTheWeek = 0; dayInTheWeek < 7; dayInTheWeek++)
             {
-                pValuesForTheCurrentYear[yearMemorySpace_].day[dayInTheYear] = dailyValue;
+                pValuesForTheCurrentYear[yearMemorySpace_].day[dayInTheYear] = weeklyValue;
                 dayInTheYear++;
             }
             break;

--- a/src/solver/variable/storage/intermediate.cpp
+++ b/src/solver/variable/storage/intermediate.cpp
@@ -246,7 +246,9 @@ void IntermediateValues::computeAnnualAveragesFromWeeklyValues()
     uint i, j;
     double d;
     
-    // months
+    // months : we need daily values in order to compute monthly averages. Indeed,
+    // weekly values would be suitable for this : there are not necessarily an integer number
+    // of weeks in a month.
     uint indx = calendar->months[pRange->month[Data::rangeBegin]].daysYear.first;
     for (i = pRange->month[Data::rangeBegin]; i <= pRange->month[Data::rangeEnd]; ++i)
     {
@@ -263,11 +265,12 @@ void IntermediateValues::computeAnnualAveragesFromWeeklyValues()
 
     // Year
     year = 0.;
-    for (i = pRange->day[Data::rangeBegin]; i <= pRange->day[Data::rangeEnd]; ++i)
+    for (i = pRange->week[Data::rangeBegin]; i <= pRange->week[Data::rangeEnd]; ++i)
     {
-        year += day[i];
+        year += week[i];
     }
-    year /= pRange->hour[Data::rangeCount];
+    year /= pRange->week[Data::rangeCount];
+
 }
 
 


### PR DESCRIPTION
This fixes issue #920 

**Note** (important) : 
- This current PR fixes incorrect marginal prices results. 
Reference results are wrong, and that's why we get a CI failure.
We must correct reference results, but to do that, we need a new tag for Antares Simulator (like **v8.4.0-rc1** for instance). The need for an Antares new tag is part of the **adding new tests** or **correct reference results** procedure.
Therefore, before correcting the reference results, we should merge the current branch into the **develop** and create a tag.
- At this occasion, we should add some more tests regarding binding constraints' marginal prices 