### PR TITLE
Add helper for thermal cluster properties loading

### DIFF
--- a/src/libs/antares/study/parts/thermal/cluster.h
+++ b/src/libs/antares/study/parts/thermal/cluster.h
@@ -59,7 +59,7 @@ enum ThermalModulation
     thermalModulationMax
 };
 
-enum class LocalTSGenerationBehavior
+enum class LocalTSGenerationBehavior : uint
 {
     useGlobalParameter = 0,
     forceGen,

--- a/src/libs/antares/study/parts/thermal/cluster_load.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_load.cpp
@@ -51,9 +51,12 @@ ThermalClusterReader::ThermalClusterReader()
     }
 
     addCallback("annuityinvestment", &ThermalCluster::annuityInvestment);
-
-    // callbackMap.emplace("annuityinvestment", [](ThermalCluster& c, const IniFile::Property& p)
-    //         { return c.annuityInvestment = p.value.to<uint>(); });
+    addCallback("must-run", &ThermalCluster::mustrun);
+    // must cast: enabled is a member of class Cluster (base class of ThermalCluster)
+    addCallback("enabled", static_cast<bool ThermalCluster::*>(&Cluster::enabled));
+    addCallback("fixed-cost", &ThermalCluster::fixedCost);
+    // must cast: tsGenBehavior is an enum class (uint)
+    addCallback("gen-ts", static_cast<uint ThermalCluster::*>(&ThermalCluster::tsGenBehavior));
 }
 
 bool ThermalClusterReader::loadFromProperty(ThermalCluster& cluster, const IniFile::Property* p)
@@ -89,10 +92,6 @@ bool ThermalClusterReader::legacyLoadFromProperty(ThermalCluster& cluster, const
         cluster.minStablePower = std::max(cluster.minStablePower, d);
         return true; // ignored since 3.7
     }
-    if (p->key == "enabled")
-        return p->value.to<bool>(cluster.enabled);
-    if (p->key == "fixed-cost")
-        return p->value.to<double>(cluster.fixedCost);
     if (p->key == "flexibility")
     {
         // The flexibility is now ignored since v3.5
@@ -106,10 +105,6 @@ bool ThermalClusterReader::legacyLoadFromProperty(ThermalCluster& cluster, const
     {
         cluster.setGroup(p->value);
         return true;
-    }
-    if (p->key == "gen-ts")
-    {
-        return p->value.to(cluster.tsGenBehavior);
     }
     if (p->key == "hourlyminimumcapacity")
     {
@@ -125,9 +120,6 @@ bool ThermalClusterReader::legacyLoadFromProperty(ThermalCluster& cluster, const
         return p->value.to<double>(cluster.marketBidCost);
     if (p->key == "marginal-cost")
         return p->value.to<double>(cluster.marginalCost);
-    if (p->key == "must-run")
-        // mustrunOrigin will be initialized later, after LoadFromSection
-        return p->value.to<bool>(cluster.mustrun);
     if (p->key == "min-stable-power")
         return p->value.to<double>(cluster.minStablePower);
 

--- a/src/libs/antares/study/parts/thermal/cluster_load.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_load.cpp
@@ -33,6 +33,14 @@
 namespace Antares::Data
 {
 
+template<class Type>
+void ThermalClusterReader::addCallback(std::string&& key, Type ThermalCluster::*value_ptr)
+{
+    auto cb = [value_ptr](ThermalCluster& c, const IniFile::Property& p)
+              { return c.*value_ptr = p.value.to<Type>();};
+    callbackMap.emplace(key, cb);
+}
+
 ThermalClusterReader::ThermalClusterReader()
 {
     for (auto const& [key, val] : Pollutant::namesToEnum)
@@ -42,8 +50,10 @@ ThermalClusterReader::ThermalClusterReader()
         });
     }
 
-    callbackMap.emplace("annuityinvestment", [](ThermalCluster& c, const IniFile::Property& p)
-            { return c.annuityInvestment = p.value.to<uint>(); });
+    addCallback("annuityinvestment", &ThermalCluster::annuityInvestment);
+
+    // callbackMap.emplace("annuityinvestment", [](ThermalCluster& c, const IniFile::Property& p)
+    //         { return c.annuityInvestment = p.value.to<uint>(); });
 }
 
 bool ThermalClusterReader::loadFromProperty(ThermalCluster& cluster, const IniFile::Property* p)

--- a/src/libs/antares/study/parts/thermal/cluster_load.h
+++ b/src/libs/antares/study/parts/thermal/cluster_load.h
@@ -34,16 +34,16 @@ namespace Antares::Data
 class ThermalClusterReader
 {
 public:
-
 ThermalClusterReader();
-
 bool loadFromProperty(ThermalCluster& cluster, const IniFile::Property* p);
 
-std::map<std::string, std::function<bool(ThermalCluster&, const IniFile::Property&)>> callbackMap;
+private:
+  std::map<std::string, std::function<bool(ThermalCluster&, const IniFile::Property&)>> callbackMap;
+  template<class Type>
+  void addCallback(std::string&& key, Type ThermalCluster::*value_ptr);
 
-
-//TODO delete
-bool legacyLoadFromProperty(ThermalCluster& cluster, const IniFile::Property* p);
+  //TODO delete
+  bool legacyLoadFromProperty(ThermalCluster& cluster, const IniFile::Property* p);
 
 }; //class ThermalClusterReader
 


### PR DESCRIPTION
Add a helper function to bind `std::string` to `ThermalCluster` members when loading properties.

This doesn't handle special cases such as pollutants (std::array), and `static_cast` must be applied in some cases (uint -> enum, member of class `Cluster`)

It's still possible to add lambdas by hand.