### PR TITLE
Avoid copies using `std::move` in `BindingConstraintsRepository::enabled`

### DIFF
--- a/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
@@ -424,7 +424,7 @@ std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintsRepository::en
                      [](const auto &bc) {
                          return bc->enabled();
                      });
-        enabledConstraints_ = out;
+        enabledConstraints_ = std::move(out);
         return enabledConstraints_.value();
     }
 }


### PR DESCRIPTION
`out` is a temporary, which will be discarded right after. There is no need to copy it, we can just take ownership of its `data`.