### PR TITLE
implement --mps-export option

### DIFF
--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1074,9 +1074,7 @@ bool Parameters::loadFromINI(const IniFile& ini, uint version, const StudyLoadOp
     if (options.usedByTheSolver)
         prepareForSimulation(options);
 
-    if (options.mpsToExport
-        && (this->include.exportMPS == mpsExportStatus::NO_EXPORT
-            || this->include.exportMPS == mpsExportStatus::UNKNOWN_EXPORT))
+    if (options.mpsToExport)
     {
         this->include.exportMPS = mpsExportStatus::EXPORT_BOTH_OPTIMS;
     }

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1074,6 +1074,13 @@ bool Parameters::loadFromINI(const IniFile& ini, uint version, const StudyLoadOp
     if (options.usedByTheSolver)
         prepareForSimulation(options);
 
+    if (options.mpsToExport
+        && (this->include.exportMPS == mpsExportStatus::NO_EXPORT
+            || this->include.exportMPS == mpsExportStatus::UNKNOWN_EXPORT))
+    {
+        this->include.exportMPS = mpsExportStatus::EXPORT_BOTH_OPTIMS;
+    }
+
     // We currently always returns true to not block any loading process
     // Anyway we already have reported all problems
     return true;


### PR DESCRIPTION
close #1400
With this Pr, ini parameter "include-exportmps" will work with Cli option "--mps-export" according to the following rules:
INI=true, CLI=true => export (both optim)
INI=false,CLI=true => export (both optim)
INI=true, CLI=false => export
INI=false, CLI=false => no export