### PR TITLE
Add cluster name for 6 constraints associated to unit-commitment = accurate

### DIFF
--- a/src/solver/optimisation/opt_construction_contraintes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_construction_contraintes_couts_demarrage.cpp
@@ -118,7 +118,8 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaireCoutsDeDemarrage(
                     if (nombreDeTermes > 0)
                     {
                         constraintNamer.PMaxDispatchableGeneration(
-                          ProblemeAResoudre->NombreDeContraintes);
+                          ProblemeAResoudre->NombreDeContraintes,
+                          PaliersThermiquesDuPays.NomsDesPaliersThermiques[palier]);
                         OPT_ChargerLaContrainteDansLaMatriceDesContraintes(
                           ProblemeAResoudre, Pi, Colonne, nombreDeTermes, '<');
                     }
@@ -162,7 +163,8 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaireCoutsDeDemarrage(
                     if (nombreDeTermes > 0)
                     {
                         constraintNamer.PMinDispatchableGeneration(
-                          ProblemeAResoudre->NombreDeContraintes);
+                          ProblemeAResoudre->NombreDeContraintes,
+                          PaliersThermiquesDuPays.NomsDesPaliersThermiques[palier]);
                         OPT_ChargerLaContrainteDansLaMatriceDesContraintes(
                           ProblemeAResoudre, Pi, Colonne, nombreDeTermes, '>');
                     }
@@ -261,7 +263,9 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaireCoutsDeDemarrage(
                 {
                     if (nombreDeTermes > 0)
                     {
-                        constraintNamer.ConsistenceNODU(ProblemeAResoudre->NombreDeContraintes);
+                        constraintNamer.ConsistenceNODU(
+                          ProblemeAResoudre->NombreDeContraintes,
+                          PaliersThermiquesDuPays.NomsDesPaliersThermiques[palier]);
                         OPT_ChargerLaContrainteDansLaMatriceDesContraintes(
                           ProblemeAResoudre, Pi, Colonne, nombreDeTermes, '=');
                     }
@@ -330,7 +334,8 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaireCoutsDeDemarrage(
                     if (nombreDeTermes > 0)
                     {
                         constraintNamer.NbUnitsOutageLessThanNbUnitsStop(
-                          ProblemeAResoudre->NombreDeContraintes);
+                          ProblemeAResoudre->NombreDeContraintes,
+                          PaliersThermiquesDuPays.NomsDesPaliersThermiques[palier]);
                         OPT_ChargerLaContrainteDansLaMatriceDesContraintes(
                           ProblemeAResoudre, Pi, Colonne, nombreDeTermes, '<');
                     }
@@ -430,7 +435,8 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaireCoutsDeDemarrage(
                           = ProblemeAResoudre->NombreDeContraintes;
 
                         constraintNamer.NbDispUnitsMinBoundSinceMinUpTime(
-                          ProblemeAResoudre->NombreDeContraintes);
+                          ProblemeAResoudre->NombreDeContraintes,
+                          PaliersThermiquesDuPays.NomsDesPaliersThermiques[palier]);
                         OPT_ChargerLaContrainteDansLaMatriceDesContraintes(
                           ProblemeAResoudre, Pi, Colonne, nombreDeTermes, '>');
                     }
@@ -514,7 +520,9 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaireCoutsDeDemarrage(
                           .NumeroDeContrainteDesContraintesDeDureeMinDArret[palier]
                           = ProblemeAResoudre->NombreDeContraintes;
 
-                        constraintNamer.MinDownTime(ProblemeAResoudre->NombreDeContraintes);
+                        constraintNamer.MinDownTime(
+                          ProblemeAResoudre->NombreDeContraintes,
+                          PaliersThermiquesDuPays.NomsDesPaliersThermiques[palier]);
                         OPT_ChargerLaContrainteDansLaMatriceDesContraintes(
                           ProblemeAResoudre, Pi, Colonne, nombreDeTermes, '<');
                     }

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -18,31 +18,32 @@ std::string BuildName(const std::string& name,
     return result;
 }
 
-void Namer::SetLinkElementName(unsigned int variable, const std::string& variableType)
+void Namer::SetLinkElementName(unsigned int element, const std::string& elementType)
 {
     const auto location = origin_ + AREA_SEP + destination_;
     targetUpdater_.UpdateTargetAtIndex(
-      BuildName(variableType, LocationIdentifier(location, LINK), TimeIdentifier(timeStep_, HOUR)),
-      variable);
+      BuildName(elementType, LocationIdentifier(location, LINK), TimeIdentifier(timeStep_, HOUR)),
+      element);
 }
 
-void Namer::SetAreaElementNameHour(unsigned int variable, const std::string& variableType)
+void Namer::SetAreaElementNameHour(unsigned int element, const std::string& elementType)
 {
-    SetAreaElementName(variable, variableType, HOUR);
-}
-void Namer::SetAreaElementNameWeek(unsigned int variable, const std::string& variableType)
-{
-    SetAreaElementName(variable, variableType, WEEK);
+    SetAreaElementName(element, elementType, HOUR);
 }
 
-void Namer::SetAreaElementName(unsigned int variable,
-                               const std::string& variableType,
+void Namer::SetAreaElementNameWeek(unsigned int element, const std::string& elementType)
+{
+    SetAreaElementName(element, elementType, WEEK);
+}
+
+void Namer::SetAreaElementName(unsigned int element,
+                               const std::string& elementType,
                                const std::string& timeStepType)
 {
     targetUpdater_.UpdateTargetAtIndex(
       BuildName(
-        variableType, LocationIdentifier(area_, AREA), TimeIdentifier(timeStep_, timeStepType)),
-      variable);
+        elementType, LocationIdentifier(area_, AREA), TimeIdentifier(timeStep_, timeStepType)),
+      element);
 }
 
 void VariableNamer::SetAreaVariableName(unsigned int variable,
@@ -56,43 +57,43 @@ void VariableNamer::SetAreaVariableName(unsigned int variable,
                                        variable);
 }
 
-void VariableNamer::SetThermalClusterVariableName(unsigned int variable,
-                                                  const std::string& variableType,
-                                                  const std::string& clusterName)
+void Namer::SetThermalClusterElementName(unsigned int variable,
+                                         const std::string& elementType,
+                                         const std::string& clusterName)
 {
     const auto location
       = LocationIdentifier(area_, AREA) + SEPARATOR + "ThermalCluster" + "<" + clusterName + ">";
 
     targetUpdater_.UpdateTargetAtIndex(
-      BuildName(variableType, location, TimeIdentifier(timeStep_, HOUR)), variable);
+      BuildName(elementType, location, TimeIdentifier(timeStep_, HOUR)), variable);
 }
 
 void VariableNamer::DispatchableProduction(unsigned int variable, const std::string& clusterName)
 {
-    SetThermalClusterVariableName(variable, "DispatchableProduction", clusterName);
+    SetThermalClusterElementName(variable, "DispatchableProduction", clusterName);
 }
 
 void VariableNamer::NODU(unsigned int variable, const std::string& clusterName)
 {
-    SetThermalClusterVariableName(variable, "NODU", clusterName);
+    SetThermalClusterElementName(variable, "NODU", clusterName);
 }
 
 void VariableNamer::NumberStoppingDispatchableUnits(unsigned int variable,
                                                     const std::string& clusterName)
 {
-    SetThermalClusterVariableName(variable, "NumberStoppingDispatchableUnits", clusterName);
+    SetThermalClusterElementName(variable, "NumberStoppingDispatchableUnits", clusterName);
 }
 
 void VariableNamer::NumberStartingDispatchableUnits(unsigned int variable,
                                                     const std::string& clusterName)
 {
-    SetThermalClusterVariableName(variable, "NumberStartingDispatchableUnits", clusterName);
+    SetThermalClusterElementName(variable, "NumberStartingDispatchableUnits", clusterName);
 }
 
 void VariableNamer::NumberBreakingDownDispatchableUnits(unsigned int variable,
                                                         const std::string& clusterName)
 {
-    SetThermalClusterVariableName(variable, "NumberBreakingDownDispatchableUnits", clusterName);
+    SetThermalClusterElementName(variable, "NumberBreakingDownDispatchableUnits", clusterName);
 }
 
 void VariableNamer::NTCDirect(unsigned int variable,

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -284,34 +284,38 @@ void ConstraintNamer::nameWithTimeGranularity(unsigned int constraint,
       constraint);
 }
 
-void ConstraintNamer::NbUnitsOutageLessThanNbUnitsStop(unsigned int constraint)
+void ConstraintNamer::NbUnitsOutageLessThanNbUnitsStop(unsigned int constraint,
+                                                       const std::string& clusterName)
 {
-    SetAreaElementNameHour(constraint, "NbUnitsOutageLessThanNbUnitsStop");
+    SetThermalClusterElementName(constraint, "NbUnitsOutageLessThanNbUnitsStop", clusterName);
 }
 
-void ConstraintNamer::NbDispUnitsMinBoundSinceMinUpTime(unsigned int constraint)
+void ConstraintNamer::NbDispUnitsMinBoundSinceMinUpTime(unsigned int constraint,
+                                                        const std::string& clusterName)
 {
-    SetAreaElementNameHour(constraint, "NbDispUnitsMinBoundSinceMinUpTime");
+    SetThermalClusterElementName(constraint, "NbDispUnitsMinBoundSinceMinUpTime", clusterName);
 }
 
-void ConstraintNamer::MinDownTime(unsigned int constraint)
+void ConstraintNamer::MinDownTime(unsigned int constraint, const std::string& clusterName)
 {
-    SetAreaElementNameHour(constraint, "MinDownTime");
+    SetThermalClusterElementName(constraint, "MinDownTime", clusterName);
 }
 
-void ConstraintNamer::PMaxDispatchableGeneration(unsigned int constraint)
+void ConstraintNamer::PMaxDispatchableGeneration(unsigned int constraint,
+                                                 const std::string& clusterName)
 {
-    SetAreaElementNameHour(constraint, "PMaxDispatchableGeneration");
+    SetThermalClusterElementName(constraint, "PMaxDispatchableGeneration", clusterName);
 }
 
-void ConstraintNamer::PMinDispatchableGeneration(unsigned int constraint)
+void ConstraintNamer::PMinDispatchableGeneration(unsigned int constraint,
+                                                 const std::string& clusterName)
 {
-    SetAreaElementNameHour(constraint, "PMinDispatchableGeneration");
+    SetThermalClusterElementName(constraint, "PMinDispatchableGeneration", clusterName);
 }
 
-void ConstraintNamer::ConsistenceNODU(unsigned int constraint)
+void ConstraintNamer::ConsistenceNODU(unsigned int constraint, const std::string& clusterName)
 {
-    SetAreaElementNameHour(constraint, "ConsistenceNODU");
+    SetThermalClusterElementName(constraint, "ConsistenceNODU", clusterName);
 }
 
 void ConstraintNamer::ShortTermStorageLevel(unsigned int constraint, const std::string& name)

--- a/src/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/opt_rename_problem.h
@@ -9,16 +9,16 @@ class TargetVectorUpdater
 {
 public:
     TargetVectorUpdater(bool isRenamingProcessed, std::vector<std::string>& target) :
-    target_(target), isRenamingProcessed_(isRenamingProcessed)
+     target_(target), isRenamingProcessed_(isRenamingProcessed)
     {
     }
 
     void UpdateTargetAtIndex(const std::string& full_name, unsigned int index)
     {
-    if (isRenamingProcessed_)
-    {
-          target_[index] = full_name;
-    }
+        if (isRenamingProcessed_)
+        {
+            target_[index] = full_name;
+        }
     }
 
 private:
@@ -122,12 +122,12 @@ public:
     void AreaHydroLevel(unsigned int constraint);
     void FinalStockEquivalent(unsigned int constraint);
     void FinalStockExpression(unsigned int constraint);
-    void NbUnitsOutageLessThanNbUnitsStop(unsigned int constraint);
-    void NbDispUnitsMinBoundSinceMinUpTime(unsigned int constraint);
-    void MinDownTime(unsigned int constraint);
-    void PMaxDispatchableGeneration(unsigned int constraint);
-    void PMinDispatchableGeneration(unsigned int constraint);
-    void ConsistenceNODU(unsigned int constraint);
+    void NbUnitsOutageLessThanNbUnitsStop(unsigned int constraint, const std::string& clusterName);
+    void NbDispUnitsMinBoundSinceMinUpTime(unsigned int constraint, const std::string& clusterName);
+    void MinDownTime(unsigned int constraint, const std::string& clusterName);
+    void PMaxDispatchableGeneration(unsigned int constraint, const std::string& clusterName);
+    void PMinDispatchableGeneration(unsigned int constraint, const std::string& clusterName);
+    void ConsistenceNODU(unsigned int constraint, const std::string& clusterName);
     void ShortTermStorageLevel(unsigned int constraint, const std::string& name);
     void BindingConstraintHour(unsigned int constraint, const std::string& name);
     void BindingConstraintDay(unsigned int constraint, const std::string& name);

--- a/src/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/opt_rename_problem.h
@@ -49,6 +49,9 @@ public:
     void SetAreaElementName(unsigned int variable,
                             const std::string& variableType,
                             const std::string& timeStepType);
+    void SetThermalClusterElementName(unsigned int variable,
+                                      const std::string& variableType,
+                                      const std::string& clusterName);
 
     unsigned int timeStep_ = 0;
     std::string origin_;
@@ -91,10 +94,6 @@ public:
     void AreaBalance(unsigned int variable);
 
 private:
-    void SetThermalClusterVariableName(unsigned int variable,
-                                       const std::string& variableType,
-                                       const std::string& clusterName);
-
     void SetAreaVariableName(unsigned int variable,
                              const std::string& variableType,
                              int layerIndex);


### PR DESCRIPTION
## Description
Add the cluster name for constraints

- `PMaxDispatchableGeneration`
- `PMinDispatchableGeneration`
- `ConsistenceNODU`
- `NbUnitsOutageLessThanNbUnitsStop`
- `NbDispUnitsMinBoundSinceMinUpTime`
- `MinDownTime`

## Before vs after
```diff
- L  MinDownTime::area<area>::hour<0>
+ L  MinDownTime::area<area>::ThermalCluster<base>::hour<0>
```

```diff
- G  NbDispUnitsMinBoundSinceMinUpTime::area<area>::hour<167>
+ G  NbDispUnitsMinBoundSinceMinUpTime::area<area>::ThermalCluster<semi*base>::hour<167>
```