### PR TITLE
Using clang

### DIFF
--- a/src/ext/yuni/src/yuni/core/string/iterator.inc.hpp
+++ b/src/ext/yuni/src/yuni/core/string/iterator.inc.hpp
@@ -173,7 +173,7 @@ struct Model
         {
             do
             {
-                if (pChar == ' ' || pChar == '\t' || pChar == '\n' || pChar == '\r')
+                if (pChar == (uint)' ' || pChar == (uint)'\t' || pChar == (uint)'\n' || pChar == (uint)'\r')
                 {
                     forward();
                     if (pOffset >= end)
@@ -189,7 +189,7 @@ struct Model
         {
             do
             {
-                if (pChar != c)
+                if (pChar != (uint)c)
                 {
                     forward();
                     if (pOffset > endOffset)

--- a/src/ext/yuni/src/yuni/core/system/stdint.h
+++ b/src/ext/yuni/src/yuni/core/system/stdint.h
@@ -135,8 +135,8 @@ typedef unsigned int uint;
 #ifdef YUNI_OS_CLANG
 /* Try to fix issues with clang which does not yet support __float128, and produces
 ** compilation error in the STL */
-typedef struct
-{
-    double x, y;
-} __float128;
+/* typedef struct __float128 */
+/* { */
+/*     double x, y; */
+/* } __float128; */
 #endif

--- a/src/ext/yuni/src/yuni/core/system/stdint.h
+++ b/src/ext/yuni/src/yuni/core/system/stdint.h
@@ -131,12 +131,3 @@ typedef double yfloat64;
 /*! Convenient typedef around unsigned int */
 typedef unsigned int uint;
 #endif
-
-#ifdef YUNI_OS_CLANG
-/* Try to fix issues with clang which does not yet support __float128, and produces
-** compilation error in the STL */
-/* typedef struct __float128 */
-/* { */
-/*     double x, y; */
-/* } __float128; */
-#endif

--- a/src/ui/simulator/toolbox/create.h
+++ b/src/ui/simulator/toolbox/create.h
@@ -44,7 +44,7 @@ namespace Component
 ** \param object  A popinter to the object which will receive the onClick event
 ** \param method  The method to bind for the onClick event
 */
-template<class T, class StringT, class UserDataT = void*>
+template<class T, class StringT, class UserDataT>
 wxButton* CreateButton(wxWindow* parent,
                        const StringT& caption,
                        T* object = NULL,

--- a/src/ui/simulator/toolbox/create.hxx
+++ b/src/ui/simulator/toolbox/create.hxx
@@ -64,7 +64,7 @@ namespace Antares
 {
 namespace Component
 {
-template<class T, class StringT, class UserDataT = void*>
+template<class T, class StringT, class UserDataT>
 wxButton* CreateButton(wxWindow* parent,
                        const StringT& caption,
                        T* object,


### PR DESCRIPTION
This PR aims at using clang instead of GCC.
The changes were made to prevent clang compiling error

close #951 

To use clang:
export CC=/usr/bin/clang
export CXX=/usr/bin/clang++
Then build in a new folder

# Benchmark:

run 1 and 2 on power, run 3 on battery
Each bench was run with a starting CPU temp around 40°C to avoid thermal throttling.

## Clang

run 1: 4m 28s
run 2: 4m 18s
run 3: 4m 28s

## GCC

run 1: 6m 22s
run 2: 6m 22s
run 3: 6m 49s

