### PR TITLE
Reduce use of study in helper functions

### DIFF
--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -300,9 +300,7 @@ AreaLink* AreaAddLinkBetweenAreas(Area* area, Area* with, bool warning)
 
 namespace // anonymous
 {
-bool AreaLinksInternalLoadFromProperty(AreaLink& link,
-                                              const String& key,
-                                              const String& value)
+bool AreaLinksInternalLoadFromProperty(AreaLink& link, const String& key, const String& value)
 {
     if (key == "hurdles-cost")
         return value.to<bool>(link.useHurdlesCost);
@@ -416,16 +414,14 @@ bool AreaLinksInternalLoadFromProperty(AreaLink& link,
     return false;
 }
 
-} // anonymous namespace
-
-void logLinkDataCheckError(Study& study, const AreaLink& link, const String& msg, int hour)
+void logLinkDataCheckError(bool& gotFatalError, const AreaLink& link, const String& msg, int hour)
 {
     logs.error() << "Link (" << link.from->name << "/" << link.with->name << "): Invalid values ("
                  << msg << ") for hour " << hour;
-    study.gotFatalError = true;
+    gotFatalError = true;
 }
 
-void logLinkDataCheckErrorDirectIndirect(Study& study,
+void logLinkDataCheckErrorDirectIndirect(bool& gotFatalError,
                                          const AreaLink& link,
                                          uint direct,
                                          uint indirect)
@@ -433,8 +429,9 @@ void logLinkDataCheckErrorDirectIndirect(Study& study,
     logs.error() << "Link (" << link.from->name << "/" << link.with->name << "): Found " << direct
                  << " direct TS "
                  << " and " << indirect << " indirect TS, expected the same number";
-    study.gotFatalError = true;
+    gotFatalError = true;
 }
+} // anonymous namespace
 
 bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyString& folder)
 {
@@ -489,7 +486,8 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
             const uint nbIndirectTS = link.indirectCapacities.width;
             if (nbDirectTS != nbIndirectTS)
             {
-                logLinkDataCheckErrorDirectIndirect(study, link, nbDirectTS, nbIndirectTS);
+                logLinkDataCheckErrorDirectIndirect(
+                  study.gotFatalError, link, nbDirectTS, nbIndirectTS);
                 return false;
             }
 
@@ -509,12 +507,13 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
                 {
                     if (directCapacities[h] < 0.)
                     {
-                        logLinkDataCheckError(study, link, "direct capacity < 0", h);
+                        logLinkDataCheckError(study.gotFatalError, link, "direct capacity < 0", h);
                         return false;
                     }
                     if (directCapacities[h] < loopFlow[h])
                     {
-                        logLinkDataCheckError(study, link, "direct capacity < loop flow", h);
+                        logLinkDataCheckError(
+                          study.gotFatalError, link, "direct capacity < loop flow", h);
                         return false;
                     }
                 }
@@ -524,12 +523,14 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
                 {
                     if (indirectCapacities[h] < 0.)
                     {
-                        logLinkDataCheckError(study, link, "indirect capacitity < 0", h);
+                        logLinkDataCheckError(
+                          study.gotFatalError, link, "indirect capacitity < 0", h);
                         return false;
                     }
                     if (indirectCapacities[h] + loopFlow[h] < 0)
                     {
-                        logLinkDataCheckError(study, link, "indirect capacity + loop flow < 0", h);
+                        logLinkDataCheckError(
+                          study.gotFatalError, link, "indirect capacity + loop flow < 0", h);
                         return false;
                     }
                 }
@@ -539,8 +540,10 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
             {
                 if (directHurdlesCost[h] + indirectHurdlesCost[h] < 0)
                 {
-                    logLinkDataCheckError(
-                      study, link, "hurdle costs direct + hurdle cost indirect < 0", h);
+                    logLinkDataCheckError(study.gotFatalError,
+                                          link,
+                                          "hurdle costs direct + hurdle cost indirect < 0",
+                                          h);
                     return false;
                 }
             }
@@ -550,7 +553,8 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
             {
                 if (PShiftPlus[h] < PShiftMinus[h])
                 {
-                    logLinkDataCheckError(study, link, "phase shift plus < phase shift minus", h);
+                    logLinkDataCheckError(
+                      study.gotFatalError, link, "phase shift plus < phase shift minus", h);
                     return false;
                 }
             }


### PR DESCRIPTION
Pass member of `study` instead of the whole object.