### PR TITLE
[CentOS 7] Remove deps from docker image

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
           git submodule update --init --recursive src/antares-deps src/tests/resources/Antares_Simulator_Tests
 
-    - name: Get antares-deps
+    - name: Download & extract precompiled deps at root
       run: |
            ANTARES_DEPS_VERSION=$(cut -d'"' -f4 antares-deps-version.json | grep -Ev '\{|\}')
            cd /

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - doc_generation
-    container: 'antaresrte/rte-antares:centos7-simulator'
+    container: 'antaresrte/rte-antares:centos7-simulator-no-deps'
     strategy:
       matrix:
         ortools-xpress: [ON, OFF]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,4 +21,4 @@ jobs:
         workdir: docker
         dockerfile: centos7-basic-requirements
         cache: true
-        tags: centos7-simulator
+        tags: centos7-simulator-no-deps

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: Publish docker images
+on:
+  push:
+    branches:
+      - 'docker/*'
+
+jobs:
+  docker_publish:
+  
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master 
+
+    - name: Docker file push
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: antaresrte/rte-antares
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        workdir: docker
+        dockerfile: centos7-basic-requirements
+        cache: true
+        tags: centos7-simulator

--- a/docker/centos7-basic-requirements
+++ b/docker/centos7-basic-requirements
@@ -10,8 +10,8 @@ RUN yum install -y epel-release
 
 # Install requirements
 RUN yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils rpm-build &&\
-    yum install -y cmake3 devtoolset-9 ccache &&\
-    yum install -y rh-git227-git
+    yum install -y cmake3 devtoolset-9 &&\
+    yum install -y rh-git227-git ccache
 
 # Install simulator requirements
 RUN yum install -y unzip libuuid-devel wxGTK3-devel boost-test boost-devel

--- a/docker/centos7-basic-requirements
+++ b/docker/centos7-basic-requirements
@@ -1,7 +1,5 @@
 FROM centos:7
 
-ARG ANTARES_DEPS_VERSION
-
 # Install requirements : update repo
 RUN yum update -y
 

--- a/docker/centos7-basic-requirements
+++ b/docker/centos7-basic-requirements
@@ -19,4 +19,4 @@ RUN yum install -y unzip libuuid-devel wxGTK3-devel boost-test boost-devel
 # Add python and pip installation
 RUN yum install -y python3-pip &&\
     python3 -m pip install --upgrade pip &&\
-    pip3 install pytest pytest-xdist numpy pandas
+    pip3 install pytest numpy pandas


### PR DESCRIPTION
- Create new tag `centos7-simulator-no-deps` for image antaresrte/rte-antares on dockerHub, a stable image containing only system deps. No OR-Tools, wxWidgets, Sirius, etc.
- Only push to it when the branch's name matches `docker/*`
- Use this new tag for all CentOS jobs