### PR TITLE
Remove use of study singleton in optimization module

### DIFF
--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
@@ -37,16 +37,17 @@ using Antares::Constants::nbHoursInAWeek;
 
 namespace Antares::Solver::Optimization
 {
-AdequacyPatchOptimization::AdequacyPatchOptimization(PROBLEME_HEBDO* problemeHebdo,
+AdequacyPatchOptimization::AdequacyPatchOptimization(const OptimizationOptions& options,
+                                                     PROBLEME_HEBDO* problemeHebdo,
                                                      AdqPatchParams& adqPatchParams,
                                                      uint thread_number) :
- WeeklyOptimization(problemeHebdo, adqPatchParams, thread_number)
+ WeeklyOptimization(options, problemeHebdo, adqPatchParams, thread_number)
 {
 }
 void AdequacyPatchOptimization::solve(uint weekInTheYear, int hourInTheYear)
 {
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = true;
-    OPT_OptimisationHebdomadaire(problemeHebdo_, adqPatchParams_);
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_);
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = false;
 
     for (int pays = 0; pays < problemeHebdo_->NombreDePays; ++pays)
@@ -63,7 +64,7 @@ void AdequacyPatchOptimization::solve(uint weekInTheYear, int hourInTheYear)
     // TODO check if we need to cut SIM_RenseignementProblemeHebdo and just pick out the
     // part that we need
     ::SIM_RenseignementProblemeHebdo(*problemeHebdo_, weekInTheYear, thread_number_, hourInTheYear);
-    OPT_OptimisationHebdomadaire(problemeHebdo_, adqPatchParams_);
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_);
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
@@ -40,14 +40,16 @@ namespace Antares::Solver::Optimization
 AdequacyPatchOptimization::AdequacyPatchOptimization(const OptimizationOptions& options,
                                                      PROBLEME_HEBDO* problemeHebdo,
                                                      AdqPatchParams& adqPatchParams,
-                                                     uint thread_number) :
- WeeklyOptimization(options, problemeHebdo, adqPatchParams, thread_number)
+                                                     uint thread_number,
+                                                     IResultWriter& writer) :
+ WeeklyOptimization(options, problemeHebdo, adqPatchParams, thread_number, writer)
 {
 }
+
 void AdequacyPatchOptimization::solve(uint weekInTheYear, int hourInTheYear)
 {
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = true;
-    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_);
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_);
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = false;
 
     for (int pays = 0; pays < problemeHebdo_->NombreDePays; ++pays)
@@ -64,7 +66,7 @@ void AdequacyPatchOptimization::solve(uint weekInTheYear, int hourInTheYear)
     // TODO check if we need to cut SIM_RenseignementProblemeHebdo and just pick out the
     // part that we need
     ::SIM_RenseignementProblemeHebdo(*problemeHebdo_, weekInTheYear, thread_number_, hourInTheYear);
-    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_);
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_);
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.h
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.h
@@ -41,7 +41,8 @@ public:
     explicit AdequacyPatchOptimization(const OptimizationOptions& options,
                                        PROBLEME_HEBDO* problemeHebdo,
                                        Antares::Data::AdequacyPatch::AdqPatchParams&, 
-                                       uint numSpace);
+                                       uint numSpace,
+                                       IResultWriter& writer);
     ~AdequacyPatchOptimization() override = default;
     void solve(uint weekInTheYear, int hourInTheYear) override;
 };

--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.h
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.h
@@ -38,7 +38,8 @@ namespace Antares::Solver::Optimization
 class AdequacyPatchOptimization : public WeeklyOptimization
 {
 public:
-    explicit AdequacyPatchOptimization(PROBLEME_HEBDO* problemeHebdo, 
+    explicit AdequacyPatchOptimization(const OptimizationOptions& options,
+                                       PROBLEME_HEBDO* problemeHebdo,
                                        Antares::Data::AdequacyPatch::AdqPatchParams&, 
                                        uint numSpace);
     ~AdequacyPatchOptimization() override = default;

--- a/src/solver/optimisation/base_weekly_optimization.cpp
+++ b/src/solver/optimisation/base_weekly_optimization.cpp
@@ -34,9 +34,11 @@ using AdqPatchParams = Antares::Data::AdequacyPatch::AdqPatchParams;
 
 namespace Antares::Solver::Optimization
 {
-WeeklyOptimization::WeeklyOptimization(PROBLEME_HEBDO* problemesHebdo,
+WeeklyOptimization::WeeklyOptimization(const OptimizationOptions& options,
+                                       PROBLEME_HEBDO* problemesHebdo,
                                        AdqPatchParams& adqPatchParams,
                                        uint thread_number) :
+    options_(options),
     problemeHebdo_(problemesHebdo),
     adqPatchParams_(adqPatchParams),
     thread_number_(thread_number)
@@ -44,14 +46,15 @@ WeeklyOptimization::WeeklyOptimization(PROBLEME_HEBDO* problemesHebdo,
 }
 
 std::unique_ptr<WeeklyOptimization> WeeklyOptimization::create(
+    const OptimizationOptions& options,
     AdqPatchParams& adqPatchParams,
     PROBLEME_HEBDO* problemeHebdo,
     uint thread_number)
 {
     if (adqPatchParams.enabled && adqPatchParams.localMatching.enabled)
-        return std::make_unique<AdequacyPatchOptimization>(problemeHebdo, adqPatchParams, thread_number);
+        return std::make_unique<AdequacyPatchOptimization>(options, problemeHebdo, adqPatchParams, thread_number);
     else
-        return std::make_unique<DefaultWeeklyOptimization>(problemeHebdo, adqPatchParams, thread_number);
+        return std::make_unique<DefaultWeeklyOptimization>(options, problemeHebdo, adqPatchParams, thread_number);
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/base_weekly_optimization.cpp
+++ b/src/solver/optimisation/base_weekly_optimization.cpp
@@ -37,11 +37,13 @@ namespace Antares::Solver::Optimization
 WeeklyOptimization::WeeklyOptimization(const OptimizationOptions& options,
                                        PROBLEME_HEBDO* problemesHebdo,
                                        AdqPatchParams& adqPatchParams,
-                                       uint thread_number) :
+                                       uint thread_number,
+                                       IResultWriter& writer) :
     options_(options),
     problemeHebdo_(problemesHebdo),
     adqPatchParams_(adqPatchParams),
-    thread_number_(thread_number)
+    thread_number_(thread_number),
+    writer_(writer)
 {
 }
 
@@ -49,12 +51,13 @@ std::unique_ptr<WeeklyOptimization> WeeklyOptimization::create(
     const OptimizationOptions& options,
     AdqPatchParams& adqPatchParams,
     PROBLEME_HEBDO* problemeHebdo,
-    uint thread_number)
+    uint thread_number,
+    IResultWriter& writer)
 {
     if (adqPatchParams.enabled && adqPatchParams.localMatching.enabled)
-        return std::make_unique<AdequacyPatchOptimization>(options, problemeHebdo, adqPatchParams, thread_number);
+        return std::make_unique<AdequacyPatchOptimization>(options, problemeHebdo, adqPatchParams, thread_number, writer);
     else
-        return std::make_unique<DefaultWeeklyOptimization>(options, problemeHebdo, adqPatchParams, thread_number);
+        return std::make_unique<DefaultWeeklyOptimization>(options, problemeHebdo, adqPatchParams, thread_number, writer);
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/base_weekly_optimization.h
+++ b/src/solver/optimisation/base_weekly_optimization.h
@@ -38,14 +38,17 @@ class WeeklyOptimization
 public:
     virtual void solve(uint weekInTheYear, int hourInTheYear) = 0;
     virtual ~WeeklyOptimization() = default;
-    static std::unique_ptr<WeeklyOptimization> create(Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams,
+    static std::unique_ptr<WeeklyOptimization> create(const OptimizationOptions& options,
+                                                      Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams,
                                                       PROBLEME_HEBDO* problemesHebdo,
                                                       uint numSpace);
 
 protected:
-    explicit WeeklyOptimization(PROBLEME_HEBDO* problemesHebdo, 
+    explicit WeeklyOptimization(const OptimizationOptions& options,
+                                PROBLEME_HEBDO* problemesHebdo,
                                 Antares::Data::AdequacyPatch::AdqPatchParams&, 
                                 uint numSpace);
+    Antares::Solver::Optimization::OptimizationOptions options_;
     PROBLEME_HEBDO* const problemeHebdo_ = nullptr;
     Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams_;
     const uint thread_number_ = 0;

--- a/src/solver/optimisation/base_weekly_optimization.h
+++ b/src/solver/optimisation/base_weekly_optimization.h
@@ -41,16 +41,19 @@ public:
     static std::unique_ptr<WeeklyOptimization> create(const OptimizationOptions& options,
                                                       Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams,
                                                       PROBLEME_HEBDO* problemesHebdo,
-                                                      uint numSpace);
+                                                      uint numSpace,
+                                                      IResultWriter& writer);
 
 protected:
     explicit WeeklyOptimization(const OptimizationOptions& options,
                                 PROBLEME_HEBDO* problemesHebdo,
                                 Antares::Data::AdequacyPatch::AdqPatchParams&, 
-                                uint numSpace);
+                                uint numSpace,
+                                IResultWriter& writer);
     Antares::Solver::Optimization::OptimizationOptions options_;
     PROBLEME_HEBDO* const problemeHebdo_ = nullptr;
     Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams_;
     const uint thread_number_ = 0;
+    IResultWriter& writer_;
 };
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -94,7 +94,8 @@ private:
     clock::time_point start_;
     clock::time_point end_;
 };
-bool OPT_AppelDuSimplexe(PROBLEME_HEBDO* problemeHebdo,
+bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
+                         PROBLEME_HEBDO* problemeHebdo,
                          int NumIntervalle,
                          const int optimizationNumber,
                          std::shared_ptr<OptPeriodStringGenerator> optPeriodStringGenerator)
@@ -111,7 +112,6 @@ bool OPT_AppelDuSimplexe(PROBLEME_HEBDO* problemeHebdo,
     auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[(int)NumIntervalle]);
 
     auto study = Data::Study::Current::Get();
-    bool ortoolsUsed = study->parameters.ortoolsUsed;
 
     const int opt = optimizationNumber - 1;
     assert(opt >= 0 && opt < 2);
@@ -128,7 +128,7 @@ RESOLUTION:
     {
         if (problemeHebdo->ReinitOptimisation)
         {
-            if (ortoolsUsed && solver != nullptr)
+            if (options.useOrtools && solver != nullptr)
             {
                 ORTOOLS_LibererProbleme(solver);
             }
@@ -149,7 +149,7 @@ RESOLUTION:
             Probleme.BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
 
             TimeMeasurement measure;
-            if (ortoolsUsed)
+            if (options.useOrtools)
             {
                 ORTOOLS_ModifierLeVecteurCouts(
                   solver, ProblemeAResoudre->CoutLineaire.data(), ProblemeAResoudre->NombreDeVariables);
@@ -224,7 +224,7 @@ RESOLUTION:
 
     Probleme.NombreDeContraintesCoupes = 0;
 
-    if (ortoolsUsed)
+    if (options.useOrtools)
     {
         solver = ORTOOLS_ConvertIfNeeded(&Probleme, solver);
     }
@@ -233,13 +233,13 @@ RESOLUTION:
                                         problemeHebdo->exportMPSOnError,
                                         optimizationNumber,
                                         &Probleme,
-                                        ortoolsUsed,
+                                        options.useOrtools,
                                         solver);
     auto mps_writer = mps_writer_factory.create();
     mps_writer->runIfNeeded(study->resultWriter, filename);
 
     TimeMeasurement measure;
-    if (ortoolsUsed)
+    if (options.useOrtools)
     {
         const bool keepBasis = (optimizationNumber == PREMIERE_OPTIMISATION);
         solver = ORTOOLS_Simplexe(&Probleme, solver, keepBasis);
@@ -265,7 +265,7 @@ RESOLUTION:
     {
         if (ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE)
         {
-            if (ortoolsUsed && solver != nullptr)
+            if (options.useOrtools && solver != nullptr)
             {
                 ORTOOLS_LibererProbleme(solver);
             }

--- a/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
@@ -154,13 +154,12 @@ static void shortTermStorageLevels(
     }
 }
 
-void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire(PROBLEME_HEBDO* problemeHebdo)
+void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire(PROBLEME_HEBDO* problemeHebdo, Solver::IResultWriter& writer)
 {
     int var;
 
     CORRESPONDANCES_DES_VARIABLES* CorrespondanceVarNativesVarOptim;
 
-    Study::Ptr study = Study::Current::Get();
     const bool exportStructure = problemeHebdo->ExportStructure;
     const bool firstWeekOfSimulation = problemeHebdo->firstWeekOfSimulation;
 
@@ -1067,8 +1066,8 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire(PROBLEME_HEBDO* pro
     // Export structure
     if (exportStructure && firstWeekOfSimulation)
     {
-        OPT_ExportInterco(study->resultWriter, problemeHebdo);
-        OPT_ExportAreaName(study->resultWriter, study->areas);
+        OPT_ExportInterco(writer, problemeHebdo);
+        OPT_ExportAreaName(writer, problemeHebdo->NomsDesPays);
     }
 
     return;

--- a/src/solver/optimisation/opt_export_structure.cpp
+++ b/src/solver/optimisation/opt_export_structure.cpp
@@ -34,7 +34,7 @@
 // Export de la structure des LPs
 ////////////////////////////////////////////////////////////////////
 
-void OPT_ExportInterco(const Antares::Solver::IResultWriter::Ptr writer,
+void OPT_ExportInterco(Antares::Solver::IResultWriter& writer,
                        PROBLEME_HEBDO* problemeHebdo)
 {
     Yuni::Clob Flot;
@@ -47,18 +47,18 @@ void OPT_ExportInterco(const Antares::Solver::IResultWriter::Ptr writer,
     }
     // TODO[FOM] "interco.txt"
     std::string filename = "interco-1-1.txt";
-    writer->addEntryFromBuffer(filename, Flot);
+    writer.addEntryFromBuffer(filename, Flot);
 }
 
-void OPT_ExportAreaName(Antares::Solver::IResultWriter::Ptr writer,
-                        const Antares::Data::AreaList& areas)
+void OPT_ExportAreaName(Antares::Solver::IResultWriter& writer,
+                        const std::vector<const char*>& areaNames)
 {
     // TODO[FOM] "area.txt"
     std::string filename = "area-1-1.txt";
     Yuni::Clob Flot;
-    for (uint i = 0; i < areas.size(); ++i)
+    for (const char* name: areaNames)
     {
-        Flot.appendFormat("%s\n", areas[i]->name.c_str());
+        Flot.appendFormat("%s\n", name);
     }
-    writer->addEntryFromBuffer(filename, Flot);
+    writer.addEntryFromBuffer(filename, Flot);
 }

--- a/src/solver/optimisation/opt_export_structure.h
+++ b/src/solver/optimisation/opt_export_structure.h
@@ -48,9 +48,9 @@ class Study;
 
 struct PROBLEME_HEBDO;
 
-void OPT_ExportInterco(const Antares::Solver::IResultWriter::Ptr writer,
+void OPT_ExportInterco(Antares::Solver::IResultWriter& writer,
                        PROBLEME_HEBDO* problemeHebdo);
-void OPT_ExportAreaName(Antares::Solver::IResultWriter::Ptr writer,
-                        const Antares::Data::AreaList& areas);
+void OPT_ExportAreaName(Antares::Solver::IResultWriter& writer,
+                        const std::vector<const char*>& areaNames);
 
 #endif

--- a/src/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/opt_fonctions.h
@@ -33,10 +33,12 @@
 #include "adequacy_patch_csr/hourly_csr_problem.h"
 #include "opt_period_string_generator_base.h"
 #include "antares/study/parameters/adq-patch-params.h"
+#include "opt_structure_probleme_a_resoudre.h"
 
 using AdqPatchParams = Antares::Data::AdequacyPatch::AdqPatchParams;
+using OptimizationOptions = Antares::Solver::Optimization::OptimizationOptions;
 
-void OPT_OptimisationHebdomadaire(PROBLEME_HEBDO*, AdqPatchParams&);
+void OPT_OptimisationHebdomadaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&);
 void OPT_NumeroDeJourDuPasDeTemps(PROBLEME_HEBDO*);
 void OPT_NumeroDIntervalleOptimiseDuPasDeTemps(PROBLEME_HEBDO*);
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(PROBLEME_HEBDO*);
@@ -66,7 +68,7 @@ bool ADQ_PATCH_CSR(PROBLEME_ANTARES_A_RESOUDRE&,
                    uint week,
                    int year);
 
-bool OPT_PilotageOptimisationLineaire(PROBLEME_HEBDO*, AdqPatchParams&);
+bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&);
 void OPT_VerifierPresenceReserveJmoins1(PROBLEME_HEBDO*);
 bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO*);
 
@@ -75,12 +77,13 @@ bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO*);
 **
 ** \return True si l'operation s'est bien deroulee, false si le probleme n'a pas de solution
 */
-bool OPT_AppelDuSimplexe(PROBLEME_HEBDO*,
+bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
+                         PROBLEME_HEBDO*,
                          int,
                          const int,
                          std::shared_ptr<OptPeriodStringGenerator>);
 void OPT_LiberationProblemesSimplexe(const PROBLEME_HEBDO*);
-bool OPT_OptimisationLineaire(PROBLEME_HEBDO*, AdqPatchParams&);
+bool OPT_OptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&);
 void OPT_RestaurerLesDonnees(const PROBLEME_HEBDO*, const int);
 /*------------------------------*/
 

--- a/src/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/opt_fonctions.h
@@ -38,12 +38,13 @@
 using AdqPatchParams = Antares::Data::AdequacyPatch::AdqPatchParams;
 using OptimizationOptions = Antares::Solver::Optimization::OptimizationOptions;
 
-void OPT_OptimisationHebdomadaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&);
+void OPT_OptimisationHebdomadaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&,
+                                  Solver::IResultWriter& writer);
 void OPT_NumeroDeJourDuPasDeTemps(PROBLEME_HEBDO*);
 void OPT_NumeroDIntervalleOptimiseDuPasDeTemps(PROBLEME_HEBDO*);
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(PROBLEME_HEBDO*);
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeQuadratique(PROBLEME_HEBDO*);
-void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire(PROBLEME_HEBDO*);
+void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire(PROBLEME_HEBDO*, Solver::IResultWriter& writer);
 void OPT_ConstruireLaMatriceDesContraintesDuProblemeQuadratique(PROBLEME_HEBDO*);
 void OPT_InitialiserLesPminHebdo(PROBLEME_HEBDO*);
 void OPT_InitialiserLesContrainteDEnergieHydrauliqueParIntervalleOptimise(PROBLEME_HEBDO*);
@@ -68,7 +69,8 @@ bool ADQ_PATCH_CSR(PROBLEME_ANTARES_A_RESOUDRE&,
                    uint week,
                    int year);
 
-bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&);
+bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&,
+                                      Solver::IResultWriter& writer);
 void OPT_VerifierPresenceReserveJmoins1(PROBLEME_HEBDO*);
 bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO*);
 
@@ -81,9 +83,12 @@ bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
                          PROBLEME_HEBDO*,
                          int,
                          const int,
-                         std::shared_ptr<OptPeriodStringGenerator>);
-void OPT_LiberationProblemesSimplexe(const PROBLEME_HEBDO*);
-bool OPT_OptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&);
+                         std::shared_ptr<OptPeriodStringGenerator>,
+                         Solver::IResultWriter& writer);
+void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options, const PROBLEME_HEBDO*);
+
+bool OPT_OptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO*, AdqPatchParams&,
+                              Solver::IResultWriter& writer);
 void OPT_RestaurerLesDonnees(const PROBLEME_HEBDO*, const int);
 /*------------------------------*/
 
@@ -105,9 +110,6 @@ int OPT_DecompteDesVariablesEtDesContraintesDuProblemeAOptimiser(PROBLEME_HEBDO*
 void OPT_AugmenterLaTailleDeLaMatriceDesContraintes(PROBLEME_ANTARES_A_RESOUDRE*);
 void OPT_LiberationMemoireDuProblemeAOptimiser(PROBLEME_HEBDO*);
 
-void OPT_EcrireResultatFonctionObjectiveAuFormatTXT(double,
-                                                    std::shared_ptr<OptPeriodStringGenerator>,
-                                                    int);
 
 /*------------------------------*/
 

--- a/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
@@ -93,8 +93,6 @@ void OPT_InitialiserLesCoutsLineaire(PROBLEME_HEBDO* problemeHebdo,
                                      const int PremierPdtDeLIntervalle,
                                      const int DernierPdtDeLIntervalle)
 {
-    const auto& study = *Antares::Data::Study::Current::Get();
-
     PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     int pdtJour = 0;
@@ -144,7 +142,6 @@ void OPT_InitialiserLesCoutsLineaire(PROBLEME_HEBDO* problemeHebdo,
 
         for (int pays = 0; pays < problemeHebdo->NombreDePays; ++pays)
         {
-            assert((unsigned int)pays < study.areas.size());
             const PALIERS_THERMIQUES& PaliersThermiquesDuPays
               = problemeHebdo->PaliersThermiquesDuPays[pays];
             int var;

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -45,7 +45,7 @@ extern "C"
 
 using namespace Antares;
 
-void OPT_LiberationProblemesSimplexe(const PROBLEME_HEBDO* problemeHebdo)
+void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options, const PROBLEME_HEBDO* problemeHebdo)
 {
     int NombreDePasDeTempsPourUneOptimisation;
     if (!problemeHebdo->OptimisationAuPasHebdomadaire)
@@ -59,9 +59,6 @@ void OPT_LiberationProblemesSimplexe(const PROBLEME_HEBDO* problemeHebdo)
     if (!ProblemeAResoudre)
         return;
 
-    const auto& study = *Data::Study::Current::Get();
-    bool ortoolsUsed = study.parameters.ortoolsUsed;
-
     if (!problemeHebdo->LeProblemeADejaEteInstancie)
     {
         for (int numIntervalle = 0; numIntervalle < nbIntervalles; numIntervalle++)
@@ -70,7 +67,7 @@ void OPT_LiberationProblemesSimplexe(const PROBLEME_HEBDO* problemeHebdo)
               = (PROBLEME_SPX*)(ProblemeAResoudre->ProblemesSpx[numIntervalle]);
             auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[numIntervalle]);
 
-            if (ortoolsUsed && solver != NULL)
+            if (options.useOrtools && solver != NULL)
             {
                 ORTOOLS_LibererProbleme(solver);
                 solver = NULL;

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -47,11 +47,12 @@ using namespace Antares::Data;
 
 using Antares::Solver::Optimization::OptimizationOptions;
 
-void OPT_OptimisationHebdomadaire(const OptimizationOptions& options, PROBLEME_HEBDO* pProblemeHebdo, AdqPatchParams& adqPatchParams)
+void OPT_OptimisationHebdomadaire(const OptimizationOptions& options, PROBLEME_HEBDO* pProblemeHebdo, AdqPatchParams& adqPatchParams,
+                                  Solver::IResultWriter& writer)
 {
     if (pProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE)
     {
-        if (!OPT_PilotageOptimisationLineaire(options, pProblemeHebdo, adqPatchParams))
+        if (!OPT_PilotageOptimisationLineaire(options, pProblemeHebdo, adqPatchParams, writer))
         {
             logs.error() << "Linear optimization failed";
             throw UnfeasibleProblemError("Linear optimization failed");
@@ -59,7 +60,7 @@ void OPT_OptimisationHebdomadaire(const OptimizationOptions& options, PROBLEME_H
     }
     else if (pProblemeHebdo->TypeDOptimisation == OPTIMISATION_QUADRATIQUE)
     {
-        OPT_LiberationProblemesSimplexe(pProblemeHebdo);
+        OPT_LiberationProblemesSimplexe(options, pProblemeHebdo);
         if (!OPT_PilotageOptimisationQuadratique(pProblemeHebdo))
         {
             logs.error() << "Quadratic optimization failed";

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -45,11 +45,13 @@ extern "C"
 using namespace Antares;
 using namespace Antares::Data;
 
-void OPT_OptimisationHebdomadaire(PROBLEME_HEBDO* pProblemeHebdo, AdqPatchParams& adqPatchParams)
+using Antares::Solver::Optimization::OptimizationOptions;
+
+void OPT_OptimisationHebdomadaire(const OptimizationOptions& options, PROBLEME_HEBDO* pProblemeHebdo, AdqPatchParams& adqPatchParams)
 {
     if (pProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE)
     {
-        if (!OPT_PilotageOptimisationLineaire(pProblemeHebdo, adqPatchParams))
+        if (!OPT_PilotageOptimisationLineaire(options, pProblemeHebdo, adqPatchParams))
         {
             logs.error() << "Linear optimization failed";
             throw UnfeasibleProblemError("Linear optimization failed");

--- a/src/solver/optimisation/opt_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_optimisation_lineaire.cpp
@@ -35,6 +35,7 @@
 
 using namespace Antares;
 using namespace Yuni;
+using Antares::Solver::Optimization::OptimizationOptions;
 
 double OPT_ObjectiveFunctionResult(const PROBLEME_HEBDO* Probleme,
                                    const int NumeroDeLIntervalle,
@@ -46,7 +47,7 @@ double OPT_ObjectiveFunctionResult(const PROBLEME_HEBDO* Probleme,
         return Probleme->coutOptimalSolution2[NumeroDeLIntervalle];
 }
 
-bool OPT_OptimisationLineaire(PROBLEME_HEBDO* problemeHebdo, AdqPatchParams& adqPatchParams)
+bool OPT_OptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO* problemeHebdo, AdqPatchParams& adqPatchParams)
 {
     int optimizationNumber = PREMIERE_OPTIMISATION;
 
@@ -105,7 +106,7 @@ OptimisationHebdo:
                                     problemeHebdo->weekInTheYear,
                                     problemeHebdo->year);
 
-        if (!OPT_AppelDuSimplexe(
+        if (!OPT_AppelDuSimplexe(options,
               problemeHebdo, numeroDeLIntervalle, optimizationNumber, optPeriodStringGenerator))
             return false;
 

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -38,7 +38,8 @@
 
 using Antares::Solver::Optimization::OptimizationOptions;
 
-bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO* problemeHebdo, AdqPatchParams& adqPatchParams)
+bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO* problemeHebdo, AdqPatchParams& adqPatchParams,
+                                      Solver::IResultWriter& writer)
 {
     if (!problemeHebdo->LeProblemeADejaEteInstancie)
     {
@@ -84,5 +85,5 @@ bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options, PROBLE
         OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage(problemeHebdo);
     }
 
-    return OPT_OptimisationLineaire(options, problemeHebdo, adqPatchParams);
+    return OPT_OptimisationLineaire(options, problemeHebdo, adqPatchParams, writer);
 }

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -36,7 +36,9 @@
 #include "spx_definition_arguments.h"
 #include "spx_fonctions.h"
 
-bool OPT_PilotageOptimisationLineaire(PROBLEME_HEBDO* problemeHebdo, AdqPatchParams& adqPatchParams)
+using Antares::Solver::Optimization::OptimizationOptions;
+
+bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options, PROBLEME_HEBDO* problemeHebdo, AdqPatchParams& adqPatchParams)
 {
     if (!problemeHebdo->LeProblemeADejaEteInstancie)
     {
@@ -82,5 +84,5 @@ bool OPT_PilotageOptimisationLineaire(PROBLEME_HEBDO* problemeHebdo, AdqPatchPar
         OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage(problemeHebdo);
     }
 
-    return OPT_OptimisationLineaire(problemeHebdo, adqPatchParams);
+    return OPT_OptimisationLineaire(options, problemeHebdo, adqPatchParams);
 }

--- a/src/solver/optimisation/opt_structure_probleme_a_resoudre.h
+++ b/src/solver/optimisation/opt_structure_probleme_a_resoudre.h
@@ -33,6 +33,16 @@
 
 /*--------------------------------------------------------------------------------------*/
 
+namespace Antares::Solver::Optimization {
+
+struct OptimizationOptions
+{
+    bool useOrtools;
+    std::string solverName;
+};
+
+}
+
 /* Le probleme a resoudre */
 typedef struct
 {

--- a/src/solver/optimisation/weekly_optimization.cpp
+++ b/src/solver/optimisation/weekly_optimization.cpp
@@ -30,16 +30,17 @@
 
 namespace Antares::Solver::Optimization
 {
-DefaultWeeklyOptimization::DefaultWeeklyOptimization(PROBLEME_HEBDO* problemeHebdo,
+DefaultWeeklyOptimization::DefaultWeeklyOptimization(const OptimizationOptions& options,
+                                                     PROBLEME_HEBDO* problemeHebdo,
                                                      AdqPatchParams& adqPatchParams,
                                                      uint thread_number) :
- WeeklyOptimization(problemeHebdo, adqPatchParams, thread_number)
+ WeeklyOptimization(options, problemeHebdo, adqPatchParams, thread_number)
 {
 }
 
 void DefaultWeeklyOptimization::solve(uint, int)
 {
-    OPT_OptimisationHebdomadaire(problemeHebdo_, adqPatchParams_);
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_);
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/weekly_optimization.cpp
+++ b/src/solver/optimisation/weekly_optimization.cpp
@@ -33,14 +33,15 @@ namespace Antares::Solver::Optimization
 DefaultWeeklyOptimization::DefaultWeeklyOptimization(const OptimizationOptions& options,
                                                      PROBLEME_HEBDO* problemeHebdo,
                                                      AdqPatchParams& adqPatchParams,
-                                                     uint thread_number) :
- WeeklyOptimization(options, problemeHebdo, adqPatchParams, thread_number)
+                                                     uint thread_number,
+                                                     IResultWriter& writer) :
+ WeeklyOptimization(options, problemeHebdo, adqPatchParams, thread_number, writer)
 {
 }
 
 void DefaultWeeklyOptimization::solve(uint, int)
 {
-    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_);
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_);
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/weekly_optimization.h
@@ -35,7 +35,8 @@ namespace Antares::Solver::Optimization
 class DefaultWeeklyOptimization : public WeeklyOptimization
 {
 public:
-    explicit DefaultWeeklyOptimization(PROBLEME_HEBDO* problemeHebdo, 
+    explicit DefaultWeeklyOptimization(const OptimizationOptions& options,
+                                       PROBLEME_HEBDO* problemeHebdo,
                                        Antares::Data::AdequacyPatch::AdqPatchParams&, 
                                        uint numSpace);
     ~DefaultWeeklyOptimization() override = default;

--- a/src/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/weekly_optimization.h
@@ -38,7 +38,8 @@ public:
     explicit DefaultWeeklyOptimization(const OptimizationOptions& options,
                                        PROBLEME_HEBDO* problemeHebdo,
                                        Antares::Data::AdequacyPatch::AdqPatchParams&, 
-                                       uint numSpace);
+                                       uint numSpace,
+                                       IResultWriter& writer);
     ~DefaultWeeklyOptimization() override = default;
     void solve(uint, int) override;
 };

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -211,7 +211,8 @@ bool Adequacy::year(Progression::Task& progression,
 
             try
             {
-                OPT_OptimisationHebdomadaire(pProblemesHebdo[numSpace],
+                OPT_OptimisationHebdomadaire(createOptimizationOptions(study),
+                                             pProblemesHebdo[numSpace],
                                              study.parameters.adqPatchParams);
 
                 computingHydroLevels(study.areas, *pProblemesHebdo[numSpace], false);

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -213,7 +213,8 @@ bool Adequacy::year(Progression::Task& progression,
             {
                 OPT_OptimisationHebdomadaire(createOptimizationOptions(study),
                                              pProblemesHebdo[numSpace],
-                                             study.parameters.adqPatchParams);
+                                             study.parameters.adqPatchParams,
+                                             *study.resultWriter);
 
                 computingHydroLevels(study.areas, *pProblemesHebdo[numSpace], false);
 

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -96,7 +96,7 @@ static void RecalculDesEchangesMoyens(Data::Study& study,
 
     try
     {
-        OPT_OptimisationHebdomadaire(&problem, study.parameters.adqPatchParams);
+        OPT_OptimisationHebdomadaire(createOptimizationOptions(study), &problem, study.parameters.adqPatchParams);
     }
     catch (Data::UnfeasibleProblemError&)
     {
@@ -400,5 +400,14 @@ void finalizeOptimizationStatistics(PROBLEME_HEBDO& problem,
     state.averageOptimizationTime2 = secondOptStat.getAverageSolveTime();
     secondOptStat.reset();
 }
+
+OptimizationOptions createOptimizationOptions(const Data::Study& study)
+{
+    return {
+        study.parameters.ortoolsUsed,
+        study.parameters.ortoolsSolver
+    };
+}
+
 
 } // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -96,7 +96,7 @@ static void RecalculDesEchangesMoyens(Data::Study& study,
 
     try
     {
-        OPT_OptimisationHebdomadaire(createOptimizationOptions(study), &problem, study.parameters.adqPatchParams);
+        OPT_OptimisationHebdomadaire(createOptimizationOptions(study), &problem, study.parameters.adqPatchParams, *study.resultWriter);
     }
     catch (Data::UnfeasibleProblemError&)
     {

--- a/src/solver/simulation/common-eco-adq.h
+++ b/src/solver/simulation/common-eco-adq.h
@@ -160,6 +160,9 @@ int retrieveAverageNTC(const Data::Study& study,
 
 void finalizeOptimizationStatistics(PROBLEME_HEBDO& problem,
                                     Antares::Solver::Variable::State& state);
+
+OptimizationOptions createOptimizationOptions(const Data::Study& study);
+
 } // namespace Simulation
 } // namespace Solver
 } // namespace Antares

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -99,8 +99,10 @@ bool Economy::simulationBegin()
                 return false;
             }
 
+            auto options = createOptimizationOptions(study);
             weeklyOptProblems_[numSpace] =
                 Antares::Solver::Optimization::WeeklyOptimization::create(
+                                                    options,
                                                     study.parameters.adqPatchParams,
                                                     pProblemesHebdo[numSpace],
                                                     numSpace);

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -105,7 +105,8 @@ bool Economy::simulationBegin()
                                                     options,
                                                     study.parameters.adqPatchParams,
                                                     pProblemesHebdo[numSpace],
-                                                    numSpace);
+                                                    numSpace,
+                                                    *study.resultWriter);
             postProcessesList_[numSpace] =
                 interfacePostProcessList::create(study.parameters.adqPatchParams,
                                                  pProblemesHebdo[numSpace],

--- a/src/solver/utils/mps_utils.cpp
+++ b/src/solver/utils/mps_utils.cpp
@@ -106,7 +106,7 @@ private:
 };
 
 void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(PROBLEME_SIMPLEXE_NOMME* Prob,
-                                               const Solver::IResultWriter::Ptr& writer,
+                                               Solver::IResultWriter& writer,
                                                const std::string& filename)
 {
     logs.info() << "Solver MPS File: `" << filename << "'";
@@ -121,7 +121,7 @@ void OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(PROBLEME_SIMPLEXE_NOMME* Prob,
         SRSwritempsprob(mps.get(), tmpPath.c_str());
     }
 
-    writer->addEntryFromFile(filename, tmpPath);
+    writer.addEntryFromFile(filename, tmpPath);
 
     removeTemporaryFile(tmpPath);
 }
@@ -134,7 +134,7 @@ fullMPSwriter::fullMPSwriter(PROBLEME_SIMPLEXE_NOMME* named_splx_problem, uint o
 {
 }
 
-void fullMPSwriter::runIfNeeded(Solver::IResultWriter::Ptr writer, const std::string& filename)
+void fullMPSwriter::runIfNeeded(Solver::IResultWriter& writer, const std::string& filename)
 {
     OPT_EcrireJeuDeDonneesLineaireAuFormatMPS(named_splx_problem_, writer, filename);
 }
@@ -146,7 +146,7 @@ fullOrToolsMPSwriter::fullOrToolsMPSwriter(MPSolver* solver, uint optNumber) :
  I_MPS_writer(optNumber), solver_(solver)
 {
 }
-void fullOrToolsMPSwriter::runIfNeeded(Solver::IResultWriter::Ptr writer,
+void fullOrToolsMPSwriter::runIfNeeded(Solver::IResultWriter& writer,
                                        const std::string& filename)
 {
     ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(solver_, writer, filename);

--- a/src/solver/utils/mps_utils.h
+++ b/src/solver/utils/mps_utils.h
@@ -27,7 +27,7 @@ public:
     {
     }
     I_MPS_writer() = default;
-    virtual void runIfNeeded(Solver::IResultWriter::Ptr writer, const std::string& filename) = 0;
+    virtual void runIfNeeded(Solver::IResultWriter& writer, const std::string& filename) = 0;
 
 protected:
     uint current_optim_number_ = 0;
@@ -37,7 +37,7 @@ class fullMPSwriter final : public I_MPS_writer
 {
 public:
     fullMPSwriter(PROBLEME_SIMPLEXE_NOMME* named_splx_problem, uint currentOptimNumber);
-    void runIfNeeded(Solver::IResultWriter::Ptr writer, const std::string& filename) override;
+    void runIfNeeded(Solver::IResultWriter& writer, const std::string& filename) override;
 
 private:
     PROBLEME_SIMPLEXE_NOMME* named_splx_problem_ = nullptr;
@@ -47,7 +47,7 @@ class fullOrToolsMPSwriter : public I_MPS_writer
 {
 public:
     fullOrToolsMPSwriter(MPSolver* solver, uint currentOptimNumber);
-    void runIfNeeded(Solver::IResultWriter::Ptr writer, const std::string& filename) override;
+    void runIfNeeded(Solver::IResultWriter& writer, const std::string& filename) override;
 
 private:
     MPSolver* solver_ = nullptr;
@@ -57,7 +57,7 @@ class nullMPSwriter : public I_MPS_writer
 {
 public:
     using I_MPS_writer::I_MPS_writer;
-    void runIfNeeded(Solver::IResultWriter::Ptr /*writer*/,
+    void runIfNeeded(Solver::IResultWriter& /*writer*/,
                      const std::string& /*filename*/) override
     {
         // Does nothing

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -224,7 +224,7 @@ void removeTemporaryFile(const std::string& tmpPath)
 }
 
 void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
-                                                   Antares::Solver::IResultWriter::Ptr writer,
+                                                   Antares::Solver::IResultWriter& writer,
                                                    const std::string& filename)
 {
     // 0. Logging file name
@@ -237,7 +237,7 @@ void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
     solver->Write(tmpPath);
 
     // 3. Copy to real output using generic writer
-    writer->addEntryFromFile(filename, tmpPath);
+    writer.addEntryFromFile(filename, tmpPath);
 
     // 4. Remove tmp file
     removeTemporaryFile(tmpPath);

--- a/src/solver/utils/ortools_utils.h
+++ b/src/solver/utils/ortools_utils.h
@@ -11,7 +11,7 @@
 using namespace operations_research;
 
 void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
-                                                   Antares::Solver::IResultWriter::Ptr writer,
+                                                   Antares::Solver::IResultWriter& writer,
                                                    const std::string& filename);
 
 /*!


### PR DESCRIPTION
**Related issue**
See #1119 

**Description**

As a first step, the "current" study singleton is removed from the optimization module.

All "back references" to study in the optimization module are removed.

Only the necessary options are passed from the simulation module to the optimization modules, which means:
- the writer (`IResultWriter&`)
- options to decide on the solver to be used (new data struct `OptimizationOptions`, to be renamed solver options ?)


