### PR TITLE
Max nb columns in output reports : computing an accurate max number of columns (based on synthesis reports)

### DIFF
--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -44,7 +44,7 @@ namespace Data
 class VariablePrintInfo
 {
 public:
-    VariablePrintInfo(AnyString vname, uint maxNbCols, uint dataLvl, uint fileLvl);
+    VariablePrintInfo(AnyString vname, uint dataLvl, uint fileLvl);
     ~VariablePrintInfo(){};
 
     // Getting name of the (represented) output variable
@@ -55,6 +55,7 @@ public:
     bool isPrinted();
 
     uint getMaxColumnsCount();
+    void setMaxColumns(uint maxColumnsNumber);
     uint getDataLevel()
     {
         return dataLevel;
@@ -70,10 +71,15 @@ private:
     // Is the variable printed ?
     bool to_be_printed;
 
-    // All this useful to compute the max number of colums any report can contain
-    // ... maximum number of columns taken up by variable in the output files
-    uint maxNumberColumns;
-    // ... data and file levels
+    // The number of columns the output variable takes in a SYNTHESIS report.
+    // Recall that synthesis reports always contain more columns than
+    // any other reports (for instance year-by-year reports)
+    uint maxNumberColumns_ = 0;
+
+    // Which reports the output variable has columns in ?
+    // Example : areas/values-<time-interval>.txt
+    // dataLevel can be : areas, links, bindingConstraint
+    // fileLevel can be : values-<time-interval>.txt, details-<time-interval>.txt, id-<time-interval>.txt, ...
     uint dataLevel;
     uint fileLevel;
 };
@@ -84,7 +90,7 @@ class variablePrintInfoCollector
 {
 public:
     variablePrintInfoCollector(AllVariablesPrintInfo* allvarsprintinfo);
-    void add(const AnyString& name, uint nbGlobalResults, uint dataLevel, uint fileLevel);
+    void add(const AnyString& name, uint dataLevel, uint fileLevel);
 
 private:
     AllVariablesPrintInfo* allvarsinfo;
@@ -107,6 +113,7 @@ public:
     bool isEmpty() const;
 
     bool setPrintStatus(std::string varname, bool printStatus);
+    void setMaxColumns(std::string varname, uint maxColumnsNumber);
 
     void prepareForSimulation(bool userSelection,
                               const std::vector<std::string>& excluded_vars = {});
@@ -114,9 +121,9 @@ public:
     // Classic search, then get the print status
     bool isPrinted(std::string var_name) const;
 
-    uint getMaxColumnsCount() const
+    uint getTotalMaxColumnsCount() const
     {
-        return maxColumnsCount;
+        return totalMaxColumnsCount_;
     }
 
     uint getNbSelectedZonalVars() const
@@ -128,9 +135,10 @@ public:
         return numberSelectedLinkVariables;
     }
 
+    void computeMaxColumnsCountInReports();
+
 private:
     void setAllPrintStatusesTo(bool b);
-    void computeMaxColumnsCountInReports();
     void countSelectedAreaVars();
     void countSelectedLinkVars();
 
@@ -140,7 +148,7 @@ private:
 
     // Max columns count a report of any kind can contain, depending on the number of selected
     // variables. The less variables are selected, the smallest this count is.
-    uint maxColumnsCount = 0;
+    uint totalMaxColumnsCount_ = 0;
 
     // Number of selected zonal variables
     uint numberSelectedAreaVariables = 0;

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -44,32 +44,23 @@ namespace Data
 class VariablePrintInfo
 {
 public:
-    VariablePrintInfo(AnyString vname, uint dataLvl, uint fileLvl);
-    ~VariablePrintInfo(){};
-
-    // Getting name of the (represented) output variable
-    std::string name();
+    VariablePrintInfo(uint dataLvl, uint fileLvl);
+    ~VariablePrintInfo() = default;
 
     // Do we enable or disable variable's print in output reports ?
     void enablePrint(bool b);
-    bool isPrinted();
+    bool isPrinted() const;
+    void reverse();
 
     uint getMaxColumnsCount();
     void setMaxColumns(uint maxColumnsNumber);
-    uint getDataLevel()
-    {
-        return dataLevel;
-    }
-    uint getFileLevel()
-    {
-        return fileLevel;
-    }
+
+    uint getDataLevel() { return dataLevel_; }
+    uint getFileLevel() { return fileLevel_; }
 
 private:
-    // Current variable's name
-    AnyString varname;
     // Is the variable printed ?
-    bool to_be_printed;
+    bool to_be_printed_ = true;
 
     // The number of columns the output variable takes in a SYNTHESIS report.
     // Recall that synthesis reports always contain more columns than
@@ -80,8 +71,8 @@ private:
     // Example : areas/values-<time-interval>.txt
     // dataLevel can be : areas, links, bindingConstraint
     // fileLevel can be : values-<time-interval>.txt, details-<time-interval>.txt, id-<time-interval>.txt, ...
-    uint dataLevel;
-    uint fileLevel;
+    uint dataLevel_ = 0;
+    uint fileLevel_ = 0;
 };
 
 class AllVariablesPrintInfo;
@@ -104,18 +95,21 @@ class AllVariablesPrintInfo
 public:
     // Public methods
     AllVariablesPrintInfo() = default;
-    ~AllVariablesPrintInfo();
+    ~AllVariablesPrintInfo() = default;
 
-    void add(VariablePrintInfo* v);
+    void add(std::string name, VariablePrintInfo v);
     void clear();
-    VariablePrintInfo* operator[](uint i) const;
+    VariablePrintInfo& operator[](uint i);
     size_t size() const;
-    bool isEmpty() const;
+    bool exists(std::string name);
 
-    bool setPrintStatus(std::string varname, bool printStatus);
+    void setPrintStatus(std::string varname, bool printStatus);
+    void setPrintStatus(unsigned int index, bool printStatus);
+
     void setMaxColumns(std::string varname, uint maxColumnsNumber);
+    std::string name_of(unsigned int index) const;
 
-    void prepareForSimulation(bool userSelection,
+    void prepareForSimulation(bool isThematicTrimmingEnabled,
                               const std::vector<std::string>& excluded_vars = {});
 
     // Classic search, then get the print status
@@ -136,15 +130,22 @@ public:
     }
 
     void computeMaxColumnsCountInReports();
+    void setAllPrintStatusesTo(bool b);
+    void reverseAll();
+
+    unsigned int numberOfEnabledVariables();
+    std::vector<std::string> namesOfEnabledVariables();
+    std::vector<std::string> namesOfDisabledVariables();
 
 private:
-    void setAllPrintStatusesTo(bool b);
+    std::vector<std::string> namesOfVariablesWithPrintStatus(bool printStatus);
     void countSelectedAreaVars();
     void countSelectedLinkVars();
 
 private:
     // Contains print info for all variables
-    std::vector<VariablePrintInfo*> allVarsPrintInfo;
+    std::map<std::string, VariablePrintInfo> allVarsPrintInfo;
+    std::map<unsigned int, std::string> index_to_name;
 
     // Max columns count a report of any kind can contain, depending on the number of selected
     // variables. The less variables are selected, the smallest this count is.

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -283,6 +283,8 @@ void ISimulation<Impl>::run()
 
     // Initialize all data
     ImplementationType::variables.initializeFromStudy(study);
+    // Computing the max number columns a report of any kind can contain.
+    study.parameters.variablesPrintInfo.computeMaxColumnsCountInReports();
 
     logs.info() << "Allocating resources...";
 

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -75,7 +75,6 @@ void Areas<NEXTTYPE>::initializeFromStudy(Data::Study& study)
     for (uint i = 0; i != pAreaCount; ++i)
     {
         // Instancing a new set of variables of the area
-        auto& n = pAreas[i];
         auto* currentArea = study.areas.byIndex[i];
         if (!(--tick))
         {
@@ -91,18 +90,18 @@ void Areas<NEXTTYPE>::initializeFromStudy(Data::Study& study)
 
         // Initialize the variables
         // From the study
-        n.initializeFromStudy(study);
+        pAreas[i].initializeFromStudy(study);
         // From the area
-        n.initializeFromArea(&study, currentArea);
+        pAreas[i].initializeFromArea(&study, currentArea);
         // Does current output variable appears non applicable in areas' output files, not
         // districts'. Note that digest gather area and district results.
-        n.broadcastNonApplicability(not currentArea->hydro.reservoirManagement);
+        pAreas[i].broadcastNonApplicability(not currentArea->hydro.reservoirManagement);
 
         // For each current area's variable, getting the print status, that is :
         // is variable's column(s) printed in output (areas) reports ?
-        n.getPrintStatusFromStudy(study);
+        pAreas[i].getPrintStatusFromStudy(study);
 
-        n.supplyMaxNumberOfColumns(study);
+        pAreas[i].supplyMaxNumberOfColumns(study);
     }
 }
 

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -101,6 +101,8 @@ void Areas<NEXTTYPE>::initializeFromStudy(Data::Study& study)
         // For each current area's variable, getting the print status, that is :
         // is variable's column(s) printed in output (areas) reports ?
         n.getPrintStatusFromStudy(study);
+
+        n.supplyMaxNumberOfColumns(study);
     }
 }
 

--- a/src/solver/variable/bindConstraints.hxx
+++ b/src/solver/variable/bindConstraints.hxx
@@ -122,6 +122,15 @@ void BindingConstraints<NextT>::initializeFromStudy(Data::Study& study)
         // Does user want to print output results related to the current binding constraint ?
         bc.getPrintStatusFromStudy(study);
     }
+
+    // This is ugly (it's a work around). We should try to improve this.
+    // Supplying the max number of columns to the variable print info collector 
+    if (pBCcount > 0)
+    {
+        NextType& bc = pBindConstraints[0];
+        bc.setBindConstraintsCount(pBCcount);
+        bc.supplyMaxNumberOfColumns(study);
+    }
 }
 
 template<class NextT>

--- a/src/solver/variable/bindConstraints.hxx
+++ b/src/solver/variable/bindConstraints.hxx
@@ -99,12 +99,12 @@ inline void BindingConstraints<NextT>::provideInformations(I& infos)
 template<class NextT>
 void BindingConstraints<NextT>::initializeFromStudy(Data::Study& study)
 {
-    const std::vector<uint> InequalityBCnumbers
+    const std::vector<uint> InequalityBCindices
       = study.runtime->getIndicesForInequalityBindingConstraints();
 
     // The total number of inequality binding constraints count
     // (we don't count BCs with equality sign)
-    pBCcount = (uint)InequalityBCnumbers.size();
+    pBCcount = (uint)InequalityBCindices.size();
 
     // Reserving the memory
     if (pBCcount > 0)
@@ -116,15 +116,24 @@ void BindingConstraints<NextT>::initializeFromStudy(Data::Study& study)
     {
         NextType& bc = pBindConstraints[i];
 
-        bc.setBindConstraintGlobalNumber(InequalityBCnumbers[i]);
+        bc.setBindConstraintGlobalIndex(InequalityBCindices[i]);
         bc.initializeFromStudy(study);
 
         // Does user want to print output results related to the current binding constraint ?
         bc.getPrintStatusFromStudy(study);
     }
 
-    // This is ugly (it's a work around). We should try to improve this.
-    // Supplying the max number of columns to the variable print info collector 
+    // Here we supply the max number of columns to the variable print info collector 
+    // This is a ugly hack (it's a work around).
+    // We should have a simple call to :
+    //      NextType::supplyMaxNumberOfColumns(study);
+    // Instead, we have a few lines as a hack.
+    // What we have to do is add to the print info collector a single VariablePrintInfo
+    // that has a max columns size of : (nb of inequality BCs) x ResultsType::count
+    // But note that for now, BC output variables are chained statically (one output variable per inequality BC).
+    // The hack is to make the first BC output variable able to supply max columns size for all BC output variables
+    // with its method getMaxNumberColumns().
+    // A solution would be to make BC output variables (like BindingConstMarginCost) some DYNAMIC variables.
     if (pBCcount > 0)
     {
         NextType& bc = pBindConstraints[0];

--- a/src/solver/variable/commons/links/links.h.inc.hxx
+++ b/src/solver/variable/commons/links/links.h.inc.hxx
@@ -140,6 +140,7 @@ public:
 
     void broadcastNonApplicability(bool applyNonApplicable);
     void getPrintStatusFromStudy(Data::Study& study);
+    void supplyMaxNumberOfColumns(Data::Study& study);
 
     void simulationBegin();
     void simulationEnd();

--- a/src/solver/variable/commons/links/links.hxx.inc.hxx
+++ b/src/solver/variable/commons/links/links.hxx.inc.hxx
@@ -69,6 +69,12 @@ inline void Links::getPrintStatusFromStudy(Data::Study& study)
         pLinks[i].getPrintStatusFromStudy(study);
 }
 
+inline void Links::supplyMaxNumberOfColumns(Data::Study& study)
+{
+    for (uint i = 0; i != pLinkCount; ++i)
+        pLinks[i].supplyMaxNumberOfColumns(study);
+}
+
 inline void Links::yearBegin(uint year, unsigned int numSpace)
 {
     for (uint i = 0; i != pLinkCount; ++i)

--- a/src/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -154,7 +154,7 @@ public:
             pValuesForTheCurrentYear[numSpace].initializeFromStudy(study);
 
         // Set the associated binding constraint
-        associatedBC_ = &(study.runtime->bindingConstraint[bindConstraintGlobalNumber_]);
+        associatedBC_ = &(study.runtime->bindingConstraint[bindConstraintGlobalIndex_]);
 
         NextType::initializeFromStudy(study);
     }
@@ -165,9 +165,9 @@ public:
         VariableAccessorType::InitializeAndReset(results, study);
     }
 
-    void setBindConstraintGlobalNumber(uint bcNumber)
+    void setBindConstraintGlobalIndex(uint bc_index)
     {
-        bindConstraintGlobalNumber_ = bcNumber;
+        bindConstraintGlobalIndex_ = bc_index;
     }
 
     void setBindConstraintsCount(uint bcCount)
@@ -253,7 +253,7 @@ public:
             {
                 pValuesForTheCurrentYear[numSpace].day[dayInTheYear]
                   -= state.problemeHebdo
-                       ->ResultatsContraintesCouplantes[bindConstraintGlobalNumber_]
+                       ->ResultatsContraintesCouplantes[bindConstraintGlobalIndex_]
                        .variablesDuales[dayInTheWeek];
 
                 dayInTheYear++;
@@ -266,7 +266,7 @@ public:
         {
             uint weekInTheYear = state.weekInTheYear;
             double weeklyValue
-              = -state.problemeHebdo->ResultatsContraintesCouplantes[bindConstraintGlobalNumber_]
+              = -state.problemeHebdo->ResultatsContraintesCouplantes[bindConstraintGlobalIndex_]
                    .variablesDuales[0];
 
             pValuesForTheCurrentYear[numSpace].week[weekInTheYear] = weeklyValue;
@@ -297,7 +297,7 @@ public:
         if (associatedBC_->type == Data::BindingConstraint::typeHourly)
         {
             pValuesForTheCurrentYear[numSpace][hourInTheYear]
-              -= state.problemeHebdo->ResultatsContraintesCouplantes[bindConstraintGlobalNumber_]
+              -= state.problemeHebdo->ResultatsContraintesCouplantes[bindConstraintGlobalIndex_]
                    .variablesDuales[state.hourInTheWeek];
         }
 
@@ -365,7 +365,7 @@ private:
 
     bool isInitialized()
     {
-        return (bindConstraintGlobalNumber_ >= 0) && associatedBC_;
+        return (bindConstraintGlobalIndex_ >= 0) && associatedBC_;
     }
 
     bool isCurrentOutputNonApplicable(int precision) const
@@ -392,7 +392,7 @@ private:
     typename VCardType::IntermediateValuesType pValuesForTheCurrentYear = nullptr;
     unsigned int pNbYearsParallel = 0;
     Data::BindingConstraintRTI* associatedBC_ = nullptr;
-    int bindConstraintGlobalNumber_ = -1;
+    int bindConstraintGlobalIndex_ = -1;
     uint nbCount_ = 0; // Number of inequality BCs 
 
 }; // class BindingConstMarginCost

--- a/src/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -170,6 +170,16 @@ public:
         bindConstraintGlobalNumber_ = bcNumber;
     }
 
+    void setBindConstraintsCount(uint bcCount)
+    {
+        nbCount_ = bcCount;
+    }
+
+    uint getMaxNumberColumns() const
+    {
+        return nbCount_ * ResultsType::count;
+    }
+
     void yearBegin(unsigned int year, unsigned int numSpace)
     {
         // Reset the values for the current year
@@ -383,6 +393,7 @@ private:
     unsigned int pNbYearsParallel = 0;
     Data::BindingConstraintRTI* associatedBC_ = nullptr;
     int bindConstraintGlobalNumber_ = -1;
+    uint nbCount_ = 0; // Number of inequality BCs 
 
 }; // class BindingConstMarginCost
 

--- a/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -217,6 +217,11 @@ public:
         NextType::initializeFromArea(study, area);
     }
 
+    uint getMaxNumberColumns() const
+    {
+        return pSize * ResultsType::count;
+    }
+
     void initializeFromLink(Data::Study* study, Data::AreaLink* link)
     {
         // Next

--- a/src/solver/variable/economy/npCostByDispatchablePlant.h
+++ b/src/solver/variable/economy/npCostByDispatchablePlant.h
@@ -220,6 +220,11 @@ public:
         NextType::initializeFromArea(study, area);
     }
 
+    uint getMaxNumberColumns() const
+    {
+        return pSize * ResultsType::count;
+    }
+
     void initializeFromLink(Data::Study* study, Data::AreaLink* link)
     {
         // Next

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -235,6 +235,11 @@ public:
         NextType::initializeFromArea(study, area);
     }
 
+    uint getMaxNumberColumns() const
+    {
+        return pSize * ResultsType::count;
+    }
+
     void initializeFromLink(Data::Study* study, Data::AreaLink* link)
     {
         // Next

--- a/src/solver/variable/economy/productionByRenewablePlant.h
+++ b/src/solver/variable/economy/productionByRenewablePlant.h
@@ -217,6 +217,11 @@ public:
         NextType::initializeFromArea(study, area);
     }
 
+    uint getMaxNumberColumns() const
+    {
+        return pSize * ResultsType::count;
+    }
+
     void initializeFromLink(Data::Study* study, Data::AreaLink* link)
     {
         // Next

--- a/src/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/economy/profitByPlant.h
@@ -213,6 +213,11 @@ public:
         NextType::initializeFromArea(study, area);
     }
 
+    uint getMaxNumberColumns() const
+    {
+        return pNbClustersOfArea * ResultsType::count;
+    }
+
     void initializeFromLink(Data::Study* study, Data::AreaLink* link)
     {
         // Next

--- a/src/solver/variable/endoflist.h
+++ b/src/solver/variable/endoflist.h
@@ -115,6 +115,10 @@ public:
     {
     }
 
+    void supplyMaxNumberOfColumns(Data::Study& study)
+    {
+    }
+
     static void simulationBegin()
     {
     }

--- a/src/solver/variable/surveyresults/surveyresults.cpp
+++ b/src/solver/variable/surveyresults/surveyresults.cpp
@@ -504,15 +504,6 @@ static inline void WriteIndexHeaderToFileDescriptor(int precisionLevel,
     s += '\n';
 }
 
-void SurveyResults::initializeMaxVariables(const Data::Study& s)
-{
-    const auto* runtime = s.runtime;
-
-    // Getting the any report's max number of columns
-    maxVariables = s.parameters.variablesPrintInfo.getTotalMaxColumnsCount();
-    logs.debug() << "  (for " << maxVariables << " columns)";
-}
-
 // TOFIX - MBO 02/06/2014 nombre de colonnes fonction du nombre de variables
 SurveyResults::SurveyResults(const Data::Study& s,
                              const String& o,
@@ -522,10 +513,11 @@ SurveyResults::SurveyResults(const Data::Study& s,
  isCurrentVarNA(nullptr),
  isPrinted(nullptr),
  pResultWriter(writer)
-{
-    initializeMaxVariables(s);
-    
+{    
     variableCaption.reserve(10);
+
+    maxVariables = s.parameters.variablesPrintInfo.getTotalMaxColumnsCount();
+    logs.debug() << "  (for " << maxVariables << " columns)";
 
     data.initialize(maxVariables);
     // logs.debug() << "  :: survey results: allocating "

--- a/src/solver/variable/surveyresults/surveyresults.cpp
+++ b/src/solver/variable/surveyresults/surveyresults.cpp
@@ -509,39 +509,8 @@ void SurveyResults::initializeMaxVariables(const Data::Study& s)
     const auto* runtime = s.runtime;
 
     // Getting the any report's max number of columns
-    maxVariables = s.parameters.variablesPrintInfo.getMaxColumnsCount();
+    maxVariables = s.parameters.variablesPrintInfo.getTotalMaxColumnsCount();
     logs.debug() << "  (for " << maxVariables << " columns)";
-
-    if (!runtime)
-        return;
-
-    // Adding new files / variables ? Change the values below to avoid maxVariables being too small
-
-    // TODO: count those variables at compile time / runtime
-    // using e.g VCardT::categoryDataLevel
-    const uint nbVariablesPerDetailThermalCluster = 4;
-    /*
-      - Production
-      - NODU,
-      - NP Costs
-      - Net profit
-    */
-    const uint nbVariablesPerDetailRenewableCluster = 1; // Production
-
-    // Max number of columns taken by an inequality binding constraint in a report
-    // (= output file). Here, this max is 4, and occurs in binding
-    // constraint synythesis reports.
-    const uint maxNbVariablesPerInequalityBindingConstraint = 4;
-
-    const auto max = [](uint a, uint b, uint c, uint d) { return std::max({a, b, c, d}); };
-
-    maxVariables = max(maxVariables,
-                       static_cast<uint>(nbVariablesPerDetailThermalCluster
-                                 * runtime->maxThermalClustersForSingleArea),
-                       static_cast<uint>(nbVariablesPerDetailRenewableCluster
-                                 * runtime->maxRenewableClustersForSingleArea),
-                       maxNbVariablesPerInequalityBindingConstraint
-                                * runtime->getNumberOfInequalityBindingConstraints());
 }
 
 // TOFIX - MBO 02/06/2014 nombre de colonnes fonction du nombre de variables

--- a/src/solver/variable/surveyresults/surveyresults.h
+++ b/src/solver/variable/surveyresults/surveyresults.h
@@ -149,8 +149,6 @@ public:
     IResultWriter::Ptr pResultWriter;
 
 private:
-    void initializeMaxVariables(const Data::Study& s);
-
     template<class StringT, class ConvertT, class PrecisionT>
     void AppendDoubleValue(uint& error,
                            const double v,

--- a/src/solver/variable/variable.h
+++ b/src/solver/variable/variable.h
@@ -113,6 +113,10 @@ public:
     template<class PredicateT>
     static void RetrieveVariableList(PredicateT& predicate);
 
+    void getPrintStatusFromStudy(Data::Study& study);
+    void supplyMaxNumberOfColumns(Data::Study& study);
+
+
 public:
     //! \name Constructor
     //@{
@@ -132,6 +136,8 @@ public:
     ** \param study The attached study
     */
     void initializeFromStudy(Data::Study& study);
+
+    uint getMaxNumberColumns() const;
 
     /*!
     ** \brief Initialize the variable with a specific area
@@ -162,8 +168,6 @@ public:
     //@}
 
     void broadcastNonApplicability(bool applyNonApplicable);
-
-    void getPrintStatusFromStudy(Data::Study& study);
 
     //! \name Simulation
     //@{

--- a/src/solver/variable/variable.hxx
+++ b/src/solver/variable/variable.hxx
@@ -152,60 +152,7 @@ inline void IVariable<ChildT, NextT, VCardT>::broadcastNonApplicability(bool app
     NextType::broadcastNonApplicability(applyNonApplicable);
 }
 
-// The class GetPrintStatusHelper is used to make a different Do(...) treatment depending on current
-// VCardType::columnCount. Recall that a variable can be single, dynamic or multiple.
-namespace // anonymous
-{
-// Case : the variable is multiple
-template<int ColumnT, class VCardT>
-class GetPrintStatusHelper
-{
-public:
-    static void Do(Data::Study& study, bool* isPrinted)
-    {
-        for (uint i = 0; i != VCardT::columnCount; ++i)
-        {
-            // Shifting inside the variables print info collection until reaching the print info
-            // associated with the current name, and then getting its print status.
-            isPrinted[i] = study.parameters.variablesPrintInfo.isPrinted(VCardT::Multiple::Caption(i));
-        }
-    }
-};
 
-// Case : the variable is single
-template<class VCardT>
-class GetPrintStatusHelper<1, VCardT>
-{
-public:
-    static void Do(Data::Study& study, bool* isPrinted)
-    {
-        // Shifting inside the variables print info collection until reaching the print info
-        // associated with the current name, and then getting its print status.
-        isPrinted[0] = study.parameters.variablesPrintInfo.isPrinted(VCardT::Caption());
-    }
-};
-
-// Case : the variable is dynamic
-template<class VCardT>
-class GetPrintStatusHelper<-1, VCardT>
-{
-public:
-    static void Do(Data::Study& study, bool* isPrinted)
-    {
-        // Shifting inside the variables print info collection until reaching the print info
-        // associated with the current name, and then getting its print status.
-        isPrinted[0] = study.parameters.variablesPrintInfo.isPrinted(VCardT::Caption());
-    }
-};
-} // namespace
-
-template<class ChildT, class NextT, class VCardT>
-inline void IVariable<ChildT, NextT, VCardT>::getPrintStatusFromStudy(Data::Study& study)
-{
-    GetPrintStatusHelper<VCardType::columnCount, VCardType>::Do(study, isPrinted);
-    // Go to the next variable
-    NextType::getPrintStatusFromStudy(study);
-}
 
 template<class ChildT, class NextT, class VCardT>
 inline void IVariable<ChildT, NextT, VCardT>::simulationBegin()
@@ -218,6 +165,11 @@ template<class ChildT, class NextT, class VCardT>
 inline void IVariable<ChildT, NextT, VCardT>::simulationEnd()
 {
     NextType::simulationEnd();
+}
+template<class ChildT, class NextT, class VCardT>
+uint IVariable<ChildT, NextT, VCardT>::getMaxNumberColumns() const
+{
+    return VCardT::ResultsType::count;
 }
 
 template<class ChildT, class NextT, class VCardT>
@@ -643,6 +595,11 @@ inline const typename Storage<VCardT>::ResultsType& IVariable<ChildT, NextT, VCa
     return pResults;
 }
 
+
+// ===================================================================
+// Each output variable gets registered in the print info collector
+// ===================================================================
+
 // class RetrieveVariableListHelper goes with function RetrieveVariableList(...).
 // This class is used to make a different Do(...) treatment depending on current
 // VCardType::columnCount. Recall that a variable can be single, dynamic or multiple.
@@ -666,7 +623,6 @@ public:
         for (int i = 0; i < VCardT::columnCount; ++i)
         {
             printInfoCollector.add(VCardT::Multiple::Caption(i),
-                                   VCardT::ResultsType::count,
                                    VCardT::categoryDataLevel,
                                    VCardT::categoryFileLevel);
         }
@@ -688,7 +644,6 @@ public:
     static void Do(Data::variablePrintInfoCollector& printInfoCollector)
     {
         printInfoCollector.add(VCardT::Caption(),
-                               VCardT::ResultsType::count,
                                VCardT::categoryDataLevel,
                                VCardT::categoryFileLevel);
     }
@@ -708,7 +663,6 @@ public:
     static void Do(Data::variablePrintInfoCollector& printInfoCollector)
     {
         printInfoCollector.add(VCardT::Caption(),
-                               VCardT::ResultsType::count,
                                VCardT::categoryDataLevel,
                                VCardT::categoryFileLevel);
     }
@@ -723,6 +677,123 @@ void IVariable<ChildT, NextT, VCardT>::RetrieveVariableList(PredicateT& predicat
     RetrieveVariableListHelper<VCardType::columnCount, VCardType, ChildT>::Do(predicate);
     // Go to the next variable
     NextType::RetrieveVariableList(predicate);
+}
+
+
+// ============================================================================= 
+// Each output variable gets its print status from the study parameters
+// =============================================================================
+
+// The class GetPrintStatusHelper is used to make a different Do(...) treatment depending on current
+// VCardType::columnCount. Recall that a variable can be single, dynamic or multiple.
+namespace // anonymous
+{
+    // Case : the variable is multiple
+    template<int ColumnT, class VCardT>
+    class GetPrintStatusHelper
+    {
+    public:
+        static void Do(Data::Study& study, bool* isPrinted)
+        {
+            for (uint i = 0; i != VCardT::columnCount; ++i)
+            {
+                // Shifting inside the variables print info collection until reaching the print info
+                // associated with the current name, and then getting its print status.
+                isPrinted[i] = study.parameters.variablesPrintInfo.isPrinted(VCardT::Multiple::Caption(i));
+            }
+        }
+    };
+
+    // Case : the variable is single
+    template<class VCardT>
+    class GetPrintStatusHelper<1, VCardT>
+    {
+    public:
+        static void Do(Data::Study& study, bool* isPrinted)
+        {
+            // Shifting inside the variables print info collection until reaching the print info
+            // associated with the current name, and then getting its print status.
+            isPrinted[0] = study.parameters.variablesPrintInfo.isPrinted(VCardT::Caption());
+        }
+    };
+
+    // Case : the variable is dynamic
+    template<class VCardT>
+    class GetPrintStatusHelper<-1, VCardT>
+    {
+    public:
+        static void Do(Data::Study& study, bool* isPrinted)
+        {
+            // Shifting inside the variables print info collection until reaching the print info
+            // associated with the current name, and then getting its print status.
+            isPrinted[0] = study.parameters.variablesPrintInfo.isPrinted(VCardT::Caption());
+        }
+    };
+} // namespace
+
+template<class ChildT, class NextT, class VCardT>
+inline void IVariable<ChildT, NextT, VCardT>::getPrintStatusFromStudy(Data::Study& study)
+{
+    GetPrintStatusHelper<VCardType::columnCount, VCardType>::Do(study, isPrinted);
+    // Go to the next variable
+    NextType::getPrintStatusFromStudy(study);
+}
+
+
+
+// =======================================================================
+// Each output variable supplies the maximum number of columns it takes 
+// in an ouptut report to the variable print info instance
+// =======================================================================
+
+// The class SupplyMaxNbColumnsHelper is used to make a different Do(...) treatment depending on current
+// VCardType::columnCount : recall that a variable can be single, dynamic or multiple.
+namespace // anonymous
+{
+    // Case : the variable is multiple
+    template<int ColumnT, class VCardT>
+    class SupplyMaxNbColumnsHelper
+    {
+    public:
+        static void Do(Data::Study& study, uint maxNumberColumns)
+        {
+            for (uint i = 0; i != VCardT::columnCount; ++i)
+            {
+                study.parameters.variablesPrintInfo.setMaxColumns(VCardT::Multiple::Caption(i), maxNumberColumns);
+            }
+        }
+    };
+
+    // Case : the variable is single
+    template<class VCardT>
+    class SupplyMaxNbColumnsHelper<1, VCardT>
+    {
+    public:
+        static void Do(Data::Study& study, uint maxNumberColumns)
+        {
+            study.parameters.variablesPrintInfo.setMaxColumns(VCardT::Caption(), maxNumberColumns);
+        }
+    };
+
+    // Case : the variable is dynamic
+    template<class VCardT>
+    class SupplyMaxNbColumnsHelper<-1, VCardT>
+    {
+    public:
+        static void Do(Data::Study& study, uint maxNumberColumns)
+        {
+            study.parameters.variablesPrintInfo.setMaxColumns(VCardT::Caption(), maxNumberColumns);
+        }
+    };
+} // namespace
+
+template<class ChildT, class NextT, class VCardT>
+inline void IVariable<ChildT, NextT, VCardT>::supplyMaxNumberOfColumns(Data::Study& study)
+{
+    uint max_columns = static_cast<const ChildT*>(this)->getMaxNumberColumns();
+    SupplyMaxNbColumnsHelper<VCardType::columnCount, VCardType>::Do(study, max_columns);
+    // Go to the next variable
+    NextType::supplyMaxNumberOfColumns(study);
 }
 
 } // namespace Variable

--- a/src/solver/variable/variable.hxx
+++ b/src/solver/variable/variable.hxx
@@ -559,7 +559,7 @@ struct HourlyResultsForCurrentYear
 };
 
 template<>
-struct HourlyResultsForCurrentYear<1>
+struct HourlyResultsForCurrentYear<Category::singleColumn>
 {
     template<class R>
     static Antares::Memory::Stored<double>::ConstReturnType Get(const R& results, uint)
@@ -569,7 +569,7 @@ struct HourlyResultsForCurrentYear<1>
 };
 
 template<>
-struct HourlyResultsForCurrentYear<0>
+struct HourlyResultsForCurrentYear<Category::noColumn>
 {
     template<class R>
     static Antares::Memory::Stored<double>::ConstReturnType Get(const R&, uint)
@@ -630,7 +630,7 @@ public:
 };
 
 template<class VCardT, class ChildT>
-class RetrieveVariableListHelper<1, VCardT, ChildT>
+class RetrieveVariableListHelper<Category::singleColumn, VCardT, ChildT>
 {
 public:
     template<class PredicateT>
@@ -650,7 +650,7 @@ public:
 };
 
 template<class VCardT, class ChildT>
-class RetrieveVariableListHelper<-1, VCardT, ChildT>
+class RetrieveVariableListHelper<Category::dynamicColumns, VCardT, ChildT>
 {
 public:
     template<class PredicateT>
@@ -706,7 +706,7 @@ namespace // anonymous
 
     // Case : the variable is single
     template<class VCardT>
-    class GetPrintStatusHelper<1, VCardT>
+    class GetPrintStatusHelper<Category::singleColumn, VCardT>
     {
     public:
         static void Do(Data::Study& study, bool* isPrinted)
@@ -719,7 +719,7 @@ namespace // anonymous
 
     // Case : the variable is dynamic
     template<class VCardT>
-    class GetPrintStatusHelper<-1, VCardT>
+    class GetPrintStatusHelper<Category::dynamicColumns, VCardT>
     {
     public:
         static void Do(Data::Study& study, bool* isPrinted)
@@ -766,7 +766,7 @@ namespace // anonymous
 
     // Case : the variable is single
     template<class VCardT>
-    class SupplyMaxNbColumnsHelper<1, VCardT>
+    class SupplyMaxNbColumnsHelper<Category::singleColumn, VCardT>
     {
     public:
         static void Do(Data::Study& study, uint maxNumberColumns)
@@ -777,7 +777,7 @@ namespace // anonymous
 
     // Case : the variable is dynamic
     template<class VCardT>
-    class SupplyMaxNbColumnsHelper<-1, VCardT>
+    class SupplyMaxNbColumnsHelper<Category::dynamicColumns, VCardT>
     {
     public:
         static void Do(Data::Study& study, uint maxNumberColumns)

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp
@@ -39,7 +39,7 @@ wxString SelectVariables::columnCaption(int) const
 
 wxString SelectVariables::rowCaption(int rowIndx) const
 {
-    return wxString(wxT(" ")) << study->parameters.variablesPrintInfo[rowIndx]->name() << wxT("  ");
+    return wxString(wxT(" ")) << study->parameters.variablesPrintInfo.name_of(rowIndx) << wxT("  ");
 }
 
 bool SelectVariables::cellValue(int, int var, const Yuni::String& value)
@@ -50,8 +50,7 @@ bool SelectVariables::cellValue(int, int var, const Yuni::String& value)
         s.trim();
         s.toLower();
         bool v = s.to<bool>() || s == "active" || s == "enabled";
-        assert(!study->parameters.variablesPrintInfo.isEmpty());
-        study->parameters.variablesPrintInfo[var]->enablePrint(v);
+        study->parameters.variablesPrintInfo.setPrintStatus(var, v);
         onTriggerUpdate();
         Dispatcher::GUI::Refresh(pControl);
         return true;
@@ -63,8 +62,7 @@ double SelectVariables::cellNumericValue(int, int var) const
 {
     if (!(!study) && (uint)var < study->parameters.variablesPrintInfo.size())
     {
-        assert(!study->parameters.variablesPrintInfo.isEmpty());
-        return study->parameters.variablesPrintInfo[var]->isPrinted();
+        return study->parameters.variablesPrintInfo[var].isPrinted();
     }
     return 0.;
 }
@@ -73,8 +71,7 @@ wxString SelectVariables::cellValue(int, int var) const
 {
     if (!(!study) && static_cast<uint>(var) < study->parameters.variablesPrintInfo.size())
     {
-        assert(!study->parameters.variablesPrintInfo.isEmpty());
-        return study->parameters.variablesPrintInfo[var]->isPrinted() ? wxT("Active") : wxT("skip");
+        return study->parameters.variablesPrintInfo[var].isPrinted() ? wxT("Active") : wxT("skip");
     }
     return wxEmptyString;
 }
@@ -83,8 +80,7 @@ IRenderer::CellStyle SelectVariables::cellStyle(int, int var) const
 {
     if (!(!study) && (uint)var < study->parameters.variablesPrintInfo.size())
     {
-        assert(!study->parameters.variablesPrintInfo.isEmpty());
-        return !study->parameters.variablesPrintInfo[var]->isPrinted()
+        return !study->parameters.variablesPrintInfo[var].isPrinted()
                  ? IRenderer::cellStyleConstraintNoWeight
                  : IRenderer::cellStyleConstraintWeight;
     }

--- a/src/ui/simulator/windows/options/select-output/select-output.cpp
+++ b/src/ui/simulator/windows/options/select-output/select-output.cpp
@@ -163,8 +163,7 @@ void SelectOutput::onSelectAll(void*)
     auto& study = *studyptr;
 
     Freeze();
-    for (uint i = 0; i != study.parameters.variablesPrintInfo.size(); ++i)
-        study.parameters.variablesPrintInfo[i]->enablePrint(true);
+    study.parameters.variablesPrintInfo.setAllPrintStatusesTo(true);
     pGrid->forceRefresh();
     updateCaption();
     Dispatcher::GUI::Refresh(pGrid);
@@ -180,8 +179,7 @@ void SelectOutput::onUnselectAll(void*)
     auto& study = *studyptr;
 
     Freeze();
-    for (uint i = 0; i != study.parameters.variablesPrintInfo.size(); ++i)
-        study.parameters.variablesPrintInfo[i]->enablePrint(false);
+    study.parameters.variablesPrintInfo.setAllPrintStatusesTo(false);
     pGrid->forceRefresh();
     updateCaption();
     Dispatcher::GUI::Refresh(pGrid);
@@ -197,11 +195,7 @@ void SelectOutput::onToggle(void*)
     auto& study = *studyptr;
 
     Freeze();
-    for (uint i = 0; i != study.parameters.variablesPrintInfo.size(); ++i)
-    {
-        study.parameters.variablesPrintInfo[i]->enablePrint(
-          not study.parameters.variablesPrintInfo[i]->isPrinted());
-    }
+    study.parameters.variablesPrintInfo.reverseAll();
     pGrid->forceRefresh();
     updateCaption();
     Dispatcher::GUI::Refresh(pGrid);
@@ -226,18 +220,13 @@ void SelectOutput::updateCaption()
 
     if (d.thematicTrimming)
     {
-        uint v = 0;
-        for (uint i = 0; i != d.variablesPrintInfo.size(); ++i)
-        {
-            if (d.variablesPrintInfo[i]->isPrinted())
-                ++v;
-        }
-        if (v < 2)
+        uint nbPrintedVars = d.variablesPrintInfo.numberOfEnabledVariables();
+        if (nbPrintedVars < 2)
             pStatus->SetLabel(wxString()
-                              << wxT(" Ask for selecting ") << v << wxT(" output variable  "));
+                              << wxT(" Ask for selecting ") << nbPrintedVars << wxT(" output variable  "));
         else
             pStatus->SetLabel(wxString()
-                              << wxT(" Ask for selecting ") << v << wxT(" output variables  "));
+                              << wxT(" Ask for selecting ") << nbPrintedVars << wxT(" output variables  "));
     }
     else
         pStatus->SetLabel(wxT(" Ask for selecting output variables "));


### PR DESCRIPTION
The current PR follows #1159, which is merely a preparatory cleaning PR.
The current PR adresses the real problem of issue #927 :  computing an accurate max number of columns an output report can contain.

Note that, as synthesis reports always contain more columns than any other report, the max number of columns computation is based on the number of columns an output variable can take in a synthesis report.

**Execution steps** : 
- Creating all output variables print info list, that is filling **variablesPrintInfo** where each variable's print status is **true**
  See **parameters.cpp** : `RetrieveVariableList(collector)`.
  At this point, clusters or BCs are not loaded, we can't give a  max column width to the dynamic or BCs output variables.
- Collecting print info status for each output variable (see reading functions in **parameters.cpp**)
- Collecting the max column width of each output variables when clusters or BCs are loaded.
  This is done inside **solver.hxx** : `variables.initializeFromStudy(study)`
  See the calls to `supplyMaxNumberOfColumns(study)`
- Computing the max number of columns a report can contains.
  This is done when calling **solver.hxx** : parameters.variablesPrintInfo.computeMaxColumnsCountInReports();
  By looping over all the kinds of generated reports, getting the number of columns they contain,  and storing the largest size. 
- Getting the already computed largest size in `SurveyResults::initializeMaxVariables`, just before printing