### PR TITLE
Short term storage : hour for clusters functions

### DIFF
--- a/src/solver/variable/CMakeLists.txt
+++ b/src/solver/variable/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SRC_VARIABLE_ECONOMY
 		economy/dtgMarginAfterCsr.h
 		economy/spilledEnergy.h
 		economy/dispatchableGeneration.h
+		economy/renewableGeneration.h
 		economy/thermalAirPollutantEmissions.h
 		economy/productionByDispatchablePlant.h
         economy/productionByRenewablePlant.h

--- a/src/solver/variable/adequacy/overallCost.h
+++ b/src/solver/variable/adequacy/overallCost.h
@@ -272,7 +272,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForThermalClusters(State& state, unsigned int numSpace)
+    void hourForClusters(State& state, unsigned int numSpace)
     {
         // Total OverallCost
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
@@ -282,7 +282,7 @@ public:
         }
 
         // Next item in the list
-        NextType::hourForThermalClusters(state, numSpace);
+        NextType::hourForClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/adequacy/overallCost.h
+++ b/src/solver/variable/adequacy/overallCost.h
@@ -275,8 +275,8 @@ public:
     void hourForClusters(State& state, unsigned int numSpace)
     {
         // Total OverallCost
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
-             ++cluster_index)
+        for (uint clusterIndex = 0; clusterIndex != state.area->thermal.clusterCount();
+             ++clusterIndex)
         {
             pValuesForTheCurrentYear[numSpace][state.hourInTheYear]
               += state.thermalClustersOperatingCost[state.area->index][clusterIndex];

--- a/src/solver/variable/adequacy/overallCost.h
+++ b/src/solver/variable/adequacy/overallCost.h
@@ -275,10 +275,10 @@ public:
     void hourForClusters(State& state, unsigned int numSpace)
     {
         // Total OverallCost
-        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
             pValuesForTheCurrentYear[numSpace][state.hourInTheYear]
-                += state.thermalClustersOperatingCost[state.area->index][cluster_index];
+                += state.thermalClustersOperatingCost[state.area->index][clusterIndex];
         }
 
         // Next item in the list

--- a/src/solver/variable/adequacy/overallCost.h
+++ b/src/solver/variable/adequacy/overallCost.h
@@ -272,7 +272,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
+    void hourForThermalClusters(State& state, unsigned int numSpace)
     {
         // Total OverallCost
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
@@ -282,7 +282,7 @@ public:
         }
 
         // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
+        NextType::hourForThermalClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/adequacy/overallCost.h
+++ b/src/solver/variable/adequacy/overallCost.h
@@ -275,8 +275,12 @@ public:
     void hourForEachThermalCluster(State& state, unsigned int numSpace)
     {
         // Total OverallCost
-        pValuesForTheCurrentYear[numSpace][state.hourInTheYear]
-          += state.thermalClusterOperatingCost;
+        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        {
+            pValuesForTheCurrentYear[numSpace][state.hourInTheYear]
+                += state.thermalClustersOperatingCost[state.area->index][cluster_index];
+        }
+
         // Next item in the list
         NextType::hourForEachThermalCluster(state, numSpace);
     }

--- a/src/solver/variable/adequacy/overallCost.h
+++ b/src/solver/variable/adequacy/overallCost.h
@@ -275,10 +275,11 @@ public:
     void hourForClusters(State& state, unsigned int numSpace)
     {
         // Total OverallCost
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
+             ++cluster_index)
         {
             pValuesForTheCurrentYear[numSpace][state.hourInTheYear]
-                += state.thermalClustersOperatingCost[state.area->index][clusterIndex];
+              += state.thermalClustersOperatingCost[state.area->index][clusterIndex];
         }
 
         // Next item in the list

--- a/src/solver/variable/area.h
+++ b/src/solver/variable/area.h
@@ -152,7 +152,6 @@ public:
 
     void hourForEachArea(State& state, uint numSpace);
     void hourForEachLink(State& state, uint numSpace);
-    void hourForEachThermalCluster(State& state, uint numSpace);
 
     void hourEnd(State& state, uint hourInTheYear);
 

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -269,13 +269,6 @@ void Areas<NEXTTYPE>::hourForEachLink(State& state, uint numSpace)
 }
 
 template<>
-void Areas<NEXTTYPE>::hourForEachThermalCluster(State& state, uint numSpace)
-{
-    for (uint i = 0; i != pAreaCount; ++i)
-        pAreas[i].hourForEachThermalCluster(state, numSpace);
-}
-
-template<>
 void Areas<NEXTTYPE>::hourEnd(State& state, uint hourInTheYear)
 {
     for (uint i = 0; i != pAreaCount; ++i)

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -141,10 +141,9 @@ void Areas<NEXTTYPE>::hourForEachArea(State& state, uint numSpace)
         {
             // Intiializing the state for the current thermal cluster
             state.initFromThermalClusterIndex(j, numSpace);
-            // Variables
-            variablesForArea.hourForEachThermalCluster(state, numSpace);
+        }
 
-        } // for each thermal cluster
+        variablesForArea.hourForEachThermalCluster(state, numSpace);
 
         // All links
         auto end = area.links.end();

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -143,7 +143,7 @@ void Areas<NEXTTYPE>::hourForEachArea(State& state, uint numSpace)
             state.initFromThermalClusterIndex(j, numSpace);
         }
 
-        variablesForArea.hourForEachThermalCluster(state, numSpace);
+        variablesForArea.hourForThermalClusters(state, numSpace);
 
         // All links
         auto end = area.links.end();

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -146,15 +146,6 @@ void Areas<NEXTTYPE>::hourForEachArea(State& state, uint numSpace)
 
         } // for each thermal cluster
 
-        // For each renewable cluster
-        for (uint j = 0; j != area.renewable.clusterCount(); ++j)
-        {
-            // Intitializing the state for the current thermal cluster
-            state.initFromRenewableClusterIndex(j, numSpace);
-            // Variables
-            variablesForArea.hourForEachRenewableCluster(state, numSpace);
-        } // for each renewable cluster
-
         // All links
         auto end = area.links.end();
         for (auto i = area.links.begin(); i != end; ++i)

--- a/src/solver/variable/area.inc.hxx
+++ b/src/solver/variable/area.inc.hxx
@@ -143,7 +143,7 @@ void Areas<NEXTTYPE>::hourForEachArea(State& state, uint numSpace)
             state.initFromThermalClusterIndex(j, numSpace);
         }
 
-        variablesForArea.hourForThermalClusters(state, numSpace);
+        variablesForArea.hourForClusters(state, numSpace);
 
         // All links
         auto end = area.links.end();

--- a/src/solver/variable/commons/join.h
+++ b/src/solver/variable/commons/join.h
@@ -268,12 +268,6 @@ public:
         RightType::hourForEachArea(state);
     }
 
-    void hourForEachThermalCluster(State& state)
-    {
-        LeftType::hourForEachThermalCluster(state);
-        RightType::hourForEachThermalCluster(state);
-    }
-
     void hourForEachLink(State& state)
     {
         LeftType::hourForEachLink(state);

--- a/src/solver/variable/commons/links/links.h.inc.hxx
+++ b/src/solver/variable/commons/links/links.h.inc.hxx
@@ -164,7 +164,7 @@ public:
     void hourBegin(uint hourInTheYear);
     void hourForEachArea(State& state, uint numSpace);
     void hourForEachLink(State& state, uint numSpace);
-    void hourForThermalClusters(State& state, uint numSpace);
+    void hourForClusters(State& state, uint numSpace);
 
     void hourEnd(State& state, uint hourInTheYear);
 

--- a/src/solver/variable/commons/links/links.h.inc.hxx
+++ b/src/solver/variable/commons/links/links.h.inc.hxx
@@ -164,7 +164,7 @@ public:
     void hourBegin(uint hourInTheYear);
     void hourForEachArea(State& state, uint numSpace);
     void hourForEachLink(State& state, uint numSpace);
-    void hourForEachThermalCluster(State& state, uint numSpace);
+    void hourForThermalClusters(State& state, uint numSpace);
 
     void hourEnd(State& state, uint hourInTheYear);
 

--- a/src/solver/variable/commons/links/links.h.inc.hxx
+++ b/src/solver/variable/commons/links/links.h.inc.hxx
@@ -165,7 +165,6 @@ public:
     void hourForEachArea(State& state, uint numSpace);
     void hourForEachLink(State& state, uint numSpace);
     void hourForEachThermalCluster(State& state, uint numSpace);
-    void hourForEachRenewableCluster(State& state, uint numSpace);
 
     void hourEnd(State& state, uint hourInTheYear);
 

--- a/src/solver/variable/commons/links/links.hxx.inc.hxx
+++ b/src/solver/variable/commons/links/links.hxx.inc.hxx
@@ -154,7 +154,7 @@ inline void Links::hourForEachLink(State& state, unsigned int numSpace)
     pLinks[state.link->indexForArea].hourForEachLink(state, numSpace);
 }
 
-inline void Links::hourForEachThermalCluster(State& state, unsigned int numSpace)
+inline void Links::hourForThermalClusters(State& state, unsigned int numSpace)
 {
     // No cluster on links
 }

--- a/src/solver/variable/commons/links/links.hxx.inc.hxx
+++ b/src/solver/variable/commons/links/links.hxx.inc.hxx
@@ -154,7 +154,7 @@ inline void Links::hourForEachLink(State& state, unsigned int numSpace)
     pLinks[state.link->indexForArea].hourForEachLink(state, numSpace);
 }
 
-inline void Links::hourForThermalClusters(State& state, unsigned int numSpace)
+inline void Links::hourForClusters(State& state, unsigned int numSpace)
 {
     // No cluster on links
 }

--- a/src/solver/variable/commons/links/links.hxx.inc.hxx
+++ b/src/solver/variable/commons/links/links.hxx.inc.hxx
@@ -156,14 +156,12 @@ inline void Links::hourForEachLink(State& state, unsigned int numSpace)
 
 inline void Links::hourForEachThermalCluster(State& state, unsigned int numSpace)
 {
-    for (uint i = 0; i != pLinkCount; ++i)
-        pLinks[i].hourForEachThermalCluster(state, numSpace);
+    // No cluster on links
 }
 
 inline void Links::hourForEachRenewableCluster(State& state, unsigned int numSpace)
 {
-    for (uint i = 0; i != pLinkCount; ++i)
-        pLinks[i].hourForEachRenewableCluster(state, numSpace);
+    // No cluster on links
 }
 
 inline void Links::hourEnd(State& state, uint hourInTheYear)

--- a/src/solver/variable/commons/links/links.hxx.inc.hxx
+++ b/src/solver/variable/commons/links/links.hxx.inc.hxx
@@ -159,11 +159,6 @@ inline void Links::hourForEachThermalCluster(State& state, unsigned int numSpace
     // No cluster on links
 }
 
-inline void Links::hourForEachRenewableCluster(State& state, unsigned int numSpace)
-{
-    // No cluster on links
-}
-
 inline void Links::hourEnd(State& state, uint hourInTheYear)
 {
     for (uint i = 0; i != pLinkCount; ++i)

--- a/src/solver/variable/commons/spatial-aggregate.h
+++ b/src/solver/variable/commons/spatial-aggregate.h
@@ -288,10 +288,10 @@ public:
         NextType::hourForEachArea(state);
     }
 
-    void hourForThermalClusters(State& state)
+    void hourForClusters(State& state)
     {
         // Next item in the list
-        NextType::hourForThermalClusters(state);
+        NextType::hourForClusters(state);
     }
 
     template<class V, class SetT>

--- a/src/solver/variable/commons/spatial-aggregate.h
+++ b/src/solver/variable/commons/spatial-aggregate.h
@@ -288,10 +288,10 @@ public:
         NextType::hourForEachArea(state);
     }
 
-    void hourForEachThermalCluster(State& state)
+    void hourForThermalClusters(State& state)
     {
         // Next item in the list
-        NextType::hourForEachThermalCluster(state);
+        NextType::hourForThermalClusters(state);
     }
 
     template<class V, class SetT>

--- a/src/solver/variable/container.h
+++ b/src/solver/variable/container.h
@@ -171,8 +171,6 @@ public:
 
     void hourForEachArea(State& state, unsigned int numSpace);
 
-    void hourForEachThermalCluster(State& state);
-
     void hourForEachLink(State& state);
 
     void hourEnd(State& state, unsigned int hourInTheYear);

--- a/src/solver/variable/container.hxx
+++ b/src/solver/variable/container.hxx
@@ -186,12 +186,6 @@ inline void List<NextT>::hourForEachArea(State& state, unsigned int numSpace)
 }
 
 template<class NextT>
-inline void List<NextT>::hourForEachThermalCluster(State& state)
-{
-    NextType::hourForEachThermalCluster(state);
-}
-
-template<class NextT>
 inline void List<NextT>::hourForEachLink(State& state)
 {
     NextType::hourForEachLink(state);

--- a/src/solver/variable/economy/dispatchable-generation-margin.h
+++ b/src/solver/variable/economy/dispatchable-generation-margin.h
@@ -244,16 +244,6 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
-    {
-        // pValuesForTheCurrentYear.hour[state.hourInTheYear] -=
-        // production for the current thermal dispatchable cluster
-        //	(state.thermalClusterProduction);
-
-        // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
-    }
-
     template<class VCardToFindT>
     inline const double* retrieveHourlyResultsForCurrentYear(unsigned int numSpace) const
     {

--- a/src/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/economy/dispatchableGeneration.h
@@ -271,11 +271,11 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
-            auto* thermalCluster = state.area->thermal.clusters[cluster_index];
+            auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             pValuesForTheCurrentYear[numSpace][thermalCluster->groupID][state.hourInTheYear]
-                += state.thermalClustersProductions[state.area->index][cluster_index];
+                += state.thermalClustersProductions[state.area->index][clusterIndex];
         }
         
         // Next item in the list

--- a/src/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/economy/dispatchableGeneration.h
@@ -271,9 +271,13 @@ public:
 
     void hourForEachThermalCluster(State& state, unsigned int numSpace)
     {
-        // Adding the dispatchable generation for the class_name fuel
-        pValuesForTheCurrentYear[numSpace][state.thermalCluster->groupID][state.hourInTheYear]
-          += state.thermalClusterProduction;
+        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        {
+            auto* thermalCluster = state.area->thermal.clusters[cluster_index];
+            pValuesForTheCurrentYear[numSpace][thermalCluster->groupID][state.hourInTheYear]
+                += state.thermalClustersProductions[state.area->index][cluster_index];
+        }
+        
         // Next item in the list
         NextType::hourForEachThermalCluster(state, numSpace);
     }

--- a/src/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/economy/dispatchableGeneration.h
@@ -269,7 +269,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
+    void hourForThermalClusters(State& state, unsigned int numSpace)
     {
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
@@ -279,7 +279,7 @@ public:
         }
         
         // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
+        NextType::hourForThermalClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/economy/dispatchableGeneration.h
@@ -269,7 +269,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForThermalClusters(State& state, unsigned int numSpace)
+    void hourForClusters(State& state, unsigned int numSpace)
     {
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
@@ -279,7 +279,7 @@ public:
         }
         
         // Next item in the list
-        NextType::hourForThermalClusters(state, numSpace);
+        NextType::hourForClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/economy/dispatchableGeneration.h
@@ -271,13 +271,14 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
+             ++cluster_index)
         {
             auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             pValuesForTheCurrentYear[numSpace][thermalCluster->groupID][state.hourInTheYear]
-                += state.thermalClustersProductions[state.area->index][clusterIndex];
+              += state.thermalClustersProductions[state.area->index][clusterIndex];
         }
-        
+
         // Next item in the list
         NextType::hourForClusters(state, numSpace);
     }

--- a/src/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/economy/dispatchableGeneration.h
@@ -271,8 +271,8 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
-             ++cluster_index)
+        for (uint clusterIndex = 0; clusterIndex != state.area->thermal.clusterCount();
+             ++clusterIndex)
         {
             auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             pValuesForTheCurrentYear[numSpace][thermalCluster->groupID][state.hourInTheYear]

--- a/src/solver/variable/economy/hydroCost.h
+++ b/src/solver/variable/economy/hydroCost.h
@@ -245,12 +245,6 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
-    {
-        // Next item in the list (static)
-        NextType::hourForEachThermalCluster(state, numSpace);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       unsigned int,
       unsigned int numSpace) const

--- a/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -322,7 +322,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForThermalClusters(State& state, unsigned int numSpace)
+    void hourForClusters(State& state, unsigned int numSpace)
     {
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
@@ -333,7 +333,7 @@ public:
         }
 
         // Next item in the list
-        NextType::hourForThermalClusters(state, numSpace);
+        NextType::hourForClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -324,10 +324,13 @@ public:
 
     void hourForEachThermalCluster(State& state, unsigned int numSpace)
     {
-        // Production for this hour
-        pValuesForTheCurrentYear[numSpace][state.thermalCluster->areaWideIndex]
-          .hour[state.hourInTheYear]
-          = state.thermalClusterNumberON;
+        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        {
+            auto* thermalCluster = state.area->thermal.clusters[cluster_index];
+            pValuesForTheCurrentYear[numSpace][thermalCluster->areaWideIndex]
+                .hour[state.hourInTheYear]
+                = state.numberOfUnitsONbyCluster[state.area->index][cluster_index];
+        }
 
         // Next item in the list
         NextType::hourForEachThermalCluster(state, numSpace);

--- a/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -322,7 +322,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
+    void hourForThermalClusters(State& state, unsigned int numSpace)
     {
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
@@ -333,7 +333,7 @@ public:
         }
 
         // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
+        NextType::hourForThermalClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -324,12 +324,12 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
-            auto* thermalCluster = state.area->thermal.clusters[cluster_index];
+            auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             pValuesForTheCurrentYear[numSpace][thermalCluster->areaWideIndex]
                 .hour[state.hourInTheYear]
-                = state.numberOfUnitsONbyCluster[state.area->index][cluster_index];
+                = state.numberOfUnitsONbyCluster[state.area->index][clusterIndex];
         }
 
         // Next item in the list

--- a/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -324,12 +324,13 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
+             ++cluster_index)
         {
             auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             pValuesForTheCurrentYear[numSpace][thermalCluster->areaWideIndex]
-                .hour[state.hourInTheYear]
-                = state.numberOfUnitsONbyCluster[state.area->index][clusterIndex];
+              .hour[state.hourInTheYear]
+              = state.numberOfUnitsONbyCluster[state.area->index][clusterIndex];
         }
 
         // Next item in the list

--- a/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -324,8 +324,8 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
-             ++cluster_index)
+        for (uint clusterIndex = 0; clusterIndex != state.area->thermal.clusterCount();
+             ++clusterIndex)
         {
             auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             pValuesForTheCurrentYear[numSpace][thermalCluster->areaWideIndex]

--- a/src/solver/variable/economy/nonProportionalCost.h
+++ b/src/solver/variable/economy/nonProportionalCost.h
@@ -255,16 +255,6 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
-    {
-        // Total Non Proportional cost
-        // NP = startup cost + fixed cost
-        // pValuesForTheCurrentYear[state.hourInTheYear] += state.thermalClusterNonProportionalCost;
-
-        // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       unsigned int,
       unsigned int numSpace) const

--- a/src/solver/variable/economy/npCostByDispatchablePlant.h
+++ b/src/solver/variable/economy/npCostByDispatchablePlant.h
@@ -311,18 +311,6 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
-    {
-        // Total Non Proportional cost for this hour
-        // NP = startup cost + fixed cost
-        // pValuesForTheCurrentYear[state.thermalCluster->areaWideIndex].hour[state.hourInTheYear]
-        // += production for the current thermal dispatchable cluster
-        //	(state.thermalClusterNonProportionalCost);
-
-        // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       unsigned int,
       unsigned int numSpace) const

--- a/src/solver/variable/economy/operatingCost.h
+++ b/src/solver/variable/economy/operatingCost.h
@@ -252,14 +252,6 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
-    {
-        // result
-        // pValuesForTheCurrentYear[state.hourInTheYear] += state.thermalClusterOperatingCost;
-        // Next item in the list (static)
-        NextType::hourForEachThermalCluster(state, numSpace);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       unsigned int,
       unsigned int numSpace) const

--- a/src/solver/variable/economy/overallCost.h
+++ b/src/solver/variable/economy/overallCost.h
@@ -276,14 +276,6 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
-    {
-        // Total OverallCost
-        // pValuesForTheCurrentYear[state.hourInTheYear] += state.thermalClusterOperatingCost;
-        // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
-    }
-
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(
       unsigned int,
       unsigned int numSpace) const

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -335,7 +335,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
+    void hourForThermalClusters(State& state, unsigned int numSpace)
     {
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
@@ -350,7 +350,7 @@ public:
         }
 
         // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
+        NextType::hourForThermalClusters(state, numSpace);
     }
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -337,16 +337,16 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
-            auto* thermalCluster = state.area->thermal.clusters[cluster_index];
+            auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             // Production for this hour
             pValuesForTheCurrentYear[numSpace][thermalCluster->areaWideIndex].hour[state.hourInTheYear]
-                += state.thermalClustersProductions[state.area->index][cluster_index];
+                += state.thermalClustersProductions[state.area->index][clusterIndex];
 
             pminOfTheClusterForYear[numSpace][(thermalCluster->areaWideIndex * maxHoursInAYear)
                                               + state.hourInTheYear]
-                = state.PMinOfClusters[state.area->index][cluster_index];
+                = state.PMinOfClusters[state.area->index][clusterIndex];
         }
 
         // Next item in the list

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -337,16 +337,18 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
+             ++cluster_index)
         {
             auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             // Production for this hour
-            pValuesForTheCurrentYear[numSpace][thermalCluster->areaWideIndex].hour[state.hourInTheYear]
-                += state.thermalClustersProductions[state.area->index][clusterIndex];
+            pValuesForTheCurrentYear[numSpace][thermalCluster->areaWideIndex]
+              .hour[state.hourInTheYear]
+              += state.thermalClustersProductions[state.area->index][clusterIndex];
 
             pminOfTheClusterForYear[numSpace][(thermalCluster->areaWideIndex * maxHoursInAYear)
                                               + state.hourInTheYear]
-                = state.PMinOfClusters[state.area->index][clusterIndex];
+              = state.PMinOfClusters[state.area->index][clusterIndex];
         }
 
         // Next item in the list

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -337,18 +337,17 @@ public:
 
     void hourForEachThermalCluster(State& state, unsigned int numSpace)
     {
-        // Production for this hour
-        pValuesForTheCurrentYear[numSpace][state.thermalCluster->areaWideIndex]
-          .hour[state.hourInTheYear]
-          +=
-          // production for the current thermal dispatchable cluster
-          (state.thermalClusterProduction);
+        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        {
+            auto* thermalCluster = state.area->thermal.clusters[cluster_index];
+            // Production for this hour
+            pValuesForTheCurrentYear[numSpace][thermalCluster->areaWideIndex].hour[state.hourInTheYear]
+                += state.thermalClustersProductions[state.area->index][cluster_index];
 
-        pminOfTheClusterForYear[numSpace][(state.thermalCluster->areaWideIndex * maxHoursInAYear)
-                                          + state.hourInTheYear]
-          =
-            // pmin of the current cluster
-          (state.thermalClusterPMinOfTheCluster);
+            pminOfTheClusterForYear[numSpace][(thermalCluster->areaWideIndex * maxHoursInAYear)
+                                              + state.hourInTheYear]
+                = state.PMinOfClusters[state.area->index][cluster_index];
+        }
 
         // Next item in the list
         NextType::hourForEachThermalCluster(state, numSpace);

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -337,8 +337,8 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
-             ++cluster_index)
+        for (uint clusterIndex = 0; clusterIndex != state.area->thermal.clusterCount();
+             ++clusterIndex)
         {
             auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
             // Production for this hour

--- a/src/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/economy/productionByDispatchablePlant.h
@@ -335,7 +335,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForThermalClusters(State& state, unsigned int numSpace)
+    void hourForClusters(State& state, unsigned int numSpace)
     {
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
@@ -350,7 +350,7 @@ public:
         }
 
         // Next item in the list
-        NextType::hourForThermalClusters(state, numSpace);
+        NextType::hourForClusters(state, numSpace);
     }
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const

--- a/src/solver/variable/economy/productionByRenewablePlant.h
+++ b/src/solver/variable/economy/productionByRenewablePlant.h
@@ -298,21 +298,18 @@ public:
 
     void hourForEachArea(State& state, unsigned int numSpace)
     {
+        for (uint clusterIndex = 0; clusterIndex != state.area->renewable.clusterCount(); ++clusterIndex)
+        {
+            auto* renewableCluster = state.area->renewable.clusters[clusterIndex];
+            uint serieIndex = state.timeseriesIndex->RenouvelableParPalier[clusterIndex];
+            double renewableClusterProduction = renewableCluster->valueAtTimeStep(serieIndex, state.hourInTheYear);
+
+            pValuesForTheCurrentYear[numSpace][renewableCluster->areaWideIndex].hour[state.hourInTheYear]
+                += renewableClusterProduction;
+        }
+
         // Next variable
         NextType::hourForEachArea(state, numSpace);
-    }
-
-    void hourForEachRenewableCluster(State& state, unsigned int numSpace)
-    {
-        // Production for this hour
-        pValuesForTheCurrentYear[numSpace][state.renewableCluster->areaWideIndex]
-          .hour[state.hourInTheYear]
-          +=
-          // production for the current renewable cluster
-          state.renewableClusterProduction;
-
-        // Next item in the list
-        NextType::hourForEachRenewableCluster(state, numSpace);
     }
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const

--- a/src/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/economy/profitByPlant.h
@@ -296,18 +296,20 @@ public:
         uint hourInTheWeek = state.hourInTheWeek;
         uint hourInTheYear = state.hourInTheYear;
 
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
+             ++cluster_index)
         {
             auto* cluster = state.area->thermal.clusters[clusterIndex];
-            double hourlyClusterProduction = state.thermalClustersProductions[state.area->index][clusterIndex];
+            double hourlyClusterProduction
+              = state.thermalClustersProductions[state.area->index][clusterIndex];
             // Thermal cluster profit
             pValuesForTheCurrentYear[numSpace][cluster->areaWideIndex].hour[hourInTheYear]
-                = (hourlyClusterProduction - cluster->PthetaInf[hourInTheYear])
-                  * (-areaMarginalCosts[hourInTheWeek]
-                     - cluster->marginalCost
-                         * cluster->modulation[Data::thermalModulationCost][hourInTheYear]);
+              = (hourlyClusterProduction - cluster->PthetaInf[hourInTheYear])
+                * (-areaMarginalCosts[hourInTheWeek]
+                   - cluster->marginalCost
+                       * cluster->modulation[Data::thermalModulationCost][hourInTheYear]);
         }
-        
+
         // Next item in the list
         NextType::hourForClusters(state, numSpace);
     }

--- a/src/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/economy/profitByPlant.h
@@ -289,7 +289,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
+    void hourForThermalClusters(State& state, unsigned int numSpace)
     {
         // Useful local variables
         double* areaMarginalCosts = state.hourlyResults->CoutsMarginauxHoraires;
@@ -309,7 +309,7 @@ public:
         }
         
         // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
+        NextType::hourForThermalClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/economy/profitByPlant.h
@@ -296,8 +296,8 @@ public:
         uint hourInTheWeek = state.hourInTheWeek;
         uint hourInTheYear = state.hourInTheYear;
 
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
-             ++cluster_index)
+        for (uint clusterIndex = 0; clusterIndex != state.area->thermal.clusterCount();
+             ++clusterIndex)
         {
             auto* cluster = state.area->thermal.clusters[clusterIndex];
             double hourlyClusterProduction

--- a/src/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/economy/profitByPlant.h
@@ -289,7 +289,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForThermalClusters(State& state, unsigned int numSpace)
+    void hourForClusters(State& state, unsigned int numSpace)
     {
         // Useful local variables
         double* areaMarginalCosts = state.hourlyResults->CoutsMarginauxHoraires;
@@ -309,7 +309,7 @@ public:
         }
         
         // Next item in the list
-        NextType::hourForThermalClusters(state, numSpace);
+        NextType::hourForClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/economy/profitByPlant.h
@@ -296,10 +296,10 @@ public:
         uint hourInTheWeek = state.hourInTheWeek;
         uint hourInTheYear = state.hourInTheYear;
 
-        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
-            auto* cluster = state.area->thermal.clusters[cluster_index];
-            double hourlyClusterProduction = state.thermalClustersProductions[state.area->index][cluster_index];
+            auto* cluster = state.area->thermal.clusters[clusterIndex];
+            double hourlyClusterProduction = state.thermalClustersProductions[state.area->index][clusterIndex];
             // Thermal cluster profit
             pValuesForTheCurrentYear[numSpace][cluster->areaWideIndex].hour[hourInTheYear]
                 = (hourlyClusterProduction - cluster->PthetaInf[hourInTheYear])

--- a/src/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/economy/profitByPlant.h
@@ -293,18 +293,21 @@ public:
     {
         // Useful local variables
         double* areaMarginalCosts = state.hourlyResults->CoutsMarginauxHoraires;
-        auto* cluster = state.thermalCluster;
-        double hourlyClusterProduction = state.thermalClusterProduction;
         uint hourInTheWeek = state.hourInTheWeek;
         uint hourInTheYear = state.hourInTheYear;
 
-        // Thermal cluster profit
-        pValuesForTheCurrentYear[numSpace][cluster->areaWideIndex].hour[hourInTheYear]
-          = (hourlyClusterProduction - cluster->PthetaInf[hourInTheYear])
-            * (-areaMarginalCosts[hourInTheWeek]
-               - cluster->marginalCost
-                   * cluster->modulation[Data::thermalModulationCost][hourInTheYear]);
-
+        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        {
+            auto* cluster = state.area->thermal.clusters[cluster_index];
+            double hourlyClusterProduction = state.thermalClustersProductions[state.area->index][cluster_index];
+            // Thermal cluster profit
+            pValuesForTheCurrentYear[numSpace][cluster->areaWideIndex].hour[hourInTheYear]
+                = (hourlyClusterProduction - cluster->PthetaInf[hourInTheYear])
+                  * (-areaMarginalCosts[hourInTheWeek]
+                     - cluster->marginalCost
+                         * cluster->modulation[Data::thermalModulationCost][hourInTheYear]);
+        }
+        
         // Next item in the list
         NextType::hourForEachThermalCluster(state, numSpace);
     }

--- a/src/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/economy/renewableGeneration.h
@@ -262,17 +262,18 @@ public:
 
     void hourForEachArea(State& state, unsigned int numSpace)
     {
+        for (uint clusterIndex = 0; clusterIndex != state.area->renewable.clusterCount(); ++clusterIndex)
+        {
+            auto* renewableCluster = state.area->renewable.clusters[clusterIndex];
+            uint serieIndex = state.timeseriesIndex->RenouvelableParPalier[clusterIndex];
+            double renewableClusterProduction = renewableCluster->valueAtTimeStep(serieIndex, state.hourInTheYear);
+
+            pValuesForTheCurrentYear[numSpace][renewableCluster->groupID][state.hourInTheYear]
+                += renewableClusterProduction;
+        }
+
         // Next variable
         NextType::hourForEachArea(state, numSpace);
-    }
-
-    void hourForEachRenewableCluster(State& state, unsigned int numSpace)
-    {
-        // Adding the dispatchable generation for the class_name fuel
-        pValuesForTheCurrentYear[numSpace][state.renewableCluster->groupID][state.hourInTheYear]
-          += state.renewableClusterProduction;
-        // Next item in the list
-        NextType::hourForEachRenewableCluster(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/thermalAirPollutantEmissions.h
+++ b/src/solver/variable/economy/thermalAirPollutantEmissions.h
@@ -245,8 +245,8 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
-             ++cluster_index)
+        for (uint clusterIndex = 0; clusterIndex != state.area->thermal.clusterCount();
+             ++clusterIndex)
         {
             auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
 

--- a/src/solver/variable/economy/thermalAirPollutantEmissions.h
+++ b/src/solver/variable/economy/thermalAirPollutantEmissions.h
@@ -242,7 +242,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForThermalClusters(State& state, unsigned int numSpace)
+    void hourForClusters(State& state, unsigned int numSpace)
     {
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
@@ -258,7 +258,7 @@ public:
         }
 
         // Next item in the list
-        NextType::hourForThermalClusters(state, numSpace);
+        NextType::hourForClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/thermalAirPollutantEmissions.h
+++ b/src/solver/variable/economy/thermalAirPollutantEmissions.h
@@ -242,7 +242,7 @@ public:
         NextType::hourForEachArea(state, numSpace);
     }
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace)
+    void hourForThermalClusters(State& state, unsigned int numSpace)
     {
         for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
@@ -258,7 +258,7 @@ public:
         }
 
         // Next item in the list
-        NextType::hourForEachThermalCluster(state, numSpace);
+        NextType::hourForThermalClusters(state, numSpace);
     }
 
     Antares::Memory::Stored<double>::ConstReturnType retrieveRawHourlyValuesForCurrentYear(

--- a/src/solver/variable/economy/thermalAirPollutantEmissions.h
+++ b/src/solver/variable/economy/thermalAirPollutantEmissions.h
@@ -107,8 +107,9 @@ struct VCardThermalAirPollutantEmissions
 ** \brief Marginal ThermalAirPollutantEmissions
 */
 template<class NextT = Container::EndOfList>
-class ThermalAirPollutantEmissions
- : public Variable::IVariable<ThermalAirPollutantEmissions<NextT>, NextT, VCardThermalAirPollutantEmissions>
+class ThermalAirPollutantEmissions : public Variable::IVariable<ThermalAirPollutantEmissions<NextT>,
+                                                                NextT,
+                                                                VCardThermalAirPollutantEmissions>
 {
 public:
     //! Type of the next static variable
@@ -244,7 +245,8 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount();
+             ++cluster_index)
         {
             auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
 
@@ -252,8 +254,8 @@ public:
             for (int i = 0; i < Antares::Data::Pollutant::POLLUTANT_MAX; i++)
             {
                 pValuesForTheCurrentYear[numSpace][i][state.hourInTheYear]
-                    += thermalCluster->emissions.factors[i]
-                        * state.thermalClustersProductions[state.area->index][clusterIndex];
+                  += thermalCluster->emissions.factors[i]
+                     * state.thermalClustersProductions[state.area->index][clusterIndex];
             }
         }
 

--- a/src/solver/variable/economy/thermalAirPollutantEmissions.h
+++ b/src/solver/variable/economy/thermalAirPollutantEmissions.h
@@ -244,12 +244,17 @@ public:
 
     void hourForEachThermalCluster(State& state, unsigned int numSpace)
     {
-        //Multiply every pollutant factor with production
-        for (int i = 0; i < Antares::Data::Pollutant::POLLUTANT_MAX; i++)
+        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
-            pValuesForTheCurrentYear[numSpace][i][state.hourInTheYear]
-                += state.thermalCluster->emissions.factors[i]
-                    * state.thermalClusterProduction;
+            auto* thermalCluster = state.area->thermal.clusters[cluster_index];
+
+            // Multiply every pollutant factor with production
+            for (int i = 0; i < Antares::Data::Pollutant::POLLUTANT_MAX; i++)
+            {
+                pValuesForTheCurrentYear[numSpace][i][state.hourInTheYear]
+                    += thermalCluster->emissions.factors[i]
+                        * state.thermalClustersProductions[state.area->index][cluster_index];
+            }
         }
 
         // Next item in the list

--- a/src/solver/variable/economy/thermalAirPollutantEmissions.h
+++ b/src/solver/variable/economy/thermalAirPollutantEmissions.h
@@ -244,16 +244,16 @@ public:
 
     void hourForClusters(State& state, unsigned int numSpace)
     {
-        for (uint cluster_index = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
+        for (uint clusterIndex = 0; cluster_index != state.area->thermal.clusterCount(); ++cluster_index)
         {
-            auto* thermalCluster = state.area->thermal.clusters[cluster_index];
+            auto* thermalCluster = state.area->thermal.clusters[clusterIndex];
 
             // Multiply every pollutant factor with production
             for (int i = 0; i < Antares::Data::Pollutant::POLLUTANT_MAX; i++)
             {
                 pValuesForTheCurrentYear[numSpace][i][state.hourInTheYear]
                     += thermalCluster->emissions.factors[i]
-                        * state.thermalClustersProductions[state.area->index][cluster_index];
+                        * state.thermalClustersProductions[state.area->index][clusterIndex];
             }
         }
 

--- a/src/solver/variable/endoflist.h
+++ b/src/solver/variable/endoflist.h
@@ -209,7 +209,7 @@ public:
         UNUSED_VARIABLE(numSpace);
     }
 
-    static void hourForThermalClusters(State&, uint numSpace)
+    static void hourForClusters(State&, uint numSpace)
     {
         UNUSED_VARIABLE(numSpace);
     }

--- a/src/solver/variable/endoflist.h
+++ b/src/solver/variable/endoflist.h
@@ -209,7 +209,7 @@ public:
         UNUSED_VARIABLE(numSpace);
     }
 
-    static void hourForEachThermalCluster(State&, uint numSpace)
+    static void hourForThermalClusters(State&, uint numSpace)
     {
         UNUSED_VARIABLE(numSpace);
     }

--- a/src/solver/variable/endoflist.h
+++ b/src/solver/variable/endoflist.h
@@ -214,11 +214,6 @@ public:
         UNUSED_VARIABLE(numSpace);
     }
 
-    static void hourForEachRenewableCluster(State&, uint numSpace)
-    {
-        UNUSED_VARIABLE(numSpace);
-    }
-
     static void hourEnd(State&, unsigned int)
     {
     }

--- a/src/solver/variable/setofareas.h
+++ b/src/solver/variable/setofareas.h
@@ -150,7 +150,7 @@ public:
     void hourBegin(unsigned int hourInTheYear);
     void hourForEachArea(State& state);
     void hourForEachLink(State& state);
-    void hourForEachThermalCluster(State& state);
+    void hourForThermalClusters(State& state);
     void hourEnd(State& state, unsigned int hourInTheYear);
 
     void weekBegin(State&);

--- a/src/solver/variable/setofareas.h
+++ b/src/solver/variable/setofareas.h
@@ -150,7 +150,7 @@ public:
     void hourBegin(unsigned int hourInTheYear);
     void hourForEachArea(State& state);
     void hourForEachLink(State& state);
-    void hourForThermalClusters(State& state);
+    void hourForClusters(State& state);
     void hourEnd(State& state, unsigned int hourInTheYear);
 
     void weekBegin(State&);

--- a/src/solver/variable/setofareas.hxx
+++ b/src/solver/variable/setofareas.hxx
@@ -202,7 +202,7 @@ inline void SetsOfAreas<NextT>::hourForEachLink(State& state)
 }
 
 template<class NextT>
-inline void SetsOfAreas<NextT>::hourForThermalClusters(State& state)
+inline void SetsOfAreas<NextT>::hourForClusters(State& state)
 {
     (void)state;
 }

--- a/src/solver/variable/setofareas.hxx
+++ b/src/solver/variable/setofareas.hxx
@@ -202,7 +202,7 @@ inline void SetsOfAreas<NextT>::hourForEachLink(State& state)
 }
 
 template<class NextT>
-inline void SetsOfAreas<NextT>::hourForEachThermalCluster(State& state)
+inline void SetsOfAreas<NextT>::hourForThermalClusters(State& state)
 {
     (void)state;
 }

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -46,21 +46,15 @@ State::State(Data::Study& s) :
  averageOptimizationTime1(0.),
  averageOptimizationTime2(0.)
 {
-    thermalClustersProductions.resize(s.areas.size());
-    for (int area_index = 0; area_index < s.areas.size(); area_index++)
-        thermalClustersProductions[area_index].resize(s.areas[area_index]->thermal.clusterCount());
+    auto resizeThermal = [&s](auto& container) {
+                           container.resize(s.areas.size());
+                           for (uint areaIndex = 0; areaIndex < s.areas.size(); areaIndex++)
+                               container[areaIndex].resize(s.areas[areaIndex]->thermal.clusterCount());
+                  };
 
-    PMinOfClusters.resize(s.areas.size());
-    for (int area_index = 0; area_index < s.areas.size(); area_index++)
-        PMinOfClusters[area_index].resize(s.areas[area_index]->thermal.clusterCount());
-
-    numberOfUnitsONbyCluster.resize(s.areas.size());
-    for (int area_index = 0; area_index < s.areas.size(); area_index++)
-        numberOfUnitsONbyCluster[area_index].resize(s.areas[area_index]->thermal.clusterCount());
-
-    thermalClustersOperatingCost.resize(s.areas.size());
-    for (int area_index = 0; area_index < s.areas.size(); area_index++)
-        thermalClustersOperatingCost[area_index].resize(s.areas[area_index]->thermal.clusterCount());
+    resizeThermal(thermalClustersProductions);
+    resizeThermal(numberOfUnitsONbyCluster);
+    resizeThermal(thermalClustersOperatingCost);
 }
 
 void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint numSpace)

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -47,10 +47,10 @@ State::State(Data::Study& s) :
  averageOptimizationTime2(0.)
 {
     auto resizeThermal = [&s](auto& container) {
-                           container.resize(s.areas.size());
-                           for (uint areaIndex = 0; areaIndex < s.areas.size(); areaIndex++)
-                               container[areaIndex].resize(s.areas[areaIndex]->thermal.clusterCount());
-                  };
+        container.resize(s.areas.size());
+        for (uint areaIndex = 0; areaIndex < s.areas.size(); areaIndex++)
+            container[areaIndex].resize(s.areas[areaIndex]->thermal.clusterCount());
+    };
 
     resizeThermal(thermalClustersProductions);
     resizeThermal(numberOfUnitsONbyCluster);
@@ -71,7 +71,8 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
     Data::ThermalCluster* thermalCluster = area->thermal.clusters[clusterAreaWideIndex];
 
     uint serieIndex = timeseriesIndex->ThermiqueParPalier[clusterAreaWideIndex];
-    double thermalClusterAvailableProduction = thermalCluster->series->series[serieIndex][hourInTheYear];
+    double thermalClusterAvailableProduction
+      = thermalCluster->series->series[serieIndex][hourInTheYear];
 
     // Minimum power of a group of the cluster for the current hour in the year
     double thermalClusterPMinOfAGroup = 0.;
@@ -85,10 +86,12 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
         assert(timeseriesIndex != NULL);
         assert(hourInTheYear < thermalCluster->series->series.height);
 
-        thermalClustersProductions[area->index][clusterAreaWideIndex] = thermalClusterAvailableProduction;
+        thermalClustersProductions[area->index][clusterAreaWideIndex]
+          = thermalClusterAvailableProduction;
 
         PMinOfClusters[area->index][clusterAreaWideIndex] = 0.;
-        numberOfUnitsONbyCluster[area->index][clusterAreaWideIndex] = 0; // will be calculated during the smoothing
+        numberOfUnitsONbyCluster[area->index][clusterAreaWideIndex]
+          = 0; // will be calculated during the smoothing
     }
     else
     {
@@ -97,12 +100,12 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
         if (studyMode != Data::stdmAdequacy) // Economy
         {
             thermalClusterPMinOfAGroup
-                = problemeHebdo->PaliersThermiquesDuPays[area->index]
-                ->pminDUnGroupeDuPalierThermique[thermalCluster->index]; // one by cluster
+              = problemeHebdo->PaliersThermiquesDuPays[area->index]
+                  ->pminDUnGroupeDuPalierThermique[thermalCluster->index]; // one by cluster
             PMinOfClusters[area->index][clusterAreaWideIndex]
-                = problemeHebdo->PaliersThermiquesDuPays[area->index]
-                ->PuissanceDisponibleEtCout[thermalCluster->index]
-                ->PuissanceMinDuPalierThermique[hourInTheWeek]; // one per hour for one
+              = problemeHebdo->PaliersThermiquesDuPays[area->index]
+                  ->PuissanceDisponibleEtCout[thermalCluster->index]
+                  ->PuissanceMinDuPalierThermique[hourInTheWeek]; // one per hour for one
             // cluster
         }
         else
@@ -111,13 +114,14 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
             PMinOfClusters[area->index][clusterAreaWideIndex] = 0.;
         }
 
-        thermalClustersProductions[area->index][clusterAreaWideIndex] = hourlyResults->ProductionThermique[hourInTheWeek]
-            ->ProductionThermiqueDuPalier[thermalCluster->index];
+        thermalClustersProductions[area->index][clusterAreaWideIndex]
+          = hourlyResults->ProductionThermique[hourInTheWeek]
+              ->ProductionThermiqueDuPalier[thermalCluster->index];
 
         if (unitCommitmentMode == Antares::Data::UnitCommitmentMode::ucMILP) // Economy accurate
             numberOfUnitsONbyCluster[area->index][clusterAreaWideIndex]
-                = static_cast<uint>(hourlyResults->ProductionThermique[hourInTheWeek]
-                        ->NombreDeGroupesEnMarcheDuPalier[thermalCluster->index]);
+              = static_cast<uint>(hourlyResults->ProductionThermique[hourInTheWeek]
+                                    ->NombreDeGroupesEnMarcheDuPalier[thermalCluster->index]);
         else
             // Economy Fast or Adequacy -- will be calculated during the smoothing
             numberOfUnitsONbyCluster[area->index][clusterAreaWideIndex] = 0;
@@ -176,7 +180,7 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
         if (p > thermalCluster->productionLastHour[numSpace])
         {
             newUnitCount
-                = static_cast<uint>(Math::Ceil(p / thermalCluster->nominalCapacityWithSpinning));
+              = static_cast<uint>(Math::Ceil(p / thermalCluster->nominalCapacityWithSpinning));
             if (newUnitCount > thermalCluster->unitCount)
                 newUnitCount = thermalCluster->unitCount;
             if (newUnitCount < previousUnitCount)
@@ -186,8 +190,8 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
         {
             if (thermalCluster->minStablePower > 0.)
             {
-                newUnitCount = static_cast<uint>(
-                        Math::Ceil(p / thermalCluster->nominalCapacityWithSpinning));
+                newUnitCount
+                  = static_cast<uint>(Math::Ceil(p / thermalCluster->nominalCapacityWithSpinning));
                 if (newUnitCount > thermalCluster->unitCount)
                     newUnitCount = thermalCluster->unitCount;
             }
@@ -201,20 +205,21 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
         // calculating the operating cost for the current hour
         // O(h) = MA * P(h) * Modulation
         assert(thermalCluster->productionCost != NULL && "invalid production cost");
-        thermalClustersOperatingCost[area->index][clusterAreaWideIndex] 
-            = (p * thermalCluster->productionCost[hourInTheYear]);
+        thermalClustersOperatingCost[area->index][clusterAreaWideIndex]
+          = (p * thermalCluster->productionCost[hourInTheYear]);
 
         // Startup cost
         if (newUnitCount > previousUnitCount && hourInTheSimulation != 0u)
         {
             thermalClustersOperatingCost[area->index][clusterAreaWideIndex]
-                += thermalCluster->startupCost * (newUnitCount - previousUnitCount);
+              += thermalCluster->startupCost * (newUnitCount - previousUnitCount);
             thermalClusterNonProportionalCost
-                = thermalCluster->startupCost * (newUnitCount - previousUnitCount);
+              = thermalCluster->startupCost * (newUnitCount - previousUnitCount);
         }
 
         // Fixed price
-        thermalClustersOperatingCost[area->index][clusterAreaWideIndex] += thermalCluster->fixedCost * newUnitCount;
+        thermalClustersOperatingCost[area->index][clusterAreaWideIndex]
+          += thermalCluster->fixedCost * newUnitCount;
         thermalClusterNonProportionalCost += thermalCluster->fixedCost * newUnitCount;
 
         // Storing the new unit count for the next hour

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -247,20 +247,6 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex, uint nu
     // en mode fast : est pris depuis l'heuristique
 }
 
-void State::initFromRenewableClusterIndex(const uint clusterAreaWideIndex, uint /* numSpace */)
-{
-    assert(area);
-    assert(clusterAreaWideIndex < area->renewable.clusterCount());
-
-    // alias to the current renewable cluster
-    renewableCluster = area->renewable.clusters[clusterAreaWideIndex];
-    assert(timeseriesIndex);
-    uint serieIndex = timeseriesIndex->RenouvelableParPalier[clusterAreaWideIndex];
-
-    assert(renewableCluster->series);
-    renewableClusterProduction = renewableCluster->valueAtTimeStep(serieIndex, hourInTheYear);
-}
-
 void State::yearEndBuildFromThermalClusterIndex(const uint clusterAreaWideIndex, uint numSpace)
 {
     uint dur;    // nombre d'heures de fonctionnement d'un groupe au delà duquel un

--- a/src/solver/variable/state.h
+++ b/src/solver/variable/state.h
@@ -27,6 +27,7 @@
 #ifndef __SOLVER_VARIABLE_STATE_H__
 #define __SOLVER_VARIABLE_STATE_H__
 
+#include <vector>
 #include <yuni/yuni.h>
 #include "constants.h"
 #include <antares/study/fwd.h>
@@ -147,8 +148,10 @@ public:
 
     //! The current area
     Data::Area* area;
-    //! The current thermal cluster
+
+    //! The current thermal cluster (used in yearEndBuildForEachThermalCluster functions)
     Data::ThermalCluster* thermalCluster;
+    
     //! The current renewable cluster
     Data::RenewableCluster* renewableCluster;
     //! The Scratchpad for the current area
@@ -169,16 +172,20 @@ public:
     RESULTATS_HORAIRES* hourlyResults;
     //! NTC Values
     VALEURS_DE_NTC_ET_RESISTANCES* ntc;
-    //! Thermal production for the current thermal cluster for the current hour in the year
-    double thermalClusterProduction;
-    //! The operating cost for the current cluster of the current hour (production level*production
+
+    //! Thermal production for thermal clusters for the current hour in the year
+    std::vector<std::vector<double>> thermalClustersProductions;
+
+    //! The operating cost for all clusters at the current hour (production level*production
     //! cost + NP Cost)
-    double thermalClusterOperatingCost;
-    //! Number of groups turned ON by cluster for the current hour in the year with the ucMILP
+    std::vector<std::vector<double>> thermalClustersOperatingCost;
+
+    //! Number of units turned ON by cluster for the current hour in the year with the ucMILP
     //! (accurate) unit commitment mode
-    uint thermalClusterNumberON;
-    //! Minimum power of the cluster for the current hour in the year
-    double thermalClusterPMinOfTheCluster;
+    std::vector<std::vector<uint>>  numberOfUnitsONbyCluster;
+    
+    //! Minimum power of all clusters for the current hour in the year
+    std::vector<std::vector<double>> PMinOfClusters;
 
     //! Thermal production for the current thermal cluster for the whole year
     double thermalClusterProductionForYear[Variable::maxHoursInAYear];

--- a/src/solver/variable/state.h
+++ b/src/solver/variable/state.h
@@ -171,20 +171,12 @@ public:
     VALEURS_DE_NTC_ET_RESISTANCES* ntc;
     //! Thermal production for the current thermal cluster for the current hour in the year
     double thermalClusterProduction;
-    //! Thermal available production for the current thermal cluster for the current hour in the
-    //! year
-    double thermalClusterAvailableProduction;
     //! The operating cost for the current cluster of the current hour (production level*production
     //! cost + NP Cost)
     double thermalClusterOperatingCost;
-    //! The non propostional cost for the current cluster of the current hour (startupCost *
-    //! (newUnitCount - previousUnitCount)) + (fixed cost * newUnitCount) - MBO - 13/05/2014 - #21
-    double thermalClusterNonProportionalCost;
     //! Number of groups turned ON by cluster for the current hour in the year with the ucMILP
     //! (accurate) unit commitment mode
     uint thermalClusterNumberON;
-    //! Minimum power of a group of the cluster for the current hour in the year
-    double thermalClusterPMinOfAGroup;
     //! Minimum power of the cluster for the current hour in the year
     double thermalClusterPMinOfTheCluster;
 

--- a/src/solver/variable/state.h
+++ b/src/solver/variable/state.h
@@ -73,16 +73,6 @@ public:
     void initFromThermalClusterIndex(const unsigned int areaWideIndex, uint numSpace);
 
     /*!
-    ** \brief Initialize some variable according a renewable cluster index
-    **
-    ** We assume here that the variables related to an area
-    ** are properly initialized.
-    **
-    ** \param areaWideIndex Index of the renewable cluster for the current area
-    */
-    void initFromRenewableClusterIndex(const unsigned int areaWideIndex, uint numSpace);
-
-    /*!
     ** \brief End the year by smoothing the thermal units run
     ** and computing costs.
     ** We assume here that the variables related to an area

--- a/src/solver/variable/variable.h
+++ b/src/solver/variable/variable.h
@@ -252,8 +252,6 @@ public:
 
     void hourForEachThermalCluster(State& state, unsigned int numSpace);
 
-    void hourForEachRenewableCluster(State& state, unsigned int numSpace);
-
     //! Event: For a given hour in the year, walking through all links
     // for a given area
     void hourForEachLink(State& state, uint numSpace);

--- a/src/solver/variable/variable.h
+++ b/src/solver/variable/variable.h
@@ -248,9 +248,9 @@ public:
     void hourForEachArea(State& state);
     //! Event: For a given hour in the year, walking through all thermal clusters
     // for a given area
-    void hourForEachThermalCluster(State& state);
+    void hourForThermalClusters(State& state);
 
-    void hourForEachThermalCluster(State& state, unsigned int numSpace);
+    void hourForThermalClusters(State& state, unsigned int numSpace);
 
     //! Event: For a given hour in the year, walking through all links
     // for a given area

--- a/src/solver/variable/variable.h
+++ b/src/solver/variable/variable.h
@@ -248,9 +248,9 @@ public:
     void hourForEachArea(State& state);
     //! Event: For a given hour in the year, walking through all thermal clusters
     // for a given area
-    void hourForThermalClusters(State& state);
+    void hourForClusters(State& state);
 
-    void hourForThermalClusters(State& state, unsigned int numSpace);
+    void hourForClusters(State& state, unsigned int numSpace);
 
     //! Event: For a given hour in the year, walking through all links
     // for a given area

--- a/src/solver/variable/variable.hxx
+++ b/src/solver/variable/variable.hxx
@@ -311,18 +311,18 @@ inline void IVariable<ChildT, NextT, VCardT>::hourForEachArea(State& state)
 }
 
 template<class ChildT, class NextT, class VCardT>
-inline void IVariable<ChildT, NextT, VCardT>::hourForEachThermalCluster(State& state)
+inline void IVariable<ChildT, NextT, VCardT>::hourForThermalClusters(State& state)
 {
     // Next item in the list
-    NextType::hourForEachThermalCluster(state);
+    NextType::hourForThermalClusters(state);
 }
 
 template<class ChildT, class NextT, class VCardT>
-inline void IVariable<ChildT, NextT, VCardT>::hourForEachThermalCluster(State& state,
+inline void IVariable<ChildT, NextT, VCardT>::hourForThermalClusters(State& state,
                                                                         unsigned int numSpace)
 {
     // Next item in the list
-    NextType::hourForEachThermalCluster(state, numSpace);
+    NextType::hourForThermalClusters(state, numSpace);
 }
 
 template<class ChildT, class NextT, class VCardT>

--- a/src/solver/variable/variable.hxx
+++ b/src/solver/variable/variable.hxx
@@ -318,14 +318,6 @@ inline void IVariable<ChildT, NextT, VCardT>::hourForEachThermalCluster(State& s
 }
 
 template<class ChildT, class NextT, class VCardT>
-inline void IVariable<ChildT, NextT, VCardT>::hourForEachRenewableCluster(State& state,
-                                                                          unsigned int numSpace)
-{
-    // Next item in the list
-    NextType::hourForEachRenewableCluster(state, numSpace);
-}
-
-template<class ChildT, class NextT, class VCardT>
 inline void IVariable<ChildT, NextT, VCardT>::hourForEachThermalCluster(State& state,
                                                                         unsigned int numSpace)
 {

--- a/src/solver/variable/variable.hxx
+++ b/src/solver/variable/variable.hxx
@@ -311,18 +311,18 @@ inline void IVariable<ChildT, NextT, VCardT>::hourForEachArea(State& state)
 }
 
 template<class ChildT, class NextT, class VCardT>
-inline void IVariable<ChildT, NextT, VCardT>::hourForThermalClusters(State& state)
+inline void IVariable<ChildT, NextT, VCardT>::hourForClusters(State& state)
 {
     // Next item in the list
-    NextType::hourForThermalClusters(state);
+    NextType::hourForClusters(state);
 }
 
 template<class ChildT, class NextT, class VCardT>
-inline void IVariable<ChildT, NextT, VCardT>::hourForThermalClusters(State& state,
+inline void IVariable<ChildT, NextT, VCardT>::hourForClusters(State& state,
                                                                         unsigned int numSpace)
 {
     // Next item in the list
-    NextType::hourForThermalClusters(state, numSpace);
+    NextType::hourForClusters(state, numSpace);
 }
 
 template<class ChildT, class NextT, class VCardT>

--- a/src/tests/run-study-tests/check_on_results/output_compare.py
+++ b/src/tests/run-study-tests/check_on_results/output_compare.py
@@ -83,6 +83,7 @@ def compare_simulation_files(simulation_files, tol):
     REF_INDEX = 0
     OTHER_INDEX = 1
     at_least_one_diff = False
+    col_name_where_diff = ""
     for file_pair in simulation_files:
         # Read reference and simulation (other) files
         ref_data_frame = read_csv(file_pair[REF_INDEX])
@@ -105,8 +106,10 @@ def compare_simulation_files(simulation_files, tol):
 
                 print_comparison_report(ref_data_frame, other_data_frame, file_path, col_name)
                 at_least_one_diff = True
+                col_name_where_diff = col_name
 
-    return not at_least_one_diff
+
+    return (not at_least_one_diff, col_name_where_diff)
 
 
 def print_comparison_report(ref_data_frame, other_data_frame, file_path, col_name):

--- a/src/tests/run-study-tests/check_on_results/output_compare.py
+++ b/src/tests/run-study-tests/check_on_results/output_compare.py
@@ -38,7 +38,9 @@ class output_compare(check_interface):
 
         simulation_files = find_simulation_files(ref_simulation_folder, other_folder)
 
-        check(compare_simulation_files(simulation_files, self.tol), "Results comparison failed")
+        (comparison_ok, output_var_if_failure) = compare_simulation_files(simulation_files, self.tol)
+        error_msg = "Results comparison failed on : %s" % output_var_if_failure
+        check(comparison_ok, error_msg)
 
     def name(self):
         return "output compare"


### PR DESCRIPTION
This work is a first refactoring before adding new output variables for ST storage.
It intends to simplify or even remove definition and use of :  
- **hourForEachThermalCluster**
- **hourForEachRenewableCluster**

in order to introduce functions **hourForClusters** to handle clusters of all kinds (thermal, renewable and ST storage).
Eventually, the content of these functions should be moved to **hourForEachArea**.