### PR TITLE
Fix build for Oracle Linux 8, build on push

### DIFF
--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -3,6 +3,15 @@ name: Oracle 8 CI (push and/or release)
 on:
   release:
     types: [created]
+  push:
+    branches:
+      - develop
+      - feature/*
+      - features/*
+      - fix/*
+      - issue-*
+      - release/*
+      - doc/*
 
 env:
   GITHUB_TOKEN: ${{ github.token }}

--- a/docker/oraclelinux
+++ b/docker/oraclelinux
@@ -1,0 +1,12 @@
+FROM oraclelinux:8
+
+# update repo
+RUN dnf update -y
+
+# install python & modules
+RUN dnf install -y python3 python3-pip
+RUN pip3 install --user pandas numpy pytest
+
+# Install build tools
+RUN dnf install -y epel-release git cmake wget rpm-build
+RUN dnf install -y unzip libuuid-devel boost-test boost-devel gcc-toolset-9-toolchain

--- a/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
@@ -1,20 +1,21 @@
 //
 // Created by marechaljas on 13/03/23.
 //
-#include "antares/study/fwd.h"
-#define BOOST_TEST_MODULE binding_constraints_FOO
 
-#include <boost/test/unit_test.hpp>
+#define WIN32_LEAN_AND_MEAN
+#define BOOST_TEST_MODULE binding_constraints
+
+#include <boost/test/included/unit_test.hpp>
 #include <fstream>
 #include "antares/study/constraint.h"
 #include "antares/study/area/area.h"
-#include "antares/study/study.h"
+#include "antares/study.h"
 #include <filesystem>
 
 using namespace Antares::Data;
 namespace fs = std::filesystem;
 
-BOOST_AUTO_TEST_SUITE(BindingConstraintTests_FOO)
+BOOST_AUTO_TEST_SUITE(BindingConstraintTests)
 
 BOOST_AUTO_TEST_CASE( load_basic_attributes ) {
     auto study = std::make_shared<Study>();

--- a/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
+++ b/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
@@ -3,7 +3,7 @@
 //
 #define BOOST_TEST_MODULE store-timeseries-number
 #define WIN32_LEAN_AND_MEAN
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <filesystem>
 #include <fstream>
 #include "timeseries-numbers.h"


### PR DESCRIPTION
We used the wrong header file in 2 tests.

**boost/test/included/unit_test.hpp** wraps **boost/test/unit_test.hpp** and adds useful declarations.

Also add an unused Dockerfile, to ease the debugging of build issues locally.