### PR TITLE
De-duplicate OPT_Export_add_variable by using `std::optional<int>`

### DIFF
--- a/src/solver/optimisation/opt_export_structure.cpp
+++ b/src/solver/optimisation/opt_export_structure.cpp
@@ -69,9 +69,9 @@ void OPT_ExportInterco(const Antares::Solver::IResultWriter::Ptr writer,
     for (int i(0); i < ProblemeHebdo->NombreDInterconnexions; ++i)
     {
         Flot.appendFormat("%d %d %d\n",
-                            i,
-                            ProblemeHebdo->PaysOrigineDeLInterconnexion[i],
-                            ProblemeHebdo->PaysExtremiteDeLInterconnexion[i]);
+                          i,
+                          ProblemeHebdo->PaysOrigineDeLInterconnexion[i],
+                          ProblemeHebdo->PaysExtremiteDeLInterconnexion[i]);
     }
     std::string filename = "interco.txt";
     writer->addEntryFromBuffer(filename, Flot);
@@ -93,23 +93,7 @@ void OPT_Export_add_variable(std::vector<std::string>& varname,
                              int Var,
                              Antares::Data::Enum::ExportStructDict structDict,
                              int firstVal,
-                             int secondVal)
-{
-    if ((int)varname.size() > Var && varname[Var].empty())
-    {
-        std::stringstream buffer;
-        buffer << Var << " ";
-        buffer << Antares::Data::Enum::toString(structDict) << " ";
-        buffer << firstVal << " ";
-        buffer << secondVal;
-        varname[Var] = buffer.str();
-    }
-}
-
-void OPT_Export_add_variable(std::vector<std::string>& varname,
-                             int Var,
-                             Antares::Data::Enum::ExportStructDict structDict,
-                             int firstVal)
+                             std::optional<int> secondVal)
 {
     if ((int)varname.size() > Var && varname[Var].empty())
     {
@@ -117,6 +101,10 @@ void OPT_Export_add_variable(std::vector<std::string>& varname,
         buffer << Var << " ";
         buffer << Antares::Data::Enum::toString(structDict) << " ";
         buffer << firstVal;
+        if (secondVal)
+        {
+            buffer << " " << *secondVal;
+        }
         varname[Var] = buffer.str();
     }
 }

--- a/src/solver/optimisation/opt_export_structure.cpp
+++ b/src/solver/optimisation/opt_export_structure.cpp
@@ -101,9 +101,9 @@ void OPT_Export_add_variable(std::vector<std::string>& varname,
         buffer << Var << " ";
         buffer << Antares::Data::Enum::toString(structDict) << " ";
         buffer << firstVal;
-        if (secondVal)
+        if (secondVal.has_value())
         {
-            buffer << " " << *secondVal;
+            buffer << " " << secondVal.value();
         }
         varname[Var] = buffer.str();
     }

--- a/src/solver/optimisation/opt_export_structure.h
+++ b/src/solver/optimisation/opt_export_structure.h
@@ -28,6 +28,7 @@
 #define __EXPORT_STRUCTURE__
 
 #include <vector>
+#include <optional>
 #include <string>
 
 #include <yuni/yuni.h>
@@ -67,12 +68,7 @@ void OPT_Export_add_variable(std::vector<std::string>& varname,
                              int Var,
                              Antares::Data::Enum::ExportStructDict structDict,
                              int firstVal,
-                             int secondVal);
-void OPT_Export_add_variable(std::vector<std::string>& varname,
-                             int Var,
-                             Antares::Data::Enum::ExportStructDict structDict,
-                             int firstVal);
-
+                             std::optional<int> secondVal = std::nullopt);
 void OPT_ExportInterco(const Antares::Solver::IResultWriter::Ptr writer,
                        PROBLEME_HEBDO* ProblemeHebdo);
 void OPT_ExportAreaName(Antares::Solver::IResultWriter::Ptr writer,


### PR DESCRIPTION
### Before
Two functions, one with an additional `int` argument `secondVal`

### After
One single function, with an `optional` argument. It works much like a pointer
```cpp
std::optional<int> p;
if (p) {
   int& v = *p;
}
// equivalent
if (p.has_value())
{
   int& v = p.value();
}
```