### PR TITLE
Remove std::shared_ptr around FinalLevelInflowsModifier

### DIFF
--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -50,6 +50,7 @@ Area::Area() :
  enabled(true),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
+ hydro(*this),
  nodalOptimization(anoAll),
  spreadUnsuppliedEnergyCost(0.),
  spreadSpilledEnergyCost(0.),
@@ -66,6 +67,7 @@ Area::Area(const AnyString& name, uint nbParallelYears) :
  index((uint)(-1)),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
+ hydro(*this),
  nodalOptimization(anoAll),
  spreadUnsuppliedEnergyCost(0.),
  spreadSpilledEnergyCost(0.),
@@ -84,6 +86,7 @@ Area::Area(const AnyString& name, const AnyString& id, uint nbParallelYears, uin
  index(indx),
  reserves(fhrMax, HOURS_PER_YEAR),
  miscGen(fhhMax, HOURS_PER_YEAR),
+ hydro(*this),
  nodalOptimization(anoAll),
  spreadUnsuppliedEnergyCost(0.),
  spreadSpilledEnergyCost(0.),
@@ -530,4 +533,4 @@ void Area::buildLinksIndexes()
     }
 }
 
-} // namespace Antares
+} // namespace Antares::Data

--- a/src/libs/antares/study/area/area.h
+++ b/src/libs/antares/study/area/area.h
@@ -853,11 +853,6 @@ void AreaListEnsureDataRenewableTimeSeries(AreaList* l);
 */
 void AreaListEnsureDataThermalPrepro(AreaList* l);
 
- /*!
-** \brief Ensure data for FinalLevelInflowsModifier are initialized
-*/
-void AreaListEnsureFinalLevelInflowsModifyerAreaPtr(AreaList* l);
-
 /*!
 ** \brief to check that Area name does not contains character *
 */

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -1043,7 +1043,6 @@ void AreaList::ensureDataIsInitialized(Parameters& params, bool loadOnlyNeeded)
     AreaListEnsureDataHydroTimeSeries(this);
     AreaListEnsureDataThermalTimeSeries(this);
     AreaListEnsureDataRenewableTimeSeries(this);
-    AreaListEnsureFinalLevelInflowsModifyerAreaPtr(this);
 
     if (loadOnlyNeeded)
     {
@@ -1322,17 +1321,6 @@ void AreaListEnsureDataHydroTimeSeries(AreaList* l)
     l->each([&](Data::Area& area) {
         if (!area.hydro.series)
             area.hydro.series = new DataSeriesHydro();
-    });
-}
-
-void AreaListEnsureFinalLevelInflowsModifyerAreaPtr(AreaList* l)
-{
-    /* Asserts */
-    assert(l);
-
-    l->each([&](Data::Area& area) {
-        if (!area.hydro.finalLevelInflowsModifier->areaPtr)
-            area.hydro.finalLevelInflowsModifier->areaPtr = &area;
     });
 }
 

--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -39,7 +39,7 @@ namespace Antares
 {
 namespace Data
 {
-PartHydro::PartHydro() :
+PartHydro::PartHydro(const Data::Area& area) :
  interDailyBreakdown(0.),
  intraDailyModulation(2.),
  intermonthlyBreakdown(0),
@@ -58,7 +58,7 @@ PartHydro::PartHydro() :
  hydroModulable(false),
  prepro(nullptr),
  series(nullptr),
- finalLevelInflowsModifier(std::make_shared<FinalLevelInflowsModifier>())
+ finalLevelInflowsModifier(*this, area.index, area.name)
 {
 }
 

--- a/src/libs/antares/study/parts/hydro/container.h
+++ b/src/libs/antares/study/parts/hydro/container.h
@@ -31,16 +31,10 @@
 #include "series.h"
 #include "../../fwd.h"
 #include "allocation.h"
-#include <memory>
+#include "finallevelinflowsmodifyer.h"
 
 namespace Antares::Data
 {
-/*!
- ** \brief Final Reservoir Level data for a single area
- */
-
-class FinalLevelInflowsModifier;
-
 /*!
 ** \brief Hydro for a single area
 */
@@ -100,7 +94,7 @@ public:
     /*!
     ** \brief Default Constructor
     */
-    PartHydro();
+    PartHydro(const Data::Area& area);
     //! Destructor
     ~PartHydro();
 
@@ -180,11 +174,8 @@ public:
     DataSeriesHydro* series;
 
     //! Data for final reservoir level
-    
-    std::shared_ptr<FinalLevelInflowsModifier> finalLevelInflowsModifier;
-
+    FinalLevelInflowsModifier finalLevelInflowsModifier;
 }; // class PartHydro
-
 
 // Interpolates a water value from a table according to a level and a day.
 // As this function can be called a lot of times, we pass working variables and returned variables

--- a/src/libs/antares/study/parts/hydro/finallevelinflowsmodifyer.h
+++ b/src/libs/antares/study/parts/hydro/finallevelinflowsmodifyer.h
@@ -27,20 +27,26 @@
 #ifndef __ANTARES_LIBS_STUDY_PARTS_HYDRO_FINAL_LEVEL_INFLOWS_MODIFYER_H__
 #define __ANTARES_LIBS_STUDY_PARTS_HYDRO_FINAL_LEVEL_INFLOWS_MODIFYER_H__
 
-#include "../../area/area.h"
-#include <antares/emergency.h>
+#include <vector>
+#include <yuni/yuni.h>
+#include <antares/study/parameters.h>
+#include <antares/array/matrix.h>
 
 namespace Antares::Data
 {
-
+class PartHydro;
 /*!
  ** \brief Final Reservoir Level data for a single area
  */
 class FinalLevelInflowsModifier
 {
-private:
-    // Final reservoir level runtime data
+public:
+    FinalLevelInflowsModifier() = delete;
+    FinalLevelInflowsModifier(const PartHydro& hydro,
+                              const unsigned int& areaIndex,
+                              const AreaName& areaName);
 
+private:
     // Simulation Data
     uint simEndDay;
 
@@ -59,17 +65,15 @@ private:
     int initReservoirLvlMonth;
 
 public:
-    Area* areaPtr;
-
+    const PartHydro& hydro;
+    const unsigned int& areaIndex;
+    const AreaName& areaName;
     // vectors containing data necessary for final reservoir level calculation
     // for one area and all MC years
     // vector indexes correspond to the MC years
     std::vector<bool> includeFinalReservoirLevel;
     std::vector<double> endLevel;
     std::vector<double> deltaLevel;
-
-    // Constructor
-    FinalLevelInflowsModifier();
 
 private:
     // methods:

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -234,12 +234,13 @@ bool HydroManagement::checkMonthlyMinGeneration(uint numSpace, uint tsIndex, con
     return true;
 }
 
-bool HydroManagement::checkYearlyMinGeneration(uint numSpace, uint tsIndex, const Data::Area& area) const
+bool HydroManagement::checkYearlyMinGeneration(uint numSpace,
+                                               uint tsIndex,
+                                               const Data::Area& area) const
 {
     const auto& data = pAreas[numSpace][area.index];
-    if (area.hydro.followLoadModulations &&
-        area.hydro.reservoirManagement &&
-        data.totalYearMingen > data.totalYearInflows)
+    if (area.hydro.followLoadModulations && area.hydro.reservoirManagement
+        && data.totalYearMingen > data.totalYearInflows)
     {
         // Yearly minimum generation <= Yearly inflows
         logs.error() << "In Area " << area.name << " the minimum generation of "
@@ -333,8 +334,7 @@ bool HydroManagement::checkHourlyMinGeneration(uint tsIndex, Data::Area& area) c
 bool HydroManagement::checkMinGeneration(uint numSpace)
 {
     bool ret = true;
-    study.areas.each([this, &numSpace, &ret](Data::Area& area)
-    {
+    study.areas.each([this, &numSpace, &ret](Data::Area& area) {
         uint z = area.index;
         const auto& ptchro = NumeroChroniquesTireesParPays[numSpace][z];
         auto tsIndex = (uint)ptchro.Hydraulique;
@@ -345,7 +345,7 @@ bool HydroManagement::checkMinGeneration(uint numSpace)
             ret = checkYearlyMinGeneration(numSpace, tsIndex, area) && ret;
             ret = checkWeeklyMinGeneration(tsIndex, area) && ret;
         }
-          
+
         ret = checkHourlyMinGeneration(tsIndex, area) && ret;
     });
     return ret;
@@ -353,23 +353,21 @@ bool HydroManagement::checkMinGeneration(uint numSpace)
 
 void HydroManagement::changeInflowsDueToFinalLevels(uint numSpace, uint year)
 {
-    study.areas.each(
-      [this, &numSpace, &year](Data::Area& area)
-      {
-          auto& data = pAreas[numSpace][area.index];
-          if (area.hydro.finalLevelInflowsModifier->deltaLevel.empty())
-              return;
+    study.areas.each([this, &numSpace, &year](Data::Area& area) {
+        auto& data = pAreas[numSpace][area.index];
+        if (area.hydro.finalLevelInflowsModifier.deltaLevel.empty())
+            return;
 
-          if (!area.hydro.finalLevelInflowsModifier->includeFinalReservoirLevel[year])
-              return;
+        if (!area.hydro.finalLevelInflowsModifier.includeFinalReservoirLevel[year])
+            return;
 
-          double delta = area.hydro.finalLevelInflowsModifier->deltaLevel[year];
-          // must be done before prepareMonthlyTargetGenerations
-          if (delta > 0)
-              data.inflows[0] += delta;
-          else if (delta < 0)
-              data.inflows[11] += delta;
-      });
+        double delta = area.hydro.finalLevelInflowsModifier.deltaLevel[year];
+        // must be done before prepareMonthlyTargetGenerations
+        if (delta > 0)
+            data.inflows[0] += delta;
+        else if (delta < 0)
+            data.inflows[11] += delta;
+    });
 }
 
 template<enum Data::StudyMode ModeT>

--- a/src/solver/simulation/hydro-final-reservoir-level-functions.cpp
+++ b/src/solver/simulation/hydro-final-reservoir-level-functions.cpp
@@ -40,13 +40,13 @@ void prepareFinalReservoirLevelDataPerMcY(Data::Study& study, uint year)
           auto& scenarioFinalHydroLevels = study.scenarioFinalHydroLevels;
           auto& parameters = study.parameters;
 
-          finalInflows->initializeData(
+          finalInflows.initializeData(
             scenarioInitialHydroLevels, scenarioFinalHydroLevels, parameters, year);
 
-          if (finalInflows->isActive())
+          if (finalInflows.isActive())
           {
-              finalInflows->updateInflows();
-              finalInflows->makeChecks();
+              finalInflows.updateInflows();
+              finalInflows.makeChecks();
           }
       });
 }

--- a/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
+++ b/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
@@ -42,7 +42,6 @@ void simulationBetweenDays(Study::Ptr study, const unsigned int firstDay, const 
 Area* addAreaToStudy(Study::Ptr study, const std::string& areaName, double loadInArea)
 {
     Area* area = study->areaAdd(areaName);
-    area->hydro.finalLevelInflowsModifier->areaPtr = area;
 
     BOOST_CHECK(area != NULL);
 

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -12,7 +12,6 @@ using namespace Antares::Data;
 Area* addArea(Study::Ptr pStudy, const std::string& areaName, int nbTS)
 {
     Area* pArea = pStudy->areaAdd(areaName);
-	pArea->hydro.finalLevelInflowsModifier->areaPtr = pArea;
 
     BOOST_CHECK(pArea != NULL);
 


### PR DESCRIPTION
Please note that `Area::index` and `Area::name` may not be set at construction (`Area` has 3 constructors, 2 of which don't define `index`). That is the reason why we take a const reference on these data members.