### PR TITLE
ST storage : fix a bug on time series

### DIFF
--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -166,9 +166,11 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
     double* Xmax = problemeHebdo->ProblemeAResoudre->Xmax;
     double** AddressForVars
       = problemeHebdo->ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees;
+    int weekFirstHour = problemeHebdo->weekInTheYear * 168;
     for (int pdtHebdo = PremierPdtDeLIntervalle, pdtJour = 0; pdtHebdo < DernierPdtDeLIntervalle;
          pdtHebdo++, pdtJour++)
     {
+        int hourInTheYear = weekFirstHour + pdtHebdo;
         const CORRESPONDANCES_DES_VARIABLES* CorrespondanceVarNativesVarOptim
           = problemeHebdo->CorrespondanceVarNativesVarOptim[pdtJour];
         for (int areaIndex = 0; areaIndex < problemeHebdo->NombreDePays; areaIndex++)
@@ -184,7 +186,7 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                                      .InjectionVariable[clusterGlobalIndex];
                 Xmin[varInjection] = 0.;
                 Xmax[varInjection]
-                  = storage.injectionNominalCapacity * storage.series->maxInjectionModulation[pdtHebdo];
+                  = storage.injectionNominalCapacity * storage.series->maxInjectionModulation[hourInTheYear];
                 AddressForVars[varInjection] = &STSResult.injection[storageIndex];
 
                 // 2. Withdrwal
@@ -192,7 +194,7 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                                       .WithdrawalVariable[clusterGlobalIndex];
                 Xmin[varWithdrawal] = 0.;
                 Xmax[varWithdrawal]
-                  = storage.withdrawalNominalCapacity * storage.series->maxWithdrawalModulation[pdtHebdo];
+                  = storage.withdrawalNominalCapacity * storage.series->maxWithdrawalModulation[hourInTheYear];
                 AddressForVars[varWithdrawal] = &STSResult.withdrawal[storageIndex];
 
                 // 3. Levels
@@ -204,8 +206,8 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                 }
                 else
                 {
-                    Xmin[varLevel] = storage.reservoirCapacity * storage.series->lowerRuleCurve[pdtHebdo];
-                    Xmax[varLevel] = storage.reservoirCapacity * storage.series->upperRuleCurve[pdtHebdo];
+                    Xmin[varLevel] = storage.reservoirCapacity * storage.series->lowerRuleCurve[hourInTheYear];
+                    Xmax[varLevel] = storage.reservoirCapacity * storage.series->upperRuleCurve[hourInTheYear];
                 }
                 AddressForVars[varLevel] = &STSResult.level[storageIndex];
 

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -44,11 +44,11 @@ using namespace Antares::Data;
 using namespace Yuni;
 
 static void shortTermStorageLevelsRHS(
-  const std::vector<::ShortTermStorage::AREA_INPUT>& shortTermStorageInput,
-  int numberOfAreas,
-  double* SecondMembre,
-  const CORRESPONDANCES_DES_CONTRAINTES* CorrespondanceCntNativesCntOptim,
-  int pdtJour)
+    const std::vector<::ShortTermStorage::AREA_INPUT>& shortTermStorageInput,
+    int numberOfAreas,
+    double* SecondMembre,
+    const CORRESPONDANCES_DES_CONTRAINTES* CorrespondanceCntNativesCntOptim,
+    int hourInTheYear)
 {
     for (int areaIndex = 0; areaIndex < numberOfAreas; areaIndex++)
     {
@@ -57,7 +57,7 @@ static void shortTermStorageLevelsRHS(
             const int clusterGlobalIndex = storage.clusterGlobalIndex;
             const int cnt
               = CorrespondanceCntNativesCntOptim->ShortTermStorageLevelConstraint[clusterGlobalIndex];
-            SecondMembre[cnt] = storage.series->inflows[pdtJour];
+            SecondMembre[cnt] = storage.series->inflows[hourInTheYear];
         }
     }
 }
@@ -68,6 +68,8 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
                                                      int NumeroDeLIntervalle,
                                                      const int optimizationNumber)
 {
+    int weekFirstHour = problemeHebdo->weekInTheYear * 168;
+
     PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     double* SecondMembre = ProblemeAResoudre->SecondMembre;
@@ -152,11 +154,12 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
             AdresseOuPlacerLaValeurDesCoutsMarginaux[cnt] = nullptr;
         }
 
+        int hourInTheYear = weekFirstHour + pdtHebdo;
         shortTermStorageLevelsRHS(problemeHebdo->ShortTermStorage,
                                   problemeHebdo->NombreDePays,
                                   ProblemeAResoudre->SecondMembre,
                                   CorrespondanceCntNativesCntOptim,
-                                  pdtJour);
+                                  hourInTheYear);
 
         for (int interco = 0; interco < problemeHebdo->NombreDInterconnexions; interco++)
         {


### PR DESCRIPTION
Before this fix, the first week of time series were used for all simulation weeks.
For each week, we find a way of using the range of data related to the week, in all ST storage time series.
Time series are :  
- [x] maxInjectionModulation
- [x] maxWithdrawalModulation
- [x] inflows
- [x] lowerRuleCurve
- [x] upperRuleCurve