### PR TITLE
adq patch : move calculation of LMR violations from CSR source file to adq patch weekly problem

### DIFF
--- a/src/solver/optimisation/adequacy_patch_weekly_optimization.h
+++ b/src/solver/optimisation/adequacy_patch_weekly_optimization.h
@@ -2,6 +2,9 @@
 
 #include "base_weekly_optimization.h"
 #include "../simulation/sim_structure_probleme_economique.h"
+#include "antares/study/area/area.h"
+
+using Antares::Data::AreaList;
 
 namespace Antares::Solver::Simulation
 {
@@ -11,9 +14,10 @@ public:
     explicit AdequacyPatchOptimization(PROBLEME_HEBDO* problemeHebdo, uint numSpace);
     virtual ~AdequacyPatchOptimization() = default;
     void solve(uint weekInTheYear, int hourInTheYear) override;
-    void solveCSR(Antares::Data::AreaList& areas, uint year, uint week, uint numSpace) override;
+    void postProcess(Antares::Data::AreaList& areas, uint year, uint week) override;
 
 private:
+    double calculateDensNewAndTotalLmrViolation(AreaList& areas);
     std::vector<double> calculateENSoverAllAreasForEachHour() const;
     std::set<int> identifyHoursForCurtailmentSharing(std::vector<double> sumENS) const;
     std::set<int> getHoursRequiringCurtailmentSharing() const;

--- a/src/solver/optimisation/base_weekly_optimization.cpp
+++ b/src/solver/optimisation/base_weekly_optimization.cpp
@@ -22,9 +22,4 @@ std::unique_ptr<interfaceWeeklyOptimization> interfaceWeeklyOptimization::create
         return std::make_unique<weeklyOptimization>(problemeHebdo, thread_number);
 }
 
-void interfaceWeeklyOptimization::solveCSR(Antares::Data::AreaList&, uint, uint, uint)
-{
-    // By default, do nothing
-}
-
 } // namespace Antares::Solver::Simulation

--- a/src/solver/optimisation/base_weekly_optimization.h
+++ b/src/solver/optimisation/base_weekly_optimization.h
@@ -9,7 +9,7 @@ class interfaceWeeklyOptimization
 {
 public:
     virtual void solve(uint weekInTheYear, int hourInTheYear) = 0;
-    virtual void solveCSR(Antares::Data::AreaList& areas, uint year, uint week, uint numSpace);
+    virtual void postProcess(Antares::Data::AreaList& areas, uint year, uint week) = 0;
     virtual ~interfaceWeeklyOptimization() = default;
     static std::unique_ptr<interfaceWeeklyOptimization> create(bool adqPatchEnabled,
                                                                PROBLEME_HEBDO* problemesHebdo,

--- a/src/solver/optimisation/weekly_optimization.cpp
+++ b/src/solver/optimisation/weekly_optimization.cpp
@@ -12,4 +12,10 @@ void weeklyOptimization::solve(uint, int)
 {
     OPT_OptimisationHebdomadaire(problemeHebdo_, thread_number_);
 }
+
+void weeklyOptimization::postProcess(Antares::Data::AreaList&, uint, uint)
+{
+    // Nothing to finalize for a classic weekly optimization
+}
+
 } // namespace Antares::Solver::Simulation

--- a/src/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/weekly_optimization.h
@@ -11,5 +11,6 @@ public:
     explicit weeklyOptimization(PROBLEME_HEBDO* problemeHebdo, uint numSpace);
     virtual ~weeklyOptimization() = default;
     void solve(uint, int) override;
+    void postProcess(Antares::Data::AreaList&, uint, uint) override;
 };
 } // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -166,7 +166,7 @@ bool Economy::year(Progression::Task& progression,
             DispatchableMarginForAllAreas(
               study, *pProblemesHebdo[numSpace], numSpace, hourInTheYear);
 
-            weeklyOptProblems_[numSpace]->solveCSR(study.areas, state.year, w, numSpace);
+            weeklyOptProblems_[numSpace]->postProcess(study.areas, state.year, w);
 
             computingHydroLevels(study, *pProblemesHebdo[numSpace], nbHoursInAWeek, false);
 
@@ -176,7 +176,7 @@ bool Economy::year(Progression::Task& progression,
             adqPatchPostProcess(study, *pProblemesHebdo[numSpace], numSpace);
 
             computingHydroLevels(study, *pProblemesHebdo[numSpace], nbHoursInAWeek, true);
-
+            
             interpolateWaterValue(
               study, *pProblemesHebdo[numSpace], hourInTheYear, nbHoursInAWeek);
 


### PR DESCRIPTION
This work is a first try to make code better in file **economy.cpp**. It calls further improvements consisting in dealing with post treatments after a weekly problem has executed. This will be done in a further PR.
- As free function **calculateDensNewAndTotalLmrViolation** is about **local matching rules**, it as nothing to do with the curtailment sharing problem. It is removed to the **adequacy patch** problem
- In **economy.cpp**, call to **solveCSR** is not right because it is supposed to call more generic methods of a generic weekly problem. So we have renamed it into a generic **postProcess(...)** method. If the underlying concrete problem is a classic weekly problem, the method does nothing, otherwise the curtailment sharing is processed
- Note that, still in  **economy.cpp**, another non generic post treatment is called : **adqPatchPostProcess(...)**. This will be addressed later in a further PR