### PR TITLE
Remove unused headers in optimization module

### DIFF
--- a/src/solver/optimisation/adequacy_patch_csr/construct_problem_constraints_RHS.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/construct_problem_constraints_RHS.cpp
@@ -27,7 +27,6 @@
 
 #include "../solver/optimisation/opt_structure_probleme_a_resoudre.h"
 #include "../simulation/adequacy_patch_runtime_data.h"
-#include "../solver/simulation/simulation.h"
 #include "hourly_csr_problem.h"
 
 void HourlyCSRProblem::setRHSvalueOnFlows()

--- a/src/solver/optimisation/adequacy_patch_csr/construct_problem_variables.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/construct_problem_variables.cpp
@@ -26,8 +26,6 @@
 */
 
 #include "../solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "../solver/simulation/simulation.h"
-#include "../solver/simulation/sim_structure_donnees.h"
 #include "../simulation/adequacy_patch_runtime_data.h"
 #include "hourly_csr_problem.h"
 

--- a/src/solver/optimisation/adequacy_patch_csr/csr_quadratic_problem.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/csr_quadratic_problem.cpp
@@ -28,8 +28,6 @@
 #include <vector>
 #include "../solver/optimisation/opt_structure_probleme_a_resoudre.h"
 
-#include "../solver/simulation/simulation.h"
-#include "../solver/simulation/sim_structure_donnees.h"
 #include "../simulation/adequacy_patch_runtime_data.h"
 #include "../solver/optimisation/opt_fonctions.h"
 #include "csr_quadratic_problem.h"

--- a/src/solver/optimisation/adequacy_patch_csr/set_problem_cost_function.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/set_problem_cost_function.cpp
@@ -25,12 +25,7 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <algorithm>
-
 #include "../solver/optimisation/opt_structure_probleme_a_resoudre.h"
-
-#include "../solver/simulation/simulation.h"
-#include "../solver/simulation/sim_structure_donnees.h"
 #include "../simulation/adequacy_patch_runtime_data.h"
 
 #include "../solver/optimisation/opt_fonctions.h"

--- a/src/solver/optimisation/adequacy_patch_csr/set_variable_boundaries.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/set_variable_boundaries.cpp
@@ -27,7 +27,6 @@
 
 #include "../solver/optimisation/opt_structure_probleme_a_resoudre.h"
 
-#include "../solver/simulation/simulation.h"
 #include "../solver/simulation/sim_structure_donnees.h"
 #include "../simulation/adequacy_patch_runtime_data.h"
 
@@ -35,7 +34,6 @@
 
 #include "pi_constantes_externes.h"
 
-#include <math.h>
 #include <yuni/core/math.h>
 
 using namespace Yuni;

--- a/src/solver/optimisation/adequacy_patch_csr/solve_problem.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/solve_problem.cpp
@@ -25,15 +25,10 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <limits>
-
 #include "../solver/optimisation/opt_structure_probleme_a_resoudre.h"
 
 #include "../solver/simulation/simulation.h"
-#include "../solver/simulation/sim_structure_donnees.h"
 #include "../solver/simulation/sim_structure_probleme_economique.h"
-#include "../solver/simulation/sim_structure_probleme_adequation.h"
-#include "../solver/simulation/sim_extern_variables_globales.h"
 
 #include "../solver/optimisation/opt_fonctions.h"
 

--- a/src/solver/optimisation/opt_alloc_probleme_a_optimiser.cpp
+++ b/src/solver/optimisation/opt_alloc_probleme_a_optimiser.cpp
@@ -25,24 +25,16 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <limits>
-
 #include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_structure_probleme_economique.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
-#include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-
-#include "spx_definition_arguments.h"
-#include "spx_fonctions.h"
 #include <stdio.h>
 
 #include <antares/logs.h>
-#include <antares/emergency.h>
 
 using namespace Antares;
 

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -26,15 +26,10 @@
 */
 
 #include <yuni/yuni.h>
-#include <yuni/core/string.h>
 #include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_structure_probleme_economique.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
-#include "../simulation/sim_extern_variables_globales.h"
-
 #include "opt_fonctions.h"
 
 extern "C"
@@ -46,11 +41,9 @@ extern "C"
 }
 
 #include <antares/logs.h>
-#include <antares/study.h>
 #include <antares/emergency.h>
 
 #include "../utils/mps_utils.h"
-#include "../utils/ortools_utils.h"
 #include "../utils/filename.h"
 
 #include "../infeasible-problem-analysis/problem.h"

--- a/src/solver/optimisation/opt_appel_solveur_quadratique.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_quadratique.cpp
@@ -29,12 +29,6 @@
 
 #include "opt_structure_probleme_a_resoudre.h"
 
-#include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
-#include "../simulation/sim_structure_probleme_economique.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
-#include "../simulation/sim_extern_variables_globales.h"
-
 #include "opt_fonctions.h"
 
 /*

--- a/src/solver/optimisation/opt_calcul_des_pmin_MUT_MDT.cpp
+++ b/src/solver/optimisation/opt_calcul_des_pmin_MUT_MDT.cpp
@@ -32,7 +32,6 @@
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
-#include <yuni/io/file.h>
 #include "opt_fonctions.h"
 
 constexpr double ZERO_PMIN = 1.e-2;

--- a/src/solver/optimisation/opt_chainage_intercos.cpp
+++ b/src/solver/optimisation/opt_chainage_intercos.cpp
@@ -25,8 +25,6 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include "opt_structure_probleme_a_resoudre.h"
-
 #include "../simulation/simulation.h"
 #include "../simulation/sim_extern_variables_globales.h"
 

--- a/src/solver/optimisation/opt_construction_contraintes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_construction_contraintes_couts_demarrage.cpp
@@ -25,23 +25,14 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <math.h>
-
 #include "opt_structure_probleme_a_resoudre.h"
 
-#include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_structure_probleme_economique.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
-#include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-
-#include <antares/study.h>
-#include <antares/study/area/scratchpad.h>
-#include "../simulation/sim_structure_donnees.h"
 #include "opt_rename_problem.h"
-#include "opt_export_structure.h"
+
 using namespace Antares::Data;
 
 void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaireCoutsDeDemarrage(

--- a/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
@@ -26,8 +26,6 @@
 */
 #include "opt_structure_probleme_a_resoudre.h"
 #include "opt_export_structure.h"
-
-#include "../simulation/simulation.h"
 #include "../utils/filename.h"
 #include "opt_fonctions.h"
 #include "opt_rename_problem.h"

--- a/src/solver/optimisation/opt_construction_matrice_des_contraintes_outils.cpp
+++ b/src/solver/optimisation/opt_construction_matrice_des_contraintes_outils.cpp
@@ -27,9 +27,7 @@
 
 #include "opt_structure_probleme_a_resoudre.h"
 
-#include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
-#include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
 

--- a/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
+++ b/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
@@ -27,13 +27,10 @@
 
 #include "opt_structure_probleme_a_resoudre.h"
 
-#include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
 #include "opt_rename_problem.h"
-#include <math.h>
 
 #include "spx_constantes_externes.h"
 

--- a/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
@@ -25,14 +25,9 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 #include "opt_structure_probleme_a_resoudre.h"
-
-#include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
-
 #include "opt_fonctions.h"
 #include "opt_rename_problem.h"
-#include <math.h>
 
 #include "spx_constantes_externes.h"
 

--- a/src/solver/optimisation/opt_decompte_variables_et_contraintes.cpp
+++ b/src/solver/optimisation/opt_decompte_variables_et_contraintes.cpp
@@ -28,7 +28,6 @@
 #include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"

--- a/src/solver/optimisation/opt_decompte_variables_et_contraintes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_decompte_variables_et_contraintes_couts_demarrage.cpp
@@ -25,10 +25,7 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include "opt_structure_probleme_a_resoudre.h"
-
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -27,24 +27,16 @@
 
 #include "opt_structure_probleme_a_resoudre.h"
 
-#include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_structure_probleme_economique.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
 #include "../simulation/adequacy_patch_runtime_data.h"
 
 #include "opt_fonctions.h"
 #include "adequacy_patch_local_matching/adq_patch_local_matching.h"
-#include <math.h>
 #include <yuni/core/math.h>
-#include <limits.h>
 
 #include "spx_constantes_externes.h"
 
-#define EPSILON_DEFAILLANCE 1e-3
-#include <antares/logs.h>
-#include <antares/study.h>
-#include <antares/emergency.h>
 using namespace Antares;
 using namespace Antares::Data;
 

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp
@@ -28,14 +28,12 @@
 #include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
 
 #include "pi_constantes_externes.h"
 
-#include <math.h>
 #include <yuni/core/math.h>
 
 #define ZERO_POUR_LES_VARIABLES_FIXES 1.e-6

--- a/src/solver/optimisation/opt_gestion_des_bornes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_couts_demarrage.cpp
@@ -30,17 +30,7 @@
 #include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_structure_probleme_economique.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
-#include "../simulation/sim_extern_variables_globales.h"
-
 #include "opt_fonctions.h"
-#include <math.h>
-#include <yuni/core/math.h>
-#include <limits.h>
-
-#include "spx_constantes_externes.h"
-
-#define EPSILON_DEFAILLANCE 1e-3
 
 using namespace Yuni;
 

--- a/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
@@ -26,8 +26,6 @@
 */
 
 #include <yuni/yuni.h>
-#include <yuni/core/math.h>
-#include <limits>
 #include <antares/study/area/scratchpad.h>
 #include "opt_structure_probleme_a_resoudre.h"
 
@@ -37,12 +35,6 @@
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-#include "../aleatoire/alea_fonctions.h"
-
-extern "C"
-{
-#include "spx_constantes_externes.h"
-}
 
 static void shortTermStorageCost(
   int PremierPdtDeLIntervalle,

--- a/src/solver/optimisation/opt_gestion_des_couts_cas_quadratique.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_cas_quadratique.cpp
@@ -28,7 +28,6 @@
 #include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"

--- a/src/solver/optimisation/opt_gestion_des_couts_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_couts_demarrage.cpp
@@ -25,9 +25,6 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <yuni/yuni.h>
-#include <yuni/core/math.h>
-#include <limits>
 #include <antares/study/area/scratchpad.h>
 #include "opt_structure_probleme_a_resoudre.h"
 
@@ -36,9 +33,6 @@
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-#include "../aleatoire/alea_fonctions.h"
-
-#include "spx_constantes_externes.h"
 
 void OPT_InitialiserLesCoutsLineaireCoutsDeDemarrage(PROBLEME_HEBDO* problemeHebdo,
                                                      const int PremierPdtDeLIntervalle,

--- a/src/solver/optimisation/opt_gestion_des_pmin.cpp
+++ b/src/solver/optimisation/opt_gestion_des_pmin.cpp
@@ -24,15 +24,10 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-
-#include <math.h>
-#include "opt_structure_probleme_a_resoudre.h"
-
 #include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
-#include <yuni/io/file.h>
 #include "opt_fonctions.h"
 
 #define ZERO 1.e-2

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -27,18 +27,12 @@
 
 #include "opt_structure_probleme_a_resoudre.h"
 
-#include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-
-#include "spx_constantes_externes.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
-
-#include <antares/logs.h>
 #include <antares/study.h>
-#include <antares/emergency.h>
+
 using namespace Antares;
 using namespace Antares::Data;
 using namespace Yuni;

--- a/src/solver/optimisation/opt_gestion_second_membre_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_couts_demarrage.cpp
@@ -27,18 +27,13 @@
 
 #include "opt_structure_probleme_a_resoudre.h"
 
-#include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
 
-#include "spx_constantes_externes.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
-
-#include <antares/logs.h>
 #include <antares/study.h>
-#include <antares/emergency.h>
+
 using namespace Antares;
 using namespace Antares::Data;
 using namespace Yuni;

--- a/src/solver/optimisation/opt_init_contraintes_hydrauliques.cpp
+++ b/src/solver/optimisation/opt_init_contraintes_hydrauliques.cpp
@@ -25,16 +25,11 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include "opt_structure_probleme_a_resoudre.h"
-
 #include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-
-#include "spx_constantes_externes.h"
-#include "../simulation/sim_structure_probleme_adequation.h"
 
 void OPT_InitialiserLesContrainteDEnergieHydrauliqueParIntervalleOptimise(
   PROBLEME_HEBDO* problemeHebdo)

--- a/src/solver/optimisation/opt_init_minmax_groupes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_init_minmax_groupes_couts_demarrage.cpp
@@ -25,8 +25,6 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include "opt_structure_probleme_a_resoudre.h"
-
 #include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -25,7 +25,6 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <math.h>
 #include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
@@ -33,8 +32,6 @@
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-#include <antares/emergency.h>
-#include <antares/logs.h>
 
 #include "../utils/ortools_utils.h"
 

--- a/src/solver/optimisation/opt_nombre_min_groupes_demarres_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_nombre_min_groupes_demarres_couts_demarrage.cpp
@@ -25,15 +25,12 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 #include <yuni/yuni.h>
-#include <yuni/core/string.h>
 
 #include "opt_structure_probleme_a_resoudre.h"
 
-#include "../simulation/simulation.h"
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
-#include <yuni/io/file.h>
 #include "opt_fonctions.h"
 
 extern "C"
@@ -41,10 +38,6 @@ extern "C"
 #include "spx_definition_arguments.h"
 #include "spx_fonctions.h"
 }
-
-#include <antares/logs.h>
-#include <antares/study.h>
-#include <antares/emergency.h>
 
 using namespace Antares;
 using namespace Antares::Data;

--- a/src/solver/optimisation/opt_numero_de_jour_du_pas_de_temps.cpp
+++ b/src/solver/optimisation/opt_numero_de_jour_du_pas_de_temps.cpp
@@ -26,7 +26,6 @@
 */
 
 #include <math.h>
-#include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
 #include "../simulation/sim_extern_variables_globales.h"

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -25,11 +25,9 @@
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
 
-#include <math.h>
 #include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"

--- a/src/solver/optimisation/opt_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_optimisation_lineaire.cpp
@@ -30,7 +30,6 @@
 #include "opt_fonctions.h"
 
 #include <antares/logs.h>
-#include <antares/emergency.h>
 #include "../utils/filename.h"
 
 using namespace Antares;

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -28,13 +28,9 @@
 #include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-
-#include "spx_definition_arguments.h"
-#include "spx_fonctions.h"
 
 bool OPT_PilotageOptimisationLineaire(PROBLEME_HEBDO* problemeHebdo, AdqPatchParams& adqPatchParams)
 {

--- a/src/solver/optimisation/opt_pilotage_optimisation_quadratique.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_quadratique.cpp
@@ -26,10 +26,8 @@
 */
 
 #include <math.h>
-#include "opt_structure_probleme_a_resoudre.h"
 
 #include "../simulation/simulation.h"
-#include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"

--- a/src/solver/optimisation/opt_restaurer_les_donnees.cpp
+++ b/src/solver/optimisation/opt_restaurer_les_donnees.cpp
@@ -32,7 +32,6 @@
 #include "../simulation/sim_extern_variables_globales.h"
 
 #include "opt_fonctions.h"
-#include <iostream>
 
 void OPT_RestaurerLesDonnees(const PROBLEME_HEBDO* problemeHebdo, const int optimizationNumber)
 {

--- a/src/solver/optimisation/opt_verification_presence_reserve_jmoins1.cpp
+++ b/src/solver/optimisation/opt_verification_presence_reserve_jmoins1.cpp
@@ -33,7 +33,6 @@
 
 #include "opt_fonctions.h"
 
-#include "spx_definition_arguments.h"
 #include "spx_fonctions.h"
 
 void OPT_VerifierPresenceReserveJmoins1(PROBLEME_HEBDO* problemeHebdo)


### PR DESCRIPTION
**Description**

Removal of unused headers in optimization module.
Unused headers can cause increased build time, and more frequent rebuilds.