### PR TITLE
Fix incomplete check on constraint group, apply clang-format

### DIFF
--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -115,32 +115,34 @@ BindingConstraintLoader::load(EnvForLoading env) {
     }
 
     // Checking for validity
-    if (!bc->pName || !bc->pID || bc->pOperator == BindingConstraint::opUnknown ||
-        bc->pType == BindingConstraint::typeUnknown) {
-        // Reporting the error into the logs
-        if (!bc->pName)
-            logs.error() << env.iniFilename << ": in [" << env.section->name
-                         << "]: Invalid binding constraint name";
-        if (!bc->pID)
-            logs.error() << env.iniFilename << ": in [" << env.section->name
-                         << "]: Invalid binding constraint id";
-        if (bc->pType == bc->typeUnknown)
-            logs.error() << env.iniFilename << ": in [" << env.section->name
-                         << "]: Invalid type [hourly,daily,weekly]";
-        if (bc->pOperator == BindingConstraint::opUnknown)
-            logs.error() << env.iniFilename << ": in [" << env.section->name
-                         << "]: Invalid operator [less,greater,equal,both]";
-        if (bc->group_.empty()) {
-            if (env.version >= version870) {
-                logs.error() << env.iniFilename << ": in [" << env.section->name
-                             << "]: Missing binding constraint group";
-            } else {
-                bc->group_ = "legacy_study_group";
-            }
-        }
-
-        // Invalid binding constraint
+    if (!bc->pName) {
+        logs.error() << env.iniFilename << ": in [" << env.section->name
+                     << "]: Invalid binding constraint name";
         return {};
+    }
+    if (!bc->pID) {
+        logs.error() << env.iniFilename << ": in [" << env.section->name
+                     << "]: Invalid binding constraint id";
+        return {};
+    }
+    if (bc->pType == bc->typeUnknown) {
+        logs.error() << env.iniFilename << ": in [" << env.section->name
+                     << "]: Invalid type [hourly,daily,weekly]";
+                    return {};
+    }
+    if (bc->pOperator == BindingConstraint::opUnknown) {
+        logs.error() << env.iniFilename << ": in [" << env.section->name
+                     << "]: Invalid operator [less,greater,equal,both]";
+        return {};
+    }
+    if (bc->group_.empty()) {
+        if (env.version >= version870) {
+            logs.error() << env.iniFilename << ": in [" << env.section->name
+                         << "]: Missing mandatory binding constraint group";
+            return {};
+        } else {
+            bc->group_ = "legacy_study_group";
+        }
     }
 
     // The binding constraint can not be enabled if there is no weight in the table
@@ -175,7 +177,6 @@ BindingConstraintLoader::load(EnvForLoading env) {
         return {};
     }
     }
-
     return {};
 }
 

--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -9,53 +9,64 @@
 #include "yuni/core/string/string.h"
 #include "antares/study/version.h"
 
-namespace Antares::Data {
+namespace Antares::Data
+{
 using namespace Yuni;
 
-std::vector<std::shared_ptr<BindingConstraint>>
-BindingConstraintLoader::load(EnvForLoading env) {
+std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintLoader::load(EnvForLoading env)
+{
     auto bc = std::make_shared<BindingConstraint>();
     bc->clear();
 
     // Foreach property in the section...
-    for (const IniFile::Property *p = env.section->firstProperty; p; p = p->next) {
+    for (const IniFile::Property* p = env.section->firstProperty; p; p = p->next)
+    {
         if (p->key.empty())
             continue;
 
-        if (p->key == "name") {
+        if (p->key == "name")
+        {
             bc->pName = p->value;
             continue;
         }
-        if (p->key == "id") {
+        if (p->key == "id")
+        {
             bc->pID = p->value;
             bc->pID.toLower(); // force the lowercase
             continue;
         }
-        if (p->key == "enabled") {
+        if (p->key == "enabled")
+        {
             bc->pEnabled = p->value.to<bool>();
             continue;
         }
-        if (p->key == "type") {
+        if (p->key == "type")
+        {
             bc->pType = BindingConstraint::StringToType(p->value);
             continue;
         }
-        if (p->key == "operator") {
+        if (p->key == "operator")
+        {
             bc->pOperator = BindingConstraint::StringToOperator(p->value);
             continue;
         }
-        if (p->key == "filter-year-by-year") {
+        if (p->key == "filter-year-by-year")
+        {
             bc->pFilterYearByYear = stringIntoDatePrecision(p->value);
             continue;
         }
-        if (p->key == "filter-synthesis") {
+        if (p->key == "filter-synthesis")
+        {
             bc->pFilterSynthesis = stringIntoDatePrecision(p->value);
             continue;
         }
-        if (p->key == "comments") {
+        if (p->key == "comments")
+        {
             bc->pComments = p->value;
             continue;
         }
-        if (p->key == "group") {
+        if (p->key == "group")
+        {
             bc->group_ = p->value.c_str();
             continue;
         }
@@ -67,12 +78,12 @@ BindingConstraintLoader::load(EnvForLoading env) {
         // Separate the value
         if (auto setKey = p->key.find('%'); setKey != 0 && setKey != String::npos) // It is a link
         {
-
             if (bool ret = SeparateValue(env, p, w, o); !ret)
                 continue;
 
-            const AreaLink *lnk = env.areaList.findLinkFromINIKey(p->key);
-            if (!lnk) {
+            const AreaLink* lnk = env.areaList.findLinkFromINIKey(p->key);
+            if (!lnk)
+            {
                 logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
                              << "`: link not found";
                 continue;
@@ -84,22 +95,24 @@ BindingConstraintLoader::load(EnvForLoading env) {
                 bc->offset(lnk, o);
 
             continue;
-        } else // It must be a cluster
+        }
+        else // It must be a cluster
         {
             // Separate the key
             setKey = p->key.find('.');
-            if (0 == setKey || setKey == String::npos) {
+            if (0 == setKey || setKey == String::npos)
+            {
                 logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
                              << "`: invalid key";
                 continue;
             }
 
-
             if (bool ret = SeparateValue(env, p, w, o); !ret)
                 continue;
 
-            const ThermalCluster *clstr = env.areaList.findClusterFromINIKey(p->key);
-            if (!clstr) {
+            const ThermalCluster* clstr = env.areaList.findClusterFromINIKey(p->key);
+            if (!clstr)
+            {
                 logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
                              << "`: cluster not found";
                 continue;
@@ -115,32 +128,40 @@ BindingConstraintLoader::load(EnvForLoading env) {
     }
 
     // Checking for validity
-    if (!bc->pName) {
+    if (!bc->pName)
+    {
         logs.error() << env.iniFilename << ": in [" << env.section->name
                      << "]: Invalid binding constraint name";
         return {};
     }
-    if (!bc->pID) {
+    if (!bc->pID)
+    {
         logs.error() << env.iniFilename << ": in [" << env.section->name
                      << "]: Invalid binding constraint id";
         return {};
     }
-    if (bc->pType == bc->typeUnknown) {
+    if (bc->pType == bc->typeUnknown)
+    {
         logs.error() << env.iniFilename << ": in [" << env.section->name
                      << "]: Invalid type [hourly,daily,weekly]";
-                    return {};
+        return {};
     }
-    if (bc->pOperator == BindingConstraint::opUnknown) {
+    if (bc->pOperator == BindingConstraint::opUnknown)
+    {
         logs.error() << env.iniFilename << ": in [" << env.section->name
                      << "]: Invalid operator [less,greater,equal,both]";
         return {};
     }
-    if (bc->group_.empty()) {
-        if (env.version >= version870) {
+    if (bc->group_.empty())
+    {
+        if (env.version >= version870)
+        {
             logs.error() << env.iniFilename << ": in [" << env.section->name
                          << "]: Missing mandatory binding constraint group";
             return {};
-        } else {
+        }
+        else
+        {
             bc->group_ = "legacy_study_group";
         }
     }
@@ -149,16 +170,18 @@ BindingConstraintLoader::load(EnvForLoading env) {
     if (bc->pLinkWeights.empty() && bc->pClusterWeights.empty())
         bc->pEnabled = false;
 
-    switch(bc->operatorType())
+    switch (bc->operatorType())
     {
     case BindingConstraint::opLess:
     case BindingConstraint::opEquality:
-    case BindingConstraint::opGreater:{
+    case BindingConstraint::opGreater:
+    {
         if (loadTimeSeries(env, bc.get()))
             return {bc};
         break;
     }
-    case BindingConstraint::opBoth:{
+    case BindingConstraint::opBoth:
+    {
         auto greater_bc = std::make_shared<BindingConstraint>();
         greater_bc->copyFrom(bc.get());
         greater_bc->name(bc->name());
@@ -167,12 +190,14 @@ BindingConstraintLoader::load(EnvForLoading env) {
 
         bc->operatorType(BindingConstraint::opLess);
 
-        if (loadTimeSeries(env, bc.get()) && loadTimeSeries(env, greater_bc.get())) {
+        if (loadTimeSeries(env, bc.get()) && loadTimeSeries(env, greater_bc.get()))
+        {
             return {bc, greater_bc};
         }
         break;
     }
-    default:{
+    default:
+    {
         logs.error() << "Wrong binding constraint operator type for constraint " << bc->name();
         return {};
     }
@@ -180,34 +205,42 @@ BindingConstraintLoader::load(EnvForLoading env) {
     return {};
 }
 
-bool
-BindingConstraintLoader::SeparateValue(const EnvForLoading &env, const IniFile::Property *p, double &w, int &o) {
+bool BindingConstraintLoader::SeparateValue(const EnvForLoading& env,
+                                            const IniFile::Property* p,
+                                            double& w,
+                                            int& o)
+{
     bool ret = true;
     CString<64> stringWO = p->value;
     String::Size setVal = p->value.find('%');
     uint occurrence = 0;
-    stringWO.words("%", [&occurrence, &setVal, &env, &ret, &p, &w, &o](const CString<64> &part) {
-        if (occurrence == 0) {
+    stringWO.words("%", [&occurrence, &setVal, &env, &ret, &p, &w, &o](const CString<64>& part) {
+        if (occurrence == 0)
+        {
             if (setVal == 0) // weight is null
             {
-                if (!part.to<int>(o)) {
-                    logs.error() << env.iniFilename << ": in [" << env.section->name
-                                 << "]: `" << p->key << "`: invalid offset";
+                if (!part.to<int>(o))
+                {
+                    logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `"
+                                 << p->key << "`: invalid offset";
                     ret = false;
                 }
-            } else // weight is not null
+            }
+            else // weight is not null
             {
-                if (!part.to<double>(w)) {
-                    logs.error() << env.iniFilename << ": in [" << env.section->name
-                                 << "]: `" << p->key << "`: invalid weight";
+                if (!part.to<double>(w))
+                {
+                    logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `"
+                                 << p->key << "`: invalid weight";
                     ret = false;
                 }
             }
         }
 
-        if (occurrence == 1 && setVal != 0 && !part.to<int>(o)) {
-            logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `"
-                         << p->key << "`: invalid offset";
+        if (occurrence == 1 && setVal != 0 && !part.to<int>(o))
+        {
+            logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
+                         << "`: invalid offset";
             ret = false;
         }
 
@@ -217,7 +250,8 @@ BindingConstraintLoader::SeparateValue(const EnvForLoading &env, const IniFile::
     return ret;
 }
 
-bool BindingConstraintLoader::loadTimeSeries(EnvForLoading &env, BindingConstraint *bindingConstraint)
+bool BindingConstraintLoader::loadTimeSeries(EnvForLoading& env,
+                                             BindingConstraint* bindingConstraint)
 {
     if (env.version >= version870)
         return loadTimeSeries(env, bindingConstraint->operatorType(), bindingConstraint);
@@ -225,28 +259,37 @@ bool BindingConstraintLoader::loadTimeSeries(EnvForLoading &env, BindingConstrai
     return loadTimeSeriesLegacyStudies(env, bindingConstraint);
 }
 
-bool
-BindingConstraintLoader::loadTimeSeries(EnvForLoading &env, BindingConstraint::Operator operatorType,
-                                        BindingConstraint *bindingConstraint) const {
+bool BindingConstraintLoader::loadTimeSeries(EnvForLoading& env,
+                                             BindingConstraint::Operator operatorType,
+                                             BindingConstraint* bindingConstraint) const
+{
     env.buffer.clear() << bindingConstraint->timeSeriesFileName(env);
-    bool load_ok = bindingConstraint->RHSTimeSeries_.loadFromCSVFile(env.buffer,
-                                                                     1,
-                                          (bindingConstraint->type() == BindingConstraint::typeHourly) ? 8784 : 366,
-                                                                     Matrix<>::optImmediate,
-                                                                     &env.matrixBuffer);
+    bool load_ok = bindingConstraint->RHSTimeSeries_.loadFromCSVFile(
+      env.buffer,
+      1,
+      (bindingConstraint->type() == BindingConstraint::typeHourly) ? 8784 : 366,
+      Matrix<>::optImmediate,
+      &env.matrixBuffer);
     if (load_ok)
     {
-        logs.info() << " loaded time series for `" << bindingConstraint->name() << "` (" << BindingConstraint::TypeToCString(bindingConstraint->type()) << ", "
+        logs.info() << " loaded time series for `" << bindingConstraint->name() << "` ("
+                    << BindingConstraint::TypeToCString(bindingConstraint->type()) << ", "
                     << BindingConstraint::OperatorToShortCString(operatorType) << ')';
         return true;
-    } else {
-        logs.error() << " unable to load time series for `" << bindingConstraint->name() << "` (" << BindingConstraint::TypeToCString(bindingConstraint->type()) << ", "
+    }
+    else
+    {
+        logs.error() << " unable to load time series for `" << bindingConstraint->name() << "` ("
+                     << BindingConstraint::TypeToCString(bindingConstraint->type()) << ", "
                      << BindingConstraint::OperatorToShortCString(operatorType) << ')';
         return false;
     }
 }
 
-bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(EnvForLoading &env, BindingConstraint *bindingConstraint) const {
+bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(
+  EnvForLoading& env,
+  BindingConstraint* bindingConstraint) const
+{
     env.buffer.clear() << env.folder << IO::Separator << bindingConstraint->pID << ".txt";
     Matrix<> intermediate;
     const int height = (bindingConstraint->pType == BindingConstraint::typeHourly) ? 8784 : 366;
@@ -257,11 +300,15 @@ bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(EnvForLoading &env, Bi
                                      &env.matrixBuffer))
     {
         if (bindingConstraint->pComments.empty())
-            logs.info() << " added `" << bindingConstraint->pName << "` (" << BindingConstraint::TypeToCString(bindingConstraint->pType) << ", "
-                        << BindingConstraint::OperatorToShortCString(bindingConstraint->pOperator) << ')';
+            logs.info() << " added `" << bindingConstraint->pName << "` ("
+                        << BindingConstraint::TypeToCString(bindingConstraint->pType) << ", "
+                        << BindingConstraint::OperatorToShortCString(bindingConstraint->pOperator)
+                        << ')';
         else
-            logs.info() << " added `" << bindingConstraint->pName << "` (" << BindingConstraint::TypeToCString(bindingConstraint->pType) << ", "
-                        << BindingConstraint::OperatorToShortCString(bindingConstraint->pOperator) << ") " << bindingConstraint->pComments;
+            logs.info() << " added `" << bindingConstraint->pName << "` ("
+                        << BindingConstraint::TypeToCString(bindingConstraint->pType) << ", "
+                        << BindingConstraint::OperatorToShortCString(bindingConstraint->pOperator)
+                        << ") " << bindingConstraint->pComments;
 
         // 0 is BindingConstraint::opLess
         int columnNumber;
@@ -281,4 +328,4 @@ bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(EnvForLoading &env, Bi
 
     return false;
 }
-} // Data
+} // namespace Antares::Data


### PR DESCRIPTION
# Previous behavior
If the name, id, operator or type of a binding constraint is incorrect, then check the group

# New behavior
Always check the group

Reported by @PPlessiez 