### PR TITLE
Fix memory errors detected by valfgrind

### DIFF
--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -67,7 +67,7 @@ struct DebugData
     using ReservoirLevelType = Matrix<double>::ColumnType;
 
     std::array<double, 366> OPP;
-    std::array<double, 366> DailyTargetGen;
+    std::array<double, 366> DailyTargetGen = {0};
 
     std::array<double, 365> OVF;
     std::array<double, 365> DEV;

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -66,17 +66,17 @@ struct DebugData
     using MaxPowerType = Matrix<double, double>::ColumnType;
     using ReservoirLevelType = Matrix<double>::ColumnType;
 
-    std::array<double, 366> OPP;
-    std::array<double, 366> DailyTargetGen = {0};
+    std::array<double, 366> OPP{0};
+    std::array<double, 366> DailyTargetGen{0};
 
-    std::array<double, 365> OVF;
-    std::array<double, 365> DEV;
-    std::array<double, 365> VIO;
-    std::array<double, 12> deviationMax;
-    std::array<double, 12> violationMax;
-    std::array<double, 12> WASTE;
-    std::array<double, 12> CoutTotal;
-    std::array<double, 12> previousMonthWaste;
+    std::array<double, 365> OVF{0};
+    std::array<double, 365> DEV{0};
+    std::array<double, 365> VIO{0};
+    std::array<double, 12> deviationMax{0};
+    std::array<double, 12> violationMax{0};
+    std::array<double, 12> WASTE{0};
+    std::array<double, 12> CoutTotal{0};
+    std::array<double, 12> previousMonthWaste{0};
 
     Solver::IResultWriter::Ptr pWriter;
     const PerArea& data;

--- a/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
+++ b/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
@@ -462,8 +462,10 @@ void SIM_AllocationProblemeHebdo(PROBLEME_HEBDO& problem, int NombreDePasDeTemps
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
         problem.ResultatsHoraires[k].ValeursHorairesDeDefaillancePositive
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
-        problem.ResultatsHoraires[k].ValeursHorairesDENS
-          = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double)); // adq patch
+        /* problem.ResultatsHoraires[k].ValeursHorairesDENS */
+        /*   = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double)); // adq patch */
+        problem.ResultatsHoraires[k].ValeursHorairesDENS = (double*)calloc(NombreDePasDeTemps, sizeof(double));
+
         problem.ResultatsHoraires[k].ValeursHorairesLmrViolations
           = (int*)MemAllocMemset(NombreDePasDeTemps * sizeof(int)); // adq patch
         problem.ResultatsHoraires[k].ValeursHorairesSpilledEnergyAfterCSR
@@ -496,8 +498,9 @@ void SIM_AllocationProblemeHebdo(PROBLEME_HEBDO& problem, int NombreDePasDeTemps
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
         problem.ResultatsHoraires[k].CoutsMarginauxHoraires
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
-        problem.ResultatsHoraires[k].niveauxHoraires
-          = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
+        /* problem.ResultatsHoraires[k].niveauxHoraires */
+        /*   = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double)); */
+        problem.ResultatsHoraires[k].niveauxHoraires = (double*)calloc(NombreDePasDeTemps, sizeof(double));
         problem.ResultatsHoraires[k].valeurH2oHoraire
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
         problem.ResultatsHoraires[k].debordementsHoraires

--- a/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
+++ b/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
@@ -462,10 +462,8 @@ void SIM_AllocationProblemeHebdo(PROBLEME_HEBDO& problem, int NombreDePasDeTemps
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
         problem.ResultatsHoraires[k].ValeursHorairesDeDefaillancePositive
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
-        /* problem.ResultatsHoraires[k].ValeursHorairesDENS */
-        /*   = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double)); // adq patch */
-        problem.ResultatsHoraires[k].ValeursHorairesDENS = (double*)calloc(NombreDePasDeTemps, sizeof(double));
-
+        problem.ResultatsHoraires[k].ValeursHorairesDENS
+          = (double*)MemAllocMemset(NombreDePasDeTemps * sizeof(double)); // adq patch
         problem.ResultatsHoraires[k].ValeursHorairesLmrViolations
           = (int*)MemAllocMemset(NombreDePasDeTemps * sizeof(int)); // adq patch
         problem.ResultatsHoraires[k].ValeursHorairesSpilledEnergyAfterCSR
@@ -498,9 +496,8 @@ void SIM_AllocationProblemeHebdo(PROBLEME_HEBDO& problem, int NombreDePasDeTemps
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
         problem.ResultatsHoraires[k].CoutsMarginauxHoraires
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
-        /* problem.ResultatsHoraires[k].niveauxHoraires */
-        /*   = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double)); */
-        problem.ResultatsHoraires[k].niveauxHoraires = (double*)calloc(NombreDePasDeTemps, sizeof(double));
+        problem.ResultatsHoraires[k].niveauxHoraires
+          = (double*)MemAllocMemset(NombreDePasDeTemps * sizeof(double));
         problem.ResultatsHoraires[k].valeurH2oHoraire
           = (double*)MemAlloc(NombreDePasDeTemps * sizeof(double));
         problem.ResultatsHoraires[k].debordementsHoraires


### PR DESCRIPTION
- Use of uninitialised value of size 8
- Conditional jump or move depends on uninitialised value(s)