### PR TITLE
fix(tests): enforce better unit test isolation

### DIFF
--- a/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
@@ -88,9 +88,9 @@ void referenceIniFile::save_section(std::string_view sectionTitle, std::vector<s
 	file << std::endl;
 }
 
-BOOST_FIXTURE_TEST_SUITE(s, Fixture)
+BOOST_AUTO_TEST_SUITE(s)
 
-BOOST_AUTO_TEST_CASE(one_area_with_default_params)
+BOOST_FIXTURE_TEST_CASE(one_area_with_default_params, Fixture)
 {
 	BOOST_CHECK(saveAreaOptimisationIniFile(*area, path_to_generated_file));
 
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_default_params)
 	BOOST_CHECK(files_identical(generatedIniFileName, referenceFile.name()));
 }
 
-BOOST_AUTO_TEST_CASE(one_area_with_none_default_params)
+BOOST_FIXTURE_TEST_CASE(one_area_with_none_default_params, Fixture)
 {
 	area->nodalOptimization = 0;
 	area->spreadUnsuppliedEnergyCost = 2.;
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_none_default_params)
 	BOOST_CHECK(files_identical(generatedIniFileName, referenceFile.name()));
 }
 
-BOOST_AUTO_TEST_CASE(one_area_with_nodal_opt_to_nonDispatchPower__other_params_to_default)
+BOOST_FIXTURE_TEST_CASE(one_area_with_nodal_opt_to_nonDispatchPower__other_params_to_default, Fixture)
 {
 	area->nodalOptimization = anoNonDispatchPower;
 
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_nodal_opt_to_nonDispatchPower__other_params_t
 
 
 
-BOOST_AUTO_TEST_CASE(one_area_with_nodal_opt_to_dispatchHydroPower__other_params_to_default)
+BOOST_FIXTURE_TEST_CASE(one_area_with_nodal_opt_to_dispatchHydroPower__other_params_to_default, Fixture)
 {
 	area->nodalOptimization = anoDispatchHydroPower;
 
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_nodal_opt_to_dispatchHydroPower__other_params
 	BOOST_CHECK(files_identical(generatedIniFileName, referenceFile.name()));
 }
 
-BOOST_AUTO_TEST_CASE(one_area_with_nodal_opt_to_otherDispatchablePower__other_params_to_default)
+BOOST_FIXTURE_TEST_CASE(one_area_with_nodal_opt_to_otherDispatchablePower__other_params_to_default, Fixture)
 {
 	area->nodalOptimization = anoOtherDispatchPower;
 
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_nodal_opt_to_otherDispatchablePower__other_pa
 	BOOST_CHECK(files_identical(generatedIniFileName, referenceFile.name()));
 }
 
-BOOST_AUTO_TEST_CASE(one_area_with_nodal_opt_to_non_or_other_DispatchPower__other_params_to_default)
+BOOST_FIXTURE_TEST_CASE(one_area_with_nodal_opt_to_non_or_other_DispatchPower__other_params_to_default, Fixture)
 {
 	area->nodalOptimization = anoOtherDispatchPower | anoNonDispatchPower;
 
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_nodal_opt_to_non_or_other_DispatchPower__othe
 	BOOST_CHECK(files_identical(generatedIniFileName, referenceIniFileName));
 }
 
-BOOST_AUTO_TEST_CASE(one_area_with_unsupplied_energy_cost_negative__other_params_to_default)
+BOOST_FIXTURE_TEST_CASE(one_area_with_unsupplied_energy_cost_negative__other_params_to_default, Fixture)
 {
 	area->spreadUnsuppliedEnergyCost = -1.;
 
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_unsupplied_energy_cost_negative__other_params
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "spread-unsupplied-energy-cost = -1.000000"));
 }
 
-BOOST_AUTO_TEST_CASE(one_area_with_spilled_energy_cost_negative__other_params_to_default)
+BOOST_FIXTURE_TEST_CASE(one_area_with_spilled_energy_cost_negative__other_params_to_default, Fixture)
 {
 	area->spreadSpilledEnergyCost = -1.;
 
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_spilled_energy_cost_negative__other_params_to
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "spread-spilled-energy-cost = -1.000000"));
 }
 
-BOOST_AUTO_TEST_CASE(one_area_with_synthesis_to_hourly_monthly_annual__other_params_to_default)
+BOOST_FIXTURE_TEST_CASE(one_area_with_synthesis_to_hourly_monthly_annual__other_params_to_default, Fixture)
 {
 	area->filterSynthesis = filterWeekly | filterMonthly | filterAnnual;
 
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(one_area_with_synthesis_to_hourly_monthly_annual__other_par
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "filter-synthesis = weekly, monthly, annual"));
 }
 
-BOOST_AUTO_TEST_CASE(one_area_with_year_by_year_to_daily_monthly__other_params_to_default)
+BOOST_FIXTURE_TEST_CASE(one_area_with_year_by_year_to_daily_monthly__other_params_to_default, Fixture)
 {
 	area->filterYearByYear = filterDaily | filterMonthly;
 

--- a/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
@@ -104,9 +104,9 @@ void saveAreaLinksOntoDisk(Area* area)
 	BOOST_CHECK(saveAreaLinksConfigurationFileToFolder(area, fs::current_path().string().c_str()));
 }
 
-BOOST_FIXTURE_TEST_SUITE(s, Fixture)
+BOOST_AUTO_TEST_SUITE(s)
 
-BOOST_AUTO_TEST_CASE(one_link_with_default_values)
+BOOST_FIXTURE_TEST_CASE(one_link_with_default_values, Fixture)
 {
 	createLinkBetweenAreas(area_1, area_2);
 
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_default_values)
 }
 
 
-BOOST_AUTO_TEST_CASE(one_link_with_none_default_values)
+BOOST_FIXTURE_TEST_CASE(one_link_with_none_default_values, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->useHurdlesCost = true;
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_none_default_values)
 }
 
 
-BOOST_AUTO_TEST_CASE(one_link_with_transmission_capacity_to_ignore__all_others_properties_are_default)
+BOOST_FIXTURE_TEST_CASE(one_link_with_transmission_capacity_to_ignore__all_others_properties_are_default, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->transmissionCapacities = LocalTransmissionCapacities::null;
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_transmission_capacity_to_ignore__all_others_p
 	BOOST_CHECK(files_identical(generatedIniFileName, referenceFile.name()));
 }
 
-BOOST_AUTO_TEST_CASE(one_link_with_asset_type_to_gas__ini_file_contains_matching_line)
+BOOST_FIXTURE_TEST_CASE(one_link_with_asset_type_to_gas__ini_file_contains_matching_line, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->assetType = atGas;
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_asset_type_to_gas__ini_file_contains_matching
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "asset-type = gaz"));
 }
 
-BOOST_AUTO_TEST_CASE(one_link_with_asset_type_to_virtual__ini_file_contains_matching_line)
+BOOST_FIXTURE_TEST_CASE(one_link_with_asset_type_to_virtual__ini_file_contains_matching_line, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->assetType = atVirt;
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_asset_type_to_virtual__ini_file_contains_matc
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "asset-type = virt"));
 }
 
-BOOST_AUTO_TEST_CASE(one_link_with_asset_type_to_other__ini_file_contains_matching_line)
+BOOST_FIXTURE_TEST_CASE(one_link_with_asset_type_to_other__ini_file_contains_matching_line, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->assetType = atOther;
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_asset_type_to_other__ini_file_contains_matchi
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "asset-type = other"));
 }
 
-BOOST_AUTO_TEST_CASE(one_link_with_style_to_dot__ini_file_contains_matching_line)
+BOOST_FIXTURE_TEST_CASE(one_link_with_style_to_dot__ini_file_contains_matching_line, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->style = stDot;
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_style_to_dot__ini_file_contains_matching_line
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "link-style = dot"));
 }
 
-BOOST_AUTO_TEST_CASE(one_link_with_style_to_dotdash__ini_file_contains_matching_line)
+BOOST_FIXTURE_TEST_CASE(one_link_with_style_to_dotdash__ini_file_contains_matching_line, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->style = stDotDash;
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_style_to_dotdash__ini_file_contains_matching_
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "link-style = dotdash"));
 }
 
-BOOST_AUTO_TEST_CASE(one_link_with_synthesis_to_hourly_monthly_annual__ini_file_contains_matching_line)
+BOOST_FIXTURE_TEST_CASE(one_link_with_synthesis_to_hourly_monthly_annual__ini_file_contains_matching_line, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->filterSynthesis = filterWeekly | filterMonthly | filterAnnual;
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(one_link_with_synthesis_to_hourly_monthly_annual__ini_file_
 	BOOST_CHECK(fileContainsLine(generatedIniFileName, "filter-synthesis = weekly, monthly, annual"));
 }
 
-BOOST_AUTO_TEST_CASE(one_link_with_year_by_year_to_daily_monthly__ini_file_contains_matching_line)
+BOOST_FIXTURE_TEST_CASE(one_link_with_year_by_year_to_daily_monthly__ini_file_contains_matching_line, Fixture)
 {
 	AreaLink* link = createLinkBetweenAreas(area_1, area_2);
 	link->filterYearByYear = filterDaily | filterMonthly;

--- a/src/tests/src/libs/antares/study/output-folder/study.cpp
+++ b/src/tests/src/libs/antares/study/output-folder/study.cpp
@@ -46,9 +46,9 @@ struct Fixture
     fs::path outputRoot;
 };
 
-BOOST_FIXTURE_TEST_SUITE(s, Fixture)
+BOOST_AUTO_TEST_SUITE(s)
 
-BOOST_AUTO_TEST_CASE(economy_legacyfiles_emptylabel)
+BOOST_FIXTURE_TEST_CASE(economy_legacyfiles_emptylabel, Fixture)
 {
     StudyMode mode = stdmEconomy;
     ResultFormat fmt = legacyFilesDirectories;
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(economy_legacyfiles_emptylabel)
     BOOST_CHECK_EQUAL(actualOutput, expectedOutput);
 }
 
-BOOST_AUTO_TEST_CASE(economy_legacyfiles_label_now)
+BOOST_FIXTURE_TEST_CASE(economy_legacyfiles_label_now, Fixture)
 {
     StudyMode mode = stdmEconomy;
     ResultFormat fmt = legacyFilesDirectories;
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(economy_legacyfiles_label_now)
     BOOST_CHECK_EQUAL(actualOutput, expectedOutput);
 }
 
-BOOST_AUTO_TEST_CASE(adequacy_legacyfiles_label_now)
+BOOST_FIXTURE_TEST_CASE(adequacy_legacyfiles_label_now, Fixture)
 {
     StudyMode mode = stdmAdequacy;
     ResultFormat fmt = legacyFilesDirectories;
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(adequacy_legacyfiles_label_now)
     BOOST_CHECK_EQUAL(actualOutput_suffix, expectedOutput_suffix);
 }
 
-BOOST_AUTO_TEST_CASE(adequacy_zip_label_now)
+BOOST_FIXTURE_TEST_CASE(adequacy_zip_label_now, Fixture)
 {
     StudyMode mode = stdmAdequacy;
     ResultFormat fmt = zipArchive;

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
@@ -164,12 +164,12 @@ struct Fixture
 // Tests section
 // ==================
 
-BOOST_FIXTURE_TEST_SUITE(s, Fixture)
+BOOST_AUTO_TEST_SUITE(s)
 
 // =================
 // Tests on Load
 // =================
-BOOST_AUTO_TEST_CASE(on_area2_and_on_year_18__load_TS_number_11_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_area2_and_on_year_18__load_TS_number_11_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "18";
 	String tsNumber = "11";
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(on_area2_and_on_year_18__load_TS_number_11_is_chosen__readi
 // =================
 // Tests on Wind
 // =================
-BOOST_AUTO_TEST_CASE(on_area3_and_on_year_7__wind_TS_number_5_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_area3_and_on_year_7__wind_TS_number_5_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "7";
 	String tsNumber = "5";
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(on_area3_and_on_year_7__wind_TS_number_5_is_chosen__reading
 // =================
 // Tests on Solar
 // =================
-BOOST_AUTO_TEST_CASE(on_area1_and_on_year_4__solar_TS_number_8_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_area1_and_on_year_4__solar_TS_number_8_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "4";
 	String tsNumber = "8";
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(on_area1_and_on_year_4__solar_TS_number_8_is_chosen__readin
 // =================
 // Tests on Hydro
 // =================
-BOOST_AUTO_TEST_CASE(on_area2_and_on_year_15__solar_TS_number_3_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_area2_and_on_year_15__solar_TS_number_3_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "15";
 	String tsNumber = "3";
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(on_area2_and_on_year_15__solar_TS_number_3_is_chosen__readi
 // ===========================
 // Tests on Thermal clusters
 // ===========================
-BOOST_AUTO_TEST_CASE(on_th_cluster11_of_area1_and_on_year_6__solar_TS_number_3_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_th_cluster11_of_area1_and_on_year_6__solar_TS_number_3_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "6";
 	String tsNumber = "3";
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(on_th_cluster11_of_area1_and_on_year_6__solar_TS_number_3_i
 	BOOST_CHECK_EQUAL(thCluster_11->series->timeseriesNumbers[0][yearNumber.to<uint>()], tsNumber.to<uint>() - 1);
 }
 
-BOOST_AUTO_TEST_CASE(on_th_cluster12_of_area1_and_on_year_13__solar_TS_number_5_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_th_cluster12_of_area1_and_on_year_13__solar_TS_number_5_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "13";
 	String tsNumber = "5";
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(on_th_cluster12_of_area1_and_on_year_13__solar_TS_number_5_
 	BOOST_CHECK_EQUAL(thCluster_12->series->timeseriesNumbers[0][yearNumber.to<uint>()], tsNumber.to<uint>() - 1);
 }
 
-BOOST_AUTO_TEST_CASE(on_th_cluster31_of_area3_and_on_year_10__solar_TS_number_7_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_th_cluster31_of_area3_and_on_year_10__solar_TS_number_7_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "10";
 	String tsNumber = "7";
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(on_th_cluster31_of_area3_and_on_year_10__solar_TS_number_7_
 // =============================
 // Tests on Renewable clusters
 // =============================
-BOOST_AUTO_TEST_CASE(on_rn_cluster21_of_area2_and_on_year_16__solar_TS_number_8_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_rn_cluster21_of_area2_and_on_year_16__solar_TS_number_8_is_chosen__reading_OK, Fixture)
 {
 	study->parameters.renewableGeneration.toClusters();
 
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(on_rn_cluster21_of_area2_and_on_year_16__solar_TS_number_8_
 	BOOST_CHECK_EQUAL(rnCluster_21->series->timeseriesNumbers[0][yearNumber.to<uint>()], tsNumber.to<uint>() - 1);
 }
 
-BOOST_AUTO_TEST_CASE(on_rn_cluster32_of_area3_and_on_year_2__solar_TS_number_4_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_rn_cluster32_of_area3_and_on_year_2__solar_TS_number_4_is_chosen__reading_OK, Fixture)
 {
 	study->parameters.renewableGeneration.toClusters();
 
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(on_rn_cluster32_of_area3_and_on_year_2__solar_TS_number_4_i
 // ========================
 // Tests on Hydro levels
 // ========================
-BOOST_AUTO_TEST_CASE(on_area1_and_on_year_17__hydro_level_0_123_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_area1_and_on_year_17__hydro_level_0_123_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "17";
 	String level = "0.123";
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(on_area1_and_on_year_17__hydro_level_0_123_is_chosen__readi
 	BOOST_CHECK_EQUAL(study->scenarioHydroLevels[area_1->index][yearNumber.to<uint>()], level.to<double>());
 }
 
-BOOST_AUTO_TEST_CASE(on_area2_and_on_year_9__hydro_level_1_5_is_chosen_level_lowered_to_1__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_area2_and_on_year_9__hydro_level_1_5_is_chosen_level_lowered_to_1__reading_OK, Fixture)
 {
 	AreaName yearNumber = "9";
 	String level = "1.5";
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(on_area2_and_on_year_9__hydro_level_1_5_is_chosen_level_low
 	BOOST_CHECK_EQUAL(study->scenarioHydroLevels[area_2->index][yearNumber.to<uint>()], 1.);
 }
 
-BOOST_AUTO_TEST_CASE(on_area3_and_on_year_5__hydro_level_neg_3_5_is_chosen__level_raised_to_0__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_area3_and_on_year_5__hydro_level_neg_3_5_is_chosen__level_raised_to_0__reading_OK, Fixture)
 {
 	AreaName yearNumber = "5";
 	String level = "-3.5";
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(on_area3_and_on_year_5__hydro_level_neg_3_5_is_chosen__leve
 // ======================
 // Tests on Links NTC
 // ======================
-BOOST_AUTO_TEST_CASE(on_link_area1_area2_and_on_year_0__ntc_TS_number_10_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_link_area1_area2_and_on_year_0__ntc_TS_number_10_is_chosen__reading_OK, Fixture)
 {	
 	AreaName yearNumber = "0";
 	String tsNumber = "10";
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(on_link_area1_area2_and_on_year_0__ntc_TS_number_10_is_chos
 	BOOST_CHECK_EQUAL(link_12->timeseriesNumbers[0][yearNumber.to<uint>()], tsNumber.to<uint>() - 1);
 }
 
-BOOST_AUTO_TEST_CASE(on_link_area1_area3_and_on_year_15__ntc_TS_number_7_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_link_area1_area3_and_on_year_15__ntc_TS_number_7_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "15";
 	String tsNumber = "7";
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(on_link_area1_area3_and_on_year_15__ntc_TS_number_7_is_chos
 	BOOST_CHECK_EQUAL(link_13->timeseriesNumbers[0][yearNumber.to<uint>()], tsNumber.to<uint>() - 1);
 }
 
-BOOST_AUTO_TEST_CASE(on_link_area2_area3_and_on_year_19__ntc_TS_number_6_is_chosen__reading_OK)
+BOOST_FIXTURE_TEST_CASE(on_link_area2_area3_and_on_year_19__ntc_TS_number_6_is_chosen__reading_OK, Fixture)
 {
 	AreaName yearNumber = "19";
 	String tsNumber = "6";
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE(on_link_area2_area3_and_on_year_19__ntc_TS_number_6_is_chos
 // ========================
 // Tests on Binding Constraints
 // ========================
-BOOST_AUTO_TEST_CASE(binding_constraints_group_groupTest__Load_TS_4_for_year_3__reading_OK)
+BOOST_FIXTURE_TEST_CASE(binding_constraints_group_groupTest__Load_TS_4_for_year_3__reading_OK, Fixture)
 {
     auto yearNumber = 3;
     auto tsNumber = 4;

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -434,9 +434,8 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_CHECK(files_identical(path_to_generated_file, referenceFile.path()));
 }
 
-BOOST_AUTO_TEST_CASE(
-    BC__TS_number_for_many_years__generated_and_ref_sc_buider_files_are_identical
-        ) {
+BOOST_FIXTURE_TEST_CASE(
+    BC__TS_number_for_many_years__generated_and_ref_sc_buider_files_are_identical, saveFixture) {
     my_rule->binding_constraints.setData("group1", 5, 20);
     my_rule->binding_constraints.setData("group2", 19, 1);
     my_rule->binding_constraints.setData("group3", 5, 43);

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -236,13 +236,13 @@ saveFixture::~saveFixture()
 // Tests section
 // ==================
 
-BOOST_FIXTURE_TEST_SUITE(s, saveFixture)
+BOOST_AUTO_TEST_SUITE(s)
 
 // ====================
 // Tests on Load
 // ====================
-BOOST_AUTO_TEST_CASE(
-  LOAD__on_area2_and_year_11_chosen_ts_number_is_6__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  LOAD__on_area2_and_year_11_chosen_ts_number_is_6__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->load.set(area_2->index, 11, 6);
 
@@ -256,8 +256,8 @@ BOOST_AUTO_TEST_CASE(
     BOOST_CHECK(files_identical(path_to_generated_file, referenceFile.path()));
 }
 
-BOOST_AUTO_TEST_CASE(
-  LOAD__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  LOAD__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->load.set(area_3->index, 7, 2);
     my_rule->load.set(area_2->index, 11, 6);
@@ -284,8 +284,8 @@ BOOST_AUTO_TEST_CASE(
 // ====================
 // Tests on Wind
 // ====================
-BOOST_AUTO_TEST_CASE(
-  WIND__on_area3_and_year_19_chosen_ts_number_is_17__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  WIND__on_area3_and_year_19_chosen_ts_number_is_17__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->wind.set(area_3->index, 19, 17);
 
@@ -302,8 +302,8 @@ BOOST_AUTO_TEST_CASE(
 // ====================
 // Tests on Solar
 // ====================
-BOOST_AUTO_TEST_CASE(
-  SOLAR__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  SOLAR__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->solar.set(area_1->index, 9, 9);
     my_rule->solar.set(area_3->index, 18, 7);
@@ -324,8 +324,8 @@ BOOST_AUTO_TEST_CASE(
 // =================
 // Tests on Hydro
 // =================
-BOOST_AUTO_TEST_CASE(
-  HYDRO__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  HYDRO__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->hydro.set(area_2->index, 17, 12);
     my_rule->hydro.set(area_3->index, 18, 7);
@@ -346,8 +346,8 @@ BOOST_AUTO_TEST_CASE(
 // ===========================
 // Tests on Thermal clusters
 // ===========================
-BOOST_AUTO_TEST_CASE(
-  THERMAL__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  THERMAL__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->thermal[area_3->index].set(thCluster_31.get(), 5, 13);
     my_rule->thermal[area_1->index].set(thCluster_11.get(), 19, 8);
@@ -369,8 +369,8 @@ BOOST_AUTO_TEST_CASE(
 // =============================
 // Tests on Renewable clusters
 // =============================
-BOOST_AUTO_TEST_CASE(
-  RENEWABLE_CLUSTERS__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  RENEWABLE_CLUSTERS__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->renewable[area_3->index].set(rnCluster_32.get(), 5, 13);
     my_rule->renewable[area_2->index].set(rnCluster_21.get(), 19, 8);
@@ -392,8 +392,8 @@ BOOST_AUTO_TEST_CASE(
 // ========================
 // Tests on Hydro levels
 // ========================
-BOOST_AUTO_TEST_CASE(
-  HYDRO_LEVEL__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  HYDRO_LEVEL__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->hydroLevels.set(area_1->index, 9, 9);
     my_rule->hydroLevels.set(area_3->index, 18, 7);
@@ -414,8 +414,8 @@ BOOST_AUTO_TEST_CASE(
 // ======================
 // Tests on Links NTC
 // ======================
-BOOST_AUTO_TEST_CASE(
-  LINKS_NTC__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  LINKS_NTC__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->linksNTC[area_1->index].setDataForLink(link_12, 5, 13);
     my_rule->linksNTC[area_1->index].setDataForLink(link_13, 19, 8);
@@ -457,8 +457,8 @@ BOOST_AUTO_TEST_CASE(
 // ================================
 // Tests on All assets together
 // ================================
-BOOST_AUTO_TEST_CASE(
-  ALL_TOGETHER__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical)
+BOOST_FIXTURE_TEST_CASE(
+  ALL_TOGETHER__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->load.set(area_2->index, 11, 6);
     my_rule->load.set(area_3->index, 7, 2);

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input.cpp
@@ -161,9 +161,9 @@ struct Fixture
 // Tests section
 // ==================
 
-BOOST_FIXTURE_TEST_SUITE(s, Fixture)
+BOOST_AUTO_TEST_SUITE(s)
 
-BOOST_AUTO_TEST_CASE(check_vector_sizes)
+BOOST_FIXTURE_TEST_CASE(check_vector_sizes, Fixture)
 {
     resizeFillVectors(series, 0.0, 12);
     BOOST_CHECK(!series.validate());
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(check_vector_sizes)
     BOOST_CHECK(series.validate());
 }
 
-BOOST_AUTO_TEST_CASE(check_series_folder_loading)
+BOOST_FIXTURE_TEST_CASE(check_series_folder_loading, Fixture)
 {
     createFileSeries(1.0, 8760);
 
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(check_series_folder_loading)
         && series.upperRuleCurve[1343] == 1);
 }
 
-BOOST_AUTO_TEST_CASE(check_series_folder_loading_different_values)
+BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values, Fixture)
 {
     createFileSeries(8760);
 
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(check_series_folder_loading_different_values)
     BOOST_CHECK(series.validate());
 }
 
-BOOST_AUTO_TEST_CASE(check_series_folder_loading_negative_value)
+BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_negative_value, Fixture)
 {
     createFileSeries(-247.0, 8760);
 
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(check_series_folder_loading_negative_value)
     BOOST_CHECK(!series.validate());
 }
 
-BOOST_AUTO_TEST_CASE(check_series_folder_loading_too_big)
+BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_too_big, Fixture)
 {
     createFileSeries(1.0, 9000);
 
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(check_series_folder_loading_too_big)
     BOOST_CHECK(series.validate());
 }
 
-BOOST_AUTO_TEST_CASE(check_series_folder_loading_too_small)
+BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_too_small, Fixture)
 {
     createFileSeries(1.0, 100);
 
@@ -214,25 +214,25 @@ BOOST_AUTO_TEST_CASE(check_series_folder_loading_too_small)
     BOOST_CHECK(!series.validate());
 }
 
-BOOST_AUTO_TEST_CASE(check_series_folder_loading_empty)
+BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_empty, Fixture)
 {
     BOOST_CHECK(series.loadFromFolder(folder));
     BOOST_CHECK(!series.validate());
 }
 
-BOOST_AUTO_TEST_CASE(check_series_vector_fill)
+BOOST_FIXTURE_TEST_CASE(check_series_vector_fill, Fixture)
 {
     series.fillDefaultSeriesIfEmpty();
     BOOST_CHECK(series.validate());
 }
 
-BOOST_AUTO_TEST_CASE(check_cluster_series_vector_fill)
+BOOST_FIXTURE_TEST_CASE(check_cluster_series_vector_fill, Fixture)
 {
     BOOST_CHECK(cluster.loadSeries(folder));
     BOOST_CHECK(cluster.series->validate());
 }
 
-BOOST_AUTO_TEST_CASE(check_cluster_series_load_vector)
+BOOST_FIXTURE_TEST_CASE(check_cluster_series_load_vector, Fixture)
 {
     createFileSeries(0.5, 8760);
 
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(check_cluster_series_load_vector)
         && cluster.series->lowerRuleCurve[6392] == 0.5);
 }
 
-BOOST_AUTO_TEST_CASE(check_container_properties_load)
+BOOST_FIXTURE_TEST_CASE(check_container_properties_load, Fixture)
 {
     createIniFile();
 
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(check_container_properties_load)
     removeIniFile();
 }
 
-BOOST_AUTO_TEST_CASE(check_container_properties_wrong_value)
+BOOST_FIXTURE_TEST_CASE(check_container_properties_wrong_value, Fixture)
 {
     createIniFileWrongValue();
 
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(check_container_properties_wrong_value)
     removeIniFile();
 }
 
-BOOST_AUTO_TEST_CASE(check_container_properties_empty_file)
+BOOST_FIXTURE_TEST_CASE(check_container_properties_empty_file, Fixture)
 {
     createEmptyIniFile();
 
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(check_container_properties_empty_file)
     removeIniFile();
 }
 
-BOOST_AUTO_TEST_CASE(check_file_save)
+BOOST_FIXTURE_TEST_CASE(check_file_save, Fixture)
 {
     createIniFile();
 
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(check_file_save)
     removeIniFile();
 }
 
-BOOST_AUTO_TEST_CASE(check_series_save)
+BOOST_FIXTURE_TEST_CASE(check_series_save, Fixture)
 {
     resizeFillVectors(series, 0.123456789, 8760);
 

--- a/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
@@ -123,8 +123,8 @@ struct FixtureStudyOnly
 // ==================
 
 // Here, we need the "lightweight fixture"
-BOOST_FIXTURE_TEST_SUITE(EconomicInputData_loadFromFolder, FixtureStudyOnly)
-BOOST_AUTO_TEST_CASE(EconomicInputData_loadFromFolder_OK)
+BOOST_AUTO_TEST_SUITE(EconomicInputData_loadFromFolder)
+BOOST_FIXTURE_TEST_CASE(EconomicInputData_loadFromFolder_OK, FixtureStudyOnly)
 {
     TimeSeriesFile fuelCostTSfile("fuelCost.txt", 8760);
     EconomicInputData eco;
@@ -133,14 +133,14 @@ BOOST_AUTO_TEST_CASE(EconomicInputData_loadFromFolder_OK)
     BOOST_CHECK_EQUAL(eco.fuelcost[0][1432], 1);
 }
 
-BOOST_AUTO_TEST_CASE(EconomicInputData_loadFromFolder_failing_not_enough_values)
+BOOST_FIXTURE_TEST_CASE(EconomicInputData_loadFromFolder_failing_not_enough_values, FixtureStudyOnly)
 {
     TimeSeriesFile fuelCostTSfile("fuelCost.txt", 80);
     EconomicInputData eco;
     BOOST_CHECK(!eco.loadFromFolder(*study, fuelCostTSfile.getFolder()));
 }
 
-BOOST_AUTO_TEST_CASE(EconomicInputData_loadFromFolder_working_with_many_values)
+BOOST_FIXTURE_TEST_CASE(EconomicInputData_loadFromFolder_working_with_many_values, FixtureStudyOnly)
 {
     TimeSeriesFile co2CostTSfile("CO2Cost.txt", 10000);
     EconomicInputData eco;
@@ -148,8 +148,8 @@ BOOST_AUTO_TEST_CASE(EconomicInputData_loadFromFolder_working_with_many_values)
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_FIXTURE_TEST_SUITE(s, FixtureFull)
-BOOST_AUTO_TEST_CASE(ThermalClusterList_loadFromFolder_basic)
+BOOST_AUTO_TEST_SUITE(s)
+BOOST_FIXTURE_TEST_CASE(ThermalClusterList_loadFromFolder_basic, FixtureFull)
 {
     clusterList.loadFromFolder(*study, folder, area);
     auto cluster = clusterList.mapping["some cluster"];
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(ThermalClusterList_loadFromFolder_basic)
     BOOST_CHECK(cluster->variableomcost == 12.12);
 }
 
-BOOST_AUTO_TEST_CASE(checkCo2_checkCO2CostColumnNumber_OK)
+BOOST_FIXTURE_TEST_CASE(checkCo2_checkCO2CostColumnNumber_OK, FixtureFull)
 {
     area->thermal.list.loadFromFolder(*study, folder, area);
     auto cluster = area->thermal.list.mapping["some cluster"];
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(checkCo2_checkCO2CostColumnNumber_OK)
     BOOST_CHECK_NO_THROW(Antares::Check::checkCO2CostColumnNumber(study->areas));
 }
 
-BOOST_AUTO_TEST_CASE(checkCo2_checkCO2CostColumnNumber_KO)
+BOOST_FIXTURE_TEST_CASE(checkCo2_checkCO2CostColumnNumber_KO, FixtureFull)
 {
     area->thermal.list.loadFromFolder(*study, folder, area);
     auto cluster = area->thermal.list.mapping["some cluster"];
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(checkCo2_checkCO2CostColumnNumber_KO)
                       Antares::Error::IncompatibleCO2CostColumns);
 }
 
-BOOST_AUTO_TEST_CASE(checkFuelAndCo2_checkColumnNumber_OK)
+BOOST_FIXTURE_TEST_CASE(checkFuelAndCo2_checkColumnNumber_OK, FixtureFull)
 {
     area->thermal.list.loadFromFolder(*study, folder, area);
     auto cluster = area->thermal.list.mapping["some cluster"];
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(checkFuelAndCo2_checkColumnNumber_OK)
     BOOST_CHECK_NO_THROW(Antares::Check::checkCO2CostColumnNumber(study->areas));
 }
 
-BOOST_AUTO_TEST_CASE(ThermalCluster_costGenManualCalculationOfMarketBidAndMarginalCostPerHour)
+BOOST_FIXTURE_TEST_CASE(ThermalCluster_costGenManualCalculationOfMarketBidAndMarginalCostPerHour, FixtureFull)
 {
     clusterList.loadFromFolder(*study, folder, area);
     auto cluster = clusterList.mapping["some cluster"];
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(ThermalCluster_costGenManualCalculationOfMarketBidAndMargin
     BOOST_CHECK_EQUAL(cluster->costsTimeSeries[0].marginalCostTS[6737], 23);
 }
 
-BOOST_AUTO_TEST_CASE(ThermalCluster_costGenTimeSeriesCalculationOfMarketBidAndMarginalCostPerHour)
+BOOST_FIXTURE_TEST_CASE(ThermalCluster_costGenTimeSeriesCalculationOfMarketBidAndMarginalCostPerHour, FixtureFull)
 {
     TimeSeriesFile fuel("fuelCost.txt", 8760);
     TimeSeriesFile co2("CO2Cost.txt", 8760);
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(ThermalCluster_costGenTimeSeriesCalculationOfMarketBidAndMa
     BOOST_CHECK_CLOSE(cluster->costsTimeSeries[0].marketBidCostTS[2637], 24.12, 0.001);
 }
 
-BOOST_AUTO_TEST_CASE(computeMarketBidCost)
+BOOST_FIXTURE_TEST_CASE(computeMarketBidCost, FixtureFull)
 {
     clusterList.loadFromFolder(*study, folder, area);
     auto cluster = clusterList.mapping["some cluster"];

--- a/src/tests/src/solver/simulation/test-time_series.cpp
+++ b/src/tests/src/solver/simulation/test-time_series.cpp
@@ -93,9 +93,9 @@ struct Fixture {
     Matrix<double> expected_equality_series;
 };
 
-BOOST_FIXTURE_TEST_SUITE(BC_TimeSeries, Fixture)
+BOOST_AUTO_TEST_SUITE(BC_TimeSeries)
 
-BOOST_AUTO_TEST_CASE(load_binding_constraints_timeseries) {
+BOOST_FIXTURE_TEST_CASE(load_binding_constraints_timeseries, Fixture) {
     bool loading_ok = bindingConstraints.loadFromFolder(*study, options, working_tmp_dir.string());
     BOOST_CHECK_EQUAL(loading_ok, true);
     BOOST_CHECK_EQUAL(bindingConstraints.size(), 1);
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(load_binding_constraints_timeseries) {
     CheckEqual(bindingConstraints.find("dummy_id")->RHSTimeSeries(), expected_upper_bound_series);
 }
 
-BOOST_AUTO_TEST_CASE(verify_all_constraints_in_a_group_have_the_same_number_of_time_series_error_case) {
+BOOST_FIXTURE_TEST_CASE(verify_all_constraints_in_a_group_have_the_same_number_of_time_series_error_case, Fixture) {
         {
             std::ofstream constraints(working_tmp_dir / "bindingconstraints.ini", std::ios_base::app);
             constraints << "[2]\n"
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(verify_all_constraints_in_a_group_have_the_same_number_of_t
         BOOST_CHECK_EQUAL(loading_ok, false);
 }
 
-BOOST_AUTO_TEST_CASE(verify_all_constraints_in_a_group_have_the_same_number_of_time_series_good_case) {
+BOOST_FIXTURE_TEST_CASE(verify_all_constraints_in_a_group_have_the_same_number_of_time_series_good_case, Fixture) {
     {
         std::ofstream constraints(working_tmp_dir / "bindingconstraints.ini", std::ios_base::app);
         constraints << "[2]\n"
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(verify_all_constraints_in_a_group_have_the_same_number_of_t
     BOOST_CHECK_EQUAL(loading_ok, true);
 }
 
-BOOST_AUTO_TEST_CASE(Check_empty_file_interpreted_as_all_zeroes) {
+BOOST_FIXTURE_TEST_CASE(Check_empty_file_interpreted_as_all_zeroes, Fixture) {
     std::vector file_names = {working_tmp_dir / "dummy_id_lt.txt",
                               working_tmp_dir / "dummy_id_gt.txt",
                               working_tmp_dir / "dummy_id_eq.txt"};
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(Check_empty_file_interpreted_as_all_zeroes) {
     CheckEqual(bindingConstraints.find("dummy_id")->RHSTimeSeries(), expectation);
 }
 
-BOOST_AUTO_TEST_CASE(Check_missing_file) {
+BOOST_FIXTURE_TEST_CASE(Check_missing_file, Fixture) {
     std::vector file_names = {working_tmp_dir / "dummy_id_lt.txt",
                               working_tmp_dir / "dummy_id_gt.txt",
                               working_tmp_dir / "dummy_id_eq.txt"};


### PR DESCRIPTION
**Related issue**
See #1474 

**Description**
Replaces the use of fixtures at test suite level with fixtures at test case level, to ensure each test case is executed with its own data.
Otherwise, we take the risk that data of one test case will be modified by another one.

**Notes**
- the tests did not need any modification to work, which means there was no actual issue in the existing tests, however it will be safer in the future to adopt that clean separation between test cases.
- the tests on BC have not been changed, since they are subject to lots of changes in concurrent PRs