### PR TITLE
Use BOOST_CHECK_EQUAL to check equality

### DIFF
--- a/src/tests/src/solver/optimisation/adequacy_patch.cpp
+++ b/src/tests/src/solver/optimisation/adequacy_patch.cpp
@@ -130,8 +130,8 @@ BOOST_AUTO_TEST_CASE(setNTCboundsForOneTimeStep_virtual_virtual_no_change_expect
     double Xmin, Xmax;
     std::tie(Xmin, Xmax) = setNTCboundsForOneTimeStep(
       virtualArea, virtualArea, true /*SetNTCOutsideToOutsideToZero*/, false);
-    BOOST_TEST(Xmax == origineExtremite);
-    BOOST_TEST(Xmin == -extremiteOrigine);
+    BOOST_CHECK_EQUAL(Xmax, origineExtremite);
+    BOOST_CHECK_EQUAL(Xmin, -extremiteOrigine);
 }
 
 // Virtual -> physical area inside adq-patch (0 -> 2)
@@ -141,8 +141,8 @@ BOOST_AUTO_TEST_CASE(setNTCboundsForOneTimeStep_virtual_inside_no_change_expecte
     double Xmin, Xmax;
     std::tie(Xmin, Xmax) = setNTCboundsForOneTimeStep(
       virtualArea, physicalAreaInsideAdqPatch, true /*SetNTCOutsideToOutsideToZero*/, false);
-    BOOST_TEST(Xmax == origineExtremite);
-    BOOST_TEST(Xmin == -extremiteOrigine);
+    BOOST_CHECK_EQUAL(Xmax, origineExtremite);
+    BOOST_CHECK_EQUAL(Xmin, -extremiteOrigine);
 }
 
 // Virtual -> physical area outside adq-patch (0 -> 1)
@@ -152,8 +152,8 @@ BOOST_AUTO_TEST_CASE(setNTCboundsForOneTimeStep_virtual_outside_no_change_expect
     double Xmin, Xmax;
     std::tie(Xmin, Xmax) = setNTCboundsForOneTimeStep(
       virtualArea, physicalAreaOutsideAdqPatch, true /*SetNTCOutsideToOutsideToZero*/, false);
-    BOOST_TEST(Xmax == origineExtremite);
-    BOOST_TEST(Xmin == -extremiteOrigine);
+    BOOST_CHECK_EQUAL(Xmax, origineExtremite);
+    BOOST_CHECK_EQUAL(Xmin, -extremiteOrigine);
 }
 
 // physical area outside adq-patch -> physical area outside adq-patch (1 -> 1)
@@ -165,8 +165,8 @@ BOOST_AUTO_TEST_CASE(setNTCboundsForOneTimeStep_outside_outside_zero_expected_bo
                                                       physicalAreaOutsideAdqPatch,
                                                       true /*SetNTCOutsideToOutsideToZero*/,
                                                       false);
-    BOOST_TEST(Xmax == 0);
-    BOOST_TEST(Xmin == 0);
+    BOOST_CHECK_EQUAL(Xmax, 0);
+    BOOST_CHECK_EQUAL(Xmin, 0);
 }
 
 // physical area outside adq-patch -> physical area outside adq-patch (1 -> 1)
@@ -178,8 +178,8 @@ BOOST_AUTO_TEST_CASE(setNTCboundsForOneTimeStep_outside_outside_no_change_expect
     std::tie(Xmin, Xmax) = setNTCboundsForOneTimeStep(
       physicalAreaOutsideAdqPatch, physicalAreaOutsideAdqPatch, false, false);
 
-    BOOST_TEST(Xmax == origineExtremite);
-    BOOST_TEST(Xmin == -extremiteOrigine);
+    BOOST_CHECK_EQUAL(Xmax, origineExtremite);
+    BOOST_CHECK_EQUAL(Xmin, -extremiteOrigine);
 }
 
 // physical area inside adq-patch -> physical area outside adq-patch (2 -> 1)
@@ -189,8 +189,8 @@ BOOST_AUTO_TEST_CASE(setNTCboundsForOneTimeStep_inside_outside_zero_expected_bot
     double Xmin, Xmax;
     std::tie(Xmin, Xmax) = setNTCboundsForOneTimeStep(
       physicalAreaInsideAdqPatch, physicalAreaOutsideAdqPatch, false, false);
-    BOOST_TEST(Xmax == 0);
-    BOOST_TEST(Xmin == 0);
+    BOOST_CHECK_EQUAL(Xmax, 0);
+    BOOST_CHECK_EQUAL(Xmin, 0);
 }
 
 // physical area outside adq-patch -> physical area inside adq-patch (1 -> 2)
@@ -202,8 +202,8 @@ BOOST_AUTO_TEST_CASE(setNTCboundsForOneTimeStep_outside_inside_zero_expected_bot
                                                       physicalAreaInsideAdqPatch,
                                                       false,
                                                       true /*SetNTCOutsideToInsideToZero*/);
-    BOOST_TEST(Xmax == 0);
-    BOOST_TEST(Xmin == 0);
+    BOOST_CHECK_EQUAL(Xmax, 0);
+    BOOST_CHECK_EQUAL(Xmin, 0);
 }
 
 // physical area outside adq-patch -> physical area inside adq-patch (1 -> 2)
@@ -214,8 +214,8 @@ BOOST_AUTO_TEST_CASE(setNTCboundsForOneTimeStep_outside_inside_change_expected_o
     double Xmin, Xmax;
     std::tie(Xmin, Xmax) = setNTCboundsForOneTimeStep(
       physicalAreaOutsideAdqPatch, physicalAreaInsideAdqPatch, false, false);
-    BOOST_TEST(Xmax == origineExtremite);
-    BOOST_TEST(Xmin == 0);
+    BOOST_CHECK_EQUAL(Xmax, origineExtremite);
+    BOOST_CHECK_EQUAL(Xmin, 0);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -230,8 +230,8 @@ BOOST_AUTO_TEST_CASE(
     double densNew;
     std::tie(netPositionInit, densNew) = calculateAreaFlowBalanceForOneTimeStep(
       0.0, false, virtualArea, virtualArea, flowArea0toArea1_positive, flowArea2toArea0_positive);
-    BOOST_TEST(netPositionInit == 0.0);
-    BOOST_TEST(densNew == 0.0);
+    BOOST_CHECK_EQUAL(netPositionInit, 0.0);
+    BOOST_CHECK_EQUAL(densNew, 0.0);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -251,8 +251,8 @@ BOOST_AUTO_TEST_CASE(
                                                virtualArea,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_positive);
-    BOOST_TEST(netPositionInit == -flowArea0toArea1_positive);
-    BOOST_TEST(densNew == 0.0);
+    BOOST_CHECK_EQUAL(netPositionInit, -flowArea0toArea1_positive);
+    BOOST_CHECK_EQUAL(densNew, 0.0);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -273,8 +273,8 @@ BOOST_AUTO_TEST_CASE(
                                                virtualArea,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_positive);
-    BOOST_TEST(netPositionInit == -flowArea0toArea1_positive);
-    BOOST_TEST(densNew == positiveEnsInit-flowArea0toArea1_positive);
+    BOOST_CHECK_EQUAL(netPositionInit, -flowArea0toArea1_positive);
+    BOOST_CHECK_EQUAL(densNew, positiveEnsInit-flowArea0toArea1_positive);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -294,8 +294,8 @@ BOOST_AUTO_TEST_CASE(
                                                physicalAreaOutsideAdqPatch,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_positive);
-    BOOST_TEST(netPositionInit == -flowArea0toArea1_positive);
-    BOOST_TEST(densNew == 0.0);
+    BOOST_CHECK_EQUAL(netPositionInit, -flowArea0toArea1_positive);
+    BOOST_CHECK_EQUAL(densNew, 0.0);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -315,8 +315,8 @@ BOOST_AUTO_TEST_CASE(
                                                physicalAreaInsideAdqPatch,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_positive);
-    BOOST_TEST(netPositionInit == -flowArea0toArea1_positive + flowArea2toArea0_positive);
-    BOOST_TEST(densNew == -flowArea0toArea1_positive + flowArea2toArea0_positive);
+    BOOST_CHECK_EQUAL(netPositionInit, -flowArea0toArea1_positive + flowArea2toArea0_positive);
+    BOOST_CHECK_EQUAL(densNew, -flowArea0toArea1_positive + flowArea2toArea0_positive);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -335,8 +335,8 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_inside_outside_Inclu
                                                physicalAreaOutsideAdqPatch,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_positive);
-    BOOST_TEST(netPositionInit == -flowArea0toArea1_positive);
-    BOOST_TEST(densNew == -flowArea0toArea1_positive + flowArea2toArea0_positive);
+    BOOST_CHECK_EQUAL(netPositionInit, -flowArea0toArea1_positive);
+    BOOST_CHECK_EQUAL(densNew, -flowArea0toArea1_positive + flowArea2toArea0_positive);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -355,8 +355,8 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_outside_outside_Incl
                                                physicalAreaOutsideAdqPatch,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_positive);
-    BOOST_TEST(netPositionInit == 0.0);
-    BOOST_TEST(densNew == flowArea2toArea0_positive);
+    BOOST_CHECK_EQUAL(netPositionInit, 0.0);
+    BOOST_CHECK_EQUAL(densNew, flowArea2toArea0_positive);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -375,8 +375,8 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_outside_inside_Inclu
                                                physicalAreaInsideAdqPatch,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_positive);
-    BOOST_TEST(netPositionInit == +flowArea2toArea0_positive);
-    BOOST_TEST(densNew == +flowArea2toArea0_positive);
+    BOOST_CHECK_EQUAL(netPositionInit, +flowArea2toArea0_positive);
+    BOOST_CHECK_EQUAL(densNew, +flowArea2toArea0_positive);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -395,8 +395,8 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_inside_outside_Inclu
                                                physicalAreaOutsideAdqPatch,
                                                flowArea0toArea1_negative,
                                                flowArea2toArea0_negative);
-    BOOST_TEST(netPositionInit == -flowArea0toArea1_negative);
-    BOOST_TEST(densNew == -flowArea0toArea1_negative);
+    BOOST_CHECK_EQUAL(netPositionInit, -flowArea0toArea1_negative);
+    BOOST_CHECK_EQUAL(densNew, -flowArea0toArea1_negative);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -415,8 +415,8 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_outside_outside_Incl
                                                physicalAreaOutsideAdqPatch,
                                                flowArea0toArea1_negative,
                                                flowArea2toArea0_negative);
-    BOOST_TEST(netPositionInit == 0.0);
-    BOOST_TEST(densNew == -flowArea0toArea1_negative);
+    BOOST_CHECK_EQUAL(netPositionInit, 0.0);
+    BOOST_CHECK_EQUAL(densNew, -flowArea0toArea1_negative);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -435,8 +435,8 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_outside_inside_Inclu
                                                physicalAreaInsideAdqPatch,
                                                flowArea0toArea1_negative,
                                                flowArea2toArea0_negative);
-    BOOST_TEST(netPositionInit == flowArea2toArea0_negative);
-    BOOST_TEST(densNew == 0.0);
+    BOOST_CHECK_EQUAL(netPositionInit, flowArea2toArea0_negative);
+    BOOST_CHECK_EQUAL(densNew, 0.0);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -456,8 +456,8 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_outside_inside_Inclu
                                                physicalAreaInsideAdqPatch,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_negative);
-    BOOST_TEST(netPositionInit == -flowArea0toArea1_positive+flowArea2toArea0_negative);
-    BOOST_TEST(densNew == positiveEnsInit+netPositionInit);
+    BOOST_CHECK_EQUAL(netPositionInit, -flowArea0toArea1_positive + flowArea2toArea0_negative);
+    BOOST_CHECK_EQUAL(densNew, positiveEnsInit+netPositionInit);
 }
 
 // Area 0 is physical area inside adq-patch connected to two areas:
@@ -477,6 +477,6 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_outside_inside_Inclu
                                                physicalAreaInsideAdqPatch,
                                                flowArea0toArea1_positive,
                                                flowArea2toArea0_negative);
-    BOOST_TEST(netPositionInit == -flowArea0toArea1_positive+flowArea2toArea0_negative);
-    BOOST_TEST(densNew == 0.0);
+    BOOST_CHECK_EQUAL(netPositionInit, -flowArea0toArea1_positive + flowArea2toArea0_negative);
+    BOOST_CHECK_EQUAL(densNew, 0.0);
 }


### PR DESCRIPTION
To display a more expressive error message in case of failure, for example
```
src/tests/src/solver/optimisation/adequacy_patch.cpp(481): error: in "calculateAreaFlowBalanceForOneTimeStep_outside_inside_IncludeOut_negativeFlow_initEnsEqualTo0": check densNew == 0.1 has failed [0 != 0.10000000000000001]
```