### PR TITLE
Fix boost tests

### DIFF
--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - develop
-      - fix/*
   schedule:
     - cron: '21 2 * * *'
 

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - develop
+      - fix/*
   schedule:
     - cron: '21 2 * * *'
 

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -46,6 +46,11 @@ jobs:
            git config --global safe.directory '*'
            git submodule update --init --remote src/antares-deps src/tests/resources/Antares_Simulator_Tests
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: 'oraclelinux-8'
+
     - name: Install dependencies
       run: |
           pip3 install -r src/tests/examples/requirements.txt
@@ -54,16 +59,23 @@ jobs:
       run: |
            source /opt/rh/gcc-toolset-9/enable
            cmake -B _build -S src \
-           -DCMAKE_BUILD_TYPE=release \
-           -DBUILD_TESTING=ON \
-           -DBUILD_TOOLS=OFF \
-           -DBUILD_UI=OFF \
-
+             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+             -DCMAKE_BUILD_TYPE=release \
+             -DBUILD_TESTING=ON \
+             -DBUILD_TOOLS=OFF \
+             -DBUILD_UI=OFF \
 
     - name: Build
       run: |
            source /opt/rh/gcc-toolset-9/enable
            cmake --build _build --config Release -j2
+
+    - name: Run unit and end-to-end tests
+      if: ${{ env.IS_PUSH == 'true' }}
+      run: |
+        cd _build
+        ctest -C ${{ matrix.buildtype }} --output-on-failure -L "unit|end-to-end"
 
     - name: Installer .rpm creation
       run: |

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -46,11 +46,6 @@ jobs:
            git config --global safe.directory '*'
            git submodule update --init --remote src/antares-deps src/tests/resources/Antares_Simulator_Tests
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: 'oraclelinux-8'
-
     - name: Install dependencies
       run: |
           pip3 install -r src/tests/examples/requirements.txt
@@ -59,8 +54,6 @@ jobs:
       run: |
            source /opt/rh/gcc-toolset-9/enable
            cmake -B _build -S src \
-             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
              -DCMAKE_BUILD_TYPE=release \
              -DBUILD_TESTING=ON \
              -DBUILD_TOOLS=OFF \
@@ -75,7 +68,7 @@ jobs:
       if: ${{ env.IS_PUSH == 'true' }}
       run: |
         cd _build
-        ctest -C ${{ matrix.buildtype }} --output-on-failure -L "unit|end-to-end"
+        ctest -C Release --output-on-failure -L "unit|end-to-end"
 
     - name: Installer .rpm creation
       run: |

--- a/src/tests/end-to-end/binding_constraints/CMakeLists.txt
+++ b/src/tests/end-to-end/binding_constraints/CMakeLists.txt
@@ -8,7 +8,7 @@ endif(MSVC)
 
 add_executable(tests-binding_constraints
         test_binding_constraints.cpp
-        )
+    )
 
 target_link_libraries(tests-binding_constraints
         PRIVATE
@@ -19,7 +19,7 @@ target_link_libraries(tests-binding_constraints
         libantares-solver-hydro
         libantares-solver-ts-generator
         libantares-solver-aleatoire
-        )
+    )
 
 target_include_directories(tests-binding_constraints
         PRIVATE

--- a/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
+++ b/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
@@ -1,6 +1,7 @@
 #define BOOST_TEST_MODULE test-end-to-end tests_binding_constraints
+#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
 #include "utils.h"

--- a/src/tests/end-to-end/simple_study/CMakeLists.txt
+++ b/src/tests/end-to-end/simple_study/CMakeLists.txt
@@ -31,8 +31,6 @@ target_include_directories(tests-simple-study
 							${CMAKE_CURRENT_SOURCE_DIR}/../utils
 							)
 
-target_compile_definitions(tests-simple-study PRIVATE "BOOST_TEST_DYN_LINK=1")
-
 add_test(NAME end-to-end-simple-study COMMAND tests-simple-study)
 set_property(TEST end-to-end-simple-study PROPERTY LABELS end-to-end)
 set_target_properties(tests-simple-study PROPERTIES FOLDER Unit-tests/end_to_end)

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -1,5 +1,6 @@
 #define BOOST_TEST_MODULE test-end-to-end tests
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
 #include "utils.h"

--- a/src/tests/end-to-end/utils/CMakeLists.txt
+++ b/src/tests/end-to-end/utils/CMakeLists.txt
@@ -18,5 +18,4 @@ target_include_directories(test_utils
 
 set_target_properties(test_utils PROPERTIES FOLDER Unit-tests/end_to_end)
 
-target_compile_definitions(test_utils PUBLIC "BOOST_TEST_DYN_LINK=1")
 target_include_directories(test_utils PUBLIC ${Boost_INCLUDE_DIRS})

--- a/src/tests/src/libs/antares/array/tests-matrix-load.cpp
+++ b/src/tests/src/libs/antares/array/tests-matrix-load.cpp
@@ -8,6 +8,7 @@
 #include "tests-matrix-load.h"
 
 #include <iostream>
+#include <fstream>
 #include <stdio.h>
 
 namespace utf = boost::unit_test;

--- a/src/tests/src/libs/antares/array/tests-matrix-load.cpp
+++ b/src/tests/src/libs/antares/array/tests-matrix-load.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE test-lib-antares-matrix tests
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "tests-matrix-load.h"
 

--- a/src/tests/src/libs/antares/array/tests-matrix-save.cpp
+++ b/src/tests/src/libs/antares/array/tests-matrix-save.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE test-lib-antares-matrix tests
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "tests-matrix-save.h"
 

--- a/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE test save area optimization.ini
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <string>
 #include <filesystem>
 

--- a/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
@@ -6,6 +6,7 @@
 #include <boost/test/unit_test.hpp>
 #include <string>
 #include <filesystem>
+#include <fstream>
 
 #include <study.h>
 #include <filter.h>

--- a/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <map>
 #include <filesystem>
+#include <fstream>
 
 #include <study.h>
 #include <filter.h>

--- a/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE test save link properties.ini
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <string>
 #include <vector>
 #include <map>

--- a/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
@@ -4,10 +4,9 @@
 
 #define WIN32_LEAN_AND_MEAN
 #define BOOST_TEST_MODULE binding_constraints
+#define BOOST_TEST_DYN_LINK
 
-// Why this header ? See here
-// https://www.boost.org/doc/libs/1_82_0/libs/test/doc/html/boost_test/adv_scenarios/single_header_customizations/multiple_translation_units.html
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <fstream>
 #include "antares/study/constraint.h"

--- a/src/tests/src/libs/antares/study/constraint/test_group.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_group.cpp
@@ -2,8 +2,9 @@
 // Created by marechaljas on 28/06/23.
 //
 #define BOOST_TEST_MODULE binding_constraints_groups
+#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <filesystem>
 #include <fstream>
 #include <memory>

--- a/src/tests/src/libs/antares/study/output-folder/study.cpp
+++ b/src/tests/src/libs/antares/study/output-folder/study.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE output folder
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <string>
 #include <fstream>
 #include <filesystem>

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE test read scenario-builder.dat 
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <study.h>
 #include <rules.h>

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <filesystem>
+#include <fstream>
 
 #include <study.h>
 #include <rules.h>

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -1,5 +1,6 @@
 #define BOOST_TEST_MODULE test save scenario - builder.dat
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 #include <string>
 #include <filesystem>

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE "test short term storage"
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <yuni/io/file.h>
 #include <filesystem>
 #include <fstream>

--- a/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE "test thermal price definition"
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <yuni/io/file.h>
 #include <filesystem>
 #include <fstream>

--- a/src/tests/src/libs/antares/test_utils.cpp
+++ b/src/tests/src/libs/antares/test_utils.cpp
@@ -1,4 +1,5 @@
 #define BOOST_TEST_MODULE test utils
+#define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
 #include <string>

--- a/src/tests/src/solver/optimisation/adequacy_patch.cpp
+++ b/src/tests/src/solver/optimisation/adequacy_patch.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE test adequacy patch functions
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "adequacy_patch_local_matching/adq_patch_local_matching.h"
 #include "adequacy_patch_csr/adq_patch_curtailment_sharing.h"

--- a/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
+++ b/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
@@ -2,10 +2,11 @@
 // Created by marechaljas on 15/03/23.
 //
 #define BOOST_TEST_MODULE store-timeseries-number
+#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
 
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <filesystem>
 #include "antares/study.h"
 #include "immediate_file_writer.h"

--- a/src/tests/src/solver/simulation/test-time_series.cpp
+++ b/src/tests/src/solver/simulation/test-time_series.cpp
@@ -2,9 +2,10 @@
 // Created by marechaljas on 07/04/23.
 //
 #define BOOST_TEST_MODULE rhsTimeSeries
+#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include "antares/study.h"
 #include <filesystem>
 #include <fstream>

--- a/src/tests/src/solver/simulation/tests-ts-numbers.cpp
+++ b/src/tests/src/solver/simulation/tests-ts-numbers.cpp
@@ -1,8 +1,9 @@
 #define BOOST_TEST_MODULE test solver simulation things
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <timeseries-numbers.h>
 


### PR DESCRIPTION
**Description**

On oracle linux 8 container, Boost.Test comes only as a shared library.
Our current code relies on the presence of the static library instead, to generate the test executables.

To make it work with this environment, we are left with 2 options:
 - use the header-only variant to generate the executable
 - use the shared-library to run the executable

Here, I am trying the second option, in order to decrease a little build time and binaries disk usage.
