### PR TITLE
Refactor : move current year and week from study to weekly optimization problem

### DIFF
--- a/src/libs/antares/study/runtime/runtime.cpp
+++ b/src/libs/antares/study/runtime/runtime.cpp
@@ -421,18 +421,12 @@ StudyRuntimeInfos::StudyRuntimeInfos(uint nbYearsParallel) :
  bindingConstraint(nullptr),
  thermalPlantTotalCount(0),
  thermalPlantTotalCountMustRun(0),
- quadraticOptimizationHasFailed(false),
- weekInTheYear(nullptr),
- currentYear(nullptr)
+ quadraticOptimizationHasFailed(false)
 {
-    currentYear = new uint[nbYearsParallel];
-    weekInTheYear = new uint[nbYearsParallel];
     // Evite les confusions de numeros de TS entre AMC
     timeseriesNumberYear = new uint[nbYearsParallel];
     for (uint numSpace = 0; numSpace < nbYearsParallel; numSpace++)
     {
-        currentYear[numSpace] = 999999;
-        weekInTheYear[numSpace] = 999999;
         timeseriesNumberYear[numSpace] = 999999;
     }
 }
@@ -711,8 +705,6 @@ StudyRuntimeInfos::~StudyRuntimeInfos()
 {
     logs.debug() << "Releasing runtime data";
 
-    delete[] weekInTheYear;
-    delete[] currentYear;
     delete[] timeseriesNumberYear;
     delete[] areaLink;
     delete[] bindingConstraint;

--- a/src/libs/antares/study/runtime/runtime.h
+++ b/src/libs/antares/study/runtime/runtime.h
@@ -196,16 +196,6 @@ public:
     */
     bool quadraticOptimizationHasFailed;
 
-    /*!
-    ** \brief Store the current week of the simulation during the optimization
-    */
-    unsigned int* weekInTheYear;
-
-    /*!
-    ** \brief Store the current year of the simulation during the optimization
-    */
-    unsigned int* currentYear;
-
 private:
     void initializeBindingConstraints(BindConstList& list);
     void initializeRangeLimits(const Study& study, StudyRangeLimits& limits);

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -378,7 +378,7 @@ RESOLUTION:
     return true;
 }
 
-void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(PROBLEME_HEBDO* Probleme,
+void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(const PROBLEME_HEBDO* Probleme,
                                                     int NumeroDeLIntervalle)
 {
     Yuni::Clob buffer;

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -95,7 +95,7 @@ private:
     clock::time_point end_;
 };
 
-bool OPT_AppelDuSimplexe(PROBLEME_HEBDO* ProblemeHebdo, uint numSpace, int NumIntervalle)
+bool OPT_AppelDuSimplexe(PROBLEME_HEBDO* ProblemeHebdo, int NumIntervalle)
 {
     int Var;
     int Cnt;
@@ -243,7 +243,7 @@ RESOLUTION:
     }
 
     mpsWriterFactory mps_writer_factory(
-      ProblemeHebdo, NumIntervalle, &Probleme, ortoolsUsed, solver, numSpace);
+      ProblemeHebdo, NumIntervalle, &Probleme, ortoolsUsed, solver);
     auto mps_writer = mps_writer_factory.create();
     mps_writer->runIfNeeded(study->resultWriter);
 
@@ -378,15 +378,11 @@ RESOLUTION:
     return true;
 }
 
-void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(void* Prob,
-                                                    uint numSpace,
+void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(PROBLEME_HEBDO* Probleme,
                                                     int NumeroDeLIntervalle)
 {
     Yuni::Clob buffer;
     double CoutOptimalDeLaSolution;
-    PROBLEME_HEBDO* Probleme;
-
-    Probleme = (PROBLEME_HEBDO*)Prob;
 
     CoutOptimalDeLaSolution = 0.;
     if (Probleme->numeroOptimisation[NumeroDeLIntervalle] == PREMIERE_OPTIMISATION)
@@ -397,8 +393,10 @@ void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(void* Prob,
     buffer.appendFormat("* Optimal criterion value :   %11.10e\n", CoutOptimalDeLaSolution);
 
     auto study = Data::Study::Current::Get();
+    int year = Probleme->year;
+    int week = Probleme->weekInTheYear;
     auto optNumber = Probleme->numeroOptimisation[NumeroDeLIntervalle];
-    auto filename = getFilenameWithExtension("criterion", "txt", numSpace, optNumber);
+    auto filename = getFilenameWithExtension("criterion", "txt", year, week, optNumber);
     auto writer = study->resultWriter;
     writer->addEntryFromBuffer(filename, buffer);
 }

--- a/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
@@ -31,16 +31,10 @@
 #include "opt_export_structure.h"
 
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
-#include "../simulation/sim_structure_probleme_economique.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
-#include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
 
 #include <antares/study.h>
-#include <antares/study/area/scratchpad.h>
-#include "../simulation/sim_structure_donnees.h"
 
 using namespace Antares::Data;
 
@@ -117,7 +111,7 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire(PROBLEME_HEBDO* Pro
 
     for (Pdt = 0; Pdt < NombreDePasDeTempsPourUneOptimisation; Pdt++)
     {
-        int timeStepInYear = study->runtime->weekInTheYear[numSpace] * 168 + Pdt;
+        int timeStepInYear = ProblemeHebdo->weekInTheYear * 168 + Pdt;
 
         CorrespondanceVarNativesVarOptim = ProblemeHebdo->CorrespondanceVarNativesVarOptim[Pdt];
         CorrespondanceCntNativesCntOptim = ProblemeHebdo->CorrespondanceCntNativesCntOptim[Pdt];
@@ -1034,7 +1028,7 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire(PROBLEME_HEBDO* Pro
         CorrespondanceVarNativesVarOptim = ProblemeHebdo->CorrespondanceVarNativesVarOptim[Pdt];
         CorrespondanceCntNativesCntOptim = ProblemeHebdo->CorrespondanceCntNativesCntOptim[Pdt];
 
-        int timeStepInYear = study->runtime->weekInTheYear[numSpace] * 168 + Pdt;
+        int timeStepInYear = ProblemeHebdo->weekInTheYear * 168 + Pdt;
 
         for (Pays = 0; Pays < ProblemeHebdo->NombreDePays; Pays++)
         {

--- a/src/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/opt_fonctions.h
@@ -83,7 +83,7 @@ void OPT_DecompteDesVariablesEtDesContraintesDuProblemeAOptimiser(PROBLEME_HEBDO
 void OPT_AugmenterLaTailleDeLaMatriceDesContraintes(PROBLEME_ANTARES_A_RESOUDRE*);
 void OPT_LiberationMemoireDuProblemeAOptimiser(PROBLEME_HEBDO*);
 
-void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(PROBLEME_HEBDO*, int);
+void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(const PROBLEME_HEBDO*, int);
 
 /*------------------------------*/
 

--- a/src/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/opt_fonctions.h
@@ -60,7 +60,7 @@ bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO*);
 **
 ** \return True si l'operation s'est bien deroulee, false si le probleme n'a pas de solution
 */
-bool OPT_AppelDuSimplexe(PROBLEME_HEBDO*, uint, int);
+bool OPT_AppelDuSimplexe(PROBLEME_HEBDO*, int);
 void OPT_LiberationProblemesSimplexe(PROBLEME_HEBDO*);
 bool OPT_OptimisationLineaire(PROBLEME_HEBDO*, uint);
 void OPT_SauvegarderLesPmaxThermiques(PROBLEME_HEBDO*);
@@ -83,7 +83,7 @@ void OPT_DecompteDesVariablesEtDesContraintesDuProblemeAOptimiser(PROBLEME_HEBDO
 void OPT_AugmenterLaTailleDeLaMatriceDesContraintes(PROBLEME_ANTARES_A_RESOUDRE*);
 void OPT_LiberationMemoireDuProblemeAOptimiser(PROBLEME_HEBDO*);
 
-void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(void*, uint, int);
+void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(PROBLEME_HEBDO*, int);
 
 /*------------------------------*/
 

--- a/src/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/opt_fonctions.h
@@ -41,9 +41,9 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeQuadratique(PROBLEME_HEBDO*)
 void OPT_InitialiserLesPminHebdo(PROBLEME_HEBDO*);
 void OPT_InitialiserLesContrainteDEnergieHydrauliqueParIntervalleOptimise(PROBLEME_HEBDO*);
 void OPT_MaxDesPmaxHydrauliques(PROBLEME_HEBDO*);
-void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO*, const int, const int);
+void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO*, const int, const int, const int);
 void OPT_InitialiserLesBornesDesVariablesDuProblemeQuadratique(PROBLEME_HEBDO*, int);
-void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO*, int, int, int);
+void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO*, int, int, int, const int);
 void OPT_InitialiserLeSecondMembreDuProblemeQuadratique(PROBLEME_HEBDO*, int);
 void OPT_InitialiserLesCoutsLineaire(PROBLEME_HEBDO*, const int, const int, uint);
 void OPT_InitialiserLesCoutsQuadratiques(PROBLEME_HEBDO*, int);
@@ -60,11 +60,11 @@ bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO*);
 **
 ** \return True si l'operation s'est bien deroulee, false si le probleme n'a pas de solution
 */
-bool OPT_AppelDuSimplexe(PROBLEME_HEBDO*, int);
+bool OPT_AppelDuSimplexe(PROBLEME_HEBDO*, int, const int);
 void OPT_LiberationProblemesSimplexe(PROBLEME_HEBDO*);
 bool OPT_OptimisationLineaire(PROBLEME_HEBDO*, uint);
 void OPT_SauvegarderLesPmaxThermiques(PROBLEME_HEBDO*);
-void OPT_RestaurerLesDonnees(PROBLEME_HEBDO*);
+void OPT_RestaurerLesDonnees(PROBLEME_HEBDO*, const int);
 /*------------------------------*/
 
 void OPT_CalculerLesPminThermiquesEnFonctionDeMUTetMDT(PROBLEME_HEBDO*);
@@ -83,7 +83,7 @@ void OPT_DecompteDesVariablesEtDesContraintesDuProblemeAOptimiser(PROBLEME_HEBDO
 void OPT_AugmenterLaTailleDeLaMatriceDesContraintes(PROBLEME_ANTARES_A_RESOUDRE*);
 void OPT_LiberationMemoireDuProblemeAOptimiser(PROBLEME_HEBDO*);
 
-void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(const PROBLEME_HEBDO*, int);
+void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(const PROBLEME_HEBDO*, int, const int);
 
 /*------------------------------*/
 

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -102,7 +102,8 @@ double OPT_SommeDesPminThermiques(PROBLEME_HEBDO* ProblemeHebdo, int Pays, int P
 
 void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO* ProblemeHebdo,
                                                             const int PremierPdtDeLIntervalle,
-                                                            const int DernierPdtDeLIntervalle)
+                                                            const int DernierPdtDeLIntervalle, 
+                                                            const int optimizationNumber)
 {
     int PdtHebdo;
     int PdtJour;
@@ -359,7 +360,7 @@ void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO* Prob
             C = ConsommationsAbattues->ConsommationAbattueDuPays[Pays];
 
             bool reserveJm1 = (ProblemeHebdo->YaDeLaReserveJmoins1 == OUI_ANTARES);
-            bool opt1 = (ProblemeAResoudre->NumeroDOptimisation == PREMIERE_OPTIMISATION);
+            bool opt1 = (optimizationNumber == PREMIERE_OPTIMISATION);
             if (reserveJm1 && opt1)
             {
                 C += ProblemeHebdo->ReserveJMoins1[Pays]->ReserveHoraireJMoins1[PdtHebdo];

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -46,7 +46,8 @@ using namespace Yuni;
 void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* ProblemeHebdo,
                                                      int PremierPdtDeLIntervalle,
                                                      int DernierPdtDeLIntervalle,
-                                                     int NumeroDeLIntervalle)
+                                                     int NumeroDeLIntervalle,
+                                                     const int optimizationNumber)
 {
     int Cnt;
     int PdtJour;
@@ -69,7 +70,6 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* ProblemeHeb
     char YaDeLaReserveJmoins1;
     double a;
     char ContrainteDeReserveJMoins1ParZone;
-    char NumeroDOptimisation;
     int NombreDePasDeTempsDUneJournee;
     char* DefaillanceNegativeUtiliserConsoAbattue;
     char* DefaillanceNegativeUtiliserPMinThermique;
@@ -116,7 +116,6 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* ProblemeHeb
     Xmin = ProblemeAResoudre->Xmin;
     Xmax = ProblemeAResoudre->Xmax;
 
-    NumeroDOptimisation = ProblemeAResoudre->NumeroDOptimisation;
     AdresseOuPlacerLaValeurDesCoutsMarginaux
       = ProblemeAResoudre->AdresseOuPlacerLaValeurDesCoutsMarginaux;
 
@@ -158,7 +157,7 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* ProblemeHeb
             SecondMembre[Cnt] = -ConsommationsAbattues->ConsommationAbattueDuPays[Pays];
 
             bool reserveJm1 = (ProblemeHebdo->YaDeLaReserveJmoins1 == OUI_ANTARES);
-            bool opt1 = (ProblemeAResoudre->NumeroDOptimisation == PREMIERE_OPTIMISATION);
+            bool opt1 = (optimizationNumber == PREMIERE_OPTIMISATION);
             if (reserveJm1 && opt1)
             {
                 SecondMembre[Cnt]
@@ -241,7 +240,7 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* ProblemeHeb
                     AdresseOuPlacerLaValeurDesCoutsMarginaux[Cnt] = NULL;
                     SecondMembre[Cnt] = -100.0;
 
-                    if (NumeroDOptimisation == PREMIERE_OPTIMISATION)
+                    if (optimizationNumber == PREMIERE_OPTIMISATION)
                     {
                         ContrainteActivable = NON_ANTARES;
                         if (YaDeLaReserveJmoins1 == OUI_ANTARES)
@@ -273,7 +272,7 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* ProblemeHeb
                     AdresseOuPlacerLaValeurDesCoutsMarginaux[Cnt] = AdresseDuResultat;
 
                     ContrainteActivable = NON_ANTARES;
-                    if (NumeroDOptimisation != PREMIERE_OPTIMISATION)
+                    if (optimizationNumber != PREMIERE_OPTIMISATION)
                     {
                         if (YaDeLaReserveJmoins1 == OUI_ANTARES)
                             ContrainteActivable = OUI_ANTARES;

--- a/src/solver/optimisation/opt_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_optimisation_lineaire.cpp
@@ -42,6 +42,7 @@ bool OPT_OptimisationLineaire(PROBLEME_HEBDO* ProblemeHebdo, uint numSpace)
     int DernierPdtDeLIntervalle;
     int NumeroDeLIntervalle;
     int NombreDePasDeTempsPourUneOptimisation;
+    int optimizationNumber = PREMIERE_OPTIMISATION;
 
     ProblemeHebdo->NombreDePasDeTemps = ProblemeHebdo->NombreDePasDeTempsRef;
     ProblemeHebdo->NombreDePasDeTempsDUneJournee = ProblemeHebdo->NombreDePasDeTempsDUneJourneeRef;
@@ -58,13 +59,11 @@ bool OPT_OptimisationLineaire(PROBLEME_HEBDO* ProblemeHebdo, uint numSpace)
 
     NombreDePasDeTempsPourUneOptimisation = ProblemeHebdo->NombreDePasDeTempsPourUneOptimisation;
 
-    ProblemeHebdo->ProblemeAResoudre->NumeroDOptimisation = PREMIERE_OPTIMISATION;
-
     OPT_NumeroDeJourDuPasDeTemps(ProblemeHebdo);
 
     OPT_NumeroDIntervalleOptimiseDuPasDeTemps(ProblemeHebdo);
 
-    OPT_RestaurerLesDonnees(ProblemeHebdo);
+    OPT_RestaurerLesDonnees(ProblemeHebdo, optimizationNumber);
 
     OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(ProblemeHebdo);
 
@@ -79,28 +78,27 @@ OptimisationHebdo:
         DernierPdtDeLIntervalle = PdtHebdo + NombreDePasDeTempsPourUneOptimisation;
 
         OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(
-          ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle);
+            ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, optimizationNumber);
 
-        OPT_InitialiserLeSecondMembreDuProblemeLineaire(
-          ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, NumeroDeLIntervalle);
+        OPT_InitialiserLeSecondMembreDuProblemeLineaire(ProblemeHebdo,
+                                                        PremierPdtDeLIntervalle,
+                                                        DernierPdtDeLIntervalle,
+                                                        NumeroDeLIntervalle,
+                                                        optimizationNumber);
 
         OPT_InitialiserLesCoutsLineaire(
           ProblemeHebdo, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle, numSpace);
 
-        ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle]++;
-
-        if (!OPT_AppelDuSimplexe(ProblemeHebdo, NumeroDeLIntervalle))
+        if (!OPT_AppelDuSimplexe(ProblemeHebdo, NumeroDeLIntervalle, optimizationNumber))
             return false;
 
         if (ProblemeHebdo->ExportMPS != Data::mpsExportStatus::NO_EXPORT || ProblemeHebdo->Expansion == OUI_ANTARES)
             OPT_EcrireResultatFonctionObjectiveAuFormatTXT(ProblemeHebdo,
-                                                           NumeroDeLIntervalle);
-
-        if (ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle] == DEUXIEME_OPTIMISATION)
-            ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle] = 0;
+                                                           NumeroDeLIntervalle, 
+                                                           optimizationNumber);
     }
 
-    if (ProblemeHebdo->ProblemeAResoudre->NumeroDOptimisation == PREMIERE_OPTIMISATION)
+    if (optimizationNumber == PREMIERE_OPTIMISATION)
     {
         if (ProblemeHebdo->OptimisationAvecCoutsDeDemarrage == NON_ANTARES)
         {
@@ -114,7 +112,7 @@ OptimisationHebdo:
             printf("BUG: l'indicateur ProblemeHebdo->OptimisationAvecCoutsDeDemarrage doit etre "
                    "initialise a OUI_ANTARES ou NON_ANTARES\n");
 
-        ProblemeHebdo->ProblemeAResoudre->NumeroDOptimisation = DEUXIEME_OPTIMISATION;
+        optimizationNumber = DEUXIEME_OPTIMISATION;
 
         if (ProblemeHebdo->Expansion == NON_ANTARES)
             goto OptimisationHebdo;

--- a/src/solver/optimisation/opt_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_optimisation_lineaire.cpp
@@ -25,16 +25,11 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include "opt_structure_probleme_a_resoudre.h"
-
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
-#include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
 
 #include <antares/logs.h>
-#include <antares/study.h>
 #include <antares/emergency.h>
 
 using namespace Antares;
@@ -94,12 +89,12 @@ OptimisationHebdo:
 
         ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle]++;
 
-        if (!OPT_AppelDuSimplexe(ProblemeHebdo, numSpace, NumeroDeLIntervalle))
+        if (!OPT_AppelDuSimplexe(ProblemeHebdo, NumeroDeLIntervalle))
             return false;
 
         if (ProblemeHebdo->ExportMPS != Data::mpsExportStatus::NO_EXPORT || ProblemeHebdo->Expansion == OUI_ANTARES)
-            OPT_EcrireResultatFonctionObjectiveAuFormatTXT(
-              (void*)ProblemeHebdo, numSpace, NumeroDeLIntervalle);
+            OPT_EcrireResultatFonctionObjectiveAuFormatTXT(ProblemeHebdo,
+                                                           NumeroDeLIntervalle);
 
         if (ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle] == DEUXIEME_OPTIMISATION)
             ProblemeHebdo->numeroOptimisation[NumeroDeLIntervalle] = 0;

--- a/src/solver/optimisation/opt_restaurer_les_donnees.cpp
+++ b/src/solver/optimisation/opt_restaurer_les_donnees.cpp
@@ -34,7 +34,7 @@
 #include "opt_fonctions.h"
 #include <iostream>
 
-void OPT_RestaurerLesDonnees(PROBLEME_HEBDO* ProblemeHebdo)
+void OPT_RestaurerLesDonnees(PROBLEME_HEBDO* ProblemeHebdo, const int optimizationNumber)
 {
     int Pays;
     int Interco;
@@ -106,8 +106,7 @@ void OPT_RestaurerLesDonnees(PROBLEME_HEBDO* ProblemeHebdo)
         }
     }
 
-    if (ProblemeHebdo->YaDeLaReserveJmoins1 == OUI_ANTARES
-        && ProblemeHebdo->ProblemeAResoudre->NumeroDOptimisation == PREMIERE_OPTIMISATION)
+    if (ProblemeHebdo->YaDeLaReserveJmoins1 == OUI_ANTARES && optimizationNumber == PREMIERE_OPTIMISATION)
     {
         for (Pdt = 0; Pdt < DernierPasDeTemps; Pdt++)
         {

--- a/src/solver/optimisation/opt_structure_probleme_a_resoudre.h
+++ b/src/solver/optimisation/opt_structure_probleme_a_resoudre.h
@@ -69,9 +69,6 @@ typedef struct
 /* Le probleme a resoudre */
 typedef struct
 {
-    /* Pour la prise en compte des PMIN */
-    char NumeroDOptimisation; /* Vaut	PREMIERE_OPTIMISATION ou DEUXIEME_OPTIMISATION */
-
     /* La matrice des contraintes */
     int NombreDeVariables;
     int NombreDeContraintes; /* Il est egal a :

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -25,18 +25,10 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <yuni/yuni.h>
-#include <antares/study/memory-usage.h>
 #include "adequacy.h"
-#include <antares/study.h>
 #include <antares/exception/UnfeasibleProblemError.hpp>
 #include <antares/exception/AssertionError.hpp>
-#include <yuni/core/math.h>
-#include "simulation.h"
-#include "../optimisation/opt_fonctions.h"
-#include "common-eco-adq.h"
 #include "opt_time_writer.h"
-#include "sim_structure_probleme_economique.h"
 
 using namespace Yuni;
 
@@ -162,6 +154,7 @@ bool Adequacy::year(Progression::Task& progression,
 {
     // No failed week at year start
     failedWeekList.clear();
+    pProblemesHebdo[numSpace]->year = state.year;
 
     PrepareRandomNumbers(study, *pProblemesHebdo[numSpace], randomForYear);
 
@@ -177,7 +170,7 @@ bool Adequacy::year(Progression::Task& progression,
     for (uint w = 0; w != pNbWeeks; ++w)
     {
         state.hourInTheYear = hourInTheYear;
-        state.study.runtime->weekInTheYear[numSpace] = state.weekInTheYear = w;
+        pProblemesHebdo[numSpace]->weekInTheYear = state.weekInTheYear = w;
         pProblemesHebdo[numSpace]->HeureDansLAnnee = hourInTheYear;
 
         ::SIM_RenseignementProblemeHebdo(

--- a/src/solver/simulation/adequacy.h
+++ b/src/solver/simulation/adequacy.h
@@ -27,8 +27,6 @@
 #ifndef __SOLVER_SIMULATION_ADEQUACY_H__
 #define __SOLVER_SIMULATION_ADEQUACY_H__
 
-#include <yuni/yuni.h>
-#include <antares/benchmarking.h>
 #include "../variable/variable.h"
 #include "../variable/adequacy/all.h"
 #include "../variable/economy/all.h"

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -25,16 +25,9 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <yuni/yuni.h>
-#include <antares/study/memory-usage.h>
 #include "economy.h"
-#include <antares/study.h>
 #include <antares/exception/UnfeasibleProblemError.hpp>
 #include <antares/exception/AssertionError.hpp>
-#include <yuni/core/math.h>
-#include "simulation.h"
-#include "../optimisation/opt_fonctions.h"
-#include "common-eco-adq.h"
 #include "opt_time_writer.h"
 
 using namespace Yuni;
@@ -194,6 +187,7 @@ bool Economy::year(Progression::Task& progression,
 {
     // No failed week at year start
     failedWeekList.clear();
+    pProblemesHebdo[numSpace]->year = state.year;
 
     PrepareRandomNumbers(study, *pProblemesHebdo[numSpace], randomForYear);
 
@@ -209,7 +203,7 @@ bool Economy::year(Progression::Task& progression,
     for (uint w = 0; w != pNbWeeks; ++w)
     {
         state.hourInTheYear = hourInTheYear;
-        state.study.runtime->weekInTheYear[numSpace] = state.weekInTheYear = w;
+        pProblemesHebdo[numSpace]->weekInTheYear = state.weekInTheYear = w;
         pProblemesHebdo[numSpace]->HeureDansLAnnee = hourInTheYear;
 
         ::SIM_RenseignementProblemeHebdo(

--- a/src/solver/simulation/economy.h
+++ b/src/solver/simulation/economy.h
@@ -27,9 +27,6 @@
 #ifndef __SOLVER_SIMULATION_ECONOMY_H__
 #define __SOLVER_SIMULATION_ECONOMY_H__
 
-#include <yuni/yuni.h>
-#include <memory>
-#include <antares/benchmarking.h>
 #include "../variable/variable.h"
 #include "../variable/economy/all.h"
 #include "../variable/state.h"

--- a/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
+++ b/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
@@ -573,7 +573,6 @@ void SIM_AllocationProblemeHebdo(PROBLEME_HEBDO& problem, int NombreDePasDeTemps
         }
     }
 
-    problem.numeroOptimisation = (int*)MemAlloc(7 * sizeof(int));
     problem.coutOptimalSolution1 = (double*)MemAlloc(7 * sizeof(double));
     problem.coutOptimalSolution2 = (double*)MemAlloc(7 * sizeof(double));
 
@@ -900,7 +899,6 @@ void SIM_DesallocationProblemeHebdo(PROBLEME_HEBDO& problem)
 
     MemFree(problem.BruitSurCoutHydraulique);
 
-    MemFree(problem.numeroOptimisation);
     MemFree(problem.coutOptimalSolution1);
     MemFree(problem.coutOptimalSolution2);
     MemFree(problem.tempsResolution1);

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -320,7 +320,6 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem,
 
     for (int opt = 0; opt < 7; opt++)
     {
-        problem.numeroOptimisation[opt] = 0;
         problem.coutOptimalSolution1[opt] = 0.;
         problem.coutOptimalSolution2[opt] = 0.;
         problem.tempsResolution1[opt] = 0.;

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -25,21 +25,11 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <yuni/yuni.h>
-#include <yuni/core/math.h>
 #include <antares/study.h>
 #include <antares/study/area/constants.h>
 #include <antares/study/area/scratchpad.h>
-#include <antares/study/parts/hydro/container.h>
 
 #include "simulation.h"
-
-#include "sim_structure_donnees.h"
-#include "sim_structure_probleme_economique.h"
-#include "sim_structure_probleme_adequation.h"
-#include "sim_extern_variables_globales.h"
-#include "../optimisation/opt_fonctions.h"
-#include "../optimisation/opt_structure_probleme_a_resoudre.h"
 
 #include <antares/emergency.h>
 
@@ -441,14 +431,14 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem,
             double nivInit = problem.CaracteristiquesHydrauliques[k]->NiveauInitialReservoir;
             if (nivInit < 0.)
             {
-                logs.fatal() << "Area " << area.name << ", week " << state.weekInTheYear + 1
+                logs.fatal() << "Area " << area.name << ", week " << problem.weekInTheYear + 1
                              << " : initial level < 0";
                 AntaresSolverEmergencyShutdown();
             }
 
             if (nivInit > area.hydro.reservoirCapacity)
             {
-                logs.fatal() << "Area " << area.name << ", week " << state.weekInTheYear + 1
+                logs.fatal() << "Area " << area.name << ", week " << problem.weekInTheYear + 1
                              << " : initial level over capacity";
                 AntaresSolverEmergencyShutdown();
             }

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -490,6 +490,10 @@ struct AdequacyPatchParameters
 
 struct PROBLEME_HEBDO
 {
+    int dayInTheYear = 0;
+    int weekInTheYear = 0;
+    int year = 0;
+    
     /* Business problem */
     char OptimisationAuPasHebdomadaire;
     char TypeDeLissageHydraulique;

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -586,8 +586,6 @@ struct PROBLEME_HEBDO
     int* NumeroDeVariableStockFinal;
     int** NumeroDeVariableDeTrancheDeStock;
 
-    int* numeroOptimisation;
-
     char YaDeLaReserveJmoins1;
     char ContrainteDeReserveJMoins1ParZone;
     int NombreDeZonesDeReserveJMoins1;

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -490,9 +490,9 @@ struct AdequacyPatchParameters
 
 struct PROBLEME_HEBDO
 {
-    int dayInTheYear = 0;
-    int weekInTheYear = 0;
-    int year = 0;
+    uint dayInTheYear = 0;
+    uint weekInTheYear = 0;
+    uint year = 0;
     
     /* Business problem */
     char OptimisationAuPasHebdomadaire;

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -1586,7 +1586,6 @@ void ISimulation<Impl>::loopThroughYears(uint firstYear,
                 yearPerformed = true;
                 numSpace = set_it->performedYearToSpace[y];
                 study.runtime->timeseriesNumberYear[numSpace] = y;
-                study.runtime->currentYear[numSpace] = y;
             }
 
             // If the year has not to be rerun, we skip the computation of the year.

--- a/src/solver/utils/filename.cpp
+++ b/src/solver/utils/filename.cpp
@@ -4,14 +4,14 @@
 
 std::string getFilenameWithExtension(const YString& prefix,
                                      const YString& extension,
-                                     uint numSpace,
+                                     int year,
+                                     int week,
                                      int optNumber)
 {
-    auto study = Data::Study::Current::Get();
     std::ostringstream outputFile;
-    outputFile << prefix.c_str() << "-" // problem ou criterion
-               << std::to_string(study->runtime->currentYear[numSpace] + 1) << "-"
-               << std::to_string(study->runtime->weekInTheYear[numSpace] + 1);
+    outputFile << prefix.c_str() << "-"
+               << std::to_string(year + 1) << "-"
+               << std::to_string(week + 1);
 
     if (optNumber)
         outputFile << "--optim-nb-" << std::to_string(optNumber);

--- a/src/solver/utils/filename.cpp
+++ b/src/solver/utils/filename.cpp
@@ -4,9 +4,9 @@
 
 std::string getFilenameWithExtension(const YString& prefix,
                                      const YString& extension,
-                                     int year,
-                                     int week,
-                                     int optNumber)
+                                     uint year,
+                                     uint week,
+                                     uint optNumber)
 {
     std::ostringstream outputFile;
     outputFile << prefix.c_str() << "-"

--- a/src/solver/utils/filename.h
+++ b/src/solver/utils/filename.h
@@ -5,5 +5,6 @@
 
 std::string getFilenameWithExtension(const YString& prefix,
                                      const YString& extension,
-                                     uint numSpace,
+                                     int year,
+                                     int week,
                                      int optNumber = 0);

--- a/src/solver/utils/filename.h
+++ b/src/solver/utils/filename.h
@@ -5,6 +5,6 @@
 
 std::string getFilenameWithExtension(const YString& prefix,
                                      const YString& extension,
-                                     int year,
-                                     int week,
-                                     int optNumber = 0);
+                                     uint year,
+                                     uint week,
+                                     uint optNumber = 0);

--- a/src/solver/utils/mps_utils.cpp
+++ b/src/solver/utils/mps_utils.cpp
@@ -362,11 +362,13 @@ void fullOrToolsMPSwriter::runIfNeeded(Solver::IResultWriter::Ptr writer)
 
 mpsWriterFactory::mpsWriterFactory(PROBLEME_HEBDO* ProblemeHebdo,
                                    int NumIntervalle,
+                                   const int current_optim_number,
                                    PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
                                    bool ortoolsUsed,
                                    MPSolver* solver) :
  pb_hebdo_(ProblemeHebdo),
  num_intervalle_(NumIntervalle),
+ current_optim_number_(current_optim_number),
  named_splx_problem_(named_splx_problem),
  ortools_used_(ortoolsUsed),
  solver_(solver)
@@ -374,7 +376,6 @@ mpsWriterFactory::mpsWriterFactory(PROBLEME_HEBDO* ProblemeHebdo,
     week_ = pb_hebdo_->weekInTheYear;
     year_ = pb_hebdo_->year;
     
-    current_optim_number_ = pb_hebdo_->numeroOptimisation[num_intervalle_];
     export_mps_ = pb_hebdo_->ExportMPS;
     export_mps_on_error_ = pb_hebdo_->exportMPSOnError;
 }

--- a/src/solver/utils/mps_utils.cpp
+++ b/src/solver/utils/mps_utils.cpp
@@ -165,9 +165,9 @@ static void printRHS(Clob& buffer, int NombreDeContraintes, const double* Second
 
 void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(
     void* Prob,
-    int year,
-    int week,
-    int optNumber,
+    uint year,
+    uint week,
+    uint optNumber,
     Solver::IResultWriter::Ptr writer)
 {
     Clob buffer;
@@ -324,9 +324,9 @@ void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(
 // Full mps writing
 // --------------------
 fullMPSwriter::fullMPSwriter(PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
-                             int year,
-                             int week,
-                             int optNumber) :
+                             uint year,
+                             uint week,
+                             uint optNumber) :
     I_MPS_writer(year, week, optNumber),
     named_splx_problem_(named_splx_problem)
 {}
@@ -344,16 +344,15 @@ void fullMPSwriter::runIfNeeded(Solver::IResultWriter::Ptr writer)
 // Full mps writing by or-tools
 // ---------------------------------
 fullOrToolsMPSwriter::fullOrToolsMPSwriter(MPSolver* solver,
-                                           int year,
-                                           int week,
-                                           int optNumber) :
+                                           uint year,
+                                           uint week,
+                                           uint optNumber) :
     I_MPS_writer(year, week, optNumber),
     solver_(solver)
 {
 }
 void fullOrToolsMPSwriter::runIfNeeded(Solver::IResultWriter::Ptr writer)
 {
-    // Make or-tools print the MPS files leads to a crash !
     ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(solver_,
                                                   year_,
                                                   week_,

--- a/src/solver/utils/mps_utils.cpp
+++ b/src/solver/utils/mps_utils.cpp
@@ -163,8 +163,12 @@ static void printRHS(Clob& buffer, int NombreDeContraintes, const double* Second
     }
 }
 
-void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(void* Prob, int optNumber, uint numSpace
-    , Solver::IResultWriter::Ptr writer)
+void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(
+    void* Prob,
+    int year,
+    int week,
+    int optNumber,
+    Solver::IResultWriter::Ptr writer)
 {
     Clob buffer;
     int Cnt;
@@ -308,7 +312,7 @@ void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(void* Prob, int optNumber, uint n
 
     buffer.appendFormat("ENDATA\n");
 
-    auto filename = getFilenameWithExtension("problem", "mps", numSpace, optNumber);
+    auto filename = getFilenameWithExtension("problem", "mps", year, week, optNumber);
     writer->addEntryFromBuffer(filename, buffer);
 
     free(Cdeb);
@@ -320,49 +324,60 @@ void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(void* Prob, int optNumber, uint n
 // Full mps writing
 // --------------------
 fullMPSwriter::fullMPSwriter(PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
-                             int optNumber,
-                             uint thread_number) :
- named_splx_problem_(named_splx_problem),
- current_optim_number_(optNumber),
- thread_number_(thread_number)
-{
-}
+                             int year,
+                             int week,
+                             int optNumber) :
+    I_MPS_writer(year, week, optNumber),
+    named_splx_problem_(named_splx_problem)
+{}
+
 void fullMPSwriter::runIfNeeded(Solver::IResultWriter::Ptr writer)
 {
-    OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(
-      (void*)named_splx_problem_, current_optim_number_, thread_number_, writer);
+    OPT_EcrireJeuDeDonneesLineaireAuFormatMPS((void*)named_splx_problem_,
+                                              year_,
+                                              week_,
+                                              current_optim_number_,
+                                              writer);
 }
 
 // ---------------------------------
 // Full mps writing by or-tools
 // ---------------------------------
-fullOrToolsMPSwriter::fullOrToolsMPSwriter(MPSolver* solver, int optNumber, uint thread_number) :
- solver_(solver), current_optim_number_(optNumber), thread_number_(thread_number)
+fullOrToolsMPSwriter::fullOrToolsMPSwriter(MPSolver* solver,
+                                           int year,
+                                           int week,
+                                           int optNumber) :
+    I_MPS_writer(year, week, optNumber),
+    solver_(solver)
 {
 }
 void fullOrToolsMPSwriter::runIfNeeded(Solver::IResultWriter::Ptr writer)
 {
     // Make or-tools print the MPS files leads to a crash !
-    ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(solver_, thread_number_, current_optim_number_, writer);
+    ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(solver_,
+                                                  year_,
+                                                  week_,
+                                                  current_optim_number_,
+                                                  writer);
 }
 
 mpsWriterFactory::mpsWriterFactory(PROBLEME_HEBDO* ProblemeHebdo,
                                    int NumIntervalle,
                                    PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
                                    bool ortoolsUsed,
-                                   MPSolver* solver,
-                                   uint thread_number) :
+                                   MPSolver* solver) :
  pb_hebdo_(ProblemeHebdo),
  num_intervalle_(NumIntervalle),
  named_splx_problem_(named_splx_problem),
  ortools_used_(ortoolsUsed),
- solver_(solver),
- thread_number_(thread_number)
+ solver_(solver)
 {
+    week_ = pb_hebdo_->weekInTheYear;
+    year_ = pb_hebdo_->year;
+    
     current_optim_number_ = pb_hebdo_->numeroOptimisation[num_intervalle_];
     export_mps_ = pb_hebdo_->ExportMPS;
     export_mps_on_error_ = pb_hebdo_->exportMPSOnError;
-    is_first_week_of_year_ = pb_hebdo_->firstWeekOfSimulation;
 }
 
 bool mpsWriterFactory::doWeExportMPS()
@@ -404,12 +419,16 @@ std::unique_ptr<I_MPS_writer> mpsWriterFactory::createFullmpsWriter()
 {
     if (ortools_used_)
     {
-        return std::make_unique<fullOrToolsMPSwriter>(
-          solver_, current_optim_number_, thread_number_);
+        return std::make_unique<fullOrToolsMPSwriter>(solver_,
+                                                      year_,
+                                                      week_,
+                                                      current_optim_number_);
     }
     else
     {
-        return std::make_unique<fullMPSwriter>(
-          named_splx_problem_, current_optim_number_, thread_number_);
+        return std::make_unique<fullMPSwriter>(named_splx_problem_,
+                                               year_,
+                                               week_,
+                                               current_optim_number_);
     }
 }

--- a/src/solver/utils/mps_utils.h
+++ b/src/solver/utils/mps_utils.h
@@ -19,6 +19,7 @@ using namespace operations_research;
 void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(void*,
                                                uint,
                                                uint,
+                                               uint,
                                                Solver::IResultWriter::Ptr writer);
 
 // ======================
@@ -28,25 +29,25 @@ void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(void*,
 class I_MPS_writer
 {
 public:
-    I_MPS_writer(int year, int week, int currentOptimNumber) : 
-       year_(year), week_(week), current_optim_number_(currentOptimNumber)
+    I_MPS_writer(uint year, uint week, uint currentOptimNumber) :
+        year_(year), week_(week), current_optim_number_(currentOptimNumber)
     {}
     I_MPS_writer() = default;
     virtual void runIfNeeded(Solver::IResultWriter::Ptr writer) = 0;
 
 protected:
-    int year_ = 0;
-    int week_ = 0;
-    int current_optim_number_ = 0;
+    uint year_ = 0;
+    uint week_ = 0;
+    uint current_optim_number_ = 0;
 };
 
 class fullMPSwriter final : public I_MPS_writer
 {
 public:
     fullMPSwriter(PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
-                  int year,
-                  int week,
-                  int currentOptimNumber);
+                  uint year,
+                  uint week,
+                  uint currentOptimNumber);
     void runIfNeeded(Solver::IResultWriter::Ptr writer) override;
 
 private:
@@ -57,9 +58,9 @@ class fullOrToolsMPSwriter : public I_MPS_writer
 {
 public:
     fullOrToolsMPSwriter(MPSolver* solver, 
-                         int year, 
-                         int week, 
-                         int currentOptimNumber);
+                         uint year, 
+                         uint week, 
+                         uint currentOptimNumber);
     void runIfNeeded(Solver::IResultWriter::Ptr writer) override;
 
 private:
@@ -99,11 +100,11 @@ private:
     PROBLEME_SIMPLEXE_NOMME* named_splx_problem_ = nullptr;
     bool ortools_used_;
     MPSolver* solver_ = nullptr;
-    int current_optim_number_;
+    uint current_optim_number_;
     Data::mpsExportStatus export_mps_;
     bool export_mps_on_error_;
 
     // About optimization period
-    int week_ = 0;
-    int year_ = 0;
+    uint week_ = 0;
+    uint year_ = 0;
 };

--- a/src/solver/utils/mps_utils.h
+++ b/src/solver/utils/mps_utils.h
@@ -82,6 +82,7 @@ class mpsWriterFactory
 public:
     mpsWriterFactory(PROBLEME_HEBDO* ProblemeHebdo,
                      int NumIntervalle,
+                     const int current_optim_number,
                      PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
                      bool ortoolsUsed,
                      MPSolver* solver);

--- a/src/solver/utils/mps_utils.h
+++ b/src/solver/utils/mps_utils.h
@@ -31,13 +31,12 @@ public:
     I_MPS_writer(int year, int week, int currentOptimNumber) : 
        year_(year), week_(week), current_optim_number_(currentOptimNumber)
     {}
-    I_MPS_writer()
-    {}
+    I_MPS_writer() = default;
     virtual void runIfNeeded(Solver::IResultWriter::Ptr writer) = 0;
 
 protected:
-    int week_ = 0;
     int year_ = 0;
+    int week_ = 0;
     int current_optim_number_ = 0;
 };
 
@@ -48,7 +47,7 @@ public:
                   int year,
                   int week,
                   int currentOptimNumber);
-    void runIfNeeded(Solver::IResultWriter::Ptr writer);
+    void runIfNeeded(Solver::IResultWriter::Ptr writer) override;
 
 private:
     PROBLEME_SIMPLEXE_NOMME* named_splx_problem_ = nullptr;
@@ -61,7 +60,7 @@ public:
                          int year, 
                          int week, 
                          int currentOptimNumber);
-    void runIfNeeded(Solver::IResultWriter::Ptr writer);
+    void runIfNeeded(Solver::IResultWriter::Ptr writer) override;
 
 private:
     MPSolver* solver_ = nullptr;
@@ -70,10 +69,7 @@ private:
 class nullMPSwriter : public I_MPS_writer
 {
 public:
-    nullMPSwriter() : I_MPS_writer()
-    {
-    }
-
+    using I_MPS_writer::I_MPS_writer;
     void runIfNeeded(Solver::IResultWriter::Ptr /*writer*/) override
     {
         // Does nothing

--- a/src/solver/utils/mps_utils.h
+++ b/src/solver/utils/mps_utils.h
@@ -28,39 +28,52 @@ void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(void*,
 class I_MPS_writer
 {
 public:
-    I_MPS_writer() = default;
+    I_MPS_writer(int year, int week, int currentOptimNumber) : 
+       year_(year), week_(week), current_optim_number_(currentOptimNumber)
+    {}
+    I_MPS_writer()
+    {}
     virtual void runIfNeeded(Solver::IResultWriter::Ptr writer) = 0;
+
+protected:
+    int week_ = 0;
+    int year_ = 0;
+    int current_optim_number_ = 0;
 };
 
 class fullMPSwriter final : public I_MPS_writer
 {
 public:
     fullMPSwriter(PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
-                  int currentOptimNumber,
-                  uint thread_number);
+                  int year,
+                  int week,
+                  int currentOptimNumber);
     void runIfNeeded(Solver::IResultWriter::Ptr writer);
 
 private:
     PROBLEME_SIMPLEXE_NOMME* named_splx_problem_ = nullptr;
-    int current_optim_number_;
-    uint thread_number_;
 };
 
 class fullOrToolsMPSwriter : public I_MPS_writer
 {
 public:
-    fullOrToolsMPSwriter(MPSolver* solver, int currentOptimNumber, uint thread_number);
+    fullOrToolsMPSwriter(MPSolver* solver, 
+                         int year, 
+                         int week, 
+                         int currentOptimNumber);
     void runIfNeeded(Solver::IResultWriter::Ptr writer);
 
 private:
     MPSolver* solver_ = nullptr;
-    int current_optim_number_;
-    uint thread_number_;
 };
 
 class nullMPSwriter : public I_MPS_writer
 {
 public:
+    nullMPSwriter() : I_MPS_writer()
+    {
+    }
+
     void runIfNeeded(Solver::IResultWriter::Ptr /*writer*/) override
     {
         // Does nothing
@@ -74,8 +87,7 @@ public:
                      int NumIntervalle,
                      PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
                      bool ortoolsUsed,
-                     MPSolver* solver,
-                     uint thread_number);
+                     MPSolver* solver);
 
     std::unique_ptr<I_MPS_writer> create();
     std::unique_ptr<I_MPS_writer> createOnOptimizationError();
@@ -91,9 +103,11 @@ private:
     PROBLEME_SIMPLEXE_NOMME* named_splx_problem_ = nullptr;
     bool ortools_used_;
     MPSolver* solver_ = nullptr;
-    uint thread_number_;
     int current_optim_number_;
     Data::mpsExportStatus export_mps_;
     bool export_mps_on_error_;
-    bool is_first_week_of_year_;
+
+    // About optimization period
+    int week_ = 0;
+    int year_ = 0;
 };

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -234,9 +234,9 @@ static void removeTemporaryFile(const std::string& tmpPath)
 }
 
 void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
-                                                   int year,
-                                                   int week,
-                                                   int const numOptim,
+                                                   uint year,
+                                                   uint week,
+                                                   uint const numOptim,
                                                    Antares::Solver::IResultWriter::Ptr writer)
 {
     // 1. Determine filename

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -234,12 +234,13 @@ static void removeTemporaryFile(const std::string& tmpPath)
 }
 
 void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
-                                                   size_t numSpace,
+                                                   int year,
+                                                   int week,
                                                    int const numOptim,
                                                    Antares::Solver::IResultWriter::Ptr writer)
 {
     // 1. Determine filename
-    const auto filename = getFilenameWithExtension("problem", "mps", numSpace, numOptim);
+    const auto filename = getFilenameWithExtension("problem", "mps", year, week, numOptim);
     const auto tmpPath = generateTempPath(filename);
 
     // 2. Write MPS to temporary file

--- a/src/solver/utils/ortools_utils.h
+++ b/src/solver/utils/ortools_utils.h
@@ -10,7 +10,11 @@
 
 using namespace operations_research;
 
-void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver, size_t numSpace, int const n, Antares::Solver::IResultWriter::Ptr writer);
+void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
+                                                   int year,
+                                                   int week,
+                                                   int const numOptim,
+                                                   Antares::Solver::IResultWriter::Ptr writer);
 
 /*!
  *  \brief Return list of available ortools solver name on our side

--- a/src/solver/utils/ortools_utils.h
+++ b/src/solver/utils/ortools_utils.h
@@ -11,9 +11,9 @@
 using namespace operations_research;
 
 void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
-                                                   int year,
-                                                   int week,
-                                                   int const numOptim,
+                                                   uint year,
+                                                   uint week,
+                                                   uint const numOptim,
                                                    Antares::Solver::IResultWriter::Ptr writer);
 
 /*!


### PR DESCRIPTION
The purpose is to move the information of the current year and week from the Study to the weekly optimization problem.
Why ?
- Because weekly problem is more the location of current year and week (the problem knows what year and week it's solving)
- It makes the code cleaner (reduces dependency on the study)
- It makes easier some changes to come (export MPS files when optimization is daily)

Some collateral cleanings were also made.