### PR TITLE
Fix annoying error log about correlation matrixes in tests

### DIFF
--- a/src/libs/antares/study/action/handler/antares-study/area/create.cpp
+++ b/src/libs/antares/study/action/handler/antares-study/area/create.cpp
@@ -220,7 +220,7 @@ bool Create::performWL(Context& ctx)
     if (not ctx.area)
     {
         // create the area
-        ctx.area = ctx.study->areaAdd(pFuturAreaName);
+        ctx.area = ctx.study->areaAdd(pFuturAreaName, true);
         logs.debug() << "[study-action] The area " << pFuturAreaName << " has been created";
     }
     else

--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -60,7 +60,7 @@ Area::Area(const AnyString& name) :
     Antares::TransformNameIntoID(this->name, this->id);
 }
 
-Area::Area(const AnyString& name, const AnyString& id, uint indx) :
+Area::Area(const AnyString& name, const AnyString& id) :
     reserves(fhrMax, HOURS_PER_YEAR),
     miscGen(fhhMax, HOURS_PER_YEAR)
 {

--- a/src/libs/antares/study/area/area.h
+++ b/src/libs/antares/study/area/area.h
@@ -83,7 +83,7 @@ public:
     ** \param name Name of the area
     ** \param id id of the area
     */
-    Area(const AnyString& name, const AnyString& id, uint indx = (uint)-1);
+    Area(const AnyString& name, const AnyString& id);
     /*!
     ** \brief Destructor
     */

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -35,7 +35,7 @@
 #include <sstream> // std::ostringstream
 #include <cassert>
 #include <climits>
-#include <memory>
+#include <optional>
 
 #include "study.h"
 #include "runtime.h"
@@ -783,12 +783,15 @@ Area* Study::areaAdd(const AreaName& name, bool updateMode)
     // and the scenario builder data
     {
         // These are only useful for the GUI, remove afterwards
-        std::unique_ptr<CorrelationUpdater> updater;
-        std::unique_ptr<ScenarioBuilderUpdater> updaterSB;
+        // We need the constructors to be called here, and the destructors
+        // to be called at the end of the scope. Using std::optional is merely
+        // a means to that end.
+        std::optional<CorrelationUpdater> updater;
+        std::optional<ScenarioBuilderUpdater> updaterSB;
         if (updateMode)
         {
-            updater.reset(new CorrelationUpdater(*this));
-            updaterSB.reset(new ScenarioBuilderUpdater(*this));
+            updater.emplace(*this);
+            updaterSB.emplace(*this);
         }
         // Adding an area
         AreaName newName;

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -35,6 +35,7 @@
 #include <sstream> // std::ostringstream
 #include <cassert>
 #include <climits>
+#include <memory>
 
 #include "study.h"
 #include "runtime.h"
@@ -44,7 +45,7 @@
 #include "area/constants.h"
 
 #include <yuni/core/system/cpu.h> // For use of Yuni::System::CPU::Count()
-#include <math.h>                 // For use of floor(...) and ceil(...)
+#include <cmath>                 // For use of floor(...) and ceil(...)
 #include <antares/writer/writer_factory.h>
 #include "ui-runtimeinfos.h"
 
@@ -764,7 +765,7 @@ void Study::saveAboutTheStudy()
     }
 }
 
-Area* Study::areaAdd(const AreaName& name)
+Area* Study::areaAdd(const AreaName& name, bool updateMode)
 {
     if (name.empty())
         return nullptr;
@@ -781,9 +782,14 @@ Area* Study::areaAdd(const AreaName& name)
     // The new scope is mandatory to rebuild the correlation matrices
     // and the scenario builder data
     {
-        CorrelationUpdater updater(*this);
-        ScenarioBuilderUpdater updaterSB(*this);
-
+        // These are only useful for the GUI, remove afterwards
+        std::unique_ptr<CorrelationUpdater> updater;
+        std::unique_ptr<ScenarioBuilderUpdater> updaterSB;
+        if (updateMode)
+        {
+            updater.reset(new CorrelationUpdater(*this));
+            updaterSB.reset(new ScenarioBuilderUpdater(*this));
+        }
         // Adding an area
         AreaName newName;
         if (not modifyAreaNameIfAlreadyTaken(newName, name) or newName.empty())

--- a/src/libs/antares/study/study.h
+++ b/src/libs/antares/study/study.h
@@ -242,7 +242,8 @@ public:
     ** \param name The name of the new area
     ** \return A pointer to a new area, or NULL if the operation failed
     */
-    Area* areaAdd(const AreaName& name);
+    // TODO no need for the 2nd argument, remove it after the GUI has been removed, keeping the default value
+    Area* areaAdd(const AreaName& name, bool update = false);
 
     /*!
     ** \brief Rename an area

--- a/src/ui/simulator/toolbox/components/map/nodes/node.cpp
+++ b/src/ui/simulator/toolbox/components/map/nodes/node.cpp
@@ -76,7 +76,7 @@ void Node::createANewAreaIfNotAlreadyAttached()
         // Creating a new Area
         Data::AreaName sFl;
         wxStringToString(pCaption, sFl);
-        pAttachedArea = study->areaAdd(sFl);
+        pAttachedArea = study->areaAdd(sFl, true);
         pCaption = wxStringFromUTF8(pAttachedArea->name);
         study->uiinfo->reload();
         MarkTheStudyAsModified();


### PR DESCRIPTION
Previously, the following errors appeared without a good reason
```
[2023-08-21 14:04:55][noname][infos] adding new area Area 1
[2023-08-21 14:04:55][noname][debug]   Correlation: Load: loading /antares-corr-save-0-0x7ffd89252430-load.tmp
[2023-08-21 14:04:55][noname][error] I/O error: /antares-corr-save-0-0x7ffd89252430-load.tmp: Impossible to read the file
[2023-08-21 14:04:55][noname][debug]   Correlation: Solar: loading /antares-corr-save-0-0x7ffd89252430-solar.tmp
[2023-08-21 14:04:55][noname][error] I/O error: /antares-corr-save-0-0x7ffd89252430-solar.tmp: Impossible to read the file
[2023-08-21 14:04:55][noname][debug]   Correlation: Wind: loading /antares-corr-save-0-0x7ffd89252430-wind.tmp
[2023-08-21 14:04:55][noname][error] I/O error: /antares-corr-save-0-0x7ffd89252430-wind.tmp: Impossible to read the file
[2023-08-21 14:04:55][noname][debug]   Correlation: Hydro: loading /antares-corr-save-0-0x7ffd89252430-hydro.tmp
[2023-08-21 14:04:55][noname][error] I/O error: /antares-corr-save-0-0x7ffd89252430-hydro.tmp: Impossible to read the file
```

Also remove unused argument in `Area::Area`.