### PR TITLE
Remove more usage of study singleton

### DIFF
--- a/src/solver/aleatoire/alea_fonctions.h
+++ b/src/solver/aleatoire/alea_fonctions.h
@@ -27,7 +27,9 @@
 #ifndef __SOLVER_ALEA_H__
 #define __SOLVER_ALEA_H__
 
-void ALEA_TirageAuSortChroniques(double** thermalNoisesByArea, uint numSpace);
+#include "antares/study/study.h"
+
+void ALEA_TirageAuSortChroniques(const Antares::Data::Study& study, double** thermalNoisesByArea, uint numSpace);
 
 void HydroVentilation();
 

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -45,10 +45,10 @@ using namespace Antares;
 using namespace Antares::Data;
 
 static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
+  const Study& study,
   double** thermalNoisesByArea,
   uint numSpace)
 {
-    auto& study = *Data::Study::Current::Get();
     auto& runtime = *study.runtime;
 
     uint year = runtime.timeseriesNumberYear[numSpace];
@@ -191,18 +191,21 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
     //To do this here we would have to check every BC for its width
     for (const auto& [group_name, _] : study.bindingConstraints.groupToTimeSeriesNumbers) {
 #ifndef NDEBUG
-        const auto number_of_ts_numbers = study.bindingConstraints.groupToTimeSeriesNumbers[group_name].timeseriesNumbers.height;
+        auto it = study.bindingConstraints.groupToTimeSeriesNumbers.find(group_name);
+        assert(it != study.bindingConstraints.groupToTimeSeriesNumbers.end());
+        auto tsNumbers = it->second;
+        const auto number_of_ts_numbers = tsNumbers.timeseriesNumbers.height;
         assert(year < number_of_ts_numbers); //If only 1 ts_number we suppose only one TS. Any "year" will be converted to "0" later
 #endif
-        NumeroChroniquesTireesParGroup[numSpace][group_name] = study.bindingConstraints.groupToTimeSeriesNumbers[group_name].timeseriesNumbers[0][year];
+        NumeroChroniquesTireesParGroup[numSpace][group_name] = tsNumbers.timeseriesNumbers[0][year];
     }
 }
 
-void ALEA_TirageAuSortChroniques(double** thermalNoisesByArea, uint numSpace)
+void ALEA_TirageAuSortChroniques(const Antares::Data::Study& study, double** thermalNoisesByArea, uint numSpace)
 {
     // Time-series numbers
     // Retrieve all time-series numbers
     // Initialize in the same time the production costs of all thermal clusters.
-    InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
+    InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(study,
       thermalNoisesByArea, numSpace);
 }

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -190,10 +190,10 @@ static void InitializeTimeSeriesNumbers_And_ThermalClusterProductionCost(
     //Setting 0 for time_series of width 0 is done when using the value.
     //To do this here we would have to check every BC for its width
     for (const auto& [group_name, _] : study.bindingConstraints.groupToTimeSeriesNumbers) {
-#ifndef NDEBUG
         auto it = study.bindingConstraints.groupToTimeSeriesNumbers.find(group_name);
         assert(it != study.bindingConstraints.groupToTimeSeriesNumbers.end());
-        auto tsNumbers = it->second;
+        const auto& tsNumbers = it->second;
+#ifndef NDEBUG
         const auto number_of_ts_numbers = tsNumbers.timeseriesNumbers.height;
         assert(year < number_of_ts_numbers); //If only 1 ts_number we suppose only one TS. Any "year" will be converted to "0" later
 #endif

--- a/src/solver/constraints-builder/cbuilder.cpp
+++ b/src/solver/constraints-builder/cbuilder.cpp
@@ -293,8 +293,7 @@ bool CBuilder::runConstraintsBuilder(bool standalone)
 
     if (standalone)
     {
-        auto& study = *Data::Study::Current::Get();
-        study.saveToFolder(study.folder);
+        pStudy->saveToFolder(pStudy->folder);
     }
     // return result;
     return result;
@@ -326,16 +325,15 @@ bool CBuilder::deletePreviousConstraints()
 
 bool CBuilder::saveCBuilderToFile(const String& filename) const
 {
-    if (!Data::Study::Current::Valid())
+    if (!pStudy)
         return false;
     String tmp;
-    auto& study = *Data::Study::Current::Get();
 
     IniFile ini;
     auto* mainSection = ini.addSection(".general");
 
     // Study
-    mainSection->add("study", study.folder);
+    mainSection->add("study", pStudy->folder);
 
     // Tmp
     /*wxStringToString(pPathTemp->GetValue(), tmp);
@@ -357,7 +355,7 @@ bool CBuilder::saveCBuilderToFile(const String& filename) const
     {
         YString buffer;
 
-        buffer.clear() << study.folder << Yuni::IO::Separator << "settings" << Yuni::IO::Separator
+        buffer.clear() << pStudy->folder << Yuni::IO::Separator << "settings" << Yuni::IO::Separator
                        << "constraintbuilder.ini";
         return ini.save(buffer);
     }
@@ -370,9 +368,7 @@ bool CBuilder::completeCBuilderFromFile(const String& filename)
     YString buffer;
     if (filename == "")
     {
-        auto& study = *Data::Study::Current::Get();
-
-        buffer.clear() << study.folder << Yuni::IO::Separator << "settings" << Yuni::IO::Separator
+        buffer.clear() << pStudy->folder << Yuni::IO::Separator << "settings" << Yuni::IO::Separator
                        << "constraintbuilder.ini";
         if (!IO::File::Exists(buffer))
         {
@@ -469,9 +465,8 @@ bool CBuilder::completeCBuilderFromFile(const String& filename)
 
 int CBuilder::alreadyExistingNetworkConstraints(const Yuni::String& prefix) const
 {
-    auto& study = *Data::Study::Current::Get();
     int nSubCount = 0;
-    for (auto j = study.bindingConstraints.begin(); j != study.bindingConstraints.end(); j++)
+    for (auto j = pStudy->bindingConstraints.begin(); j != pStudy->bindingConstraints.end(); j++)
     {
         std::string name = (*j)->name().c_str();
         if (name.find(prefix.to<std::string>()) == 0) // name starts with the prefix

--- a/src/solver/constraints-builder/cbuilder.h
+++ b/src/solver/constraints-builder/cbuilder.h
@@ -270,8 +270,7 @@ public:
     void buildAreaToLinkInfosMap()
     {
         areaToLinks.clear();
-        auto& study = *Data::Study::Current::Get();
-        for (auto& area : study.areas)
+        for (auto& area : pStudy->areas)
         {
             auto a = area.second;
             std::for_each(pLink.begin(), pLink.end(), [&a, this](linkInfo* edgeP) {

--- a/src/solver/infeasible-problem-analysis/problem.cpp
+++ b/src/solver/infeasible-problem-analysis/problem.cpp
@@ -11,9 +11,9 @@ namespace Antares
 {
 namespace Optimization
 {
-InfeasibleProblemAnalysis::InfeasibleProblemAnalysis(const PROBLEME_SIMPLEXE_NOMME* ProbSpx)
+InfeasibleProblemAnalysis::InfeasibleProblemAnalysis(const std::string& solverName, const PROBLEME_SIMPLEXE_NOMME* ProbSpx)
 {
-    mSolver = std::unique_ptr<MPSolver>(convert_to_MPSolver(ProbSpx));
+    mSolver = std::unique_ptr<MPSolver>(convert_to_MPSolver(solverName, ProbSpx));
 }
 
 void InfeasibleProblemAnalysis::addSlackVariables()

--- a/src/solver/infeasible-problem-analysis/problem.h
+++ b/src/solver/infeasible-problem-analysis/problem.h
@@ -15,7 +15,7 @@ class InfeasibleProblemAnalysis
 {
 public:
     InfeasibleProblemAnalysis() = delete;
-    explicit InfeasibleProblemAnalysis(const PROBLEME_SIMPLEXE_NOMME* ProbSpx);
+    explicit InfeasibleProblemAnalysis(const std::string& solverName, const PROBLEME_SIMPLEXE_NOMME* ProbSpx);
     InfeasibleProblemReport produceReport();
 
 private:

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -219,7 +219,7 @@ RESOLUTION:
 
     if (options.useOrtools)
     {
-        solver = ORTOOLS_ConvertIfNeeded(&Probleme, solver);
+        solver = ORTOOLS_ConvertIfNeeded(options.solverName, &Probleme, solver);
     }
     const std::string filename = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
     mpsWriterFactory mps_writer_factory(problemeHebdo->ExportMPS,
@@ -338,7 +338,7 @@ RESOLUTION:
             logs.info() << " Solver: Safe resolution failed";
         }
 
-        Optimization::InfeasibleProblemAnalysis analysis(&Probleme);
+        Optimization::InfeasibleProblemAnalysis analysis(options.solverName, &Probleme);
         logs.notice() << " Solver: Starting infeasibility analysis...";
         try
         {

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -152,7 +152,7 @@ private:
 
             // 2 - Preparing the Time-series numbers
             // We want to draw lots of numbers for time-series
-            ALEA_TirageAuSortChroniques(thermalNoisesByArea, numSpace);
+            ALEA_TirageAuSortChroniques(study, thermalNoisesByArea, numSpace);
 
             // 3 - Preparing data related to Clusters in 'must-run' mode
             simulationObj->prepareClustersInMustRunMode(numSpace);

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -1,7 +1,6 @@
 #include "ortools_utils.h"
 
 #include <antares/logs.h>
-#include <antares/study.h>
 #include <antares/exception/AssertionError.hpp>
 #include <antares/Enum.hpp>
 #include <antares/emergency.h>
@@ -139,12 +138,11 @@ namespace Antares
 namespace Optimization
 {
 MPSolver* convert_to_MPSolver(
-  const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* problemeSimplexe)
+    const std::string& solverName,
+    const PROBLEME_SIMPLEXE_NOMME* problemeSimplexe)
 {
-    auto study = Data::Study::Current::Get();
-
     // Create the MPSolver
-    MPSolver* solver = MPSolverFactory(problemeSimplexe, study->parameters.ortoolsSolver);
+    MPSolver* solver = MPSolverFactory(problemeSimplexe, solverName);
 
     tuneSolverSpecificOptions(solver);
 
@@ -228,7 +226,7 @@ void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
                                                    const std::string& filename)
 {
     // 0. Logging file name
-    logs.info() << "Solver OR-Tools MPS File: `" << filename << "'";
+    Antares::logs.info() << "Solver OR-Tools MPS File: `" << filename << "'";
 
     // 1. Determine filename
     const auto tmpPath = generateTempPath(filename);
@@ -259,12 +257,13 @@ bool solveAndManageStatus(MPSolver* solver, int& resultStatus, const MPSolverPar
     return resultStatus == OUI_SPX;
 }
 
-MPSolver* ORTOOLS_ConvertIfNeeded(const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme,
+MPSolver* ORTOOLS_ConvertIfNeeded(const std::string& solverName,
+                                  const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme,
                                   MPSolver* solver)
 {
     if (solver == nullptr)
     {
-        return Antares::Optimization::convert_to_MPSolver(Probleme);
+        return Antares::Optimization::convert_to_MPSolver(solverName, Probleme);
     }
     else
     {
@@ -391,7 +390,7 @@ MPSolver* MPSolverFactory(const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* 
     }
     catch (...)
     {
-        logs.error() << "Solver creation failed";
+        Antares::logs.error() << "Solver creation failed";
         AntaresSolverEmergencyShutdown();
     }
 

--- a/src/solver/utils/ortools_utils.h
+++ b/src/solver/utils/ortools_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 
 #include <i_writer.h>
 
@@ -47,6 +48,7 @@ namespace Antares
 namespace Optimization
 {
 MPSolver* convert_to_MPSolver(
+  const std::string& solverName,
   const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* problemeSimplexe);
 }
 } // namespace Antares

--- a/src/solver/utils/ortools_wrapper.h
+++ b/src/solver/utils/ortools_wrapper.h
@@ -1,6 +1,7 @@
 #ifndef __ORTOOLS_WRAPPER__
 #define __ORTOOLS_WRAPPER__
 
+#include <string>
 #include "named_problem.h"
 
 using namespace operations_research;
@@ -9,7 +10,8 @@ MPSolver* ORTOOLS_Simplexe(Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probl
                            MPSolver* ProbSpx,
                            bool keepBasis);
 
-MPSolver* ORTOOLS_ConvertIfNeeded(const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme,
+MPSolver* ORTOOLS_ConvertIfNeeded(const std::string& solverName,
+                                  const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme,
                                   MPSolver* solver);
 
 void ORTOOLS_ModifierLeVecteurCouts(MPSolver* ProbSpx, const double* costs, int nbVar);


### PR DESCRIPTION
**Related issue**
#1119 

**Description**

Removes last usages of the study singleton in the solver part, **except in technical parts** (signal handling and emergency shutdown...).
Those parts must be limited to the application scope, in a future PR.
