### PR TITLE
Fix/global var hydro modulable

### DIFF
--- a/src/libs/antares/study/runtime/runtime.cpp
+++ b/src/libs/antares/study/runtime/runtime.cpp
@@ -246,19 +246,12 @@ void StudyRuntimeInfos::initializeRangeLimits(const Study& study, StudyRangeLimi
 }
 
 StudyRuntimeInfos::StudyRuntimeInfos(uint nbYearsParallel) :
- nbYears(0),
- parameters(nullptr),
- timeseriesNumberYear(nullptr),
- thermalPlantTotalCount(0),
- thermalPlantTotalCountMustRun(0),
- quadraticOptimizationHasFailed(false)
+    nbYears(0),
+    parameters(nullptr),
+    thermalPlantTotalCount(0),
+    thermalPlantTotalCountMustRun(0),
+    quadraticOptimizationHasFailed(false)
 {
-    // Evite les confusions de numeros de TS entre AMC
-    timeseriesNumberYear = new uint[nbYearsParallel];
-    for (uint numSpace = 0; numSpace < nbYearsParallel; numSpace++)
-    {
-        timeseriesNumberYear[numSpace] = 999999;
-    }
 }
 
 void StudyRuntimeInfos::checkThermalTSGeneration(Study& study)
@@ -447,8 +440,6 @@ void StudyRuntimeInfos::removeAllRenewableClustersFromSolverComputations(Study& 
 StudyRuntimeInfos::~StudyRuntimeInfos()
 {
     logs.debug() << "Releasing runtime data";
-
-    delete[] timeseriesNumberYear;
 }
 
 #ifndef NDEBUG

--- a/src/libs/antares/study/runtime/runtime.h
+++ b/src/libs/antares/study/runtime/runtime.h
@@ -109,14 +109,6 @@ public:
     //! Random numbers generators
     MersenneTwister random[seedMax];
 
-    /*!
-    ** \brief The index to use when retrieving the time-series numbers
-    **
-    ** To allow the drop of the years with no solution, we can not fully rely
-    ** on the current year. So we have to maintain a rotating index (0..nbYears)
-    */
-    uint* timeseriesNumberYear;
-
     //! Total
     uint thermalPlantTotalCount;
     uint thermalPlantTotalCountMustRun;

--- a/src/solver/aleatoire/alea_fonctions.h
+++ b/src/solver/aleatoire/alea_fonctions.h
@@ -30,4 +30,5 @@
 #include "antares/study/study.h"
 
 void ApplyRandomTSnumbers(const Antares::Data::Study& study,
+                          unsigned int year,
                           uint numSpace);

--- a/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
+++ b/src/solver/aleatoire/alea_tirage_au_sort_chroniques.cpp
@@ -34,12 +34,9 @@ using namespace Antares;
 using namespace Antares::Data;
 
 void ApplyRandomTSnumbers(const Study& study,
+                          unsigned int year,
                           uint numSpace)
 {
-    auto& runtime = *study.runtime;
-
-    uint year = runtime.timeseriesNumberYear[numSpace];
-
     // each area
     const unsigned int count = study.areas.size();
     for (unsigned int areaIndex = 0; areaIndex != count; ++areaIndex)
@@ -126,9 +123,9 @@ void ApplyRandomTSnumbers(const Study& study,
     // Transmission capacities
     // ------------------------------
     // each link
-    for (unsigned int linkIndex = 0; linkIndex < runtime.interconnectionsCount(); ++linkIndex)
+    for (unsigned int linkIndex = 0; linkIndex < study.runtime->interconnectionsCount(); ++linkIndex)
     {
-        AreaLink* link = runtime.areaLink[linkIndex];
+        AreaLink* link = study.runtime->areaLink[linkIndex];
         assert(year < link->timeseriesNumbers.height);
         NUMERO_CHRONIQUES_TIREES_PAR_INTERCONNEXION& ptchro
           = NumeroChroniquesTireesParInterconnexion[numSpace][linkIndex];

--- a/src/solver/hydro/daily2/h2o2_j_donnees_optimisation.h
+++ b/src/solver/hydro/daily2/h2o2_j_donnees_optimisation.h
@@ -144,7 +144,7 @@ constexpr unsigned int seed = 0x79683264; // "hyd2" in hexa
 class Hydro_problem_costs
 {
 public:
-    Hydro_problem_costs(const Data::Study& study);
+    Hydro_problem_costs(const Data::Parameters& parameters);
 
     inline double get_end_days_levels_cost() const
     {

--- a/src/solver/hydro/daily2/h2o2_j_optim_costs.cpp
+++ b/src/solver/hydro/daily2/h2o2_j_optim_costs.cpp
@@ -28,7 +28,7 @@
 #include "h2o2_j_donnees_optimisation.h"
 #include "antares/study/fwd.h"
 
-Hydro_problem_costs::Hydro_problem_costs(const Data::Study& study)
+Hydro_problem_costs::Hydro_problem_costs(const Data::Parameters& parameters)
 {
     noiseGenerator.reset(Constants::seed);
     end_days_levels = -1. / 32.;
@@ -36,7 +36,7 @@ Hydro_problem_costs::Hydro_problem_costs(const Data::Study& study)
     deviations = 1.;
     violations = 68.;
 
-    switch (study.parameters.hydroHeuristicPolicy.hhPolicy)
+    switch (parameters.hydroHeuristicPolicy.hhPolicy)
     {
     case Data::hhpMaximizeGeneration:
         waste = 33 * 68.;

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -264,7 +264,7 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
     {
         debugData = std::make_shared<DebugData>(resultWriter_,
                                                 data,
-                                                ventilationResults_[numSpace][z],
+                                                ventilationResults,
                                                 srcinflows,
                                                 maxP,
                                                 maxE,

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -99,7 +99,7 @@ struct DebugData
 
     Solver::IResultWriter::Ptr pWriter;
     const TmpDataByArea& data;
-    const VALEURS_GENEREES_PAR_PAYS& valgen;
+    const VENTILATION_HYDRO_RESULTS_BY_AREA& ventilationResults;
     const InflowsType& srcinflows;
     const MaxPowerType& maxP;
     const MaxPowerType& maxE;
@@ -109,7 +109,7 @@ struct DebugData
 
     DebugData(Solver::IResultWriter::Ptr writer,
               const TmpDataByArea& data,
-              const VALEURS_GENEREES_PAR_PAYS& valgen,
+              const VENTILATION_HYDRO_RESULTS_BY_AREA& ventilationResults,
               const InflowsType& srcinflows,
               const MaxPowerType& maxP,
               const MaxPowerType& maxE,
@@ -118,7 +118,7 @@ struct DebugData
               double reservoirCapacity) :
      pWriter(writer),
      data(data),
-     valgen(valgen),
+     ventilationResults(ventilationResults),
      srcinflows(srcinflows),
      maxP(maxP),
      maxE(maxE),
@@ -144,7 +144,7 @@ struct DebugData
         buffer << "\tTurbine\t\t\tOPP\t\t\t\tTurbine Cible\tDLE\t\t\t\tDLN\n";
         for (uint day = 0; day != 365; ++day)
         {
-            double value = valgen.HydrauliqueModulableQuotidien[day];
+            double value = ventilationResults.HydrauliqueModulableQuotidien[day];
             buffer << day << '\t' << value << '\t' << OPP[day] << '\t' << DailyTargetGen[day]
                    << '\t' << data.DLE[day] << '\t' << data.DLN[day];
             buffer << '\n';
@@ -188,9 +188,9 @@ struct DebugData
             uint dayMonth = 1;
             for (uint day = firstDay; day != endDay; ++day)
             {
-                double turbines = valgen.HydrauliqueModulableQuotidien[day] / reservoirCapacity;
-                double niveauDeb = valgen.NiveauxReservoirsDebutJours[day];
-                double niveauFin = valgen.NiveauxReservoirsFinJours[day];
+                double turbines = ventilationResults.HydrauliqueModulableQuotidien[day] / reservoirCapacity;
+                double niveauDeb = ventilationResults.NiveauxReservoirsDebutJours[day];
+                double niveauFin = ventilationResults.NiveauxReservoirsFinJours[day];
                 double apports = srcinflows[day] / reservoirCapacity;
                 double turbMax = maxP[day] * maxE[day] / reservoirCapacity;
                 double turbCible = dailyTargetGen[day] / reservoirCapacity;
@@ -225,8 +225,7 @@ struct DebugData
 inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::State& state,
                                                             Data::Area& area,
                                                             uint y,
-                                                            uint numSpace,
-                                                            VAL_GEN_PAR_PAYS& valeursGenereesParPays)
+                                                            uint numSpace)
 {
     uint z = area.index;
     assert(z < areas_.size());
@@ -257,15 +256,15 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
     auto const& maxP = maxPower[Data::PartHydro::genMaxP];
     auto const& maxE = maxPower[Data::PartHydro::genMaxE];
 
-    auto& valgen = valeursGenereesParPays[numSpace][z];
-
+    auto& ventilationResults = ventilationResults_[numSpace][z];
+    
     std::shared_ptr<DebugData> debugData(nullptr);
 
     if (parameters_.hydroDebug && resultWriter_)
     {
         debugData = std::make_shared<DebugData>(resultWriter_,
                                                 data,
-                                                valgen,
+                                                ventilationResults_[numSpace][z],
                                                 srcinflows,
                                                 maxP,
                                                 maxE,
@@ -411,7 +410,7 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
                 dayMonth = 0;
                 for (uint day = firstDay; day != endDay; ++day)
                 {
-                    valgen.HydrauliqueModulableQuotidien[day] = problem.Turbine[dayMonth];
+                    ventilationResults.HydrauliqueModulableQuotidien[day] = problem.Turbine[dayMonth];
                     dayMonth++;
                 }
                 break;
@@ -428,8 +427,8 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
 #ifndef NDEBUG
             for (uint day = firstDay; day != endDay; ++day)
             {
-                assert(!Math::NaN(valgen.HydrauliqueModulableQuotidien[day]));
-                assert(!Math::Infinite(valgen.HydrauliqueModulableQuotidien[day]));
+                assert(!Math::NaN(ventilationResults.HydrauliqueModulableQuotidien[day]));
+                assert(!Math::Infinite(ventilationResults.HydrauliqueModulableQuotidien[day]));
             }
 #endif
         }
@@ -505,10 +504,10 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
                 dayMonth = 0;
                 for (uint day = firstDay; day != endDay; ++day)
                 {
-                    valgen.HydrauliqueModulableQuotidien[day]
+                    ventilationResults.HydrauliqueModulableQuotidien[day]
                       = problem.Turbine[dayMonth] * reservoirCapacity;
 
-                    valgen.NiveauxReservoirsFinJours[day] = problem.niveauxFinJours[dayMonth];
+                    ventilationResults.NiveauxReservoirsFinJours[day] = problem.niveauxFinJours[dayMonth];
 
                     if (debugData)
                     {
@@ -520,10 +519,10 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
                     dayMonth++;
                 }
 
-                valgen.NiveauxReservoirsDebutJours[firstDay] = monthInitialLevel;
+                ventilationResults.NiveauxReservoirsDebutJours[firstDay] = monthInitialLevel;
                 for (uint day = firstDay + 1; day != endDay; ++day)
-                    valgen.NiveauxReservoirsDebutJours[day]
-                      = valgen.NiveauxReservoirsFinJours[day - 1];
+                    ventilationResults.NiveauxReservoirsDebutJours[day]
+                      = ventilationResults.NiveauxReservoirsFinJours[day - 1];
 
                 monthInitialLevel = problem.niveauxFinJours[dayMonth - 1];
 
@@ -543,7 +542,7 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
 
         uint firstDaySimu = parameters_.simulationDays.first;
         state.problemeHebdo->previousSimulationFinalLevel[z]
-          = valgen.NiveauxReservoirsDebutJours[firstDaySimu] * reservoirCapacity;
+          = ventilationResults.NiveauxReservoirsDebutJours[firstDaySimu] * reservoirCapacity;
 
         if (debugData)
         {
@@ -554,12 +553,11 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
 
 void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::State& state,
                                                      uint y,
-                                                     uint numSpace,
-                                                     VAL_GEN_PAR_PAYS& valeursGenereesParPays)
+                                                     uint numSpace)
 {
     areas_.each(
       [&](Data::Area& area) {
-          prepareDailyOptimalGenerations(state, area, y, numSpace, valeursGenereesParPays);
+          prepareDailyOptimalGenerations(state, area, y, numSpace);
           });
 }
 

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -46,8 +46,8 @@ double HydroManagement::GammaVariable(double r)
     do
     {
         double s = r - 1.;
-        double u = random();
-        double v = random();
+        double u = random_();
+        double v = random_();
         double w = u * (1. - u);
         assert(Math::Abs(w) > 1e-12);
         assert(3. * (r - 0.25) / w > 0.);
@@ -78,28 +78,33 @@ inline double HydroManagement::BetaVariable(double a, double b)
     return y / (y + z);
 }
 
-HydroManagement::HydroManagement(Data::Study& study) : study(study), parameters(study.parameters)
+HydroManagement::HydroManagement(const Data::AreaList& areas,
+                                 const Data::Parameters& params,
+                                 const Date::Calendar& calendar,
+                                 unsigned int maxNbYearsInParallel,
+                                 Solver::IResultWriter::Ptr resultWriter) :
+    areas_(areas),
+    calendar_(calendar),
+    parameters_(params),
+    maxNbYearsInParallel_(maxNbYearsInParallel),
+    resultWriter_(resultWriter)
 {
-    pAreas = new PerArea*[study.maxNbYearsInParallel];
-    for (uint numSpace = 0; numSpace < study.maxNbYearsInParallel; numSpace++)
-        pAreas[numSpace] = new PerArea[study.areas.size()];
-
-    random.reset(study.parameters.seed[Data::seedHydroManagement]);
+    tmpDataByArea_ = new TmpDataByArea* [maxNbYearsInParallel_];
+    for (uint numSpace = 0; numSpace < maxNbYearsInParallel_; numSpace++)
+        tmpDataByArea_[numSpace] = new TmpDataByArea[areas_.size()];
+    random_.reset(parameters_.seed[Data::seedHydroManagement]);
 }
 
 HydroManagement::~HydroManagement()
 {
-    for (uint numSpace = 0; numSpace < study.maxNbYearsInParallel; numSpace++)
-        delete[] pAreas[numSpace];
-    delete[] pAreas;
+    for (uint numSpace = 0; numSpace < maxNbYearsInParallel_; numSpace++)
+        delete[] tmpDataByArea_[numSpace];
+    delete[] tmpDataByArea_;
 }
 
 void HydroManagement::prepareInflowsScaling(uint numSpace)
 {
-    auto& calendar = study.calendar;
-
-    study.areas.each(
-      [&](Data::Area& area)
+    areas_.each([&](Data::Area& area)
       {
           uint z = area.index;
 
@@ -110,18 +115,18 @@ void HydroManagement::prepareInflowsScaling(uint numSpace)
           auto tsIndex = (uint)ptchro.Hydraulique;
           auto const& srcinflows = inflowsmatrix[tsIndex < inflowsmatrix.width ? tsIndex : 0];
 
-          auto& data = pAreas[numSpace][z];
+          auto& data = tmpDataByArea_[numSpace][z];
           double totalYearInflows = 0.0;
 
           for (uint month = 0; month != 12; ++month)
           {
-              uint realmonth = calendar.months[month].realmonth;
+              uint realmonth = calendar_.months[month].realmonth;
 
               double totalMonthInflows = 0.0;
 
-              uint firstDayOfMonth = calendar.months[month].daysYear.first;
+              uint firstDayOfMonth = calendar_.months[month].daysYear.first;
 
-              uint firstDayOfNextMonth = calendar.months[month].daysYear.end;
+              uint firstDayOfNextMonth = calendar_.months[month].daysYear.end;
 
               for (uint d = firstDayOfMonth; d != firstDayOfNextMonth; ++d)
                   totalMonthInflows += srcinflows[d];
@@ -152,10 +157,7 @@ void HydroManagement::prepareInflowsScaling(uint numSpace)
 
 void HydroManagement::minGenerationScaling(uint numSpace)
 {
-    const auto& calendar = study.calendar;
-
-    study.areas.each(
-      [this, &numSpace, &calendar](Data::Area& area)
+    areas_.each([this, &numSpace](Data::Area& area)
       {
           uint z = area.index;
 
@@ -164,14 +166,14 @@ void HydroManagement::minGenerationScaling(uint numSpace)
           auto tsIndex = (uint)ptchro.Hydraulique;
           auto const& srcmingen = mingenmatrix[tsIndex < mingenmatrix.width ? tsIndex : 0];
 
-          auto& data = pAreas[numSpace][z];
+          auto& data = tmpDataByArea_[numSpace][z];
           double totalYearMingen = 0.0;
 
           for (uint month = 0; month != 12; ++month)
           {
-              uint realmonth = calendar.months[month].realmonth;
-              uint firstDayOfMonth = calendar.months[month].daysYear.first;
-              uint firstDayOfNextMonth = calendar.months[month].daysYear.end;
+              uint realmonth = calendar_.months[month].realmonth;
+              uint firstDayOfMonth = calendar_.months[month].daysYear.first;
+              uint firstDayOfNextMonth = calendar_.months[month].daysYear.end;
 
               double totalMonthMingen = std::accumulate(
                 srcmingen + firstDayOfMonth * 24, srcmingen + firstDayOfNextMonth * 24, 0.);
@@ -198,9 +200,9 @@ void HydroManagement::minGenerationScaling(uint numSpace)
               }
 
               // Set daily mingen, used later for h2o_d
-              uint simulationMonth = study.calendar.mapping.months[realmonth];
-              auto daysPerMonth = study.calendar.months[simulationMonth].days;
-              uint firstDay = study.calendar.months[simulationMonth].daysYear.first;
+              uint simulationMonth = calendar_.mapping.months[realmonth];
+              auto daysPerMonth = calendar_.months[simulationMonth].days;
+              uint firstDay = calendar_.months[simulationMonth].daysYear.first;
               uint endDay = firstDay + daysPerMonth;
 
               for (uint day = firstDay; day != endDay; ++day)
@@ -215,10 +217,10 @@ void HydroManagement::minGenerationScaling(uint numSpace)
 
 bool HydroManagement::checkMonthlyMinGeneration(uint numSpace, uint tsIndex, const Data::Area& area) const
 {
-    const auto& data = pAreas[numSpace][area.index];
+    const auto& data = tmpDataByArea_[numSpace][area.index];
     for (uint month = 0; month != 12; ++month)
     {
-        uint realmonth = study.calendar.months[month].realmonth;
+        uint realmonth = calendar_.months[month].realmonth;
         // Monthly minimum generation <= Monthly inflows for each month
         if (area.hydro.followLoadModulations &&
             !area.hydro.reservoirManagement &&
@@ -236,7 +238,7 @@ bool HydroManagement::checkMonthlyMinGeneration(uint numSpace, uint tsIndex, con
 
 bool HydroManagement::checkYearlyMinGeneration(uint numSpace, uint tsIndex, const Data::Area& area) const
 {
-    const auto& data = pAreas[numSpace][area.index];
+    const auto& data = tmpDataByArea_[numSpace][area.index];
     if (area.hydro.followLoadModulations &&
         area.hydro.reservoirManagement &&
         data.totalYearMingen > data.totalYearInflows)
@@ -254,25 +256,24 @@ bool HydroManagement::checkWeeklyMinGeneration(uint tsIndex, Data::Area& area) c
 {
     if (!area.hydro.followLoadModulations)
     {
-        const auto& calendar = study.calendar;
         auto& inflowsmatrix = area.hydro.series->storage;
         auto& mingenmatrix = area.hydro.series->mingen;
         auto const& srcinflows = inflowsmatrix[tsIndex < inflowsmatrix.width ? tsIndex : 0];
         auto const& srcmingen = mingenmatrix[tsIndex < mingenmatrix.width ? tsIndex : 0];
         // Weekly minimum generation <= Weekly inflows for each week
-        for (uint week = 0; week < calendar.maxWeeksInYear - 1; ++week)
+        for (uint week = 0; week < calendar_.maxWeeksInYear - 1; ++week)
         {
             double totalWeekMingen = 0.0;
             double totalWeekInflows = 0.0;
-            for (uint hour = calendar.weeks[week].hours.first;
-                 hour < calendar.weeks[week].hours.end && hour < HOURS_PER_YEAR;
+            for (uint hour = calendar_.weeks[week].hours.first;
+                 hour < calendar_.weeks[week].hours.end && hour < HOURS_PER_YEAR;
                  ++hour)
             {
                 totalWeekMingen += srcmingen[hour];
             }
 
-            for (uint day = calendar.weeks[week].daysYear.first;
-                 day < calendar.weeks[week].daysYear.end;
+            for (uint day = calendar_.weeks[week].daysYear.first;
+                 day < calendar_.weeks[week].daysYear.end;
                  ++day)
             {
                 totalWeekInflows += srcinflows[day];
@@ -293,7 +294,6 @@ bool HydroManagement::checkWeeklyMinGeneration(uint tsIndex, Data::Area& area) c
 bool HydroManagement::checkHourlyMinGeneration(uint tsIndex, Data::Area& area) const
 {
     // Hourly minimum generation <= hourly inflows for each hour
-    const auto& calendar = study.calendar;
     auto& mingenmatrix = area.hydro.series->mingen;
     auto const& srcmingen = mingenmatrix[tsIndex < mingenmatrix.width ? tsIndex : 0];
     auto const& maxPower = area.hydro.maxPower;
@@ -303,10 +303,10 @@ bool HydroManagement::checkHourlyMinGeneration(uint tsIndex, Data::Area& area) c
     {
         for (uint month = 0; month != 12; ++month)
         {
-            uint realmonth = calendar.months[month].realmonth;
-            uint simulationMonth = study.calendar.mapping.months[realmonth];
-            auto daysPerMonth = study.calendar.months[simulationMonth].days;
-            uint firstDay = study.calendar.months[simulationMonth].daysYear.first;
+            uint realmonth = calendar_.months[month].realmonth;
+            uint simulationMonth = calendar_.mapping.months[realmonth];
+            auto daysPerMonth = calendar_.months[simulationMonth].days;
+            uint firstDay = calendar_.months[simulationMonth].daysYear.first;
             uint endDay = firstDay + daysPerMonth;
 
             for (uint day = firstDay; day != endDay; ++day)
@@ -333,7 +333,7 @@ bool HydroManagement::checkHourlyMinGeneration(uint tsIndex, Data::Area& area) c
 bool HydroManagement::checkMinGeneration(uint numSpace)
 {
     bool ret = true;
-    study.areas.each([this, &numSpace, &ret](Data::Area& area)
+    areas_.each([this, &numSpace, &ret](Data::Area& area)
     {
         uint z = area.index;
         const auto& ptchro = NumeroChroniquesTireesParPays[numSpace][z];
@@ -354,7 +354,7 @@ bool HydroManagement::checkMinGeneration(uint numSpace)
 template<enum Data::StudyMode ModeT>
 void HydroManagement::prepareNetDemand(uint numSpace)
 {
-    study.areas.each([&](Data::Area& area) {
+    areas_.each([&](Data::Area& area) {
         uint z = area.index;
 
         auto& scratchpad = area.scratchpad[numSpace];
@@ -365,16 +365,16 @@ void HydroManagement::prepareNetDemand(uint numSpace)
         auto tsIndex = (uint)ptchro.Hydraulique;
         auto& ror = rormatrix[tsIndex < rormatrix.width ? tsIndex : 0];
 
-        auto& data = pAreas[numSpace][z];
+        auto& data = tmpDataByArea_[numSpace][z];
 
         for (uint hour = 0; hour != 8760; ++hour)
         {
-            auto dayYear = study.calendar.hours[hour].dayYear;
+            auto dayYear = calendar_.hours[hour].dayYear;
 
             double netdemand = 0;
 
             // Aggregated renewable production: wind & solar
-            if (parameters.renewableGeneration.isAggregated())
+            if (parameters_.renewableGeneration.isAggregated())
             {
                 netdemand = +scratchpad.ts.load[ptchro.Consommation][hour]
                             - scratchpad.ts.wind[ptchro.Eolien][hour] - scratchpad.miscGenSum[hour]
@@ -384,7 +384,7 @@ void HydroManagement::prepareNetDemand(uint numSpace)
             }
 
             // Renewable clusters, if enabled
-            else if (parameters.renewableGeneration.isClusters())
+            else if (parameters_.renewableGeneration.isClusters())
             {
                 netdemand = scratchpad.ts.load[ptchro.Consommation][hour]
                             - scratchpad.miscGenSum[hour] - ror[hour]
@@ -407,20 +407,20 @@ void HydroManagement::prepareNetDemand(uint numSpace)
 
 void HydroManagement::prepareEffectiveDemand(uint numSpace)
 {
-    study.areas.each([&](Data::Area& area) {
+    areas_.each([&](Data::Area& area) {
         auto z = area.index;
 
-        auto& data = pAreas[numSpace][z];
+        auto& data = tmpDataByArea_[numSpace][z];
 
         for (uint day = 0; day != 365; ++day)
         {
-            auto month = study.calendar.days[day].month;
+            auto month = calendar_.days[day].month;
             assert(month < 12 && "Invalid month index");
-            auto realmonth = study.calendar.months[month].realmonth;
+            auto realmonth = calendar_.months[month].realmonth;
 
             double effectiveDemand = 0;
             area.hydro.allocation.eachNonNull([&](unsigned areaindex, double value) {
-                effectiveDemand += (pAreas[numSpace][areaindex]).DLN[day] * value;
+                effectiveDemand += (tmpDataByArea_[numSpace][areaindex]).DLN[day] * value;
             });
 
             assert(!Math::NaN(effectiveDemand) && "nan value detected for effectiveDemand");
@@ -437,8 +437,8 @@ void HydroManagement::prepareEffectiveDemand(uint numSpace)
         for (uint month = 0; month != 12; ++month)
         {
             auto minimumMonth = +std::numeric_limits<double>::infinity();
-            auto daysPerMonth = study.calendar.months[month].days;
-            auto realmonth = study.calendar.months[month].realmonth;
+            auto daysPerMonth = calendar_.months[month].days;
+            auto realmonth = calendar_.months[month].realmonth;
 
             for (uint d = 0; d != daysPerMonth; ++d)
             {
@@ -493,13 +493,13 @@ double HydroManagement::randomReservoirLevel(double min, double avg, double max)
     return x * max + (1. - x) * min;
 }
 
-void HydroManagement::operator()(double* randomReservoirLevel,
-                                 Solver::Variable::State& state,
-                                 uint y,
-                                 uint numSpace,
-                                 VAL_GEN_PAR_PAYS& valeursGenereesParPays)
+void HydroManagement::makeVentilation(double* randomReservoirLevel,
+                                      Solver::Variable::State& state,
+                                      uint y,
+                                      uint numSpace,
+                                      VAL_GEN_PAR_PAYS& valeursGenereesParPays)
 {
-    memset(pAreas[numSpace], 0, sizeof(PerArea) * study.areas.size());
+    memset(tmpDataByArea_[numSpace], 0, sizeof(TmpDataByArea) * areas_.size());
 
     prepareInflowsScaling(numSpace);
     minGenerationScaling(numSpace);
@@ -508,7 +508,7 @@ void HydroManagement::operator()(double* randomReservoirLevel,
         throw FatalError("hydro management: invalid minimum generation");
     }
 
-    if (parameters.adequacy())
+    if (parameters_.adequacy())
         prepareNetDemand<Data::stdmAdequacy>(numSpace);
     else
         prepareNetDemand<Data::stdmEconomy>(numSpace);

--- a/src/solver/hydro/management/management.h
+++ b/src/solver/hydro/management/management.h
@@ -85,6 +85,18 @@ struct TmpDataByArea
 
 }; // struct TmpDataByArea
 
+typedef struct
+{
+    std::vector<double> HydrauliqueModulableQuotidien; /* indice par jour */
+    std::vector<double> NiveauxReservoirsDebutJours;   //Niveaux (quotidiens) du reservoir de début
+    //de jour (en cas de gestion des reservoirs).
+    std::vector<double> NiveauxReservoirsFinJours; //Niveaux (quotidiens) du reservoir de fin
+    //de jour (en cas de gestion des reservoirs).
+} VENTILATION_HYDRO_RESULTS_BY_AREA;
+
+// vector of [numSpace][area]
+using ALL_HYDRO_VENTILATION_RESULTS = std::vector<std::vector<VENTILATION_HYDRO_RESULTS_BY_AREA>>;
+
 
 class HydroManagement final
 {
@@ -103,8 +115,9 @@ public:
     void makeVentilation(double* randomReservoirLevel,
                         Solver::Variable::State& state,
                         uint y,
-                        uint numSpace,
-                        VAL_GEN_PAR_PAYS& valeursGenereesParPays);
+                        uint numSpace);
+
+    ALL_HYDRO_VENTILATION_RESULTS& ventilationResults() { return ventilationResults_; }
 
 private:
     //! Prepare inflows scaling for each area
@@ -136,14 +149,12 @@ private:
 
     void prepareDailyOptimalGenerations(Solver::Variable::State& state,
                                         uint y,
-                                        uint numSpace,
-                                        VAL_GEN_PAR_PAYS& valeursGenereesParPays);
+                                        uint numSpace);
 
     void prepareDailyOptimalGenerations(Solver::Variable::State& state,
                                         Data::Area& area,
                                         uint y,
-                                        uint numSpace,
-                                        VAL_GEN_PAR_PAYS& valeursGenereesParPays);
+                                        uint numSpace);
     //@}
 
     //! \name Utilities
@@ -162,6 +173,8 @@ private:
     MersenneTwister random_;
     unsigned int maxNbYearsInParallel_ = 0;
     Solver::IResultWriter::Ptr resultWriter_;
+
+    ALL_HYDRO_VENTILATION_RESULTS ventilationResults_;
 }; // class HydroManagement
 } // namespace Antares
 

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -87,7 +87,7 @@ static void CheckHydroAllocationProblem(Data::Area& area,
 }
 
 
-double HydroManagement::prepareMonthlyTargetGenerations(Data::Area& area, PerArea& data)
+double HydroManagement::prepareMonthlyTargetGenerations(Data::Area& area, TmpDataByArea& data)
 {
     double total = 0;
 
@@ -147,10 +147,10 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
                                                        uint numSpace)
 {
     uint indexArea = 0;
-    study.areas.each([&](Data::Area& area) {
+    areas_.each([&](Data::Area& area) {
         uint z = area.index;
 
-        auto& data = pAreas[numSpace][z];
+        auto& data = tmpDataByArea_[numSpace][z];
 
         auto& minLvl = area.hydro.reservoirLevel[Data::PartHydro::minimum];
         auto& maxLvl = area.hydro.reservoirLevel[Data::PartHydro::maximum];
@@ -181,8 +181,8 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
             {
                 uint realmonth = (initReservoirLvlMonth + month) % 12;
 
-                uint simulationMonth = study.calendar.mapping.months[realmonth];
-                uint firstDay = study.calendar.months[simulationMonth].daysYear.first;
+                uint simulationMonth = calendar_.mapping.months[realmonth];
+                uint firstDay = calendar_.months[simulationMonth].daysYear.first;
 
                 problem.TurbineMax[month] = totalInflowsYear;
                 problem.TurbineMin[month] = data.mingens[realmonth];
@@ -247,8 +247,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
             assert(!Math::Infinite(data.MOL[realmonth]) && "infinite value detected for MOL");
         }
 #endif
-        auto writer = study.resultWriter;
-        if (study.parameters.hydroDebug && writer)
+        if (parameters_.hydroDebug && resultWriter_)
         {
             std::ostringstream buffer, path;
             path << "debug" << SEP << "solver" << SEP << (1 + y) << SEP << "monthly." << area.name
@@ -276,11 +275,11 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
             {
                 uint realmonth = (initReservoirLvlMonth + month) % 12;
 
-                uint simulationMonth = study.calendar.mapping.months[realmonth];
+                uint simulationMonth = calendar_.mapping.months[realmonth];
 
-                uint firstDay = study.calendar.months[simulationMonth].daysYear.first;
+                uint firstDay = calendar_.months[simulationMonth].daysYear.first;
 
-                auto monthName = study.calendar.text.months[simulationMonth].name;
+                auto monthName = calendar_.text.months[simulationMonth].name;
 
                 buffer << monthName[0] << monthName[1] << monthName[2] << '\t';
                 buffer << '\t';
@@ -293,7 +292,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
                 buffer << '\n';
             }
             auto content = buffer.str();
-            writer->addEntryFromBuffer(path.str(), content);
+            resultWriter_->addEntryFromBuffer(path.str(), content);
         }
     });
 }

--- a/src/solver/optimisation/adequacy_patch_csr/adq_patch_curtailment_sharing.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/adq_patch_curtailment_sharing.cpp
@@ -32,7 +32,6 @@
 #include "../simulation/adequacy_patch_runtime_data.h"
 
 #include <cmath>
-#include "../study/area/scratchpad.h"
 
 using namespace Yuni;
 

--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
@@ -29,7 +29,6 @@
 #include "../opt_fonctions.h"
 #include "../simulation/simulation.h"
 #include "../simulation/adequacy_patch_runtime_data.h"
-#include "antares/study/area/scratchpad.h"
 #include "antares/study/fwd.h"
 
 using namespace Antares::Data::AdequacyPatch;

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -91,8 +91,9 @@ bool Adequacy::simulationBegin()
     return true;
 }
 
-bool Adequacy::simplexIsRequired(uint hourInTheYear, uint numSpace,
-        const VAL_GEN_PAR_PAYS& valeursGenereesParPays) const
+bool Adequacy::simplexIsRequired(uint hourInTheYear, 
+                                 uint numSpace,
+                                 const VAL_GEN_PAR_PAYS& valeursGenereesParPays) const
 {
     uint areaCount = study.areas.size();
     uint indx = hourInTheYear;
@@ -156,8 +157,8 @@ bool Adequacy::year(Progression::Task& progression,
         pProblemesHebdo[numSpace].ReinitOptimisation = reinitOptim;
         reinitOptim = false;
 
-        state.simplexHasBeenRan = (w == 0) || simplexIsRequired(hourInTheYear, numSpace, valeursGenereesParPays);
-        if (state.simplexHasBeenRan) // Call to Solver is mandatory for the first week and optional
+        state.simplexRunNeeded = (w == 0) || simplexIsRequired(hourInTheYear, numSpace, valeursGenereesParPays);
+        if (state.simplexRunNeeded) // Call to Solver is mandatory for the first week and optional
                                      // otherwise
         {
             uint nbAreas = study.areas.size();

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -93,7 +93,7 @@ bool Adequacy::simulationBegin()
 
 bool Adequacy::simplexIsRequired(uint hourInTheYear, 
                                  uint numSpace,
-                                 const VAL_GEN_PAR_PAYS& valeursGenereesParPays) const
+                                 const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults) const
 {
     uint areaCount = study.areas.size();
     uint indx = hourInTheYear;
@@ -104,11 +104,11 @@ bool Adequacy::simplexIsRequired(uint hourInTheYear,
 
         for (uint areaIdx = 0; areaIdx != areaCount; ++areaIdx)
         {
-            auto& valgen = valeursGenereesParPays[numSpace][areaIdx];
+            auto& hydroVentilation = hydroVentilationResults[numSpace][areaIdx];
 
             double quantity
               = pProblemesHebdo[numSpace].ConsommationsAbattues[j].ConsommationAbattueDuPays[areaIdx]
-                - valgen.HydrauliqueModulableQuotidien[dayInTheYear] / 24.;
+                - hydroVentilation.HydrauliqueModulableQuotidien[dayInTheYear] / 24.;
 
             if (quantity > 0.)
                 return true; // Call to the solver is required to find an optimal solution
@@ -124,7 +124,7 @@ bool Adequacy::year(Progression::Task& progression,
                     yearRandomNumbers& randomForYear,
                     std::list<uint>& failedWeekList,
                     bool isFirstPerformedYearOfSimulation,
-                    const VAL_GEN_PAR_PAYS& valeursGenereesParPays)
+                    const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
 {
     // No failed week at year start
     failedWeekList.clear();
@@ -148,7 +148,7 @@ bool Adequacy::year(Progression::Task& progression,
         pProblemesHebdo[numSpace].HeureDansLAnnee = hourInTheYear;
 
         ::SIM_RenseignementProblemeHebdo(study, pProblemesHebdo[numSpace], state.weekInTheYear, 
-                                         numSpace, hourInTheYear, valeursGenereesParPays);
+                                         numSpace, hourInTheYear, hydroVentilationResults);
 
         BuildThermalPartOfWeeklyProblem(study, pProblemesHebdo[numSpace],
                                         numSpace, hourInTheYear, randomForYear.pThermalNoisesByArea);
@@ -157,7 +157,7 @@ bool Adequacy::year(Progression::Task& progression,
         pProblemesHebdo[numSpace].ReinitOptimisation = reinitOptim;
         reinitOptim = false;
 
-        state.simplexRunNeeded = (w == 0) || simplexIsRequired(hourInTheYear, numSpace, valeursGenereesParPays);
+        state.simplexRunNeeded = (w == 0) || simplexIsRequired(hourInTheYear, numSpace, hydroVentilationResults);
         if (state.simplexRunNeeded) // Call to Solver is mandatory for the first week and optional
                                      // otherwise
         {
@@ -292,14 +292,14 @@ bool Adequacy::year(Progression::Task& progression,
                 {
                     assert(k < state.resSpilled.width);
                     assert(j < state.resSpilled.height);
-                    auto& valgen = valeursGenereesParPays[numSpace][k];
+                    auto& hydroVentilation = hydroVentilationResults[numSpace][k];
                     auto& hourlyResults = pProblemesHebdo[numSpace].ResultatsHoraires[k];
 
                     hourlyResults.TurbinageHoraire[j]
-                      = valgen.HydrauliqueModulableQuotidien[dayInTheYear] / 24.;
+                      = hydroVentilation.HydrauliqueModulableQuotidien[dayInTheYear] / 24.;
 
                     state.resSpilled[k][j]
-                      = +valgen.HydrauliqueModulableQuotidien[dayInTheYear] / 24.
+                      = +hydroVentilation.HydrauliqueModulableQuotidien[dayInTheYear] / 24.
                         - pProblemesHebdo[numSpace]
                             .ConsommationsAbattues[j]
                             .ConsommationAbattueDuPays[k];

--- a/src/solver/simulation/adequacy.h
+++ b/src/solver/simulation/adequacy.h
@@ -94,8 +94,9 @@ protected:
     void initializeState(Variable::State& state, uint numSpace);
 
 private:
-    bool simplexIsRequired(uint hourInTheYear, uint numSpace,
-            const VAL_GEN_PAR_PAYS& valeursGenereesParPays) const;
+    bool simplexIsRequired(uint hourInTheYear,
+                           uint numSpace,
+                           const VAL_GEN_PAR_PAYS& valeursGenereesParPays) const;
 
     uint pNbWeeks;
     uint pStartTime;

--- a/src/solver/simulation/adequacy.h
+++ b/src/solver/simulation/adequacy.h
@@ -80,7 +80,7 @@ protected:
               yearRandomNumbers& randomForYear,
               std::list<uint>& failedWeekList,
               bool isFirstPerformedYearOfSimulation,
-              const VAL_GEN_PAR_PAYS& valeursGenereesParPays);
+              const ALL_HYDRO_VENTILATION_RESULTS&);
 
     void incrementProgression(Progression::Task& progression);
 
@@ -96,7 +96,7 @@ protected:
 private:
     bool simplexIsRequired(uint hourInTheYear,
                            uint numSpace,
-                           const VAL_GEN_PAR_PAYS& valeursGenereesParPays) const;
+                           const ALL_HYDRO_VENTILATION_RESULTS&) const;
 
     uint pNbWeeks;
     uint pStartTime;

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -119,7 +119,7 @@ bool Economy::year(Progression::Task& progression,
                    yearRandomNumbers& randomForYear,
                    std::list<uint>& failedWeekList,
                    bool isFirstPerformedYearOfSimulation,
-                   VAL_GEN_PAR_PAYS& valeursGenereesParPays)
+                   ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
 {
     // No failed week at year start
     failedWeekList.clear();
@@ -143,7 +143,7 @@ bool Economy::year(Progression::Task& progression,
         pProblemesHebdo[numSpace].HeureDansLAnnee = hourInTheYear;
 
         ::SIM_RenseignementProblemeHebdo(study, pProblemesHebdo[numSpace], state.weekInTheYear, 
-                                         numSpace, hourInTheYear, valeursGenereesParPays);
+                                         numSpace, hourInTheYear, hydroVentilationResults);
 
         BuildThermalPartOfWeeklyProblem(study, pProblemesHebdo[numSpace], 
                                         numSpace, hourInTheYear, randomForYear.pThermalNoisesByArea);

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -119,7 +119,7 @@ bool Economy::year(Progression::Task& progression,
                    yearRandomNumbers& randomForYear,
                    std::list<uint>& failedWeekList,
                    bool isFirstPerformedYearOfSimulation,
-                   ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
+                   const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
 {
     // No failed week at year start
     failedWeekList.clear();

--- a/src/solver/simulation/economy.h
+++ b/src/solver/simulation/economy.h
@@ -81,7 +81,7 @@ protected:
               yearRandomNumbers& randomForYear,
               std::list<uint>& failedWeekList,
               bool isFirstPerformedYearOfSimulation,
-              ALL_HYDRO_VENTILATION_RESULTS&);
+              const ALL_HYDRO_VENTILATION_RESULTS&);
 
     void incrementProgression(Progression::Task& progression);
 

--- a/src/solver/simulation/economy.h
+++ b/src/solver/simulation/economy.h
@@ -81,7 +81,7 @@ protected:
               yearRandomNumbers& randomForYear,
               std::list<uint>& failedWeekList,
               bool isFirstPerformedYearOfSimulation,
-              VAL_GEN_PAR_PAYS& valeursGenereesParPays);
+              ALL_HYDRO_VENTILATION_RESULTS&);
 
     void incrementProgression(Progression::Task& progression);
 

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -314,7 +314,8 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
 }
 
 void preparerBindingConstraint(const PROBLEME_HEBDO &problem, uint numSpace, int PasDeTempsDebut,
-                               const BindingConstraintsRepository &bindingConstraints, const uint weekFirstDay, int pasDeTemps) {
+                               const BindingConstraintsRepository &bindingConstraints, const uint weekFirstDay, int pasDeTemps) 
+{
     auto activeContraints = bindingConstraints.activeContraints();
     const auto constraintCount = activeContraints.size();
     for (unsigned constraintIndex = 0; constraintIndex != constraintCount; ++constraintIndex)
@@ -379,7 +380,7 @@ void SIM_RenseignementProblemeHebdo(const Study& study,
                                     uint weekInTheYear,
                                     uint numSpace,
                                     const int PasDeTempsDebut,
-                                    const VAL_GEN_PAR_PAYS& valeursGenereesParPays)
+                                    const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
 {
     const auto& parameters = study.parameters;
     auto& studyruntime = *study.runtime;
@@ -681,7 +682,7 @@ void SIM_RenseignementProblemeHebdo(const Study& study,
                                         .MinEnergieHydrauParIntervalleOptimise;
 
                         const std::vector<double>& DNT
-                          = valeursGenereesParPays[numSpace][k].HydrauliqueModulableQuotidien;
+                          = hydroVentilationResults[numSpace][k].HydrauliqueModulableQuotidien;
 
                         double WSL
                           = problem.CaracteristiquesHydrauliques[k].NiveauInitialReservoir;
@@ -770,7 +771,7 @@ void SIM_RenseignementProblemeHebdo(const Study& study,
                     for (uint j = 0; j < 7; ++j)
                     {
                         uint day = study.calendar.hours[PasDeTempsDebut + j * 24].dayYear;
-                        weekTarget_tmp += valeursGenereesParPays[numSpace][k]
+                        weekTarget_tmp += hydroVentilationResults[numSpace][k]
                                             .HydrauliqueModulableQuotidien[day];
                     }
 
@@ -791,7 +792,7 @@ void SIM_RenseignementProblemeHebdo(const Study& study,
                         uint day = study.calendar.hours[PasDeTempsDebut + j * 24].dayYear;
                         problem.CaracteristiquesHydrauliques[k]
                           .CntEnergieH2OParIntervalleOptimise[j]
-                          = valeursGenereesParPays[numSpace][k].HydrauliqueModulableQuotidien[day]
+                          = hydroVentilationResults[numSpace][k].HydrauliqueModulableQuotidien[day]
                             * problem.CaracteristiquesHydrauliques[k].WeeklyGeneratingModulation
                             * marginGen / weekGenerationTarget;
                     }

--- a/src/solver/simulation/sim_structure_donnees.h
+++ b/src/solver/simulation/sim_structure_donnees.h
@@ -46,15 +46,6 @@ typedef struct
 
 typedef struct
 {
-    std::vector<double> HydrauliqueModulableQuotidien; /* indice par jour */
-    std::vector<double> NiveauxReservoirsDebutJours;   //Niveaux (quotidiens) du reservoir de début
-                                                       //de jour (en cas de gestion des reservoirs).
-    std::vector<double> NiveauxReservoirsFinJours; //Niveaux (quotidiens) du reservoir de fin
-                                                   //de jour (en cas de gestion des reservoirs).
-} VALEURS_GENEREES_PAR_PAYS;
-
-typedef struct
-{
     double* Horaire;
 } PRODUCTION_THERMIQUE;
 
@@ -62,9 +53,6 @@ typedef struct
 {
     double* ParLigne;
 } MATRICE_2D;
-
-// vector of [numSpace][area]
-using VAL_GEN_PAR_PAYS = std::vector<std::vector<VALEURS_GENEREES_PAR_PAYS>>;
 
 /* Old define */
 #define DEFINITION_STRUCTURES_DONNEES

--- a/src/solver/simulation/simulation.h
+++ b/src/solver/simulation/simulation.h
@@ -30,6 +30,7 @@
 #include "../config.h"
 #include "sim_structure_donnees.h"
 #include <antares/study/study.h>
+#include "../solver/hydro/management.h"
 
 struct PROBLEME_HEBDO;
 
@@ -57,7 +58,7 @@ void SIM_RenseignementProblemeHebdo(const Antares::Data::Study& study,
                                     uint weekInTheYear,
                                     uint numSpace,
                                     const int,
-                                    const VAL_GEN_PAR_PAYS&);
+                                    const ALL_HYDRO_VENTILATION_RESULTS&);
 
 void SIM_RenseignementProblemeHoraireAdequation(uint);
 

--- a/src/solver/simulation/solver.h
+++ b/src/solver/simulation/solver.h
@@ -169,8 +169,6 @@ private:
     // Collecting durations inside the simulation
     Benchmarking::IDurationCollector* pDurationCollector;
 
-    VAL_GEN_PAR_PAYS valeursGenereesParPays;
-
 public:
     //! The queue service that runs every set of parallel years
     std::shared_ptr<Yuni::Job::QueueService> pQueueService = nullptr;

--- a/src/solver/simulation/solver.h
+++ b/src/solver/simulation/solver.h
@@ -157,7 +157,7 @@ private:
     //! Year by year output results
     bool pYearByYear;
     //! Hydro management
-    HydroManagement pHydroManagement;
+    HydroManagement hydroManagement;
     //! Hydro hot start
     bool pHydroHotStart;
     //! The first set of parallel year(s) with a performed year was already run ?

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -163,8 +163,7 @@ private:
                 simulation_->hydroManagement.makeVentilation(randomReservoirLevel, 
                                                              state[numSpace], 
                                                              y,
-                                                             numSpace, 
-                                                             simulation_->valeursGenereesParPays);
+                                                             numSpace);
                 timer.stop();
                 pDurationCollector->addDuration("hydro_ventilation", timer.get_duration());
             }
@@ -186,7 +185,7 @@ private:
                                                randomForCurrentYear,
                                                failedWeekList,
                                                isFirstPerformedYearOfSimulation,
-                                               simulation_->valeursGenereesParPays);
+                                               simulation_->hydroManagement.ventilationResults());
 
             // Log failing weeks
             logFailedWeek(y, study, failedWeekList);
@@ -228,30 +227,6 @@ private:
     } // End of onExecute() method
 };
 
-static void allocateValeursGenereesParPays(VAL_GEN_PAR_PAYS& val,
-                                           const Data::Study& study)
-{
-    uint nbDaysPerYear = 365;
-    val.resize(study.maxNbYearsInParallel);
-    for (uint numSpace = 0; numSpace < study.maxNbYearsInParallel; numSpace++)
-    {
-        val[numSpace].resize(study.areas.size());
-        for (uint areaIndex = 0; areaIndex < study.areas.size(); ++areaIndex)
-        {
-            auto& area = *study.areas.byIndex[areaIndex];
-            size_t clusterCount = area.thermal.clusterCount();
-
-            val[numSpace][areaIndex].HydrauliqueModulableQuotidien.assign(nbDaysPerYear, 0);
-
-            if (area.hydro.reservoirManagement)
-            {
-                val[numSpace][areaIndex].NiveauxReservoirsDebutJours.assign(nbDaysPerYear, 0.);
-                val[numSpace][areaIndex].NiveauxReservoirsFinJours.assign(nbDaysPerYear, 0.);
-            }
-        }
-    }
-}
-
 template<class Impl>
 inline ISimulation<Impl>::ISimulation(Data::Study& study,
     const ::Settings& settings,
@@ -284,8 +259,6 @@ inline ISimulation<Impl>::ISimulation(Data::Study& study,
         pYearByYear = false;
 
     pHydroHotStart = (study.parameters.initialReservoirLevels.iniLevels == Data::irlHotStart);
-
-    allocateValeursGenereesParPays(valeursGenereesParPays, study);
 }
 
 template<class Impl>

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -160,8 +160,11 @@ private:
             // 4 - Hydraulic ventilation
             {
                 Benchmarking::Timer timer;
-                simulation_->pHydroManagement(randomReservoirLevel, state[numSpace], y,
-                                              numSpace, simulation_->valeursGenereesParPays);
+                simulation_->hydroManagement.makeVentilation(randomReservoirLevel, 
+                                                             state[numSpace], 
+                                                             y,
+                                                             numSpace, 
+                                                             simulation_->valeursGenereesParPays);
                 timer.stop();
                 pDurationCollector->addDuration("hydro_ventilation", timer.get_duration());
             }
@@ -251,15 +254,19 @@ static void allocateValeursGenereesParPays(VAL_GEN_PAR_PAYS& val,
 
 template<class Impl>
 inline ISimulation<Impl>::ISimulation(Data::Study& study,
-                                      const ::Settings& settings,
-                                      Benchmarking::IDurationCollector* duration_collector) :
+    const ::Settings& settings,
+    Benchmarking::IDurationCollector* duration_collector) :
     ImplementationType(study),
     study(study),
     settings(settings),
     pNbYearsReallyPerformed(0),
     pNbMaxPerformedYearsInParallel(0),
     pYearByYear(study.parameters.yearByYear),
-    pHydroManagement(study),
+    hydroManagement(study.areas, 
+                    study.parameters, 
+                    study.calendar, 
+                    study.maxNbYearsInParallel,
+                    study.resultWriter),
     pFirstSetParallelWithAPerformedYearWasRun(false),
     pDurationCollector(duration_collector),
     pQueueService(study.pQueueService),
@@ -740,7 +747,7 @@ void ISimulation<Impl>::computeRandomNumbers(randomNumbers& randomForYears,
             // Previous month's first day in the year
             int firstDayOfMonth = study.calendar.months[initResLevelOnSimMonth].daysYear.first;
 
-            double randomLevel = pHydroManagement.randomReservoirLevel(min[firstDayOfMonth], 
+            double randomLevel = hydroManagement.randomReservoirLevel(min[firstDayOfMonth],
                                                                        avg[firstDayOfMonth],
                                                                        max[firstDayOfMonth]);
 

--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -152,7 +152,7 @@ private:
 
             // 2 - Preparing the Time-series numbers
             // We want to draw lots of numbers for time-series
-            ApplyRandomTSnumbers(study, numSpace);
+            ApplyRandomTSnumbers(study, y, numSpace);
 
             // 3 - Preparing data related to Clusters in 'must-run' mode
             simulation_->prepareClustersInMustRunMode(numSpace);
@@ -980,7 +980,6 @@ void ISimulation<Impl>::loopThroughYears(uint firstYear,
             {
                 yearPerformed = true;
                 numSpace = set_it->performedYearToSpace[y];
-                study.runtime->timeseriesNumberYear[numSpace] = y;
             }
 
             // If the year has not to be rerun, we skip the computation of the year.

--- a/src/solver/variable/economy/max-mrg.cpp
+++ b/src/solver/variable/economy/max-mrg.cpp
@@ -176,7 +176,7 @@ inline void PrepareMaxMRGFor(const State& state, double* opmrg, uint numSpace)
 
 void PrepareMaxMRG(const State& state, double* opmrg, uint numSpace)
 {
-    if (state.simplexHasBeenRan)
+    if (state.simplexRunNeeded)
         PrepareMaxMRGFor<true>(state, opmrg, numSpace);
     else
         PrepareMaxMRGFor<false>(state, opmrg, numSpace);

--- a/src/solver/variable/economy/max-mrg.h
+++ b/src/solver/variable/economy/max-mrg.h
@@ -245,10 +245,9 @@ public:
 
     void weekForEachArea(State& state, unsigned int numSpace)
     {
-        {
-            double* rawhourly = Memory::RawPointer(pValuesForTheCurrentYear[numSpace].hour);
-            PrepareMaxMRG(state, rawhourly + state.hourInTheYear, numSpace);
-        }
+        double* rawhourly = Memory::RawPointer(pValuesForTheCurrentYear[numSpace].hour);
+        PrepareMaxMRG(state, rawhourly + state.hourInTheYear, numSpace);
+
         // next
         NextType::weekForEachArea(state, numSpace);
     }

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -67,7 +67,7 @@ State::State(Data::Study& s) :
  unitCommitmentMode(s.parameters.unitCommitment.ucMode),
  study(s),
  thermal(s.areas),
- simplexHasBeenRan(true),
+ simplexRunNeeded(true),
  annualSystemCost(0.),
  optimalSolutionCost1(0.),
  optimalSolutionCost2(0.),

--- a/src/solver/variable/state.h
+++ b/src/solver/variable/state.h
@@ -221,7 +221,7 @@ public:
     /*!
     ** \brief Flag to know if the simplex has been used for the current week
     */
-    bool simplexHasBeenRan;
+    bool simplexRunNeeded;
 
     // Annual costs to be printed in output into separate files
     // -----------------------------------------------------------------


### PR DESCRIPTION
Before the current pull request, type **VAL_GEN_PAR_PAYS** contained only data members related to hydro, and even hydro made available by hydro ventilation.

- Moving `VAL_GEN_PAR_PAYS valeursGenereesParPays` from class **ISimulation** into class **HydroManagement**, and renaming it `ALL_HYDRO_VENTILATION_RESULTS ventilationResults`.
- Cleaning the class **HydroManagement** : 
    - Removing dependency to **Study**, replaced with dependencies to **AreaList**, **Parameters**, **Calendar**, ...
    - Renaming **operator () (...)** into **makeVentilation(...)**, much more clear