### PR TITLE
ST storage : correcting the hourly constraint on levels

### DIFF
--- a/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
@@ -112,31 +112,30 @@ static void shortTermStorageLevels(
 {
     const auto& VarOptim_current = CorrespondanceVarNativesVarOptim[pdt];
     // Cycle over the simulation period
-    const int pdt1 = (pdt + 1) % nombreDePasDeTempsPourUneOptimisation;
-    const auto& VarOptim_next = CorrespondanceVarNativesVarOptim[pdt1];
+    const int pdt_1 = (pdt - 1 + nombreDePasDeTempsPourUneOptimisation) % nombreDePasDeTempsPourUneOptimisation;
+    const auto& VarOptim_previous = CorrespondanceVarNativesVarOptim[pdt_1];
     for (auto& storage : shortTermStorageInput)
     {
         int nombreDeTermes = 0;
         const int clusterGlobalIndex = storage.clusterGlobalIndex;
-        // L[h+1] - L[h] - efficiency * injection[h] + withdrawal[h] = inflows[h]
-        if (const int varLevel_next = VarOptim_next->SIM_ShortTermStorage.LevelVariable[clusterGlobalIndex];
-            varLevel_next >= 0)
-        {
-            Pi[nombreDeTermes] = 1.0;
-            Colonne[nombreDeTermes] = varLevel_next;
-            nombreDeTermes++;
-        }
-
+        // L[h] - L[h-1] - efficiency * injection[h] + withdrawal[h] = inflows[h]
         if (const int varLevel = VarOptim_current->SIM_ShortTermStorage.LevelVariable[clusterGlobalIndex];
             varLevel >= 0)
         {
-            Pi[nombreDeTermes] = -1.0;
+            Pi[nombreDeTermes] = 1.0;
             Colonne[nombreDeTermes] = varLevel;
             nombreDeTermes++;
         }
 
-        if (const int varInjection
-            = VarOptim_current->SIM_ShortTermStorage.InjectionVariable[clusterGlobalIndex];
+        if (const int varLevel_previous = VarOptim_previous->SIM_ShortTermStorage.LevelVariable[clusterGlobalIndex];
+            varLevel_previous >= 0)
+        {
+            Pi[nombreDeTermes] = -1.0;
+            Colonne[nombreDeTermes] = varLevel_previous;
+            nombreDeTermes++;
+        }
+
+        if (const int varInjection = VarOptim_current->SIM_ShortTermStorage.InjectionVariable[clusterGlobalIndex];
             varInjection >= 0)
         {
             Pi[nombreDeTermes] = -1.0 * storage.efficiency;
@@ -144,8 +143,7 @@ static void shortTermStorageLevels(
             nombreDeTermes++;
         }
 
-        if (const int varWithdrawal
-            = VarOptim_current->SIM_ShortTermStorage.WithdrawalVariable[clusterGlobalIndex];
+        if (const int varWithdrawal = VarOptim_current->SIM_ShortTermStorage.WithdrawalVariable[clusterGlobalIndex];
             varWithdrawal >= 0)
         {
             Pi[nombreDeTermes] = 1.0;

--- a/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
@@ -110,16 +110,16 @@ static void shortTermStorageLevels(
   int nombreDePasDeTempsPourUneOptimisation,
   int pdt)
 {
-    const auto& VarOptim_current = CorrespondanceVarNativesVarOptim[pdt];
+    const auto& VarOptimCurrent = CorrespondanceVarNativesVarOptim[pdt];
     // Cycle over the simulation period
     const int timestepPrevious = (pdt - 1 + nombreDePasDeTempsPourUneOptimisation) % nombreDePasDeTempsPourUneOptimisation;
-    const auto& VarOptim_previous = CorrespondanceVarNativesVarOptim[timestepPrevious];
+    const auto& VarOptimPrevious = CorrespondanceVarNativesVarOptim[timestepPrevious];
     for (auto& storage : shortTermStorageInput)
     {
         int nombreDeTermes = 0;
         const int clusterGlobalIndex = storage.clusterGlobalIndex;
         // L[h] - L[h-1] - efficiency * injection[h] + withdrawal[h] = inflows[h]
-        if (const int varLevel = VarOptim_current->SIM_ShortTermStorage.LevelVariable[clusterGlobalIndex];
+        if (const int varLevel = VarOptimCurrent->SIM_ShortTermStorage.LevelVariable[clusterGlobalIndex];
             varLevel >= 0)
         {
             Pi[nombreDeTermes] = 1.0;
@@ -127,7 +127,7 @@ static void shortTermStorageLevels(
             nombreDeTermes++;
         }
 
-        if (const int varLevel_previous = VarOptim_previous->SIM_ShortTermStorage.LevelVariable[clusterGlobalIndex];
+        if (const int varLevel_previous = VarOptimPrevious->SIM_ShortTermStorage.LevelVariable[clusterGlobalIndex];
             varLevel_previous >= 0)
         {
             Pi[nombreDeTermes] = -1.0;
@@ -135,7 +135,7 @@ static void shortTermStorageLevels(
             nombreDeTermes++;
         }
 
-        if (const int varInjection = VarOptim_current->SIM_ShortTermStorage.InjectionVariable[clusterGlobalIndex];
+        if (const int varInjection = VarOptimCurrent->SIM_ShortTermStorage.InjectionVariable[clusterGlobalIndex];
             varInjection >= 0)
         {
             Pi[nombreDeTermes] = -1.0 * storage.efficiency;
@@ -143,7 +143,7 @@ static void shortTermStorageLevels(
             nombreDeTermes++;
         }
 
-        if (const int varWithdrawal = VarOptim_current->SIM_ShortTermStorage.WithdrawalVariable[clusterGlobalIndex];
+        if (const int varWithdrawal = VarOptimCurrent->SIM_ShortTermStorage.WithdrawalVariable[clusterGlobalIndex];
             varWithdrawal >= 0)
         {
             Pi[nombreDeTermes] = 1.0;

--- a/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
@@ -112,8 +112,8 @@ static void shortTermStorageLevels(
 {
     const auto& VarOptim_current = CorrespondanceVarNativesVarOptim[pdt];
     // Cycle over the simulation period
-    const int pdt_1 = (pdt - 1 + nombreDePasDeTempsPourUneOptimisation) % nombreDePasDeTempsPourUneOptimisation;
-    const auto& VarOptim_previous = CorrespondanceVarNativesVarOptim[pdt_1];
+    const int timestepPrevious = (pdt - 1 + nombreDePasDeTempsPourUneOptimisation) % nombreDePasDeTempsPourUneOptimisation;
+    const auto& VarOptim_previous = CorrespondanceVarNativesVarOptim[timestepPrevious];
     for (auto& storage : shortTermStorageInput)
     {
         int nombreDeTermes = 0;

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -200,7 +200,7 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                 // 3. Levels
                 int varLevel
                   = CorrespondanceVarNativesVarOptim->SIM_ShortTermStorage.LevelVariable[clusterGlobalIndex];
-                if (pdtHebdo == PremierPdtDeLIntervalle && storage.initialLevel.has_value())
+                if (pdtHebdo == DernierPdtDeLIntervalle - 1 && storage.initialLevel.has_value())
                 {
                     Xmin[varLevel] = Xmax[varLevel] = storage.reservoirCapacity * storage.initialLevel.value();
                 }


### PR DESCRIPTION
We correct the hourly constraint on levels to make it consistent with its hydro counterpart.

**From** : 
Level(h + 1) = Level(h) + efficiency * pump(h) - Generation(h) + inflow(h)

**To** :
Level(h) = Level(h-1) + efficiency * pump(h) - Generation(h) + inflow(h)