### PR TITLE
Use std::vector<bool> for yearsFilter

### DIFF
--- a/src/libs/antares/study/memory-usage.cpp
+++ b/src/libs/antares/study/memory-usage.cpp
@@ -54,9 +54,9 @@ StudyMemoryUsage::StudyMemoryUsage(const Study& s) :
 {
     // alias to parameters
     auto& parameters = study.parameters;
-
+    assert(parameters.yearsFilter.size() == years && "Invalid size for yearsFilter");
     // playlist
-    if (parameters.userPlaylist and parameters.yearsFilter)
+    if (parameters.userPlaylist && !parameters.yearsFilter.empty())
     {
         uint y = 0;
         for (uint i = 0; i != years; ++i)

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -249,7 +249,7 @@ public:
     //! Custom playlist (each year will be manually selected by the user)
     bool userPlaylist;
     //! Flag to perform the calculations or not from the solver
-    bool* yearsFilter;
+    std::vector<bool> yearsFilter;
 
     //! Custom variable selection (each variable will be manually selected for print by the user)
     bool thematicTrimming;

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -159,8 +159,7 @@ void Study::createAsNew()
     // Source)
     parameters.renewableGeneration.rgModelling = Antares::Data::rgClusters;
 
-    parameters.yearsFilter = new bool[1];
-    parameters.yearsFilter[0] = true;
+    parameters.yearsFilter = std::vector<bool>(1, true);
 
     // Sets
     setsOfAreas.defaultForAreas();

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -1085,7 +1085,7 @@ uint ISimulation<Impl>::buildSetsOfParallelYears(
   std::vector<setOfParallelYears>& setsOfParallelYears)
 {
     // Filter on the years
-    const bool* yearsFilter = study.parameters.yearsFilter;
+    const auto& yearsFilter = study.parameters.yearsFilter;
 
     // number max of years (to be executed or not) in a set of parallel years
     uint maxNbYearsPerformed = 0;

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/mc-playlist.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/mc-playlist.cpp
@@ -91,7 +91,6 @@ bool MCPlaylist::cellValue(int x, int y, const Yuni::String& value)
         case MCPlaylistCol::STATUS:
         {
             bool v = s.to<bool>() || s == "active" || s == "enabled";
-            assert(study->parameters.yearsFilter);
             study->parameters.yearsFilter[y] = v;
             break;
         }
@@ -128,7 +127,6 @@ double MCPlaylist::cellNumericValue(int x, int y) const
         {
         case MCPlaylistCol::STATUS:
         {
-            assert(study->parameters.yearsFilter);
             return study->parameters.yearsFilter[y];
         }
         case MCPlaylistCol::WEIGHT:
@@ -150,7 +148,6 @@ wxString MCPlaylist::cellValue(int x, int y) const
         {
         case MCPlaylistCol::STATUS:
         {
-            assert(study->parameters.yearsFilter);
             return study->parameters.yearsFilter[y] ? wxT("Active") : wxT("skip");
         }
         case MCPlaylistCol::WEIGHT:
@@ -173,7 +170,6 @@ IRenderer::CellStyle MCPlaylist::cellStyle(int, int y) const
 {
     if (!(!study) && (uint)y < study->parameters.nbYears)
     {
-        assert(study->parameters.yearsFilter);
         return !study->parameters.yearsFilter[y] ? IRenderer::cellStyleConstraintNoWeight
                                                  : IRenderer::cellStyleConstraintWeight;
     }

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/scenario-builder-renderer-base.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/scenario-builder-renderer-base.cpp
@@ -102,7 +102,7 @@ IRenderer::CellStyle ScBuilderRendererBase::cellStyle(int x, int y) const
     if (valid)
     {
         auto& parameters = study->parameters;
-        if (parameters.userPlaylist && parameters.yearsFilter)
+        if (parameters.userPlaylist)
             valid = parameters.yearsFilter[x];
     }
     return alternateEnabledDisabled(y, valid);


### PR DESCRIPTION
Modification for PR #892  (bugfix)

Using `std::vector` is both safer and easier to read than C arrays.