### PR TITLE
Use `shared_ptr` instead of raw pointer

### DIFF
--- a/src/libs/antares/study/parts/short-term-storage/cluster.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/cluster.cpp
@@ -33,6 +33,10 @@
 
 namespace Antares::Data::ShortTermStorage
 {
+STStorageCluster::STStorageCluster() : series(std::make_shared<Series>())
+{
+}
+
 bool STStorageCluster::loadFromSection(const IniFile::Section& section)
 {
     if (!section.firstProperty)
@@ -64,13 +68,13 @@ bool STStorageCluster::loadFromSection(const IniFile::Section& section)
 
 bool STStorageCluster::validate()
 {
-    return properties.validate() && series.validate();
+    return properties.validate() && series->validate();
 }
 
 bool STStorageCluster::loadSeries(const std::string& folder)
 {
-    bool ret = series.loadFromFolder(folder);
-    series.fillDefaultSeriesIfEmpty(); // fill series if no file series
+    bool ret = series->loadFromFolder(folder);
+    series->fillDefaultSeriesIfEmpty(); // fill series if no file series
     return ret;
 }
 

--- a/src/libs/antares/study/parts/short-term-storage/cluster.h
+++ b/src/libs/antares/study/parts/short-term-storage/cluster.h
@@ -27,6 +27,7 @@
 
 #pragma once
 #include <string>
+#include <memory>
 #include <antares/inifile.h>
 #include "properties.h"
 #include "series.h"
@@ -36,6 +37,7 @@ namespace Antares::Data::ShortTermStorage
 class STStorageCluster
 {
 public:
+    STStorageCluster();
     bool validate();
     bool loadFromSection(const IniFile::Section& section);
 
@@ -43,7 +45,7 @@ public:
 
     std::string id;
 
-    Series series;
+    std::shared_ptr<Series> series;
     Properties properties;
 };
 } // namespace Antares::Data::ShortTermStorage

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -183,7 +183,7 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                                      .InjectionVariable[globalIndex];
                 Xmin[varInjection] = 0.;
                 Xmax[varInjection]
-                  = storage.injectionCapacity * storage.injectionModulation[pdtHebdo];
+                  = storage.injectionCapacity * storage.series->maxInjectionModulation[pdtHebdo];
                 AddressForVars[varInjection] = &STSResult.injection[areaWideIndex];
 
                 // 2. Withdrwal
@@ -191,7 +191,7 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                                       .WithdrawalVariable[globalIndex];
                 Xmin[varWithdrawal] = 0.;
                 Xmax[varWithdrawal]
-                  = storage.withdrawalCapacity * storage.withdrawalModulation[pdtHebdo];
+                  = storage.withdrawalCapacity * storage.series->maxWithdrawalModulation[pdtHebdo];
                 AddressForVars[varWithdrawal] = &STSResult.withdrawal[areaWideIndex];
 
                 // 3. Levels
@@ -203,8 +203,8 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                 }
                 else
                 {
-                    Xmin[varLevel] = storage.capacity * storage.lowerRuleCurve[pdtHebdo];
-                    Xmax[varLevel] = storage.capacity * storage.upperRuleCurve[pdtHebdo];
+                    Xmin[varLevel] = storage.capacity * storage.series->lowerRuleCurve[pdtHebdo];
+                    Xmax[varLevel] = storage.capacity * storage.series->upperRuleCurve[pdtHebdo];
                 }
                 AddressForVars[varLevel] = &STSResult.level[areaWideIndex];
 

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -57,7 +57,7 @@ static void shortTermStorageLevelsRHS(
             const int globalIndex = storage.globalIndex;
             const int cnt
               = CorrespondanceCntNativesCntOptim->ShortTermStorageLevelConstraint[globalIndex];
-            SecondMembre[cnt] = storage.inflows[pdtJour];
+            SecondMembre[cnt] = storage.series->inflows[pdtJour];
         }
     }
 }

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -59,16 +59,7 @@ static void importShortTermStorages(
             toInsert.withdrawalCapacity = st->properties.withdrawalCapacity.value();
             toInsert.initialLevel = st->properties.initialLevel;
 
-            // Series - Inflows
-            toInsert.inflows = std::move(st->series.inflows);
-
-            // Series - Withdrawal / injection modulation
-            toInsert.withdrawalModulation = std::move(st->series.maxWithdrawalModulation);
-            toInsert.injectionModulation = std::move(st->series.maxInjectionModulation);
-
-            // Series - Rule curves
-            toInsert.lowerRuleCurve = std::move(st->series.lowerRuleCurve);
-            toInsert.upperRuleCurve = std::move(st->series.upperRuleCurve);
+            toInsert.series = st->series;
 
             // TODO add missing properties, or use the same struct
             STindex++;

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -60,15 +60,15 @@ static void importShortTermStorages(
             toInsert.initialLevel = st->properties.initialLevel;
 
             // Series - Inflows
-            toInsert.inflows = st->series.inflows.data();
+            toInsert.inflows = std::move(st->series.inflows);
 
             // Series - Withdrawal / injection modulation
-            toInsert.withdrawalModulation = st->series.maxWithdrawalModulation.data();
-            toInsert.injectionModulation = st->series.maxInjectionModulation.data();
+            toInsert.withdrawalModulation = std::move(st->series.maxWithdrawalModulation);
+            toInsert.injectionModulation = std::move(st->series.maxInjectionModulation);
 
             // Series - Rule curves
-            toInsert.lowerRuleCurve = st->series.lowerRuleCurve.data();
-            toInsert.upperRuleCurve = st->series.upperRuleCurve.data();
+            toInsert.lowerRuleCurve = std::move(st->series.lowerRuleCurve);
+            toInsert.upperRuleCurve = std::move(st->series.upperRuleCurve);
 
             // TODO add missing properties, or use the same struct
             STindex++;

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -167,14 +167,10 @@ struct PROPERTIES
     double injectionCapacity;
     double withdrawalCapacity;
     double efficiency;
-
     std::optional<double> initialLevel;
 
-    std::vector<double> inflows;
-    std::vector<double> withdrawalModulation;
-    std::vector<double> injectionModulation;
-    std::vector<double> lowerRuleCurve;
-    std::vector<double> upperRuleCurve;
+    std::shared_ptr<Antares::Data::ShortTermStorage::Series> series;
+
     int globalIndex;
 };
 

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -170,12 +170,11 @@ struct PROPERTIES
 
     std::optional<double> initialLevel;
 
-    // TODO[FOM] move to better place
-    const double* inflows;
-    const double* withdrawalModulation;
-    const double* injectionModulation;
-    const double* lowerRuleCurve;
-    const double* upperRuleCurve;
+    std::vector<double> inflows;
+    std::vector<double> withdrawalModulation;
+    std::vector<double> injectionModulation;
+    std::vector<double> lowerRuleCurve;
+    std::vector<double> upperRuleCurve;
     int globalIndex;
 };
 


### PR DESCRIPTION
Using raw pointers is dangerous : the memory address can change or be de-allocated.

`std::move` intends to clarify what's intended, still avoiding deep copies.