### PR TITLE
Fix RPATH for solver-only asset

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Solver archive creation
       run: |
            cd _build
-           cmake --install . --prefix install
+           cmake3 --install . --prefix install
            tar czf antares-solver_centos7.tar.gz install/bin/antares-*-solver install/bin/libsirius_solver.so
            rm -rf install
 

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -98,7 +98,9 @@ jobs:
     - name: Solver archive creation
       run: |
            cd _build
-           tar czf antares-solver_centos7.tar.gz solver/antares-*-solver solver/libsirius_solver.so
+           cmake --install . --prefix install
+           tar czf antares-solver_centos7.tar.gz install/bin/antares-*-solver install/bin/libsirius_solver.so
+           rm -rf install
 
     - name: .tar.gz creation
       run: |

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -99,7 +99,10 @@ jobs:
       run: |
            cd _build
            cmake3 --install . --prefix install
-           tar czf antares-solver_centos7.tar.gz install/bin/antares-*-solver install/bin/libsirius_solver.so
+           pushd .
+           cd install/bin
+           tar czf ../../antares-solver_centos7.tar.gz antares-*-solver libsirius_solver.so
+           popd
            rm -rf install
 
     - name: .tar.gz creation

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -216,7 +216,9 @@ jobs:
     - name: Solver archive creation
       run: |
            cd _build
-           tar czf antares-solver_ubuntu20.04.tar.gz solver/antares-*-solver solver/libsirius_solver.so
+           cmake --install . --prefix install
+           tar czf antares-solver_ubuntu20.04.tar.gz install/bin/antares-*-solver install/bin/libsirius_solver.so
+           rm -rf install
 
     - name: Installer archive upload push
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -217,7 +217,10 @@ jobs:
       run: |
            cd _build
            cmake --install . --prefix install
-           tar czf antares-solver_ubuntu20.04.tar.gz install/bin/antares-*-solver install/bin/libsirius_solver.so
+           pushd .
+           cd install/bin
+           tar czf ../../antares-solver_ubuntu20.04.tar.gz antares-*-solver libsirius_solver.so
+           popd
            rm -rf install
 
     - name: Installer archive upload push


### PR DESCRIPTION
Adding a `cmake install` step should fix the RPATH for executable `antares-x.y-solver`.