### PR TITLE
Fix regression related to while loop and unitialized quadratic costs

### DIFF
--- a/src/solver/optimisation/adequacy_patch_csr/csr_quadratic_problem.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/csr_quadratic_problem.cpp
@@ -156,20 +156,22 @@ void CsrQuadraticProblem::setNodeBalanceConstraints(double* Pi, int* Colonne)
             if (problemeHebdo_->adequacyPatchRuntimeData.originAreaMode[Interco]
                 != Data::AdequacyPatch::physicalAreaInsideAdqPatch)
             {
-                Var = CorrespondanceVarNativesVarOptim
-                        ->NumeroDeVariableDeLInterconnexion[Interco]; // flow (2 -> A)
-                if (Var >= 0)
-                {
-                    Pi[NombreDeTermes] = 1.0;
-                    Colonne[NombreDeTermes] = Var;
-                    NombreDeTermes++;
-                    logs.debug()
-                      << "E-Interco number: [" << std::to_string(Interco) << "] between: ["
-                      << problemeHebdo_->NomsDesPays[Area] << "]-["
-                      << problemeHebdo_
-                           ->NomsDesPays[problemeHebdo_->PaysOrigineDeLInterconnexion[Interco]]
-                      << "]";
-                }
+                Interco = problemeHebdo_->IndexSuivantIntercoExtremite[Interco];
+                continue;
+            }
+            Var = CorrespondanceVarNativesVarOptim
+                    ->NumeroDeVariableDeLInterconnexion[Interco]; // flow (2 -> A)
+            if (Var >= 0)
+            {
+                Pi[NombreDeTermes] = 1.0;
+                Colonne[NombreDeTermes] = Var;
+                NombreDeTermes++;
+                logs.debug()
+                  << "E-Interco number: [" << std::to_string(Interco) << "] between: ["
+                  << problemeHebdo_->NomsDesPays[Area] << "]-["
+                  << problemeHebdo_
+                       ->NomsDesPays[problemeHebdo_->PaysOrigineDeLInterconnexion[Interco]]
+                  << "]";
             }
             Interco = problemeHebdo_->IndexSuivantIntercoExtremite[Interco];
         }

--- a/src/solver/optimisation/adequacy_patch_csr/set_problem_cost_function.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/set_problem_cost_function.cpp
@@ -65,9 +65,13 @@ void setQuadraticCost(const PROBLEME_HEBDO* ProblemeHebdo,
     const CORRESPONDANCES_DES_VARIABLES* CorrespondanceVarNativesVarOptim;
     CorrespondanceVarNativesVarOptim = ProblemeHebdo->CorrespondanceVarNativesVarOptim[hour];
 
+    std::fill_n(ProblemeAResoudre.CoutQuadratique,
+                ProblemeAResoudre.NombreDeVariables,
+                0.);
+
     // variables: ENS for each area inside adq patch
-    // obj function term is: 1 / (PTO * PTO) * ENS * ENS
-    //  => quadratic cost: 1 / (PTO * PTO)
+    // obj function term is: 1 / (PTO) * ENS * ENS
+    //  => quadratic cost: 1 / (PTO)
     //  => linear cost: 0
     // PTO can take two different values according to option:
     //  1. from DENS


### PR DESCRIPTION
Only cosmetic differences in the logs & results for the 2 small test-cases provided by RTE-i.

```diff
--- /home/omnesflo/csr1/output/1457eco.log
+++ /home/omnesflo/csr1/output/1022eco.log
@@ -1,9 +1,9 @@
-[solver][check] Antares Solver v8.4.2 (fc96105)
+[solver][check] Antares Solver v8.4.2 (063c88d)
 [solver][infos]   :: built for 64-bit architectures, GNU/Linux, 12 cpu(s)
 [solver][infos]   :: hostname = localhost
 [solver][infos] 
 [solver][infos]   :: from /home/omnesflo/Antares_Simulator/build/solver
-[solver][infos]   :: log filename: /home/omnesflo/csr1/logs/solver-20230124-145748.log
+[solver][infos]   :: log filename: /home/omnesflo/csr1/logs/solver-20230125-102224.log
 [solver][infos] 
 [solver][notic] Preparing adq_patch_test_study...
 [solver][infos]   detected version: 830
@@ -170,7 +170,7 @@
 [solver][infos] [statistics] network: read: 0 ko, written: 0 ko
 [solver][infos] The study is loaded.
 [solver][infos] [UI] Display messages: Off
-[solver][infos]   Output folder : /home/omnesflo/csr1/output/20230124-1457eco-fc96105
+[solver][infos]   Output folder : /home/omnesflo/csr1/output/20230125-1022eco-063c88d
 [solver][infos] 
 [solver][infos] Generating calendar informations
 [solver][debug]   reset calendar, month : January, january 1rst : Monday, first weekday : Monday
@@ -218,7 +218,7 @@
 [solver][debug]   random number generator: Noise on virtual Hydro costs, seed: 9005489
 [solver][debug]   random number generator: Initial reservoir levels, seed: 10005489
 [solver][infos]   The progression is disabled
-[solver][infos]   system memory report: 26932 Mib / 31705 Mib,  84.945592% free
+[solver][infos]   system memory report: 27298 Mib / 31705 Mib,  86.099984% free
 [solver][infos] 
 [solver][infos] [UI] Display messages: On
 [solver][check] Running the simulation (economy)
@@ -378,13 +378,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 199.999980
-[solver][debug] [CSR]1 = 200.000000
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -0.000145
-[solver][debug] [CSR]5 = 50.098436
-[solver][debug] [CSR]6 = 50.098581
+[solver][debug] [CSR] X[0] = 199.999980
+[solver][debug] [CSR] X[1] = 200.000000
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -0.000145
+[solver][debug] [CSR] X[5] = 50.098436
+[solver][debug] [CSR] X[6] = 50.098581
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:2
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -429,13 +429,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 199.999980
-[solver][debug] [CSR]1 = 0.000000
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -0.000145
-[solver][debug] [CSR]5 = 493.045960
-[solver][debug] [CSR]6 = 493.046105
+[solver][debug] [CSR] X[0] = 199.999980
+[solver][debug] [CSR] X[1] = 0.000000
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -0.000145
+[solver][debug] [CSR] X[5] = 493.045960
+[solver][debug] [CSR] X[6] = 493.046105
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:3
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -480,13 +480,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 199.999981
-[solver][debug] [CSR]1 = 0.000000
-[solver][debug] [CSR]2 = 0.000001
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -450.000145
-[solver][debug] [CSR]5 = 183.050289
-[solver][debug] [CSR]6 = 633.050434
+[solver][debug] [CSR] X[0] = 199.999981
+[solver][debug] [CSR] X[1] = 0.000000
+[solver][debug] [CSR] X[2] = 0.000001
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -450.000145
+[solver][debug] [CSR] X[5] = 183.050289
+[solver][debug] [CSR] X[6] = 633.050434
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:4
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -531,13 +531,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 198.999990
-[solver][debug] [CSR]1 = 198.000000
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -50.000160
-[solver][debug] [CSR]5 = 73.955574
-[solver][debug] [CSR]6 = 123.955734
+[solver][debug] [CSR] X[0] = 198.999990
+[solver][debug] [CSR] X[1] = 198.000000
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -50.000160
+[solver][debug] [CSR] X[5] = 73.955574
+[solver][debug] [CSR] X[6] = 123.955734
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:5
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -582,13 +582,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 33.333331
-[solver][debug] [CSR]1 = 166.666650
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 833.333341
-[solver][debug] [CSR]5 = 881.274049
-[solver][debug] [CSR]6 = 47.940709
+[solver][debug] [CSR] X[0] = 33.333331
+[solver][debug] [CSR] X[1] = 166.666650
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 833.333341
+[solver][debug] [CSR] X[5] = 881.274049
+[solver][debug] [CSR] X[6] = 47.940709
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:7
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -633,13 +633,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 110.905926
-[solver][debug] [CSR]1 = 280.094064
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 214.905936
-[solver][debug] [CSR]5 = 258.024353
-[solver][debug] [CSR]6 = 43.118416
+[solver][debug] [CSR] X[0] = 110.905926
+[solver][debug] [CSR] X[1] = 280.094064
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 214.905936
+[solver][debug] [CSR] X[5] = 258.024353
+[solver][debug] [CSR] X[6] = 43.118416
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:8
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -684,13 +684,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 33.333332
-[solver][debug] [CSR]1 = 166.666658
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 833.333342
-[solver][debug] [CSR]5 = 880.707251
-[solver][debug] [CSR]6 = 47.373909
+[solver][debug] [CSR] X[0] = 33.333332
+[solver][debug] [CSR] X[1] = 166.666658
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 833.333342
+[solver][debug] [CSR] X[5] = 880.707251
+[solver][debug] [CSR] X[6] = 47.373909
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:9
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -735,13 +735,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 74.999993
-[solver][debug] [CSR]1 = 224.999987
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 675.000013
-[solver][debug] [CSR]5 = 848.159459
-[solver][debug] [CSR]6 = 173.159446
+[solver][debug] [CSR] X[0] = 74.999993
+[solver][debug] [CSR] X[1] = 224.999987
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 675.000013
+[solver][debug] [CSR] X[5] = 848.159459
+[solver][debug] [CSR] X[6] = 173.159446
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:11
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -786,13 +786,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 33.333331
-[solver][debug] [CSR]1 = 166.666650
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 833.333341
-[solver][debug] [CSR]5 = 876.254117
-[solver][debug] [CSR]6 = 42.920777
+[solver][debug] [CSR] X[0] = 33.333331
+[solver][debug] [CSR] X[1] = 166.666650
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 833.333341
+[solver][debug] [CSR] X[5] = 876.254117
+[solver][debug] [CSR] X[6] = 42.920777
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:12
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -837,13 +837,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 184.981559
-[solver][debug] [CSR]1 = 500.018431
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 291.981569
-[solver][debug] [CSR]5 = 347.847331
-[solver][debug] [CSR]6 = 55.865761
+[solver][debug] [CSR] X[0] = 184.981559
+[solver][debug] [CSR] X[1] = 500.018431
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 291.981569
+[solver][debug] [CSR] X[5] = 347.847331
+[solver][debug] [CSR] X[6] = 55.865761
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:21
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -888,13 +888,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 18.181815
-[solver][debug] [CSR]1 = 181.818165
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 818.181835
-[solver][debug] [CSR]5 = 913.823057
-[solver][debug] [CSR]6 = 95.641222
+[solver][debug] [CSR] X[0] = 18.181815
+[solver][debug] [CSR] X[1] = 181.818165
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 818.181835
+[solver][debug] [CSR] X[5] = 913.823057
+[solver][debug] [CSR] X[6] = 95.641222
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:22
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -939,13 +939,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 36.363632
-[solver][debug] [CSR]1 = 163.636348
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 736.363652
-[solver][debug] [CSR]5 = 814.539889
-[solver][debug] [CSR]6 = 78.176237
+[solver][debug] [CSR] X[0] = 36.363632
+[solver][debug] [CSR] X[1] = 163.636348
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 736.363652
+[solver][debug] [CSR] X[5] = 814.539889
+[solver][debug] [CSR] X[6] = 78.176237
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:23
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -990,13 +990,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 253.337122
-[solver][debug] [CSR]1 = 123.662868
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -336.662868
-[solver][debug] [CSR]5 = 91.364039
-[solver][debug] [CSR]6 = 428.026908
+[solver][debug] [CSR] X[0] = 253.337122
+[solver][debug] [CSR] X[1] = 123.662868
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -336.662868
+[solver][debug] [CSR] X[5] = 91.364039
+[solver][debug] [CSR] X[6] = 428.026908
 [solver][infos] [adq-patch] Year:1 Week:2.Total LMR violation:0.000000
 [solver][debug] number of triggered hours: 1
 [solver][infos] [adq-patch] CSR triggered for Year:1 Hour:169
@@ -1043,13 +1043,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 769.230751
-[solver][debug] [CSR]1 = 1230.769231
-[solver][debug] [CSR]2 = 0.000001
-[solver][debug] [CSR]3 = 0.000001
-[solver][debug] [CSR]4 = 369.230770
-[solver][debug] [CSR]5 = 487.844534
-[solver][debug] [CSR]6 = 118.613764
+[solver][debug] [CSR] X[0] = 769.230751
+[solver][debug] [CSR] X[1] = 1230.769231
+[solver][debug] [CSR] X[2] = 0.000001
+[solver][debug] [CSR] X[3] = 0.000001
+[solver][debug] [CSR] X[4] = 369.230770
+[solver][debug] [CSR] X[5] = 487.844534
+[solver][debug] [CSR] X[6] = 118.613764
 [solver][infos] Exporting the annual results
 [solver][debug]   (for 175 columns)
 [solver][debug]   :: initializing survey results (max: 175 variables)
@@ -1210,13 +1210,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 199.999980
-[solver][debug] [CSR]1 = 200.000000
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -0.000145
-[solver][debug] [CSR]5 = 50.098436
-[solver][debug] [CSR]6 = 50.098581
+[solver][debug] [CSR] X[0] = 199.999980
+[solver][debug] [CSR] X[1] = 200.000000
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -0.000145
+[solver][debug] [CSR] X[5] = 50.098436
+[solver][debug] [CSR] X[6] = 50.098581
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:2
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1261,13 +1261,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 199.999980
-[solver][debug] [CSR]1 = 0.000000
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -0.000145
-[solver][debug] [CSR]5 = 493.045960
-[solver][debug] [CSR]6 = 493.046105
+[solver][debug] [CSR] X[0] = 199.999980
+[solver][debug] [CSR] X[1] = 0.000000
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -0.000145
+[solver][debug] [CSR] X[5] = 493.045960
+[solver][debug] [CSR] X[6] = 493.046105
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:3
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1312,13 +1312,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 199.999981
-[solver][debug] [CSR]1 = 0.000000
-[solver][debug] [CSR]2 = 0.000001
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -450.000145
-[solver][debug] [CSR]5 = 183.050289
-[solver][debug] [CSR]6 = 633.050434
+[solver][debug] [CSR] X[0] = 199.999981
+[solver][debug] [CSR] X[1] = 0.000000
+[solver][debug] [CSR] X[2] = 0.000001
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -450.000145
+[solver][debug] [CSR] X[5] = 183.050289
+[solver][debug] [CSR] X[6] = 633.050434
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:4
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1363,13 +1363,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 198.999990
-[solver][debug] [CSR]1 = 198.000000
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -50.000160
-[solver][debug] [CSR]5 = 73.955574
-[solver][debug] [CSR]6 = 123.955734
+[solver][debug] [CSR] X[0] = 198.999990
+[solver][debug] [CSR] X[1] = 198.000000
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -50.000160
+[solver][debug] [CSR] X[5] = 73.955574
+[solver][debug] [CSR] X[6] = 123.955734
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:5
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1414,13 +1414,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 33.333331
-[solver][debug] [CSR]1 = 166.666650
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 833.333341
-[solver][debug] [CSR]5 = 881.274049
-[solver][debug] [CSR]6 = 47.940709
+[solver][debug] [CSR] X[0] = 33.333331
+[solver][debug] [CSR] X[1] = 166.666650
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 833.333341
+[solver][debug] [CSR] X[5] = 881.274049
+[solver][debug] [CSR] X[6] = 47.940709
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:7
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1465,13 +1465,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 110.905926
-[solver][debug] [CSR]1 = 280.094064
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 214.905936
-[solver][debug] [CSR]5 = 258.024353
-[solver][debug] [CSR]6 = 43.118416
+[solver][debug] [CSR] X[0] = 110.905926
+[solver][debug] [CSR] X[1] = 280.094064
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 214.905936
+[solver][debug] [CSR] X[5] = 258.024353
+[solver][debug] [CSR] X[6] = 43.118416
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:8
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1516,13 +1516,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 33.333332
-[solver][debug] [CSR]1 = 166.666658
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 833.333342
-[solver][debug] [CSR]5 = 880.707251
-[solver][debug] [CSR]6 = 47.373909
+[solver][debug] [CSR] X[0] = 33.333332
+[solver][debug] [CSR] X[1] = 166.666658
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 833.333342
+[solver][debug] [CSR] X[5] = 880.707251
+[solver][debug] [CSR] X[6] = 47.373909
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:9
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1567,13 +1567,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 74.999993
-[solver][debug] [CSR]1 = 224.999987
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 675.000013
-[solver][debug] [CSR]5 = 848.159459
-[solver][debug] [CSR]6 = 173.159446
+[solver][debug] [CSR] X[0] = 74.999993
+[solver][debug] [CSR] X[1] = 224.999987
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 675.000013
+[solver][debug] [CSR] X[5] = 848.159459
+[solver][debug] [CSR] X[6] = 173.159446
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:11
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1618,13 +1618,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 33.333331
-[solver][debug] [CSR]1 = 166.666650
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 833.333341
-[solver][debug] [CSR]5 = 876.254117
-[solver][debug] [CSR]6 = 42.920777
+[solver][debug] [CSR] X[0] = 33.333331
+[solver][debug] [CSR] X[1] = 166.666650
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 833.333341
+[solver][debug] [CSR] X[5] = 876.254117
+[solver][debug] [CSR] X[6] = 42.920777
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:12
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1669,13 +1669,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 184.981559
-[solver][debug] [CSR]1 = 500.018431
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 291.981569
-[solver][debug] [CSR]5 = 347.847331
-[solver][debug] [CSR]6 = 55.865761
+[solver][debug] [CSR] X[0] = 184.981559
+[solver][debug] [CSR] X[1] = 500.018431
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 291.981569
+[solver][debug] [CSR] X[5] = 347.847331
+[solver][debug] [CSR] X[6] = 55.865761
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:21
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1720,13 +1720,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 18.181815
-[solver][debug] [CSR]1 = 181.818165
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 818.181835
-[solver][debug] [CSR]5 = 913.823057
-[solver][debug] [CSR]6 = 95.641222
+[solver][debug] [CSR] X[0] = 18.181815
+[solver][debug] [CSR] X[1] = 181.818165
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 818.181835
+[solver][debug] [CSR] X[5] = 913.823057
+[solver][debug] [CSR] X[6] = 95.641222
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:22
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1771,13 +1771,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 36.363632
-[solver][debug] [CSR]1 = 163.636348
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = 736.363652
-[solver][debug] [CSR]5 = 814.539889
-[solver][debug] [CSR]6 = 78.176237
+[solver][debug] [CSR] X[0] = 36.363632
+[solver][debug] [CSR] X[1] = 163.636348
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = 736.363652
+[solver][debug] [CSR] X[5] = 814.539889
+[solver][debug] [CSR] X[6] = 78.176237
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:23
 [solver][debug] [CSR] variable list:
 [solver][debug]  ENS of each area inside adq patch: 
@@ -1822,13 +1822,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 253.337122
-[solver][debug] [CSR]1 = 123.662868
-[solver][debug] [CSR]2 = 0.000000
-[solver][debug] [CSR]3 = 0.000000
-[solver][debug] [CSR]4 = -336.662868
-[solver][debug] [CSR]5 = 91.364039
-[solver][debug] [CSR]6 = 428.026908
+[solver][debug] [CSR] X[0] = 253.337122
+[solver][debug] [CSR] X[1] = 123.662868
+[solver][debug] [CSR] X[2] = 0.000000
+[solver][debug] [CSR] X[3] = 0.000000
+[solver][debug] [CSR] X[4] = -336.662868
+[solver][debug] [CSR] X[5] = 91.364039
+[solver][debug] [CSR] X[6] = 428.026908
 [solver][infos] [adq-patch] Year:2 Week:2.Total LMR violation:0.000000
 [solver][debug] number of triggered hours: 1
 [solver][infos] [adq-patch] CSR triggered for Year:2 Hour:169
@@ -1875,13 +1875,13 @@
 [solver][debug] CheckCsrCostFunctionValue = FALSE
 [solver][debug] calculateCsrCostFunctionValue! 
 [solver][debug] CheckCsrCostFunctionValue = FALSE
-[solver][debug] [CSR]0 = 769.230751
-[solver][debug] [CSR]1 = 1230.769231
-[solver][debug] [CSR]2 = 0.000001
-[solver][debug] [CSR]3 = 0.000001
-[solver][debug] [CSR]4 = 369.230770
-[solver][debug] [CSR]5 = 487.844534
-[solver][debug] [CSR]6 = 118.613764
+[solver][debug] [CSR] X[0] = 769.230751
+[solver][debug] [CSR] X[1] = 1230.769231
+[solver][debug] [CSR] X[2] = 0.000001
+[solver][debug] [CSR] X[3] = 0.000001
+[solver][debug] [CSR] X[4] = 369.230770
+[solver][debug] [CSR] X[5] = 487.844534
+[solver][debug] [CSR] X[6] = 118.613764
 [solver][infos] Exporting the annual results
 [solver][debug]   (for 175 columns)
 [solver][debug]   :: initializing survey results (max: 175 variables)
```