### PR TITLE
Fix version check for mingen

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -1585,7 +1585,7 @@ void AreaList::removeHydroTimeseries()
     each([&](Data::Area& area) {
         area.hydro.series->ror.reset(1, HOURS_PER_YEAR);
         area.hydro.series->storage.reset(1, DAYS_PER_YEAR);
-        area.hydro.series->mingen.reset(0, HOURS_PER_YEAR);
+        area.hydro.series->mingen.reset(1, HOURS_PER_YEAR);
         area.hydro.series->count = 1;
     });
 }

--- a/src/libs/antares/study/parts/hydro/series.cpp
+++ b/src/libs/antares/study/parts/hydro/series.cpp
@@ -92,7 +92,7 @@ bool DataSeriesHydro::loadFromFolder(Study& study, const AreaName& areaID, const
     }
     else
     {
-        mingen.reset(0, HOURS_PER_YEAR);
+        mingen.reset(1, HOURS_PER_YEAR);
         mingen.markAsModified();
     }
 
@@ -104,7 +104,7 @@ bool DataSeriesHydro::loadFromFolder(Study& study, const AreaName& areaID, const
                          << "`: empty matrix detected. Fixing it with default values";
             ror.reset(1, HOURS_PER_YEAR);
             storage.reset(1, DAYS_PER_YEAR);
-            mingen.reset(0, HOURS_PER_YEAR);
+            mingen.reset(1, HOURS_PER_YEAR);
         }
         else
         {

--- a/src/libs/antares/study/parts/hydro/series.cpp
+++ b/src/libs/antares/study/parts/hydro/series.cpp
@@ -44,6 +44,11 @@ namespace Data
 {
 DataSeriesHydro::DataSeriesHydro() : count(0)
 {
+    // Pmin was introduced in v8.6
+    // The previous behavior was Pmin=0
+    // For compatibility reasons with existing studies, mingen is set to one column of zeros
+    // by default
+    mingen.reset(1, HOURS_PER_YEAR);
 }
 
 bool DataSeriesHydro::saveToFolder(const AreaName& areaID, const AnyString& folder) const
@@ -89,11 +94,6 @@ bool DataSeriesHydro::loadFromFolder(Study& study, const AreaName& areaID, const
     {
         buffer.clear() << folder << SEP << areaID << SEP << "mingen." << study.inputExtension;
         ret = mingen.loadFromCSVFile(buffer, 1, HOURS_PER_YEAR, &study.dataBuffer) && ret;
-    }
-    else
-    {
-        mingen.reset(1, HOURS_PER_YEAR);
-        mingen.markAsModified();
     }
 
     if (study.usedByTheSolver)

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -151,8 +151,6 @@ void HydroManagement::prepareInflowsScaling(uint numSpace)
 
 void HydroManagement::minGenerationScaling(uint numSpace)
 {
-    if (study.header.version < 860)
-        return;
     const auto& calendar = study.calendar;
 
     study.areas.each(
@@ -323,9 +321,6 @@ void HydroManagement::checkHourlyMinGeneration(uint tsIndex, Data::Area& area) c
 
 void HydroManagement::checkMinGeneration(uint numSpace)
 {
-    if (study.header.version < 860)
-        return;
-
     study.areas.each(
       [this, &numSpace](Data::Area& area)
       {

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -664,11 +664,9 @@ void SIM_RenseignementProblemeHebdo(PROBLEME_HEBDO& problem,
                 uint tsIndex = (*NumeroChroniquesTireesParPays[numSpace][k]).Hydraulique;
                 auto& inflowsmatrix = area.hydro.series->storage;
                 auto const& srcinflows = inflowsmatrix[tsIndex < inflowsmatrix.width ? tsIndex : 0];
-
-                auto& mingenmatrix = area.hydro.series->mingen;
-                if (study.header.version >= 860)
                 {
-                    auto const& srcmingen
+                auto& mingenmatrix = area.hydro.series->mingen;
+                auto const& srcmingen
                       = mingenmatrix[tsIndex < mingenmatrix.width ? tsIndex : 0];
                     for (uint j = 0; j < problem.NombreDePasDeTemps; ++j)
                     {

--- a/src/solver/ts-generator/hydro.cpp
+++ b/src/solver/ts-generator/hydro.cpp
@@ -62,6 +62,14 @@ static void PreproHydroInitMatrices(Data::Study& study, uint tsCount)
     });
 }
 
+static void PreproHydroFixMingenToZero(Data::Study& study)
+{
+    study.areas.each([&](Data::Area& area) {
+        auto& hydroseries = *(area.hydro.series);
+        hydroseries.mingen.reset(1, HOURS_PER_YEAR);
+    });
+}
+
 static void PreproRoundAllEntriesPlusDerated(Data::Study& study)
 {
     bool derated = study.parameters.derated;
@@ -321,6 +329,8 @@ bool GenerateHydroTimeSeries(Data::Study& study, uint currentYear, IResultWriter
     }
 
     delete[] NORM;
+
+    PreproHydroFixMingenToZero(study);
 
     return true;
 }

--- a/src/solver/ts-generator/hydro.cpp
+++ b/src/solver/ts-generator/hydro.cpp
@@ -58,7 +58,6 @@ static void PreproHydroInitMatrices(Data::Study& study, uint tsCount)
 
         hydroseries.ror.resize(tsCount, HOURS_PER_YEAR);
         hydroseries.storage.resize(tsCount, DAYS_PER_YEAR);
-        hydroseries.mingen.resize(tsCount, HOURS_PER_YEAR);
         hydroseries.count = tsCount;
     });
 }
@@ -72,13 +71,11 @@ static void PreproRoundAllEntriesPlusDerated(Data::Study& study)
 
         hydroseries.ror.roundAllEntries();
         hydroseries.storage.roundAllEntries();
-        hydroseries.mingen.roundAllEntries();
 
         if (derated)
         {
             hydroseries.ror.averageTimeseries();
             hydroseries.storage.averageTimeseries();
-            hydroseries.mingen.averageTimeseries();
         }
     });
 }
@@ -317,12 +314,6 @@ bool GenerateHydroTimeSeries(Data::Study& study, uint currentYear, IResultWriter
                       std::string storage_buffer;
                       output.clear() << study.buffer << SEP << "storage.txt";
                       writer->addEntryFromBuffer(output.c_str(), storage_buffer);
-                  }
-
-                  {
-                      std::string mingen_buffer;
-                      output.clear() << study.buffer << SEP << "mingen.txt";
-                      writer->addEntryFromBuffer(output.c_str(), mingen_buffer);
                   }
                   ++progression;
               });

--- a/src/solver/ts-generator/hydro.cpp
+++ b/src/solver/ts-generator/hydro.cpp
@@ -62,14 +62,6 @@ static void PreproHydroInitMatrices(Data::Study& study, uint tsCount)
     });
 }
 
-static void PreproHydroFixMingenToZero(Data::Study& study)
-{
-    study.areas.each([&](Data::Area& area) {
-        auto& hydroseries = *(area.hydro.series);
-        hydroseries.mingen.reset(1, HOURS_PER_YEAR);
-    });
-}
-
 static void PreproRoundAllEntriesPlusDerated(Data::Study& study)
 {
     bool derated = study.parameters.derated;
@@ -329,8 +321,6 @@ bool GenerateHydroTimeSeries(Data::Study& study, uint currentYear, IResultWriter
     }
 
     delete[] NORM;
-
-    PreproHydroFixMingenToZero(study);
 
     return true;
 }


### PR DESCRIPTION
Hello @Milos-RTEi, following [this discussion](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/1273#discussion_r1184988018), I removed a few checks on version in the "core".The problem was that mingen was empty (width=0, height=8760), see call to function `reset`.

The idea is that if no Pmin files are present, we set one column of 0. This way
- The existing behavior is kept (Pmin=0)
- We don't need to worry about version numbers in the computation _ie_ after loading the data