### PR TITLE
Remove study singleton in application signal handlers

### DIFF
--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -11,6 +11,8 @@
 #include <antares/checks/checkLoadedInputData.h>
 #include <antares/version.h>
 
+#include "signal-handling/public.h"
+
 #include "misc/system-memory.h"
 #include "utils/ortools_utils.h"
 #include "../config.h"
@@ -127,8 +129,10 @@ void Application::prepare(int argc, char* argv[])
     // Allocate a study
     pStudy = std::make_shared<Antares::Data::Study>(true /* for the solver */);
 
+    // Initialize signal handlers for application study
+    Antares::Solver::initializeSignalHandlers(pStudy);
+
     // Setting global variables for backward compatibility
-    Data::Study::Current::Set(pStudy);
     pParameters = &(pStudy->parameters);
 
     // Loading the study

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -128,9 +128,8 @@ void Application::prepare(int argc, char* argv[])
 
     // Allocate a study
     pStudy = std::make_shared<Antares::Data::Study>(true /* for the solver */);
-
-    // Initialize signal handlers for application study
-    Antares::Solver::initializeSignalHandlers(pStudy);
+    //TODO: still necessary for emergency shutdown, to be removed
+    Antares::Data::Study::Current::Set(pStudy);
 
     // Setting global variables for backward compatibility
     pParameters = &(pStudy->parameters);
@@ -341,6 +340,7 @@ void Application::readDataForTheStudy(Data::StudyLoadOptions& options)
 
     // Initialize the result writer
     study.prepareWriter(&pDurationCollector);
+    Antares::Solver::initializeSignalHandlers(study.resultWriter);
 
     // Save about-the-study files (comments, notes, etc.)
     study.saveAboutTheStudy();
@@ -463,8 +463,9 @@ Application::~Application()
         logs.info() << LOG_UI_SOLVER_DONE;
 
         // Copy the log file
-        if (!pStudy->parameters.noOutput)
+        if (!pStudy->parameters.noOutput) {
             pStudy->importLogsToOutputFolder();
+        }
 
         // release all reference to the current study held by this class
         pStudy->clear();

--- a/src/solver/main.cpp
+++ b/src/solver/main.cpp
@@ -137,9 +137,6 @@ int main(int argc, char** argv)
     // locale
     InitializeDefaultLocale();
 
-    // Initialize signal handler
-    Antares::Solver::initializeSignalHandlers();
-
     // Getting real UTF8 arguments
     argv = AntaresGetUTF8Arguments(argc, argv);
 

--- a/src/solver/signal-handling/common.cpp
+++ b/src/solver/signal-handling/common.cpp
@@ -6,8 +6,6 @@ using namespace Antares;
 
 namespace Antares::Solver {
 
-using Antares::Solver::IResultWriter;
-
 // weak_ptr because the lifetime must not be managed by this feature.
 // If the study lifetime ends before we receive a signal, we shoud just do
 // nothing when receiving the signal.
@@ -21,10 +19,8 @@ void setApplicationResultWriter(std::weak_ptr<IResultWriter> writer)
 }
 
 namespace {
-
-static void finalizeWrite() {
-    auto writer = Antares::Solver::APPLICATION_WRITER.lock();
-    if (writer) {
+void finalizeWrite() {
+    if (auto writer = Antares::Solver::APPLICATION_WRITER.lock()) {
         writer->finalize(true);
     } else {
         logs.warning() << "Could not finalize write: invalid writer";

--- a/src/solver/signal-handling/common.cpp
+++ b/src/solver/signal-handling/common.cpp
@@ -6,14 +6,16 @@ using namespace Antares;
 
 namespace Antares::Solver {
 
+using Antares::Solver::IResultWriter;
+
 // weak_ptr because the lifetime must not be managed by this feature.
 // If the study lifetime ends before we receive a signal, we shoud just do
 // nothing when receiving the signal.
-static std::weak_ptr<Antares::Data::Study> APPLICATION_STUDY;
+static std::weak_ptr<IResultWriter> APPLICATION_WRITER;
 
-void setApplicationStudy(std::weak_ptr<Antares::Data::Study> study)
+void setApplicationResultWriter(std::weak_ptr<IResultWriter> writer)
 {
-    APPLICATION_STUDY = study;
+    APPLICATION_WRITER = writer;
 }
 
 }
@@ -21,17 +23,11 @@ void setApplicationStudy(std::weak_ptr<Antares::Data::Study> study)
 namespace {
 
 static void finalizeWrite() {
-    auto study = Antares::Solver::APPLICATION_STUDY.lock();
-    if (study) {
-        auto writer = study->resultWriter;
-        if (writer)
-            writer->finalize(true);
-        else {
-            logs.warning() << "Could not finalize write: invalid writer";
-            exit(EXIT_FAILURE);
-        }
+    auto writer = Antares::Solver::APPLICATION_WRITER.lock();
+    if (writer) {
+        writer->finalize(true);
     } else {
-        logs.warning() << "Could not finalize write: invalid study";
+        logs.warning() << "Could not finalize write: invalid writer";
         exit(EXIT_FAILURE);
     }
 

--- a/src/solver/signal-handling/common.cpp
+++ b/src/solver/signal-handling/common.cpp
@@ -4,27 +4,40 @@
 
 using namespace Antares;
 
-static void finalizeWrite()
+namespace Antares::Solver {
+
+// weak_ptr because the lifetime must not be managed by this feature.
+// If the study lifetime ends before we receive a signal, we shoud just do
+// nothing when receiving the signal.
+static std::weak_ptr<Antares::Data::Study> APPLICATION_STUDY;
+
+void setApplicationStudy(std::weak_ptr<Antares::Data::Study> study)
 {
-    auto study = Data::Study::Current::Get();
-    if (study)
-    {
+    APPLICATION_STUDY = study;
+}
+
+}
+
+namespace {
+
+static void finalizeWrite() {
+    auto study = Antares::Solver::APPLICATION_STUDY.lock();
+    if (study) {
         auto writer = study->resultWriter;
         if (writer)
             writer->finalize(true);
-        else
-        {
+        else {
             logs.warning() << "Could not finalize write: invalid writer";
             exit(EXIT_FAILURE);
         }
-    }
-    else
-    {
+    } else {
         logs.warning() << "Could not finalize write: invalid study";
         exit(EXIT_FAILURE);
     }
 
     exit(EXIT_SUCCESS);
+}
+
 }
 
 void signalCtrl_term(int)

--- a/src/solver/signal-handling/common.h
+++ b/src/solver/signal-handling/common.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include "antares/study.h"
+#include <writer/i_writer.h>
 
 void signalCtrl_term(int);
 void signalCtrl_int(int);

--- a/src/solver/signal-handling/common.h
+++ b/src/solver/signal-handling/common.h
@@ -8,8 +8,8 @@ void signalCtrl_int(int);
 
 namespace Antares::Solver {
 /*!
- * Defines the provided study as the unique study managed by the running application.
+ * Defines the provided writer as the unique writer managed by the running application.
  */
-void setApplicationStudy(std::weak_ptr<Antares::Data::Study> study);
+void setApplicationResultWriter(std::weak_ptr<IResultWriter> writer);
 
 }

--- a/src/solver/signal-handling/common.h
+++ b/src/solver/signal-handling/common.h
@@ -1,4 +1,15 @@
 #pragma once
 
+#include <memory>
+#include "antares/study.h"
+
 void signalCtrl_term(int);
 void signalCtrl_int(int);
+
+namespace Antares::Solver {
+/*!
+ * Defines the provided study as the unique study managed by the running application.
+ */
+void setApplicationStudy(std::weak_ptr<Antares::Data::Study> study);
+
+}

--- a/src/solver/signal-handling/linux.cpp
+++ b/src/solver/signal-handling/linux.cpp
@@ -6,9 +6,9 @@
 
 namespace Antares::Solver
 {
-void initializeSignalHandlers(std::weak_ptr<Antares::Data::Study> study)
+void initializeSignalHandlers(std::weak_ptr<IResultWriter> writer)
 {
-    setApplicationStudy(study);
+    setApplicationResultWriter(writer);
     std::signal(SIGTERM, &signalCtrl_term);
     std::signal(SIGINT, signalCtrl_int);
 }

--- a/src/solver/signal-handling/linux.cpp
+++ b/src/solver/signal-handling/linux.cpp
@@ -1,15 +1,18 @@
 #ifndef YUNI_OS_WINDOWS
 #include <csignal>
+
 #include "common.h"
-#include "../application.h"
+#include "public.h"
 
 namespace Antares::Solver
 {
-void initializeSignalHandlers()
+void initializeSignalHandlers(std::weak_ptr<Antares::Data::Study> study)
 {
-    std::signal(SIGTERM, signalCtrl_term);
+    setApplicationStudy(study);
+    std::signal(SIGTERM, &signalCtrl_term);
     std::signal(SIGINT, signalCtrl_int);
 }
+
 } // namespace Antares::Solver
 
 #endif

--- a/src/solver/signal-handling/public.h
+++ b/src/solver/signal-handling/public.h
@@ -5,5 +5,5 @@
 
 namespace Antares::Solver
 {
-void initializeSignalHandlers(std::weak_ptr<Antares::Data::Study> study);
+void initializeSignalHandlers(std::weak_ptr<IResultWriter> writer);
 }

--- a/src/solver/signal-handling/public.h
+++ b/src/solver/signal-handling/public.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <memory>
+#include <antares/study.h>
+
 namespace Antares::Solver
 {
-void initializeSignalHandlers();
+void initializeSignalHandlers(std::weak_ptr<Antares::Data::Study> study);
 }

--- a/src/solver/signal-handling/public.h
+++ b/src/solver/signal-handling/public.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <antares/study.h>
+#include <writer/i_writer.h>
 
 namespace Antares::Solver
 {

--- a/src/solver/signal-handling/windows.cpp
+++ b/src/solver/signal-handling/windows.cpp
@@ -21,9 +21,9 @@ BOOL WINAPI ConsoleHandler(DWORD dwType)
 
 namespace Antares::Solver
 {
-void initializeSignalHandlers(std::weak_ptr<Antares::Data::Study> study)
+void initializeSignalHandlers(std::weak_ptr<IResultWriter> writer)
 {
-    setApplicationStudy(study);
+    setApplicationResultWriter(writer);
     SetConsoleCtrlHandler((PHANDLER_ROUTINE)ConsoleHandler, TRUE);
 }
 } // namespace Antares::Solver

--- a/src/solver/signal-handling/windows.cpp
+++ b/src/solver/signal-handling/windows.cpp
@@ -21,8 +21,9 @@ BOOL WINAPI ConsoleHandler(DWORD dwType)
 
 namespace Antares::Solver
 {
-void initializeSignalHandlers()
+void initializeSignalHandlers(std::weak_ptr<Antares::Data::Study> study)
 {
+    setApplicationStudy(study);
     SetConsoleCtrlHandler((PHANDLER_ROUTINE)ConsoleHandler, TRUE);
 }
 } // namespace Antares::Solver


### PR DESCRIPTION
**Description**

Removal of `Study::Current` usage in signal handlers.
Instead, the application uses its own singleton for that particular use.
This way, it's really the responsibility of the application (the executable) to maintain its study, the library does not manage it at all.

**Implementation note:**
we use a `weak_ptr` so that the study is not kept alive only for the use of those signal handlers.
