### PR TITLE
Add coefficient for hurdle cost in the CSR problem

### DIFF
--- a/src/solver/optimisation/adequacy_patch_csr/set_problem_cost_function.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/set_problem_cost_function.cpp
@@ -113,7 +113,8 @@ void HourlyCSRProblem::setLinearCost()
         {
             continue;
         }
-        const double coeff = problemeHebdo_->adequacyPatchRuntimeData.linkCostCoefficient[Interco];
+        const double coeff
+          = problemeHebdo_->adequacyPatchRuntimeData.hurdleCostCoefficients[Interco];
         TransportCost = problemeHebdo_->CoutDeTransport[Interco];
         // flow
         var = CorrespondanceVarNativesVarOptim->NumeroDeVariableDeLInterconnexion[Interco];

--- a/src/solver/optimisation/adequacy_patch_csr/set_problem_cost_function.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/set_problem_cost_function.cpp
@@ -113,7 +113,7 @@ void HourlyCSRProblem::setLinearCost()
         {
             continue;
         }
-
+        const double coeff = problemeHebdo_->adequacyPatchRuntimeData.linkCostCoefficient[Interco];
         TransportCost = problemeHebdo_->CoutDeTransport[Interco];
         // flow
         var = CorrespondanceVarNativesVarOptim->NumeroDeVariableDeLInterconnexion[Interco];
@@ -131,7 +131,7 @@ void HourlyCSRProblem::setLinearCost()
                 problemeAResoudre_.CoutLineaire[var] = 0;
             else
                 problemeAResoudre_.CoutLineaire[var]
-                  = TransportCost->CoutDeTransportOrigineVersExtremite[triggeredHour];
+                  = TransportCost->CoutDeTransportOrigineVersExtremite[triggeredHour] * coeff;
             logs.debug() << var << ". Linear C = " << problemeAResoudre_.CoutLineaire[var];
         }
 
@@ -143,7 +143,7 @@ void HourlyCSRProblem::setLinearCost()
                 problemeAResoudre_.CoutLineaire[var] = 0;
             else
                 problemeAResoudre_.CoutLineaire[var]
-                  = TransportCost->CoutDeTransportExtremiteVersOrigine[triggeredHour];
+                  = TransportCost->CoutDeTransportExtremiteVersOrigine[triggeredHour] * coeff;
             logs.debug() << var << ". Linear C = " << problemeAResoudre_.CoutLineaire[var];
         }
     }

--- a/src/solver/simulation/adequacy_patch_runtime_data.cpp
+++ b/src/solver/simulation/adequacy_patch_runtime_data.cpp
@@ -2,10 +2,10 @@
 
 namespace
 {
-constexpr double thresholdForCostCoefficient = 1.e-9;
-double computeHurdleCostCoefficient(double a, double b)
+constexpr double thresholdForCostCoefficient = 1.e-12;
+double computeHurdleCostCoefficient(double unsuppliedEnergyCost1, double unsuppliedEnergyCost2)
 {
-    double m = std::max(a, b);
+    double m = std::max(unsuppliedEnergyCost1, unsuppliedEnergyCost2);
     if (std::fabs(m) < thresholdForCostCoefficient)
         m = thresholdForCostCoefficient;
     return 1. / m;

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -305,11 +305,14 @@ typedef struct
 class AdequacyPatchRuntimeData
 {
 private:
-    static double computeLinkCostCoefficient(double a, double b)
+    // TODO[FOM] out of class
+    static constexpr double thresholdForCostCoefficient = 1.e-9;
+    // TODO[FOM] free function
+    static double computeHurdleCostCoefficient(double a, double b)
     {
         double m = std::max(a, b);
-        if (std::fabs(m) < 1.e-9)
-            m = 1.e-9;
+        if (std::fabs(m) < thresholdForCostCoefficient)
+            m = thresholdForCostCoefficient;
         return 1. / m;
     }
     using adqPatchParamsMode = Antares::Data::AdequacyPatch::AdequacyPatchMode;
@@ -318,7 +321,7 @@ public:
     std::vector<adqPatchParamsMode> areaMode;
     std::vector<adqPatchParamsMode> originAreaMode;
     std::vector<adqPatchParamsMode> extremityAreaMode;
-    std::vector<double> linkCostCoefficient;
+    std::vector<double> hurdleCostCoefficients;
 
     void initialize(Antares::Data::Study& study)
     {
@@ -331,13 +334,13 @@ public:
         const auto numberOfLinks = study.runtime->interconnectionsCount();
         originAreaMode.resize(numberOfLinks);
         extremityAreaMode.resize(numberOfLinks);
-        linkCostCoefficient.resize(numberOfLinks);
+        hurdleCostCoefficients.resize(numberOfLinks);
         for (uint i = 0; i < numberOfLinks; ++i)
         {
             auto& link = *(study.runtime->areaLink[i]);
             originAreaMode[i] = link.from->adequacyPatchMode;
             extremityAreaMode[i] = link.with->adequacyPatchMode;
-            linkCostCoefficient[i] = computeLinkCostCoefficient(
+            hurdleCostCoefficients[i] = computeHurdleCostCoefficient(
               link.from->thermal.unsuppliedEnergyCost, link.with->thermal.unsuppliedEnergyCost);
         }
     }


### PR DESCRIPTION
If hurdle costs are enabled, use `1/max(unsupplied cost origin area, unsupplied cost destination area)` as a multiplicative coefficient on them to avoid side-effects.