### PR TITLE
Add short options for MPS generation, force generation if named MPS requested

### DIFF
--- a/docs/reference-guide/10-command_line.md
+++ b/docs/reference-guide/10-command_line.md
@@ -38,7 +38,8 @@ _In all cases, arguments " –h" or "–help" can be used to get help_
 |--optimization-range | Force the simplex optimization range ('day' or 'week') |
 |--no-constraints | Ignore all binding constraints|
 |--no-ts-import | Do not import timeseries into the input folder. <br/> (This option may be useful for running old studies without upgrade)|
-|--mps-export | Export weekly or daily optimal UC+dispatch linear |
+|-m, --mps-export | Export anonymous mps weekly or daily optimal UC+dispatch linear |
+|-s, --named-mps-problems | Export named mps weekly or daily optimal UC+dispatch linear |
 
 - Misc.
 

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1075,7 +1075,7 @@ bool Parameters::loadFromINI(const IniFile& ini, uint version, const StudyLoadOp
     if (options.usedByTheSolver)
         prepareForSimulation(options);
 
-    if (options.mpsToExport)
+    if (options.mpsToExport || options.namedProblems)
     {
         this->include.exportMPS = mpsExportStatus::EXPORT_BOTH_OPTIMS;
     }

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -164,15 +164,15 @@ std::unique_ptr<GetOpt::Parser> CreateParser(Settings& settings,
 
     // --mps-export
     parser->addFlag(options.mpsToExport,
-                    ' ',
+                    'm',
                     "mps-export",
-                    "Export in the mps format the optimization problems.");
+                    "Export in the mps (anonymous) format the optimization problems (both optim).");
 
     // --named-problems
     parser->addFlag(options.namedProblems,
-                    ' ',
+                    's',
                     "named-mps-problems",
-                    "Naming constraints and variables in problems.");
+                    "Export named constraints and variables in mps (both optim).");
 
     parser->addParagraph("\nMisc.");
     // --progress


### PR DESCRIPTION
What? add short options :
- --mps-export  = -m (anonymous mps)
- --named-mps-problems = -s

*To be discussed: the fact that if we want named mps, we want mps but from  which optim?