### PR TITLE
GUI : adapt logs reading from GUI

### DIFF
--- a/src/ui/simulator/toolbox/jobs/job.cpp
+++ b/src/ui/simulator/toolbox/jobs/job.cpp
@@ -619,7 +619,7 @@ Job::Job(const wxString& title, const wxString& subTitle, const char* icon) :
  pThread(nullptr),
  pAnim(nullptr),
  pLblErrors(nullptr),
- pLogRegex(wxT("\\[([a-zA-Z0-9 :]+)\\]\\[([a-zA-Z0-9 "
+ pLogRegex(wxT("\\[([0-9 :-]+)\\]\\[([a-zA-Z0-9 "
                "-]+)\\](\\[[a-z0-9;]+){0,2}\\[([a-z]+)\\](\\[[a-z0-9;]+){0,2} "
                "(\\[[a-z0-9;]+){0,2}([^]*)(\\[[a-z0-9;]+){0,2}")),
  pCatchLogEvents(true),

--- a/src/ui/simulator/windows/studylogs.cpp
+++ b/src/ui/simulator/windows/studylogs.cpp
@@ -518,10 +518,10 @@ protected:
         //
         if (line.size() < 38 /*arbitrary*/ or line.at(0) != '[')
             return false;
-        if (line.at(25) != ']' or line.at(26) != '[')
+        if (line.at(20) != ']' or line.at(21) != '[')
             return false;
 
-        const BufferType::Size applR = line.find(']', 27);
+        const BufferType::Size applR = line.find(']', 22);
         if (BufferType::npos == applR)
             return false;
         const BufferType::Size verbosityR = line.find(']', applR + 1);
@@ -547,11 +547,11 @@ protected:
         if (message.empty() or message.startsWith(LOG_UI))
             return false;
 
-        date.adapt(bcstr + 1, 24);
+        date.adapt(bcstr + 1, 19);
 
         // Application
         if (applR > 27)
-            application.adapt(bcstr + 27, applR - 27);
+            application.adapt(bcstr + 22, applR - 22);
         else
             application.clear();
 


### PR DESCRIPTION
Because we recently change the date format in logs, we currently face problems in the GUI : 
- [x]  Fixing the logs loader (button on left of inspector). The logs loader is currently empty whereas log file is not.
- [x] Fixing the errors/warnings catch when simulation ends. The errors/warnings are not currently caught.