### PR TITLE
Remove barely-used `ThermalCluster::productionCost` temporary

### DIFF
--- a/src/libs/antares/study/parts/thermal/cluster.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster.cpp
@@ -800,7 +800,7 @@ double ThermalCluster::getOperatingCost(uint serieIndex, uint hourInTheYear) con
 {
     if (costgeneration == Data::setManually)
     {
-        const auto& modCost = modulation[thermalModulationCost];
+        const auto* modCost = modulation[thermalModulationCost];
         return marginalCost * modCost[hourInTheYear];
     }
     else

--- a/src/libs/antares/study/parts/thermal/cluster.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster.cpp
@@ -146,7 +146,6 @@ Data::ThermalCluster::ThermalCluster(Area* parent) :
 
 Data::ThermalCluster::~ThermalCluster()
 {
-    delete[] productionCost;
     delete prepro;
     delete series;
 }
@@ -160,15 +159,6 @@ void Data::ThermalCluster::copyFrom(const ThermalCluster& cluster)
 {
     // Note: In this method, only the data can be copied (and not the name or
     //   the ID for example)
-
-    // production cost, even if this variable should not be used
-    if (productionCost)
-    {
-        if (cluster.productionCost)
-            memcpy(productionCost, cluster.productionCost, HOURS_PER_YEAR * sizeof(double));
-        else
-            memset(productionCost, 0, HOURS_PER_YEAR * sizeof(double));
-    }
 
     // mustrun
     mustrun = cluster.mustrun;
@@ -512,12 +502,6 @@ void Data::ThermalCluster::reverseCalculationOfSpinning()
 
 void Data::ThermalCluster::reset()
 {
-    // production cost
-    // reminder: this variable should be considered as valid only when used from the
-    // solver
-    if (productionCost)
-        (void)::memset(productionCost, 0, HOURS_PER_YEAR * sizeof(double));
-
     Cluster::reset();
 
     mustrun = false;
@@ -816,7 +800,8 @@ double ThermalCluster::getOperatingCost(uint serieIndex, uint hourInTheYear) con
 {
     if (costgeneration == Data::setManually)
     {
-        return productionCost[hourInTheYear];
+        const auto& modCost = modulation[thermalModulationCost];
+        return marginalCost * modCost[hourInTheYear];
     }
     else
     {

--- a/src/libs/antares/study/parts/thermal/cluster.h
+++ b/src/libs/antares/study/parts/thermal/cluster.h
@@ -352,23 +352,6 @@ public:
     //! Data for the preprocessor
     PreproThermal* prepro = nullptr;
 
-    //! \name Temporary data for simulation
-    //@{
-    /*!
-    ** \brief Production cost for the thermal cluster
-    **
-    ** This value is computed from `modulation` and the reference annual cost of
-    ** the thermal cluster. The formula is :
-    ** \code
-    ** each hour (h) in the year do
-    **     productionCost[h] = marginalCost * modulation[0][h]
-    ** \endcode
-    **
-    ** This value is only set when loaded from a folder
-    ** 8760 (HOURS_PER_YEAR) array
-    */
-    double* productionCost = nullptr;
-
     /*!
     ** \brief Production Cost, Market Bid Cost and Marginal Cost Matrixes - Per Hour and per Time
     *Series

--- a/src/libs/antares/study/parts/thermal/cluster_list.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_list.cpp
@@ -38,7 +38,6 @@ void ThermalClusterList::estimateMemoryUsage(StudyMemoryUsage& u) const
         uint prepoCnt = Math::Max(cluster.ecoInput.co2cost.width, cluster.ecoInput.fuelcost.width);
         u.requiredMemoryForInput += sizeof(ThermalCluster);
         u.requiredMemoryForInput += sizeof(void*);
-        u.requiredMemoryForInput += sizeof(double) * HOURS_PER_YEAR * prepoCnt; // productionCost
         u.requiredMemoryForInput += sizeof(double) * HOURS_PER_YEAR; // PthetaInf
         u.requiredMemoryForInput += sizeof(double) * HOURS_PER_YEAR * prepoCnt; // marketBidCostPerHour
         u.requiredMemoryForInput += sizeof(double) * HOURS_PER_YEAR * prepoCnt; // marginalCostPerHour
@@ -134,29 +133,6 @@ bool ThermalClusterList::loadFromFolder(Study& study, const AnyString& folder, A
         // Special operations when not ran from the interface (aka solver)
         if (study.usedByTheSolver)
         {
-            if (not cluster->productionCost)
-                cluster->productionCost = new double[HOURS_PER_YEAR];
-
-            // alias to the production cost
-            double* prodCost = cluster->productionCost;
-            // alias to the marginal cost
-            double marginalCost = cluster->marginalCost;
-            // Production cost
-            auto& modulation = cluster->modulation[thermalModulationCost];
-            if (cluster->costgeneration == Data::setManually)
-            {
-                // alias to the marginal cost
-                for (uint h = 0; h != cluster->modulation.height; ++h)
-                    prodCost[h] = marginalCost * modulation[h];
-            }
-            else
-            {
-                const auto& marginalCostPerHour
-                  = cluster->costsTimeSeries[0].marginalCostTS;
-                for (uint h = 0; h != cluster->modulation.height; ++h)
-                    prodCost[h] = marginalCostPerHour[h] * modulation[h];
-            }
-
             if (not study.parameters.include.thermal.minStablePower)
                 cluster->minStablePower = 0.;
             if (not study.parameters.include.thermal.minUPTime)

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -157,10 +157,6 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex)
 
 void State::initFromThermalClusterIndexProduction(const uint clusterAreaWideIndex)
 {
-    // Reminder: the variable 'productionCost' is a vector only valid when used
-    //   from the solver, which is, for each hour in the year, the product
-    //   of the market bid price with the modulation vector
-
     uint serieIndex = timeseriesIndex->ThermiqueParPalier[clusterAreaWideIndex];
 
     if (thermal[area->index].thermalClustersProductions[clusterAreaWideIndex] > 0.)
@@ -199,7 +195,6 @@ void State::initFromThermalClusterIndexProduction(const uint clusterAreaWideInde
 
         // calculating the operating cost for the current hour
         // O(h) = MA * P(h) * Modulation
-        assert(thermalCluster->productionCost != NULL && "invalid production cost");
         thermal[area->index].thermalClustersOperatingCost[clusterAreaWideIndex]
           = (p * thermalCluster->getOperatingCost(serieIndex, hourInTheYear));
 

--- a/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
+++ b/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
@@ -99,21 +99,6 @@ std::shared_ptr<ThermalCluster> addClusterToArea(Area* area, const std::string& 
     cluster->modulation.reset(thermalModulationMax, HOURS_PER_YEAR);
     cluster->modulation.fill(1.);
     cluster->modulation.fillColumn(thermalMinGenModulation, 0.);
-
-    //Initialize production cost from modulation
-    if (not cluster->productionCost)
-        cluster->productionCost = new double[HOURS_PER_YEAR];
-
-
-    double* prodCost	= cluster->productionCost;
-    double marginalCost = cluster->marginalCost;
-
-    // Production cost
-    auto& modulation = cluster->modulation[thermalModulationCost];
-    for (uint h = 0; h != cluster->modulation.height; ++h)
-        prodCost[h] = marginalCost * modulation[h];
-
-
     cluster->nominalCapacityWithSpinning = cluster->nominalCapacity;
 
     auto added = area->thermal.list.add(cluster);

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -52,21 +52,6 @@ std::shared_ptr<ThermalCluster> addCluster(Area* pArea, const std::string& clust
     pCluster->modulation.reset(thermalModulationMax, HOURS_PER_YEAR);
     pCluster->modulation.fill(1.);
     pCluster->modulation.fillColumn(thermalMinGenModulation, 0.);
-
-    //Initialize production cost from modulation
-    if (not pCluster->productionCost)
-        pCluster->productionCost = new double[HOURS_PER_YEAR];
-
-
-    double* prodCost	= pCluster->productionCost;
-    double marginalCost = pCluster->marginalCost;
-
-    // Production cost
-    auto& modulation = pCluster->modulation[thermalModulationCost];
-    for (uint h = 0; h != pCluster->modulation.height; ++h)
-        prodCost[h] = marginalCost * modulation[h];
-
-
     pCluster->nominalCapacityWithSpinning = pCluster->nominalCapacity;
 
     auto added = pArea->thermal.list.add(pCluster);


### PR DESCRIPTION
- Having a raw pointer forced us to manage memory (`memcpy`, `memset`, `new`, `delete[]`)
- Having temporary data forced is to compute it right after loading data from files. It was also visible in the tests. Meaning that anyone changing a property of the cluster should update `productionCost` (data consistency issue)
- `productionCost` was only used in `getOperatingCost`, so we add a computation there
- In the case where `cluster.costgeneration == useCostTimeseries`, `cluster.productionCost` was set to the 1st column, which is only valid if there is a single TS for costs.

Overall, I think the code is way more clear after removing `productionCost`.