### PR TITLE
Automatically include yuni include directory in dependents

### DIFF
--- a/src/ext/yuni/src/CMakeLists.txt
+++ b/src/ext/yuni/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # Minimum CMake version check
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 include("cmake/message.cmake")
 
 project(yuni)

--- a/src/ext/yuni/src/yuni/cmake/core/core.cmake
+++ b/src/ext/yuni/src/yuni/cmake/core/core.cmake
@@ -533,3 +533,9 @@ install(FILES io/directory/info/iterator.inc.hpp
 install(FILES "${YUNI_LIBYUNI_CONFIG_TARGET_INIFILE}"
 	COMPONENT ${YUNICOMPONENT_CORE}
 	DESTINATION include/yuni RENAME "yuni.config.${YUNI_LIBYUNI_CONFIG_COMPILER}")
+
+# Marginal addition so that dependent include automatically yuni root directory
+# Note: if we want to use an installed version of yuni, we'll
+#       need to add INSTALL_INTERFACE.
+target_include_directories(yuni-static-core PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>)

--- a/src/libs/antares/CMakeLists.txt
+++ b/src/libs/antares/CMakeLists.txt
@@ -515,11 +515,12 @@ add_library( libantares-core-calendar
 	date/date.h
 	date/date.cpp
 )
-#TODO : needed for include yuni : why yuni must be include first ???
-#TODO : needed for include
+
+target_link_libraries(libantares-core-calendar
+		PRIVATE yuni-static-core)
+
 target_include_directories(libantares-core-calendar
 		PRIVATE
-			${CMAKE_SOURCE_DIR}/ext/yuni/src/
 			${CMAKE_SOURCE_DIR}/libs
 		)
 
@@ -527,9 +528,11 @@ add_library(libantares-core-exceptions
     ${SRC_EXCEPTION}
 )
 
+target_link_libraries(libantares-core-exceptions
+	PRIVATE yuni-static-core)
+
 target_include_directories(libantares-core-exceptions
 		PRIVATE
-			${CMAKE_SOURCE_DIR}/ext/yuni/src/
 			${CMAKE_SOURCE_DIR}/libs
 		)
 
@@ -539,12 +542,15 @@ add_library(libantares-core-checks
 
 target_include_directories(libantares-core-checks
 		PRIVATE
-			${CMAKE_SOURCE_DIR}/ext/yuni/src/
 			${CMAKE_SOURCE_DIR}/libs/antares/study
             ${CMAKE_SOURCE_DIR}/libs/antares/logs
 			${CMAKE_SOURCE_DIR}/libs
             ${CMAKE_SOURCE_DIR}/solver/writer
 )
+
+target_link_libraries(libantares-core-checks
+	PRIVATE
+		yuni-static-core)
 
 add_library(libantares-core
 	antares.h
@@ -581,7 +587,6 @@ add_library(libantares-core
 #TODO : needed for include
 target_include_directories(libantares-core
 		PUBLIC
-			${CMAKE_SOURCE_DIR}/ext/yuni/src
 			${CMAKE_SOURCE_DIR}/libs
 			${CMAKE_SOURCE_DIR}/libs/antares/logs
             ${CMAKE_SOURCE_DIR}/solver/writer

--- a/src/libs/antares/array/CMakeLists.txt
+++ b/src/libs/antares/array/CMakeLists.txt
@@ -17,6 +17,5 @@ target_link_libraries(array
 
 target_include_directories(array
         PRIVATE
-        ${CMAKE_SOURCE_DIR}/ext/yuni/src
         ${CMAKE_SOURCE_DIR}/libs
         )

--- a/src/libs/antares/correlation/CMakeLists.txt
+++ b/src/libs/antares/correlation/CMakeLists.txt
@@ -15,7 +15,6 @@ target_link_libraries(correlation
 
 target_include_directories(correlation
         PRIVATE
-        ${CMAKE_SOURCE_DIR}/ext/yuni/src
         ${CMAKE_SOURCE_DIR}/libs
         ${CMAKE_SOURCE_DIR}/libs/solver
         )

--- a/src/libs/antares/inifile/CMakeLists.txt
+++ b/src/libs/antares/inifile/CMakeLists.txt
@@ -18,5 +18,4 @@ target_link_libraries(inifile
 
 target_include_directories(inifile
         PRIVATE
-        ${CMAKE_SOURCE_DIR}/ext/yuni/src
         )

--- a/src/libs/antares/io/CMakeLists.txt
+++ b/src/libs/antares/io/CMakeLists.txt
@@ -17,5 +17,4 @@ target_link_libraries(io
 
 target_include_directories(io
         PRIVATE
-        ${CMAKE_SOURCE_DIR}/ext/yuni/src
         )

--- a/src/libs/antares/jit/CMakeLists.txt
+++ b/src/libs/antares/jit/CMakeLists.txt
@@ -18,6 +18,5 @@ target_link_libraries(jit
 
 target_include_directories(jit
         PRIVATE
-        ${CMAKE_SOURCE_DIR}/ext/yuni/src
         ${CMAKE_SOURCE_DIR}/libs
         )

--- a/src/libs/antares/logs/CMakeLists.txt
+++ b/src/libs/antares/logs/CMakeLists.txt
@@ -13,8 +13,3 @@ target_link_libraries(logs
         PRIVATE
         yuni-static-core
         )
-
-target_include_directories(logs
-        PRIVATE
-        ${CMAKE_SOURCE_DIR}/ext/yuni/src
-        )

--- a/src/libs/antares/object/CMakeLists.txt
+++ b/src/libs/antares/object/CMakeLists.txt
@@ -11,11 +11,6 @@ source_group("object" FILES ${SRC_OBJECT})
 add_library(object
         ${SRC_OBJECT})
 
-target_include_directories(object
-        PRIVATE
-        ${CMAKE_SOURCE_DIR}/ext/yuni/src
-        )
-
 target_link_libraries(object
         PRIVATE
         yuni-static-core

--- a/src/libs/fswalker/CMakeLists.txt
+++ b/src/libs/fswalker/CMakeLists.txt
@@ -17,7 +17,6 @@ add_library(libantares-fswalker
 #TODO : needed for include
 target_include_directories(libantares-fswalker
 		PRIVATE
-			${CMAKE_SOURCE_DIR}/ext/yuni/src
 			${CMAKE_SOURCE_DIR}/libs
 		)
 target_link_libraries(libantares-fswalker

--- a/src/tests/src/libs/antares/CMakeLists.txt
+++ b/src/tests/src/libs/antares/CMakeLists.txt
@@ -16,11 +16,13 @@ set(SRC_MATRIX_LIB
 	)
 
 add_library(lib-matrix ${SRC_MATRIX_LIB})
+
+target_link_libraries(lib-matrix PRIVATE libantares-core yuni-static-core)
+
 target_include_directories(lib-matrix
 								PRIVATE
 									"${CMAKE_CURRENT_SOURCE_DIR}"
 									"${CMAKE_CURRENT_SOURCE_DIR}/logs"
-									"${CMAKE_SOURCE_DIR}/ext/yuni/src"
 									"${CMAKE_SOURCE_DIR}/tests/src/libs"
 
 		)
@@ -44,7 +46,6 @@ target_include_directories(tests-matrix-save
 									"${src_libs_antares}/array"
 									"${CMAKE_CURRENT_SOURCE_DIR}/logs"
 									"${CMAKE_CURRENT_SOURCE_DIR}/jit"
-									"${CMAKE_SOURCE_DIR}/ext/yuni/src"
 									"${CMAKE_SOURCE_DIR}/tests/src/libs"
 
 		)
@@ -77,7 +78,6 @@ target_include_directories(tests-matrix-load
 									"${src_libs_antares}/array"
 									"${CMAKE_CURRENT_SOURCE_DIR}/logs"
 									"${CMAKE_CURRENT_SOURCE_DIR}/jit"
-									"${CMAKE_SOURCE_DIR}/ext/yuni/src"
 									"${CMAKE_SOURCE_DIR}/tests/src/libs"
 )
 


### PR DESCRIPTION
**Description**

Marginal "modernization" of yuni cmake target, so that it defines its public include directory for its dependents.

Allows to remove explicit inclusion of yuni root directory in dependent cmake files.
