### PR TITLE
Restore failures in GH actions

### DIFF
--- a/.github/workflows/run-tests/action.yml
+++ b/.github/workflows/run-tests/action.yml
@@ -28,7 +28,7 @@ runs:
     run: |
            cd _build
            ctest -C Release --output-on-failure -R json
-           echo "RET_CODE=$?" >> GITTHUB_ENV
+           echo "RET_CODE=$?" >> $GITHUB_ENV
 
   - name: Clean batches
     shell: bash

--- a/simtest.json
+++ b/simtest.json
@@ -1,3 +1,3 @@
 {
-    "version": "v8.3.2"
+    "version": "v8.4.1"
 }


### PR DESCRIPTION
Our results changed slightly, some `ctest` executions failed. But that wasn't reported by GH Actions