### PR TITLE
Check for incompatible hurdle cost options

### DIFF
--- a/src/libs/antares/exception/LoadingError.cpp
+++ b/src/libs/antares/exception/LoadingError.cpp
@@ -133,6 +133,11 @@ NoAreaInsideAdqPatchMode::NoAreaInsideAdqPatchMode() :
 {
 }
 
+IncompatibleHurdleCostCSR::IncompatibleHurdleCostCSR() :
+ LoadingError("Incompatible options include.hurdleCost and curtailmentSharing.includeHurdleCost")
+{
+}
+
 IncompatibleOutputOptions::IncompatibleOutputOptions(const std::string& text) : LoadingError(text)
 {
 }

--- a/src/libs/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/LoadingError.hpp
@@ -179,6 +179,12 @@ public:
     NoAreaInsideAdqPatchMode();
 };
 
+class IncompatibleHurdleCostCSR : public LoadingError
+{
+public:
+    IncompatibleHurdleCostCSR();
+};
+
 class IncompatibleOutputOptions : public LoadingError
 {
 public:

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -115,6 +115,18 @@ void checkAdqPatchContainsAdqPatchArea(const bool adqPatchOn, const Antares::Dat
     }
 }
 
+void checkAdqPatchIncludeHurdleCost(const bool adqPatchOn,
+                                    const bool includeHurdleCost,
+                                    const bool includeHurdleCostCsr)
+{
+    // No need to check if adq-patch is disabled
+    if (!adqPatchOn)
+        return;
+
+    if (includeHurdleCostCsr && !includeHurdleCost)
+        throw Error::IncompatibleHurdleCostCSR();
+}
+
 void checkMinStablePower(bool tsGenThermal, const Antares::Data::AreaList& areas)
 {
     if (tsGenThermal)
@@ -282,7 +294,11 @@ void Application::prepare(int argc, char* argv[])
     checkSimplexRangeHydroHeuristic(pParameters->simplexOptimizationRange, pStudy->areas);
 
     checkAdqPatchStudyModeEconomyOnly(pParameters->adqPatch.enabled, pParameters->mode);
+
     checkAdqPatchContainsAdqPatchArea(pParameters->adqPatch.enabled, pStudy->areas);
+    checkAdqPatchIncludeHurdleCost(pParameters->adqPatch.enabled,
+                                   pParameters->include.hurdleCosts,
+                                   pParameters->adqPatch.curtailmentSharing.includeHurdleCost);
 
     bool tsGenThermal
       = (0 != (pParameters->timeSeriesToGenerate & Antares::Data::TimeSeries::timeSeriesThermal));


### PR DESCRIPTION
If hurdle costs are disabled (existing parameter), then CSR's "include hurdle cost" (new parameter) makes no sense since direct/indirect flux variable don't even exist.

This would lead to difficult to understand bugs/crashes.