### PR TITLE
Thermal price definition (RTEi's -> CR20) - UI remarks from Paul

### DIFF
--- a/src/ui/simulator/windows/inspector/accumulator.hxx
+++ b/src/ui/simulator/windows/inspector/accumulator.hxx
@@ -114,6 +114,37 @@ public:
                                                            PredicateT::TextColor(*i));
         }
     }
+
+    template<class ListT>
+    static void ApplyGreyColor(wxPGProperty* property_one,
+                               wxPGProperty* property_two,
+                               const ListT& list)
+    {
+        assert(list.size() != 0);
+        assert(property_one != NULL);
+        assert(property_two != NULL);
+        if (list.size() == 1)
+        {
+            auto study = *list.begin();
+            property_one->GetGrid()->EnableProperty(property_one->GetBaseName(),
+                                                    PredicateT::Enable(study));
+            property_two->GetGrid()->EnableProperty(property_two->GetBaseName(),
+                                                    PredicateT::Enable(study));
+        }
+        else
+        {
+            auto i = list.cbegin();
+            const auto end = list.cend();
+            ++i;
+            for (; i != end; ++i)
+            {
+                property_one->GetGrid()->EnableProperty(property_one->GetBaseName(),
+                                                        PredicateT::Enable(*i));
+                property_two->GetGrid()->EnableProperty(property_two->GetBaseName(),
+                                                        PredicateT::Enable(*i));
+            }
+        }
+    }
 };
 
 struct PAreaColor
@@ -892,6 +923,17 @@ struct PClusterMarginalCost
     static wxString ConvertToString(const Type v)
     {
         return DoubleToWxString(v);
+    }
+};
+
+struct PClusterMarginalCostEnable
+{
+    static bool Enable(Data::ThermalCluster* cluster)
+    {
+        if (cluster->costgeneration == Data::useCostTimeseries)
+            return false;
+
+        return true;
     }
 };
 

--- a/src/ui/simulator/windows/inspector/accumulator.hxx
+++ b/src/ui/simulator/windows/inspector/accumulator.hxx
@@ -116,20 +116,28 @@ public:
     }
 
     template<class ListT>
-    static void ApplyGreyColor(wxPGProperty* property_one,
-                               wxPGProperty* property_two,
+    static void ApplyGreyColor(wxPGProperty* property_MargCost,
+                               wxPGProperty* property_OperCost,
+                               wxPGProperty* property_FuelEff,
+                               wxPGProperty* property_VarOMcost,
                                const ListT& list)
     {
         assert(list.size() != 0);
-        assert(property_one != NULL);
-        assert(property_two != NULL);
+        assert(property_MargCost != NULL);
+        assert(property_OperCost != NULL);
+        assert(property_FuelEff != NULL);
+        assert(property_VarOMcost != NULL);
         if (list.size() == 1)
         {
             auto study = *list.begin();
-            property_one->GetGrid()->EnableProperty(property_one->GetBaseName(),
-                                                    PredicateT::Enable(study));
-            property_two->GetGrid()->EnableProperty(property_two->GetBaseName(),
-                                                    PredicateT::Enable(study));
+            property_MargCost->GetGrid()->EnableProperty(property_MargCost->GetBaseName(),
+                                                         PredicateT::Enable(study));
+            property_OperCost->GetGrid()->EnableProperty(property_OperCost->GetBaseName(),
+                                                         PredicateT::Enable(study));
+            property_FuelEff->GetGrid()->EnableProperty(property_FuelEff->GetBaseName(),
+                                                        !PredicateT::Enable(study));
+            property_VarOMcost->GetGrid()->EnableProperty(property_VarOMcost->GetBaseName(),
+                                                          !PredicateT::Enable(study));
         }
         else
         {
@@ -138,10 +146,14 @@ public:
             ++i;
             for (; i != end; ++i)
             {
-                property_one->GetGrid()->EnableProperty(property_one->GetBaseName(),
-                                                        PredicateT::Enable(*i));
-                property_two->GetGrid()->EnableProperty(property_two->GetBaseName(),
-                                                        PredicateT::Enable(*i));
+                property_MargCost->GetGrid()->EnableProperty(property_MargCost->GetBaseName(),
+                                                             PredicateT::Enable(*i));
+                property_OperCost->GetGrid()->EnableProperty(property_OperCost->GetBaseName(),
+                                                             PredicateT::Enable(*i));
+                property_FuelEff->GetGrid()->EnableProperty(property_FuelEff->GetBaseName(),
+                                                            !PredicateT::Enable(*i));
+                property_VarOMcost->GetGrid()->EnableProperty(property_VarOMcost->GetBaseName(),
+                                                              !PredicateT::Enable(*i));
             }
         }
     }

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -973,6 +973,8 @@ void Frame::apply(const InspectorData::Ptr& data)
         // check Min. Stable Power with thermal modulation
         AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pPGThClusterSpinning,
                                                                 data->ThClusters);
+        AccumulatorCheck<PClusterMarginalCostEnable>::ApplyGreyColor(
+          pPGThClusterMarginalCost, pPGThClusterOperatingCost, data->ThClusters);
     }
 
     pPGThClusterParams->Hide(hide);

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -973,8 +973,11 @@ void Frame::apply(const InspectorData::Ptr& data)
         // check Min. Stable Power with thermal modulation
         AccumulatorCheck<PClusterSpinningColor>::ApplyTextColor(pPGThClusterSpinning,
                                                                 data->ThClusters);
-        AccumulatorCheck<PClusterMarginalCostEnable>::ApplyGreyColor(
-          pPGThClusterMarginalCost, pPGThClusterOperatingCost, data->ThClusters);
+        AccumulatorCheck<PClusterMarginalCostEnable>::ApplyGreyColor(pPGThClusterMarginalCost,
+                                                                     pPGThClusterOperatingCost,
+                                                                     pPGThClusterEfficiency,
+                                                                     pPGThClusterVariableOMcost,
+                                                                     data->ThClusters);
     }
 
     pPGThClusterParams->Hide(hide);

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -754,9 +754,11 @@ bool InspectorGrid::onPropertyChanging_ThermalCluster(wxPGProperty*,
         }
         for (; i != end; ++i)
         {
-            (*i)->costgeneration = costgeneration;    
-            (*i)->ComputeCostTimeSeries(); //update     
+            (*i)->costgeneration = costgeneration;
+            (*i)->ComputeCostTimeSeries(); // update
         }
+        AccumulatorCheck<PClusterMarginalCostEnable>::ApplyGreyColor(
+          pFrame.pPGThClusterMarginalCost, pFrame.pPGThClusterOperatingCost, data->ThClusters);
         // Notify
         OnStudyThermalClusterCommonSettingsChanged();
         pFrame.Refresh();        

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -758,10 +758,15 @@ bool InspectorGrid::onPropertyChanging_ThermalCluster(wxPGProperty*,
             (*i)->ComputeCostTimeSeries(); // update
         }
         AccumulatorCheck<PClusterMarginalCostEnable>::ApplyGreyColor(
-          pFrame.pPGThClusterMarginalCost, pFrame.pPGThClusterOperatingCost, data->ThClusters);
+          pFrame.pPGThClusterMarginalCost,
+          pFrame.pPGThClusterOperatingCost,
+          pFrame.pPGThClusterEfficiency,
+          pFrame.pPGThClusterVariableOMcost,
+          data->ThClusters);
+
         // Notify
         OnStudyThermalClusterCommonSettingsChanged();
-        pFrame.Refresh();        
+        pFrame.Refresh();
         return true;
     }
     // MBO 15/04/2014

--- a/src/ui/simulator/windows/thermal/panel.cpp
+++ b/src/ui/simulator/windows/thermal/panel.cpp
@@ -121,12 +121,12 @@ Panel::Panel(Component::Notebook* parent) :
         pageThermalTimeSeriesFuelCost = subbook->add(
           new Component::Datagrid::Component(
             subbook, new Component::Datagrid::Renderer::TimeSeriesThermalClusterFuelCost(subbook, tag)),
-          wxT("Fuel Cost [€/GJ]"));
+          wxT("Fuel Cost [\u20AC/GJ]"));
 
         pageThermalTimeSeriesCO2Cost = subbook->add(
           new Component::Datagrid::Component(
             subbook, new Component::Datagrid::Renderer::TimeSeriesThermalClusterCO2Cost(subbook, tag)),
-          wxT("CO2 Cost [€/ton]"));
+          wxT("CO2 Cost [\u20AC/ton]"));
 
         // Availability (ex Time Series)
         pageThermalTimeSeries = subbook->add(


### PR DESCRIPTION
This PR is open to clear the issues/remarks Paul has with the UI of https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/1272

"In general, the feature works well, but I experienced two issues with the GUI, which would need to be fixed in my view:

1. Units in € are not well displayed in the new tabs “Fuel Cost” and “CO2 cost”.
2. In general, I found that the interface was quite confusing, in particular regarding which parameters are taken into account or not depending on the value of the “Cost generation” parameter. It would be pretty valuable to grey out the parameters which won’t be taken into account depending on the value of the parameter (e.g. grey out “Marginal cost” and “Market bid” in case Cost generation is set to “Use cost timeseries”)."