### PR TITLE
Add missing sirius_solver dependency

### DIFF
--- a/src/solver/utils/CMakeLists.txt
+++ b/src/solver/utils/CMakeLists.txt
@@ -23,5 +23,6 @@ endif()
 target_link_libraries(utils
         PUBLIC
         ortools::ortools
+        sirius_solver
         libantares-core
         )


### PR DESCRIPTION
File `named_problem.h` needs Sirius, but CMake doesn't inject it if dependency isn't specified.
```cpp
#pragma once

#include "spx_definition_arguments.h"
#include "spx_fonctions.h"

```

```
In file included from /home/omnesflo/Antares_Simulator/src/solver/utils/ortools_wrapper.h:4,
                 from /home/omnesflo/Antares_Simulator/src/solver/utils/ortools_utils.h:9,
                 from /home/omnesflo/Antares_Simulator/src/solver/utils/ortools_utils.cpp:1:
/home/omnesflo/Antares_Simulator/src/solver/utils/named_problem.h:3:10: fatal error: spx_definition_arguments.h: Aucun fichier ou dossier de ce type
    3 | #include "spx_definition_arguments.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```