### PR TITLE
max nb columns for print : more cleaning

### DIFF
--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1874,7 +1874,7 @@ void Parameters::saveToINI(IniFile& ini) const
     // Variable selection
     {
         uint nb_tot_vars = (uint)variablesPrintInfo.size();
-        uint nb_selected_vars = (uint)variablesPrintInfo.namesOfEnabledVariables.size();
+        uint nb_selected_vars = (uint)variablesPrintInfo.namesOfEnabledVariables().size();
 
         if (nb_selected_vars != nb_tot_vars)
         {
@@ -1883,12 +1883,12 @@ void Parameters::saveToINI(IniFile& ini) const
             if (nb_selected_vars <= (nb_tot_vars / 2))
             {
                 section->add("selected_vars_reset", "false");
-                for (auto& name : variablesPrintInfo.namesOfEnabledVariables)
+                for (auto& name : variablesPrintInfo.namesOfEnabledVariables())
                     section->add("select_var +", name);
             }
             else
             {
-                for (auto& name : variablesPrintInfo.namesOfDisabledVariables)
+                for (auto& name : variablesPrintInfo.namesOfDisabledVariables())
                     section->add("select_var -", name);
             }
         }

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1874,7 +1874,7 @@ void Parameters::saveToINI(IniFile& ini) const
     // Variable selection
     {
         uint nb_tot_vars = (uint)variablesPrintInfo.size();
-        uint nb_selected_vars = (uint)variablesPrintInfo.namesPrinted.size();
+        uint nb_selected_vars = (uint)variablesPrintInfo.namesOfEnabledVariables.size();
 
         if (nb_selected_vars != nb_tot_vars)
         {
@@ -1883,12 +1883,12 @@ void Parameters::saveToINI(IniFile& ini) const
             if (nb_selected_vars <= (nb_tot_vars / 2))
             {
                 section->add("selected_vars_reset", "false");
-                for (auto name : variablesPrintInfo.namesPrinted)
+                for (auto& name : variablesPrintInfo.namesOfEnabledVariables)
                     section->add("select_var +", name);
             }
             else
             {
-                for (auto name : variablesPrintInfo.namesNotPrinted)
+                for (auto& name : variablesPrintInfo.namesOfDisabledVariables)
                     section->add("select_var -", name);
             }
         }

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -966,23 +966,20 @@ static bool SGDIntLoadFamily_VariablesSelection(Parameters& d,
 {
     if (key == "selected_vars_reset")
     {
-        bool mode = value.to<bool>();
-        if (mode)
-        {
-            for (uint i = 0; i != d.variablesPrintInfo.size(); ++i)
-                d.variablesPrintInfo[i]->enablePrint(true);
-        }
-        else
-        {
-            for (uint i = 0; i != d.variablesPrintInfo.size(); ++i)
-                d.variablesPrintInfo[i]->enablePrint(false);
-        }
+        bool printAllVariables = value.to<bool>();
+        d.variablesPrintInfo.setAllPrintStatusesTo(printAllVariables);
         return true;
     }
-    if (key == "select_var +")
-        return d.variablesPrintInfo.setPrintStatus(value.to<std::string>(), true);
-    if (key == "select_var -")
-        return d.variablesPrintInfo.setPrintStatus(value.to<std::string>(), false);
+    if (key == "select_var +" || key == "select_var -")
+    {
+        // Check if the read output variable exists 
+        if (not d.variablesPrintInfo.exists(value.to<std::string>()))
+            return false;
+
+        bool is_var_printed = (key == "select_var +");
+        d.variablesPrintInfo.setPrintStatus(value.to<std::string>(), is_var_printed);
+        return true;
+    }
     return false;
 }
 static bool SGDIntLoadFamily_SeedsMersenneTwister(Parameters& d,

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1928,17 +1928,17 @@ bool Parameters::saveToFile(const AnyString& filename) const
 
 void Parameters::RenewableGeneration::addExcludedVariables(std::vector<std::string>& out) const
 {
-    const static std::vector<std::string> ren = {"wind offshore",
-                                                 "wind onshore",
-                                                 "solar concrt.",
-                                                 "solar pv",
-                                                 "solar rooft",
-                                                 "renw. 1",
-                                                 "renw. 2",
-                                                 "renw. 3",
-                                                 "renw. 4"};
+    const static std::vector<std::string> ren = {"WIND OFFSHORE",
+                                                 "WIND ONSHORE",
+                                                 "SOLAR CONCRT.",
+                                                 "SOLAR PV",
+                                                 "SOLAR ROOFT",
+                                                 "RENW. 1",
+                                                 "RENW. 2",
+                                                 "RENW. 3",
+                                                 "RENW. 4"};
 
-    const static std::vector<std::string> agg = {"wind", "solar"};
+    const static std::vector<std::string> agg = {"WIND", "SOLAR"};
 
     switch (rgModelling)
     {

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1889,7 +1889,7 @@ void Parameters::saveToINI(IniFile& ini) const
             else
             {
                 for (auto name : variablesPrintInfo.namesNotPrinted)
-                    section->add("select_var +", name);
+                    section->add("select_var -", name);
             }
         }
     }

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1873,35 +1873,23 @@ void Parameters::saveToINI(IniFile& ini) const
 
     // Variable selection
     {
-        assert(!variablesPrintInfo.isEmpty());
         uint nb_tot_vars = (uint)variablesPrintInfo.size();
-        uint selected_vars = 0;
+        uint nb_selected_vars = (uint)variablesPrintInfo.namesPrinted.size();
 
-        for (uint i = 0; i != nb_tot_vars; ++i)
-        {
-            if (variablesPrintInfo[i]->isPrinted())
-                ++selected_vars;
-        }
-        if (selected_vars != nb_tot_vars)
+        if (nb_selected_vars != nb_tot_vars)
         {
             // We have something to write !
             auto* section = ini.addSection("variables selection");
-            if (selected_vars <= (nb_tot_vars / 2))
+            if (nb_selected_vars <= (nb_tot_vars / 2))
             {
                 section->add("selected_vars_reset", "false");
-                for (uint i = 0; i != nb_tot_vars; ++i)
-                {
-                    if (variablesPrintInfo[i]->isPrinted())
-                        section->add("select_var +", variablesPrintInfo[i]->name());
-                }
+                for (auto name : variablesPrintInfo.namesPrinted)
+                    section->add("select_var +", name);
             }
             else
             {
-                for (uint i = 0; i != nb_tot_vars; ++i)
-                {
-                    if (not variablesPrintInfo[i]->isPrinted())
-                        section->add("select_var -", variablesPrintInfo[i]->name());
-                }
+                for (auto name : variablesPrintInfo.namesNotPrinted)
+                    section->add("select_var +", name);
             }
         }
     }

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1874,7 +1874,7 @@ void Parameters::saveToINI(IniFile& ini) const
     // Variable selection
     {
         uint nb_tot_vars = (uint)variablesPrintInfo.size();
-        uint nb_selected_vars = (uint)variablesPrintInfo.namesOfEnabledVariables().size();
+        uint nb_selected_vars = (uint)variablesPrintInfo.numberOfEnabledVariables();
 
         if (nb_selected_vars != nb_tot_vars)
         {

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -188,6 +188,13 @@ void AllVariablesPrintInfo::reverseAll()
 
 }
 
+unsigned int AllVariablesPrintInfo::numberOfEnabledVariables()
+{
+    return std::count_if(allVarsPrintInfo.begin(), 
+                         allVarsPrintInfo.end(), 
+                         [](auto& p) {return p.second.isPrinted(); });
+}
+
 std::vector<std::string> AllVariablesPrintInfo::namesOfVariablesWithPrintStatus(bool printStatus)
 {
     std::vector<std::string> vector_to_return;

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -128,11 +128,6 @@ bool AllVariablesPrintInfo::exists(std::string name)
     return allVarsPrintInfo.find(to_uppercase(name)) != allVarsPrintInfo.end();
 }
 
-bool AllVariablesPrintInfo::isEmpty() const
-{
-    return allVarsPrintInfo.empty();
-}
-
 void AllVariablesPrintInfo::setPrintStatus(std::string varname, bool printStatus)
 {
     allVarsPrintInfo.at(to_uppercase(varname)).enablePrint(printStatus);

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -41,12 +41,11 @@ namespace Data
 // One variable print information
 // ============================================================
 VariablePrintInfo::VariablePrintInfo(AnyString vname, uint dataLvl, uint fileLvl) :
- varname(""),
- to_be_printed(true),
- dataLevel(dataLvl),
- fileLevel(fileLvl)
+    varname(vname),
+    to_be_printed(true),
+    dataLevel(dataLvl),
+    fileLevel(fileLvl)
 {
-    varname = vname;
 }
 
 std::string VariablePrintInfo::name()
@@ -158,13 +157,11 @@ void AllVariablesPrintInfo::setMaxColumns(std::string varname, uint maxColumnsNu
         return (*it)->setMaxColumns(maxColumnsNumber);
 }
 
-void AllVariablesPrintInfo::prepareForSimulation(bool userSelection,
+void AllVariablesPrintInfo::prepareForSimulation(bool isThematicTrimmingEnabled,
                                                  const std::vector<std::string>& excluded_vars)
 {
-    assert(!isEmpty() && "The variable print info list must not be empty at this point");
-
     // Initializing output variables status
-    if (!userSelection)
+    if (not isThematicTrimmingEnabled)
         setAllPrintStatusesTo(true);
 
     for (const auto& varname : excluded_vars)

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -95,7 +95,7 @@ static std::string to_uppercase(std::string& str)
     return str;
 }
 
-void AllVariablesPrintInfo::add(std::string name, VariablePrintInfo v)
+void AllVariablesPrintInfo::add(std::string& name, VariablePrintInfo v)
 {
     std::string upperCaseName = to_uppercase(name);
     if (not exists(upperCaseName))

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -251,9 +251,9 @@ void AllVariablesPrintInfo::countSelectedLinkVars()
 
 static void moveNameFromTo(std::string name, std::list<std::string>& fromList, std::list<std::string>& targetList)
 {
-    auto& it_begin = targetList.begin();
-    auto& it_end = targetList.end();
-    auto& it_found = std::find(it_begin, it_end, name);
+    auto it_begin = targetList.begin();
+    auto it_end = targetList.end();
+    auto it_found = std::find(it_begin, it_end, name);
 
     // name is already in the target list
     if (it_found != it_end)

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -89,7 +89,7 @@ void variablePrintInfoCollector::add(const AnyString& name,
 // All variables print information
 // ============================================================
 
-static std::string to_uppercase(std::string str)
+static std::string to_uppercase(std::string& str)
 {
     std::transform(str.begin(), str.end(), str.begin(), ::toupper);
     return str;
@@ -154,7 +154,7 @@ void AllVariablesPrintInfo::prepareForSimulation(bool isThematicTrimmingEnabled,
                                                  const std::vector<std::string>& excluded_vars)
 {
     // Initializing output variables status
-    if (not isThematicTrimmingEnabled)
+    if (!isThematicTrimmingEnabled)
         setAllPrintStatusesTo(true);
 
     for (const auto& varname : excluded_vars)

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -174,19 +174,20 @@ bool AllVariablesPrintInfo::isPrinted(std::string var_name) const
 
 void AllVariablesPrintInfo::setAllPrintStatusesTo(bool b)
 {
-    for (auto& pair : allVarsPrintInfo)
+    for (auto& [name, variable] : allVarsPrintInfo)
     {
-        pair.second.enablePrint(b);
-        moveNameToAppropriateList(pair.first, b);
+        variable.enablePrint(b);
+        moveNameToAppropriateList(name, b);
     }
+
 }
 
 void AllVariablesPrintInfo::reverseAll()
 {
-    for (auto& pair : allVarsPrintInfo)
+    for (auto& [name, variable] : allVarsPrintInfo)
     {
-        pair.second.reverse();
-        moveNameToAppropriateList(pair.first, pair.second.isPrinted());
+        variable.reverse();
+        moveNameToAppropriateList(name, variable.isPrinted());
     }
 
 }
@@ -214,15 +215,15 @@ void AllVariablesPrintInfo::computeMaxColumnsCountInReports()
         for (uint CFileLevel = 1; CFileLevel <= Category::maxFileLevel; CFileLevel *= 2)
         {
             uint currentColumnsCount = 0;
-            for (auto& pair : allVarsPrintInfo)
+            for (auto& [name, variable] : allVarsPrintInfo)
             {
-                if (pair.second.isPrinted() &&
-                    pair.second.getFileLevel() & CFileLevel &&
-                    pair.second.getDataLevel() & CDataLevel)
+                if (variable.isPrinted() &&
+                    variable.getFileLevel() & CFileLevel &&
+                    variable.getDataLevel() & CDataLevel)
                 {
                     // For the current output variable, we retrieve the max number
                     // of columns it takes in a sysnthesis report. 
-                    currentColumnsCount += pair.second.getMaxColumnsCount();
+                    currentColumnsCount += variable.getMaxColumnsCount();
                 }
             }
 
@@ -233,18 +234,18 @@ void AllVariablesPrintInfo::computeMaxColumnsCountInReports()
 
 void AllVariablesPrintInfo::countSelectedAreaVars()
 {
-    for (auto& pair : allVarsPrintInfo)
+    for (auto& [name, variable] : allVarsPrintInfo)
     {
-        if (pair.second.isPrinted() && pair.second.getDataLevel() == Category::area)
+        if (variable.isPrinted() && variable.getDataLevel() == Category::area)
             numberSelectedAreaVariables++;
     }
 }
 
 void AllVariablesPrintInfo::countSelectedLinkVars()
 {
-    for (auto& pair : allVarsPrintInfo)
+    for (auto& [name, variable] : allVarsPrintInfo)
     {
-        if (pair.second.isPrinted() && pair.second.getDataLevel() == Category::link)
+        if (variable.isPrinted() && variable.getDataLevel() == Category::link)
             numberSelectedLinkVariables++;
     }
 }

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -95,7 +95,7 @@ static std::string to_uppercase(std::string& str)
     return str;
 }
 
-void AllVariablesPrintInfo::add(std::string& name, VariablePrintInfo v)
+void AllVariablesPrintInfo::add(std::string name, VariablePrintInfo v)
 {
     std::string upperCaseName = to_uppercase(name);
     if (not exists(upperCaseName))

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -102,7 +102,6 @@ void AllVariablesPrintInfo::add(std::string name, VariablePrintInfo v)
     {
         index_to_name[(unsigned int)allVarsPrintInfo.size()] = upperCaseName;
         allVarsPrintInfo.insert(std::pair<std::string, VariablePrintInfo>(upperCaseName, v));
-        namesOfEnabledVariables.push_back(upperCaseName);
     }
 }
 
@@ -131,7 +130,6 @@ bool AllVariablesPrintInfo::exists(std::string name)
 void AllVariablesPrintInfo::setPrintStatus(std::string varname, bool printStatus)
 {
     allVarsPrintInfo.at(to_uppercase(varname)).enablePrint(printStatus);
-    moveNameToAppropriateList(to_uppercase(varname), printStatus);
 }
 
 void AllVariablesPrintInfo::setPrintStatus(unsigned int index, bool printStatus)
@@ -177,7 +175,6 @@ void AllVariablesPrintInfo::setAllPrintStatusesTo(bool b)
     for (auto& [name, variable] : allVarsPrintInfo)
     {
         variable.enablePrint(b);
-        moveNameToAppropriateList(name, b);
     }
 
 }
@@ -187,9 +184,29 @@ void AllVariablesPrintInfo::reverseAll()
     for (auto& [name, variable] : allVarsPrintInfo)
     {
         variable.reverse();
-        moveNameToAppropriateList(name, variable.isPrinted());
     }
 
+}
+
+std::vector<std::string> AllVariablesPrintInfo::namesOfVariablesWithPrintStatus(bool printStatus)
+{
+    std::vector<std::string> vector_to_return;
+    for (auto& [name, variable] : allVarsPrintInfo)
+    {
+        if (variable.isPrinted() == printStatus)
+            vector_to_return.push_back(name);
+    }
+    return vector_to_return;
+}
+
+std::vector<std::string> AllVariablesPrintInfo::namesOfEnabledVariables()
+{
+    return namesOfVariablesWithPrintStatus(true);
+}
+
+std::vector<std::string> AllVariablesPrintInfo::namesOfDisabledVariables()
+{
+    return namesOfVariablesWithPrintStatus(false);
 }
 
 void AllVariablesPrintInfo::computeMaxColumnsCountInReports()
@@ -250,28 +267,6 @@ void AllVariablesPrintInfo::countSelectedLinkVars()
     }
 }
 
-static void moveNameFromTo(std::string name, std::list<std::string>& fromList, std::list<std::string>& targetList)
-{
-    auto it_begin = targetList.begin();
-    auto it_end = targetList.end();
-    auto it_found = std::find(it_begin, it_end, name);
-
-    // name is already in the target list
-    if (it_found != it_end)
-        return;
-
-    // Actually move name into the target list
-    it_found = std::find(fromList.begin(), fromList.end(), name);
-    targetList.splice(it_end, fromList, it_found);
-}
-
-void AllVariablesPrintInfo::moveNameToAppropriateList(std::string name, bool printStatus)
-{
-    if (printStatus)
-        moveNameFromTo(name, namesOfDisabledVariables, namesOfEnabledVariables);
-    else
-        moveNameFromTo(name, namesOfEnabledVariables, namesOfDisabledVariables);
-}
 
 } // namespace Data
 } // namespace Antares

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -125,9 +125,15 @@ bool AllVariablesPrintInfo::isEmpty() const
     return allVarsPrintInfo.empty();
 }
 
+static std::string to_uppercase(std::string str)
+{
+    std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+    return str;
+}
+
 void AllVariablesPrintInfo::setPrintStatus(std::string varname, bool printStatus)
 {
-    allVarsPrintInfo.at(varname).enablePrint(printStatus);
+    allVarsPrintInfo.at(to_uppercase(varname)).enablePrint(printStatus);
 }
 
 void AllVariablesPrintInfo::setMaxColumns(std::string varname, uint maxColumnsNumber)
@@ -165,20 +171,20 @@ bool AllVariablesPrintInfo::isPrinted(std::string var_name) const
 
 void AllVariablesPrintInfo::setAllPrintStatusesTo(bool b)
 {
-    for (auto pair : allVarsPrintInfo)
+    for (auto& pair : allVarsPrintInfo)
         pair.second.enablePrint(b);
 }
 
 void AllVariablesPrintInfo::reverseAll()
 {
-    for (auto pair : allVarsPrintInfo)
+    for (auto& pair : allVarsPrintInfo)
         pair.second.reverse();
 
 }
 
 void AllVariablesPrintInfo::splitByPrintStatus()
 {
-    for (auto pair : allVarsPrintInfo)
+    for (auto& pair : allVarsPrintInfo)
     {
         if (pair.second.isPrinted())
             namesPrinted.push_back(pair.first);
@@ -209,7 +215,7 @@ void AllVariablesPrintInfo::computeMaxColumnsCountInReports()
         for (uint CFileLevel = 1; CFileLevel <= Category::maxFileLevel; CFileLevel *= 2)
         {
             uint currentColumnsCount = 0;
-            for (auto pair : allVarsPrintInfo)
+            for (auto& pair : allVarsPrintInfo)
             {
                 if (pair.second.isPrinted() &&
                     pair.second.getFileLevel() & CFileLevel &&
@@ -228,7 +234,7 @@ void AllVariablesPrintInfo::computeMaxColumnsCountInReports()
 
 void AllVariablesPrintInfo::countSelectedAreaVars()
 {
-    for (auto pair : allVarsPrintInfo)
+    for (auto& pair : allVarsPrintInfo)
     {
         if (pair.second.isPrinted() && pair.second.getDataLevel() == Category::area)
             numberSelectedAreaVariables++;
@@ -237,7 +243,7 @@ void AllVariablesPrintInfo::countSelectedAreaVars()
 
 void AllVariablesPrintInfo::countSelectedLinkVars()
 {
-    for (auto pair : allVarsPrintInfo)
+    for (auto& pair : allVarsPrintInfo)
     {
         if (pair.second.isPrinted() && pair.second.getDataLevel() == Category::link)
             numberSelectedLinkVariables++;

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -102,7 +102,6 @@ public:
     VariablePrintInfo& operator[](uint i);
     size_t size() const;
     bool exists(std::string name);
-    bool isEmpty() const;
 
     void setPrintStatus(std::string varname, bool printStatus);
     void setPrintStatus(unsigned int index, bool printStatus);

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -135,9 +135,9 @@ public:
     // Public attributes
     std::vector<std::string> namesPrinted;
     std::vector<std::string> namesNotPrinted;
+    void sortVariablesByPrintStatus();
 
 private:
-    void splitByPrintStatus();
     void countSelectedAreaVars();
     void countSelectedLinkVars();
 

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -115,7 +115,7 @@ public:
     bool setPrintStatus(std::string varname, bool printStatus);
     void setMaxColumns(std::string varname, uint maxColumnsNumber);
 
-    void prepareForSimulation(bool userSelection,
+    void prepareForSimulation(bool isThematicTrimmingEnabled,
                               const std::vector<std::string>& excluded_vars = {});
 
     // Classic search, then get the print status
@@ -136,15 +136,16 @@ public:
     }
 
     void computeMaxColumnsCountInReports();
+    void setAllPrintStatusesTo(bool b);
 
 private:
-    void setAllPrintStatusesTo(bool b);
     void countSelectedAreaVars();
     void countSelectedLinkVars();
 
 private:
     // Contains print info for all variables
     std::vector<VariablePrintInfo*> allVarsPrintInfo;
+    // std::map<std::string, VariablePrintInfo> allVarsPrintInfo;
 
     // Max columns count a report of any kind can contain, depending on the number of selected
     // variables. The less variables are selected, the smallest this count is.

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -44,32 +44,23 @@ namespace Data
 class VariablePrintInfo
 {
 public:
-    VariablePrintInfo(AnyString vname, uint dataLvl, uint fileLvl);
-    ~VariablePrintInfo(){};
-
-    // Getting name of the (represented) output variable
-    std::string name();
+    VariablePrintInfo(uint dataLvl, uint fileLvl);
+    ~VariablePrintInfo() = default;
 
     // Do we enable or disable variable's print in output reports ?
     void enablePrint(bool b);
-    bool isPrinted();
+    bool isPrinted() const;
+    void reverse();
 
     uint getMaxColumnsCount();
     void setMaxColumns(uint maxColumnsNumber);
-    uint getDataLevel()
-    {
-        return dataLevel;
-    }
-    uint getFileLevel()
-    {
-        return fileLevel;
-    }
+
+    uint getDataLevel() { return dataLevel_; }
+    uint getFileLevel() { return fileLevel_; }
 
 private:
-    // Current variable's name
-    AnyString varname;
     // Is the variable printed ?
-    bool to_be_printed;
+    bool to_be_printed_ = true;
 
     // The number of columns the output variable takes in a SYNTHESIS report.
     // Recall that synthesis reports always contain more columns than
@@ -80,8 +71,8 @@ private:
     // Example : areas/values-<time-interval>.txt
     // dataLevel can be : areas, links, bindingConstraint
     // fileLevel can be : values-<time-interval>.txt, details-<time-interval>.txt, id-<time-interval>.txt, ...
-    uint dataLevel;
-    uint fileLevel;
+    uint dataLevel_ = 0;
+    uint fileLevel_ = 0;
 };
 
 class AllVariablesPrintInfo;
@@ -104,16 +95,18 @@ class AllVariablesPrintInfo
 public:
     // Public methods
     AllVariablesPrintInfo() = default;
-    ~AllVariablesPrintInfo();
+    ~AllVariablesPrintInfo() = default;
 
-    void add(VariablePrintInfo* v);
+    void add(std::string name, VariablePrintInfo v);
     void clear();
-    VariablePrintInfo* operator[](uint i) const;
+    VariablePrintInfo& operator[](uint i);
     size_t size() const;
+    bool exists(std::string name);
     bool isEmpty() const;
 
-    bool setPrintStatus(std::string varname, bool printStatus);
+    void setPrintStatus(std::string varname, bool printStatus);
     void setMaxColumns(std::string varname, uint maxColumnsNumber);
+    std::string name_of(unsigned int index) const;
 
     void prepareForSimulation(bool isThematicTrimmingEnabled,
                               const std::vector<std::string>& excluded_vars = {});
@@ -137,15 +130,21 @@ public:
 
     void computeMaxColumnsCountInReports();
     void setAllPrintStatusesTo(bool b);
+    void reverseAll();
+
+    // Public attributes
+    std::vector<std::string> namesPrinted;
+    std::vector<std::string> namesNotPrinted;
 
 private:
+    void splitByPrintStatus();
     void countSelectedAreaVars();
     void countSelectedLinkVars();
 
 private:
     // Contains print info for all variables
-    std::vector<VariablePrintInfo*> allVarsPrintInfo;
-    // std::map<std::string, VariablePrintInfo> allVarsPrintInfo;
+    std::map<std::string, VariablePrintInfo> allVarsPrintInfo;
+    std::map<unsigned int, std::string> index_to_name;
 
     // Max columns count a report of any kind can contain, depending on the number of selected
     // variables. The less variables are selected, the smallest this count is.

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -105,6 +105,8 @@ public:
     bool isEmpty() const;
 
     void setPrintStatus(std::string varname, bool printStatus);
+    void setPrintStatus(unsigned int index, bool printStatus);
+
     void setMaxColumns(std::string varname, uint maxColumnsNumber);
     std::string name_of(unsigned int index) const;
 
@@ -133,11 +135,11 @@ public:
     void reverseAll();
 
     // Public attributes
-    std::vector<std::string> namesPrinted;
-    std::vector<std::string> namesNotPrinted;
-    void sortVariablesByPrintStatus();
+    std::list<std::string> namesOfEnabledVariables;
+    std::list<std::string> namesOfDisabledVariables;
 
 private:
+    void moveNameToAppropriateList(std::string name, bool printStatus);
     void countSelectedAreaVars();
     void countSelectedLinkVars();
 

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -97,7 +97,7 @@ public:
     AllVariablesPrintInfo() = default;
     ~AllVariablesPrintInfo() = default;
 
-    void add(std::string name, VariablePrintInfo v);
+    void add(std::string& name, VariablePrintInfo v);
     void clear();
     VariablePrintInfo& operator[](uint i);
     size_t size() const;

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -97,7 +97,7 @@ public:
     AllVariablesPrintInfo() = default;
     ~AllVariablesPrintInfo() = default;
 
-    void add(std::string& name, VariablePrintInfo v);
+    void add(std::string name, VariablePrintInfo v);
     void clear();
     VariablePrintInfo& operator[](uint i);
     size_t size() const;

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -133,6 +133,7 @@ public:
     void setAllPrintStatusesTo(bool b);
     void reverseAll();
 
+    unsigned int numberOfEnabledVariables();
     std::vector<std::string> namesOfEnabledVariables();
     std::vector<std::string> namesOfDisabledVariables();
 

--- a/src/libs/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/variable-print-info.h
@@ -133,12 +133,11 @@ public:
     void setAllPrintStatusesTo(bool b);
     void reverseAll();
 
-    // Public attributes
-    std::list<std::string> namesOfEnabledVariables;
-    std::list<std::string> namesOfDisabledVariables;
+    std::vector<std::string> namesOfEnabledVariables();
+    std::vector<std::string> namesOfDisabledVariables();
 
 private:
-    void moveNameToAppropriateList(std::string name, bool printStatus);
+    std::vector<std::string> namesOfVariablesWithPrintStatus(bool printStatus);
     void countSelectedAreaVars();
     void countSelectedLinkVars();
 

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -75,7 +75,6 @@ void Areas<NEXTTYPE>::initializeFromStudy(Data::Study& study)
     for (uint i = 0; i != pAreaCount; ++i)
     {
         // Instancing a new set of variables of the area
-        auto& n = pAreas[i];
         auto* currentArea = study.areas.byIndex[i];
         if (!(--tick))
         {
@@ -91,18 +90,18 @@ void Areas<NEXTTYPE>::initializeFromStudy(Data::Study& study)
 
         // Initialize the variables
         // From the study
-        n.initializeFromStudy(study);
+        pAreas[i].initializeFromStudy(study);
         // From the area
-        n.initializeFromArea(&study, currentArea);
+        pAreas[i].initializeFromArea(&study, currentArea);
         // Does current output variable appears non applicable in areas' output files, not
         // districts'. Note that digest gather area and district results.
-        n.broadcastNonApplicability(not currentArea->hydro.reservoirManagement);
+        pAreas[i].broadcastNonApplicability(not currentArea->hydro.reservoirManagement);
 
         // For each current area's variable, getting the print status, that is :
         // is variable's column(s) printed in output (areas) reports ?
-        n.getPrintStatusFromStudy(study);
+        pAreas[i].getPrintStatusFromStudy(study);
 
-        n.supplyMaxNumberOfColumns(study);
+        pAreas[i].supplyMaxNumberOfColumns(study);
     }
 }
 

--- a/src/solver/variable/bindConstraints.hxx
+++ b/src/solver/variable/bindConstraints.hxx
@@ -99,12 +99,12 @@ inline void BindingConstraints<NextT>::provideInformations(I& infos)
 template<class NextT>
 void BindingConstraints<NextT>::initializeFromStudy(Data::Study& study)
 {
-    const std::vector<uint> InequalityBCnumbers
+    const std::vector<uint> InequalityBCindices
       = study.runtime->getIndicesForInequalityBindingConstraints();
 
     // The total number of inequality binding constraints count
     // (we don't count BCs with equality sign)
-    pBCcount = (uint)InequalityBCnumbers.size();
+    pBCcount = (uint)InequalityBCindices.size();
 
     // Reserving the memory
     if (pBCcount > 0)
@@ -116,15 +116,24 @@ void BindingConstraints<NextT>::initializeFromStudy(Data::Study& study)
     {
         NextType& bc = pBindConstraints[i];
 
-        bc.setBindConstraintGlobalNumber(InequalityBCnumbers[i]);
+        bc.setBindConstraintGlobalIndex(InequalityBCindices[i]);
         bc.initializeFromStudy(study);
 
         // Does user want to print output results related to the current binding constraint ?
         bc.getPrintStatusFromStudy(study);
     }
 
-    // This is ugly (it's a work around). We should try to improve this.
-    // Supplying the max number of columns to the variable print info collector 
+    // Here we supply the max number of columns to the variable print info collector 
+    // This is a ugly hack (it's a work around).
+    // We should have a simple call to :
+    //      NextType::supplyMaxNumberOfColumns(study);
+    // Instead, we have a few lines as a hack.
+    // What we have to do is add to the print info collector a single VariablePrintInfo
+    // that has a max columns size of : (nb of inequality BCs) x ResultsType::count
+    // But note that for now, BC output variables are chained statically (one output variable per inequality BC).
+    // The hack is to make the first BC output variable able to supply max columns size for all BC output variables
+    // with its method getMaxNumberColumns().
+    // A solution would be to make BC output variables (like BindingConstMarginCost) some DYNAMIC variables.
     if (pBCcount > 0)
     {
         NextType& bc = pBindConstraints[0];

--- a/src/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -154,7 +154,7 @@ public:
             pValuesForTheCurrentYear[numSpace].initializeFromStudy(study);
 
         // Set the associated binding constraint
-        associatedBC_ = &(study.runtime->bindingConstraint[bindConstraintGlobalNumber_]);
+        associatedBC_ = &(study.runtime->bindingConstraint[bindConstraintGlobalIndex_]);
 
         NextType::initializeFromStudy(study);
     }
@@ -165,9 +165,9 @@ public:
         VariableAccessorType::InitializeAndReset(results, study);
     }
 
-    void setBindConstraintGlobalNumber(uint bcNumber)
+    void setBindConstraintGlobalIndex(uint bc_index)
     {
-        bindConstraintGlobalNumber_ = bcNumber;
+        bindConstraintGlobalIndex_ = bc_index;
     }
 
     void setBindConstraintsCount(uint bcCount)
@@ -253,7 +253,7 @@ public:
             {
                 pValuesForTheCurrentYear[numSpace].day[dayInTheYear]
                   -= state.problemeHebdo
-                       ->ResultatsContraintesCouplantes[bindConstraintGlobalNumber_]
+                       ->ResultatsContraintesCouplantes[bindConstraintGlobalIndex_]
                        .variablesDuales[dayInTheWeek];
 
                 dayInTheYear++;
@@ -266,7 +266,7 @@ public:
         {
             uint weekInTheYear = state.weekInTheYear;
             double weeklyValue
-              = -state.problemeHebdo->ResultatsContraintesCouplantes[bindConstraintGlobalNumber_]
+              = -state.problemeHebdo->ResultatsContraintesCouplantes[bindConstraintGlobalIndex_]
                    .variablesDuales[0];
 
             pValuesForTheCurrentYear[numSpace].week[weekInTheYear] = weeklyValue;
@@ -297,7 +297,7 @@ public:
         if (associatedBC_->type == Data::BindingConstraint::typeHourly)
         {
             pValuesForTheCurrentYear[numSpace][hourInTheYear]
-              -= state.problemeHebdo->ResultatsContraintesCouplantes[bindConstraintGlobalNumber_]
+              -= state.problemeHebdo->ResultatsContraintesCouplantes[bindConstraintGlobalIndex_]
                    .variablesDuales[state.hourInTheWeek];
         }
 
@@ -365,7 +365,7 @@ private:
 
     bool isInitialized()
     {
-        return (bindConstraintGlobalNumber_ >= 0) && associatedBC_;
+        return (bindConstraintGlobalIndex_ >= 0) && associatedBC_;
     }
 
     bool isCurrentOutputNonApplicable(int precision) const
@@ -392,7 +392,7 @@ private:
     typename VCardType::IntermediateValuesType pValuesForTheCurrentYear = nullptr;
     unsigned int pNbYearsParallel = 0;
     Data::BindingConstraintRTI* associatedBC_ = nullptr;
-    int bindConstraintGlobalNumber_ = -1;
+    int bindConstraintGlobalIndex_ = -1;
     uint nbCount_ = 0; // Number of inequality BCs 
 
 }; // class BindingConstMarginCost

--- a/src/solver/variable/surveyresults/surveyresults.cpp
+++ b/src/solver/variable/surveyresults/surveyresults.cpp
@@ -504,15 +504,6 @@ static inline void WriteIndexHeaderToFileDescriptor(int precisionLevel,
     s += '\n';
 }
 
-void SurveyResults::initializeMaxVariables(const Data::Study& s)
-{
-    const auto* runtime = s.runtime;
-
-    // Getting the any report's max number of columns
-    maxVariables = s.parameters.variablesPrintInfo.getTotalMaxColumnsCount();
-    logs.debug() << "  (for " << maxVariables << " columns)";
-}
-
 // TOFIX - MBO 02/06/2014 nombre de colonnes fonction du nombre de variables
 SurveyResults::SurveyResults(const Data::Study& s,
                              const String& o,
@@ -522,10 +513,11 @@ SurveyResults::SurveyResults(const Data::Study& s,
  isCurrentVarNA(nullptr),
  isPrinted(nullptr),
  pResultWriter(writer)
-{
-    initializeMaxVariables(s);
-    
+{    
     variableCaption.reserve(10);
+
+    maxVariables = s.parameters.variablesPrintInfo.getTotalMaxColumnsCount();
+    logs.debug() << "  (for " << maxVariables << " columns)";
 
     data.initialize(maxVariables);
     // logs.debug() << "  :: survey results: allocating "

--- a/src/solver/variable/surveyresults/surveyresults.h
+++ b/src/solver/variable/surveyresults/surveyresults.h
@@ -149,8 +149,6 @@ public:
     IResultWriter::Ptr pResultWriter;
 
 private:
-    void initializeMaxVariables(const Data::Study& s);
-
     template<class StringT, class ConvertT, class PrecisionT>
     void AppendDoubleValue(uint& error,
                            const double v,

--- a/src/solver/variable/variable.hxx
+++ b/src/solver/variable/variable.hxx
@@ -559,7 +559,7 @@ struct HourlyResultsForCurrentYear
 };
 
 template<>
-struct HourlyResultsForCurrentYear<1>
+struct HourlyResultsForCurrentYear<Category::singleColumn>
 {
     template<class R>
     static Antares::Memory::Stored<double>::ConstReturnType Get(const R& results, uint)
@@ -569,7 +569,7 @@ struct HourlyResultsForCurrentYear<1>
 };
 
 template<>
-struct HourlyResultsForCurrentYear<0>
+struct HourlyResultsForCurrentYear<Category::noColumn>
 {
     template<class R>
     static Antares::Memory::Stored<double>::ConstReturnType Get(const R&, uint)
@@ -630,7 +630,7 @@ public:
 };
 
 template<class VCardT, class ChildT>
-class RetrieveVariableListHelper<1, VCardT, ChildT>
+class RetrieveVariableListHelper<Category::singleColumn, VCardT, ChildT>
 {
 public:
     template<class PredicateT>
@@ -650,7 +650,7 @@ public:
 };
 
 template<class VCardT, class ChildT>
-class RetrieveVariableListHelper<-1, VCardT, ChildT>
+class RetrieveVariableListHelper<Category::dynamicColumns, VCardT, ChildT>
 {
 public:
     template<class PredicateT>
@@ -706,7 +706,7 @@ namespace // anonymous
 
     // Case : the variable is single
     template<class VCardT>
-    class GetPrintStatusHelper<1, VCardT>
+    class GetPrintStatusHelper<Category::singleColumn, VCardT>
     {
     public:
         static void Do(Data::Study& study, bool* isPrinted)
@@ -719,7 +719,7 @@ namespace // anonymous
 
     // Case : the variable is dynamic
     template<class VCardT>
-    class GetPrintStatusHelper<-1, VCardT>
+    class GetPrintStatusHelper<Category::dynamicColumns, VCardT>
     {
     public:
         static void Do(Data::Study& study, bool* isPrinted)
@@ -766,7 +766,7 @@ namespace // anonymous
 
     // Case : the variable is single
     template<class VCardT>
-    class SupplyMaxNbColumnsHelper<1, VCardT>
+    class SupplyMaxNbColumnsHelper<Category::singleColumn, VCardT>
     {
     public:
         static void Do(Data::Study& study, uint maxNumberColumns)
@@ -777,7 +777,7 @@ namespace // anonymous
 
     // Case : the variable is dynamic
     template<class VCardT>
-    class SupplyMaxNbColumnsHelper<-1, VCardT>
+    class SupplyMaxNbColumnsHelper<Category::dynamicColumns, VCardT>
     {
     public:
         static void Do(Data::Study& study, uint maxNumberColumns)

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp
@@ -51,7 +51,7 @@ bool SelectVariables::cellValue(int, int var, const Yuni::String& value)
         s.toLower();
         bool v = s.to<bool>() || s == "active" || s == "enabled";
         assert(!study->parameters.variablesPrintInfo.isEmpty());
-        study->parameters.variablesPrintInfo[var].enablePrint(v);
+        study->parameters.variablesPrintInfo.setPrintStatus(var, v);
         onTriggerUpdate();
         Dispatcher::GUI::Refresh(pControl);
         return true;

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp
@@ -50,7 +50,6 @@ bool SelectVariables::cellValue(int, int var, const Yuni::String& value)
         s.trim();
         s.toLower();
         bool v = s.to<bool>() || s == "active" || s == "enabled";
-        assert(!study->parameters.variablesPrintInfo.isEmpty());
         study->parameters.variablesPrintInfo.setPrintStatus(var, v);
         onTriggerUpdate();
         Dispatcher::GUI::Refresh(pControl);
@@ -63,7 +62,6 @@ double SelectVariables::cellNumericValue(int, int var) const
 {
     if (!(!study) && (uint)var < study->parameters.variablesPrintInfo.size())
     {
-        assert(!study->parameters.variablesPrintInfo.isEmpty());
         return study->parameters.variablesPrintInfo[var].isPrinted();
     }
     return 0.;
@@ -73,7 +71,6 @@ wxString SelectVariables::cellValue(int, int var) const
 {
     if (!(!study) && static_cast<uint>(var) < study->parameters.variablesPrintInfo.size())
     {
-        assert(!study->parameters.variablesPrintInfo.isEmpty());
         return study->parameters.variablesPrintInfo[var].isPrinted() ? wxT("Active") : wxT("skip");
     }
     return wxEmptyString;
@@ -83,7 +80,6 @@ IRenderer::CellStyle SelectVariables::cellStyle(int, int var) const
 {
     if (!(!study) && (uint)var < study->parameters.variablesPrintInfo.size())
     {
-        assert(!study->parameters.variablesPrintInfo.isEmpty());
         return !study->parameters.variablesPrintInfo[var].isPrinted()
                  ? IRenderer::cellStyleConstraintNoWeight
                  : IRenderer::cellStyleConstraintWeight;

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp
@@ -39,7 +39,7 @@ wxString SelectVariables::columnCaption(int) const
 
 wxString SelectVariables::rowCaption(int rowIndx) const
 {
-    return wxString(wxT(" ")) << study->parameters.variablesPrintInfo[rowIndx]->name() << wxT("  ");
+    return wxString(wxT(" ")) << study->parameters.variablesPrintInfo.name_of(rowIndx) << wxT("  ");
 }
 
 bool SelectVariables::cellValue(int, int var, const Yuni::String& value)
@@ -51,7 +51,7 @@ bool SelectVariables::cellValue(int, int var, const Yuni::String& value)
         s.toLower();
         bool v = s.to<bool>() || s == "active" || s == "enabled";
         assert(!study->parameters.variablesPrintInfo.isEmpty());
-        study->parameters.variablesPrintInfo[var]->enablePrint(v);
+        study->parameters.variablesPrintInfo[var].enablePrint(v);
         onTriggerUpdate();
         Dispatcher::GUI::Refresh(pControl);
         return true;
@@ -64,7 +64,7 @@ double SelectVariables::cellNumericValue(int, int var) const
     if (!(!study) && (uint)var < study->parameters.variablesPrintInfo.size())
     {
         assert(!study->parameters.variablesPrintInfo.isEmpty());
-        return study->parameters.variablesPrintInfo[var]->isPrinted();
+        return study->parameters.variablesPrintInfo[var].isPrinted();
     }
     return 0.;
 }
@@ -74,7 +74,7 @@ wxString SelectVariables::cellValue(int, int var) const
     if (!(!study) && static_cast<uint>(var) < study->parameters.variablesPrintInfo.size())
     {
         assert(!study->parameters.variablesPrintInfo.isEmpty());
-        return study->parameters.variablesPrintInfo[var]->isPrinted() ? wxT("Active") : wxT("skip");
+        return study->parameters.variablesPrintInfo[var].isPrinted() ? wxT("Active") : wxT("skip");
     }
     return wxEmptyString;
 }
@@ -84,7 +84,7 @@ IRenderer::CellStyle SelectVariables::cellStyle(int, int var) const
     if (!(!study) && (uint)var < study->parameters.variablesPrintInfo.size())
     {
         assert(!study->parameters.variablesPrintInfo.isEmpty());
-        return !study->parameters.variablesPrintInfo[var]->isPrinted()
+        return !study->parameters.variablesPrintInfo[var].isPrinted()
                  ? IRenderer::cellStyleConstraintNoWeight
                  : IRenderer::cellStyleConstraintWeight;
     }

--- a/src/ui/simulator/windows/options/select-output/select-output.cpp
+++ b/src/ui/simulator/windows/options/select-output/select-output.cpp
@@ -220,8 +220,7 @@ void SelectOutput::updateCaption()
 
     if (d.thematicTrimming)
     {
-        d.variablesPrintInfo.sortVariablesByPrintStatus();
-        uint nbPrintedVars = d.variablesPrintInfo.namesPrinted.size();
+        uint nbPrintedVars = d.variablesPrintInfo.namesOfEnabledVariables.size();
         if (nbPrintedVars < 2)
             pStatus->SetLabel(wxString()
                               << wxT(" Ask for selecting ") << nbPrintedVars << wxT(" output variable  "));

--- a/src/ui/simulator/windows/options/select-output/select-output.cpp
+++ b/src/ui/simulator/windows/options/select-output/select-output.cpp
@@ -220,6 +220,7 @@ void SelectOutput::updateCaption()
 
     if (d.thematicTrimming)
     {
+        d.variablesPrintInfo.sortVariablesByPrintStatus();
         uint nbPrintedVars = d.variablesPrintInfo.namesPrinted.size();
         if (nbPrintedVars < 2)
             pStatus->SetLabel(wxString()

--- a/src/ui/simulator/windows/options/select-output/select-output.cpp
+++ b/src/ui/simulator/windows/options/select-output/select-output.cpp
@@ -220,7 +220,7 @@ void SelectOutput::updateCaption()
 
     if (d.thematicTrimming)
     {
-        uint nbPrintedVars = d.variablesPrintInfo.namesOfEnabledVariables.size();
+        uint nbPrintedVars = d.variablesPrintInfo.namesOfEnabledVariables().size();
         if (nbPrintedVars < 2)
             pStatus->SetLabel(wxString()
                               << wxT(" Ask for selecting ") << nbPrintedVars << wxT(" output variable  "));

--- a/src/ui/simulator/windows/options/select-output/select-output.cpp
+++ b/src/ui/simulator/windows/options/select-output/select-output.cpp
@@ -220,7 +220,7 @@ void SelectOutput::updateCaption()
 
     if (d.thematicTrimming)
     {
-        uint nbPrintedVars = d.variablesPrintInfo.namesOfEnabledVariables().size();
+        uint nbPrintedVars = d.variablesPrintInfo.numberOfEnabledVariables();
         if (nbPrintedVars < 2)
             pStatus->SetLabel(wxString()
                               << wxT(" Ask for selecting ") << nbPrintedVars << wxT(" output variable  "));

--- a/src/ui/simulator/windows/options/select-output/select-output.cpp
+++ b/src/ui/simulator/windows/options/select-output/select-output.cpp
@@ -163,8 +163,7 @@ void SelectOutput::onSelectAll(void*)
     auto& study = *studyptr;
 
     Freeze();
-    for (uint i = 0; i != study.parameters.variablesPrintInfo.size(); ++i)
-        study.parameters.variablesPrintInfo[i]->enablePrint(true);
+    study.parameters.variablesPrintInfo.setAllPrintStatusesTo(true);
     pGrid->forceRefresh();
     updateCaption();
     Dispatcher::GUI::Refresh(pGrid);
@@ -180,8 +179,7 @@ void SelectOutput::onUnselectAll(void*)
     auto& study = *studyptr;
 
     Freeze();
-    for (uint i = 0; i != study.parameters.variablesPrintInfo.size(); ++i)
-        study.parameters.variablesPrintInfo[i]->enablePrint(false);
+    study.parameters.variablesPrintInfo.setAllPrintStatusesTo(false);
     pGrid->forceRefresh();
     updateCaption();
     Dispatcher::GUI::Refresh(pGrid);
@@ -197,11 +195,7 @@ void SelectOutput::onToggle(void*)
     auto& study = *studyptr;
 
     Freeze();
-    for (uint i = 0; i != study.parameters.variablesPrintInfo.size(); ++i)
-    {
-        study.parameters.variablesPrintInfo[i]->enablePrint(
-          not study.parameters.variablesPrintInfo[i]->isPrinted());
-    }
+    study.parameters.variablesPrintInfo.reverseAll();
     pGrid->forceRefresh();
     updateCaption();
     Dispatcher::GUI::Refresh(pGrid);
@@ -226,18 +220,13 @@ void SelectOutput::updateCaption()
 
     if (d.thematicTrimming)
     {
-        uint v = 0;
-        for (uint i = 0; i != d.variablesPrintInfo.size(); ++i)
-        {
-            if (d.variablesPrintInfo[i]->isPrinted())
-                ++v;
-        }
-        if (v < 2)
+        uint nbPrintedVars = d.variablesPrintInfo.namesPrinted.size();
+        if (nbPrintedVars < 2)
             pStatus->SetLabel(wxString()
-                              << wxT(" Ask for selecting ") << v << wxT(" output variable  "));
+                              << wxT(" Ask for selecting ") << nbPrintedVars << wxT(" output variable  "));
         else
             pStatus->SetLabel(wxString()
-                              << wxT(" Ask for selecting ") << v << wxT(" output variables  "));
+                              << wxT(" Ask for selecting ") << nbPrintedVars << wxT(" output variables  "));
     }
     else
         pStatus->SetLabel(wxT(" Ask for selecting output variables "));


### PR DESCRIPTION
The current PR follows #1172.
This is a cleaning work.

**All PR about max nb columns for print** : 
There are currently 3 PR about  **max nb columns for print**
- #1159 : some preliminary cleaning
- #1172 : adresses the real problem : computing this max number of columns accurately
- The current PR

**What this PR is about** :
The first target was to replace an **std::vector** with a **std::map** in class **AllVariablesPrintInfo** and hope it would simplify the code. As a matter of fact, it does.
What was done actually : 
-  replacing an **std::vector** with a **std::map** in class **AllVariablesPrintInfo**, it simplifies methods **setPrintStatus(...)**, **setMaxColumns(...)** and **isPrinted(...)**
- In this **std::map** (that associates **name of vars** to instance of **VariablesPrintInfo**), avoid inserting **VariablesPrintInfo** as pointers. This allows to make the destructor of  **AllVariablesPrintInfo** empty.
- Introducing some more methods to class **AllVariablesPrintInfo** to simplify the code elsewhere, see : 
     - **src/libs/antares/study/parameters.cpp**
     - 	**src/ui/simulator/toolbox/components/datagrid/renderer/select-variables.cpp**
     - **src/ui/simulator/windows/options/select-output/select-output.cpp**
- some more renaming and comments left in the code