### PR TITLE
Only add "active" thermal clusters, fix segfault of death

### DIFF
--- a/src/libs/antares/study/binding_constraint/BindingConstraint.h
+++ b/src/libs/antares/study/binding_constraint/BindingConstraint.h
@@ -282,14 +282,6 @@ public:
     ** \brief Get how many thermal clusters the binding constraint contains
     */
     uint clusterCount() const;
-
-    /*!
-    ** \brief Get how many thermal clusters the binding constraint contains
-    */
-    uint enabledClusterCount() const;
-
-    //@}
-
     //@}
 
     //! \name Type of the binding constraint

--- a/src/libs/antares/study/binding_constraint/BindingConstraint.hxx
+++ b/src/libs/antares/study/binding_constraint/BindingConstraint.hxx
@@ -81,9 +81,9 @@ inline void BindingConstraint::mutateTypeWithoutCheck(Type t)
         pType = t;
 }
 
-        inline bool BindingConstraint::skipped() const
+inline bool BindingConstraint::skipped() const
 {
-    return linkCount() == 0 && enabledClusterCount() == 0;
+    return linkCount() == 0 && clusterCount() == 0;
 }
 
 inline BindingConstraint::iterator BindingConstraint::begin() {

--- a/src/libs/antares/study/parts/thermal/cluster.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster.cpp
@@ -851,5 +851,9 @@ void ThermalCluster::checkAndCorrectAvailability()
                        << " available power lifted to match Pmin and Pnom requirements";
 }
 
+bool ThermalCluster::isActive() const {
+    return enabled && !mustrun;
+}
+
 } // namespace Data
 } // namespace Antares

--- a/src/libs/antares/study/parts/thermal/cluster.h
+++ b/src/libs/antares/study/parts/thermal/cluster.h
@@ -230,6 +230,8 @@ public:
     // Only applies if time-series are ready-made
     void checkAndCorrectAvailability();
 
+    bool isActive() const;
+
     /*!
     ** \brief The group ID
     **

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -190,8 +190,10 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
     //Setting 0 for time_series of width 0 is done when using the value.
     //To do this here we would have to check every BC for its width
     for (const auto& [group_name, _] : study.bindingConstraints.groupToTimeSeriesNumbers) {
-        auto number_of_ts_numbers = study.bindingConstraints.groupToTimeSeriesNumbers[group_name].timeseriesNumbers.height;
+#ifndef NDEBUG
+        const auto number_of_ts_numbers = study.bindingConstraints.groupToTimeSeriesNumbers[group_name].timeseriesNumbers.height;
         assert(year < number_of_ts_numbers); //If only 1 ts_number we suppose only one TS. Any "year" will be converted to "0" later
+#endif
         NumeroChroniquesTireesParGroup[numSpace][group_name] = study.bindingConstraints.groupToTimeSeriesNumbers[group_name].timeseriesNumbers[0][year];
     }
 }

--- a/src/ui/simulator/toolbox/input/bindingconstraint/bindingconstraint.cpp
+++ b/src/ui/simulator/toolbox/input/bindingconstraint/bindingconstraint.cpp
@@ -157,7 +157,7 @@ public:
 
             auto item = std::make_shared<Toolbox::Spotlight::ItemConstraint>(&constraint);
             if (constraint.enabled()
-                && (constraint.linkCount() > 0 || constraint.enabledClusterCount() > 0))
+                && (constraint.linkCount() > 0 || constraint.clusterCount() > 0))
             {
                 if (pBmpOn)
                     item->image(*pBmpOn);


### PR DESCRIPTION
* Add `ThermalCluster::isActive`
* Only add active clusters to binding constraints
* Remove `enabledClusterCount` (replaced by `clusterCount`)