### PR TITLE
Remove useless comparison & compilation warning

### DIFF
--- a/src/solver/optimisation/opt_alloc_probleme_a_optimiser.cpp
+++ b/src/solver/optimisation/opt_alloc_probleme_a_optimiser.cpp
@@ -193,12 +193,6 @@ static void optimisationAllocateProblem(PROBLEME_HEBDO* problemeHebdo, const int
     logs.info() << " Expected Number of Non-zero terms in Problem Matrix : " << NbTermes;
     logs.info();
 
-    if ((uint)NbTermes > (std::numeric_limits<std::size_t>::max() / 8) - 1)
-    {
-        logs.fatal() << "Optimisation problem too large to be allocated.";
-        AntaresSolverEmergencyShutdown();
-    }
-
     OPT_AllocateFromNumberOfVariableConstraints(problemeHebdo->ProblemeAResoudre, NbTermes);
 
     NbIntervalles
@@ -238,12 +232,6 @@ void OPT_AugmenterLaTailleDeLaMatriceDesContraintes(PROBLEME_ANTARES_A_RESOUDRE*
     logs.info() << " Expected Number of Non-zero terms in Problem Matrix : increased to : "
                 << NbTermes;
     logs.info();
-
-    if (NbTermes > (std::numeric_limits<std::size_t>::max() / 8) - 1)
-    {
-        logs.fatal() << "Optimisation problem too large to be allocated.";
-        AntaresSolverEmergencyShutdown();
-    }
 
     ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes = (double*)MemRealloc(
       ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes, NbTermes * sizeof(double));


### PR DESCRIPTION
Comparing an `int` to `std::numeric_limits<std::size_t>::max() / 8 - 1` always returns `false` for "most" 64-bit environments. ~~This also holds true for 32-bit environments.~~

```cpp
// sizeof.cpp
#include <iostream>
#include <limits>
#include <cassert>

int main() {
  using uint = unsigned int;
  std::cout << "std::numeric_limits<std::size_t>::max() / 8 - 1 = " << std::numeric_limits<std::size_t>::max() / 8 - 1 << std::endl;
  std::cout << "std::numeric_limits<uint>::max() = " << std::numeric_limits<uint>::max() << std::endl;
  assert(std::numeric_limits<uint>::max() < std::numeric_limits<std::size_t>::max() / 8 - 1);
}
// Linux (32-bits i686-linux-gnu-g++ sizeof.cpp && ./a.out)
std::numeric_limits<std::size_t>::max() / 8 - 1 = 536870910
std::numeric_limits<uint>::max() = 4294967295
a.out: sizeof.cpp:9: int main(): Assertion `std::numeric_limits<uint>::max() < std::numeric_limits<std::size_t>::max() / 8 - 1' failed.
Abandon (core dumped)
// Linux 64-bits (x86_64-linux-gnu-g++ sizeof.cpp && ./a.out)
std::numeric_limits<std::size_t>::max() / 8 - 1 = 2305843009213693950
std::numeric_limits<uint>::max() = 4294967295
// Windows 64-bits (x86_64-w64-mingw32-g++ sizeof.cpp && wine ./a.exe)
std::numeric_limits<std::size_t>::max() / 8 - 1 = 2305843009213693950
std::numeric_limits<uint>::max() = 4294967295
```
**Conclusion** This check made sense for 32-bit targets, but it doesn't for 64-bit targets