### PR TITLE
Fix MPS tests on Windows

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -155,6 +155,13 @@ jobs:
            cd _build
            ctest -C Release --output-on-failure -R mps
 
+    - name: Upload build on failure
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: MPS-diff
+        path: ${{ github.workspace }}/src/tests/mps
+
     # simtest
     - name: Read simtest version
       id: simtest-version

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -121,7 +121,6 @@ bool OPT_AppelDuSimplexe(PROBLEME_HEBDO* ProblemeHebdo, uint numSpace, int NumIn
     bool ortoolsUsed = study->parameters.ortoolsUsed;
 
     const int opt = ProblemeHebdo->numeroOptimisation[NumIntervalle] - 1;
-    logs.notice() << "OPT_AppelDuSimplexe" << opt;
     assert(opt >= 0 && opt < 2);
     OptimizationStatistics* optimizationStatistics = &(ProblemeHebdo->optimizationStatistics[opt]);
 

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -121,6 +121,7 @@ bool OPT_AppelDuSimplexe(PROBLEME_HEBDO* ProblemeHebdo, uint numSpace, int NumIn
     bool ortoolsUsed = study->parameters.ortoolsUsed;
 
     const int opt = ProblemeHebdo->numeroOptimisation[NumIntervalle] - 1;
+    logs.notice() << "OPT_AppelDuSimplexe" << opt;
     assert(opt >= 0 && opt < 2);
     OptimizationStatistics* optimizationStatistics = &(ProblemeHebdo->optimizationStatistics[opt]);
 

--- a/src/tests/mps/test_mps.py
+++ b/src/tests/mps/test_mps.py
@@ -2,7 +2,6 @@ import pytest
 import tarfile as tf
 from pathlib import Path
 import subprocess
-import filecmp
 
 class StudyReference(object):
 
@@ -35,7 +34,9 @@ class StudyReference(object):
 
         zipped_list = [(ref, output) for ref in ref_files for output in output_files if ref.name == output.name]
         for pair in zipped_list:
-            assert filecmp.cmp(pair[0], pair[1]), f"Difference between files {pair[0]} and {pair[1]}"
+            ref_content = open(pair[0]).read()
+            output_content = open(pair[1]).read()
+            assert ref_content == output_content, f"Difference between files {pair[0]} and {pair[1]}"
 
 def test_mps_025(solver_path, reference_archive_path, use_ortools, ortools_solver):
     reference = StudyReference(solver_path, reference_archive_path, use_ortools, ortools_solver)


### PR DESCRIPTION
Use `open(path).read()` instead of `filecmp.cmp` to ignore differences related to CR;LF newline separators that are present only in Windows.