### PR TITLE
Fix loading of legacy binding constraints

### DIFF
--- a/src/libs/antares/study/binding_constraint/BindingConstraint.hxx
+++ b/src/libs/antares/study/binding_constraint/BindingConstraint.hxx
@@ -112,7 +112,7 @@ inline std::string BindingConstraint::timeSeriesFileName(const Env &env) const {
         case BindingConstraint::opEquality:
             return std::string() + env.folder.c_str() + Yuni::IO::Separator + name().c_str() + "_eq" + ".txt";
         default:
-            assert(false && "Cannot load/save time series of type other that eq/gt/lt");
+            logs.error("Cannot load/save time series of type other that eq/gt/lt");
             return "";
     }
 }

--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -247,13 +247,15 @@ bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(EnvForLoading &env, Bi
                         << BindingConstraint::OperatorToShortCString(bindingConstraint->pOperator) << ") " << bindingConstraint->pComments;
 
         // 0 is BindingConstraint::opLess
-        int columnNumber = BindingConstraint::Column::columnInferior;
-        if (bindingConstraint->operatorType() == BindingConstraint::opGreater)
+        int columnNumber;
+        if (bindingConstraint->operatorType() == BindingConstraint::opLess)
+            columnNumber = BindingConstraint::Column::columnInferior;
+        else if (bindingConstraint->operatorType() == BindingConstraint::opGreater)
             columnNumber = BindingConstraint::Column::columnSuperior;
         else if (bindingConstraint->operatorType() == BindingConstraint::opEquality)
             columnNumber = BindingConstraint::Column::columnEquality;
         else
-            assert(false && "Cannot load time series of type other that eq/gt/lt");
+            logs.error("Cannot load time series of type other that eq/gt/lt");
 
         bindingConstraint->timeSeries.pasteToColumn(0, intermediate[columnNumber]);
         return true;

--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -233,9 +233,10 @@ BindingConstraintLoader::loadTimeSeries(EnvForLoading &env, BindingConstraint::O
 bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(EnvForLoading &env, BindingConstraint *bindingConstraint) const {
     env.buffer.clear() << env.folder << IO::Separator << bindingConstraint->pID << ".txt";
     Matrix<> intermediate;
+    const int height = (bindingConstraint->pType == BindingConstraint::typeHourly) ? 8784 : 366;
     if (intermediate.loadFromCSVFile(env.buffer,
                                      BindingConstraint::columnMax,
-                                     (bindingConstraint->pType == BindingConstraint::typeHourly) ? 8784 : 366,
+                                     height,
                                      Matrix<>::optImmediate | Matrix<>::optFixedSize,
                                      &env.matrixBuffer))
     {
@@ -257,6 +258,7 @@ bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(EnvForLoading &env, Bi
         else
             logs.error("Cannot load time series of type other that eq/gt/lt");
 
+        bindingConstraint->timeSeries.resize(1, height);
         bindingConstraint->timeSeries.pasteToColumn(0, intermediate[columnNumber]);
         return true;
     }

--- a/src/libs/antares/study/runtime/runtime.cpp
+++ b/src/libs/antares/study/runtime/runtime.cpp
@@ -162,14 +162,14 @@ static void CopyBCData(BindingConstraintRTI& rti, const BindingConstraint& b)
     rti.timeSeries.resize(b.TimeSeries().width, b.TimeSeries().height);
     rti.timeSeries.copyFrom(b.TimeSeries());
 
-    rti.linkWeight.reserve(rti.linkCount);
-    rti.linkOffset.reserve(rti.linkCount);
-    rti.linkIndex.reserve(rti.linkCount);
+    rti.linkWeight.resize(rti.linkCount);
+    rti.linkOffset.resize(rti.linkCount);
+    rti.linkIndex.resize(rti.linkCount);
 
-    rti.clusterWeight.reserve(rti.linkCount);
-    rti.clusterOffset.reserve(rti.linkCount);
-    rti.clusterIndex.reserve(rti.linkCount);
-    rti.clustersAreaIndex.reserve(rti.linkCount);
+    rti.clusterWeight.resize(rti.clusterCount);
+    rti.clusterOffset.resize(rti.clusterCount);
+    rti.clusterIndex.resize(rti.clusterCount);
+    rti.clustersAreaIndex.resize(rti.clusterCount);
 
     b.initLinkArrays(rti.linkWeight,
                      rti.clusterWeight,


### PR DESCRIPTION
- Handle `opLess` when loading legacy binding constraints
- Avoid `pasteToColumn` into an empty matrix by resizing it first
- Use `std::vector::resize` instead of `std::vector::resize`
- Fix size of said vectors
- Use `logs.error` instead of `assert(false)`