### PR TITLE
Bug on renewable clusters

### DIFF
--- a/src/libs/antares/study/parts/renewable/cluster.cpp
+++ b/src/libs/antares/study/parts/renewable/cluster.cpp
@@ -133,22 +133,22 @@ void Data::RenewableCluster::setGroup(Data::ClusterName newgrp)
         groupID = windOffShore;
         return;
     }
-    if (newgrp == "other renewable 1")
+    if (newgrp == "other res 1")
     {
         groupID = renewableOther1;
         return;
     }
-    if (newgrp == "other renewable 2")
+    if (newgrp == "other res 2")
     {
         groupID = renewableOther2;
         return;
     }
-    if (newgrp == "other renewable 3")
+    if (newgrp == "other res 3")
     {
         groupID = renewableOther3;
         return;
     }
-    if (newgrp == "other renewable 4")
+    if (newgrp == "other res 4")
     {
         groupID = renewableOther4;
         return;

--- a/src/libs/antares/study/parts/renewable/cluster.cpp
+++ b/src/libs/antares/study/parts/renewable/cluster.cpp
@@ -173,15 +173,6 @@ bool Data::RenewableCluster::integrityCheck()
     return ret;
 }
 
-const char* Data::RenewableCluster::GroupName(enum RenewableGroup grp)
-{
-    auto it = groupToName.find(grp);
-    if (it != groupToName.end())
-        return it->second;
-
-    return "";
-}
-
 bool Data::RenewableCluster::setTimeSeriesModeFromString(const YString& value)
 {
     if (value == "power-generation")

--- a/src/libs/antares/study/parts/renewable/cluster.cpp
+++ b/src/libs/antares/study/parts/renewable/cluster.cpp
@@ -97,6 +97,19 @@ void Data::RenewableCluster::copyFrom(const RenewableCluster& cluster)
         parentArea->forceReload();
 }
 
+const std::map < RenewableCluster::RenewableGroup, const char* > groupToName =
+{
+    {RenewableCluster::thermalSolar, "solar thermal"},
+    {RenewableCluster::PVSolar, "solar pv"},
+    {RenewableCluster::rooftopSolar, "solar rooftop"},
+    {RenewableCluster::windOnShore, "wind onshore"},
+    {RenewableCluster::windOffShore,"wind offshore"},
+    {RenewableCluster::renewableOther1, "other res 1"},
+    {RenewableCluster::renewableOther2, "other res 2"},
+    {RenewableCluster::renewableOther3, "other res 3"},
+    {RenewableCluster::renewableOther4, "other res 4"}
+};
+
 void Data::RenewableCluster::setGroup(Data::ClusterName newgrp)
 {
     if (newgrp.empty())
@@ -108,51 +121,15 @@ void Data::RenewableCluster::setGroup(Data::ClusterName newgrp)
     pGroup = newgrp;
     boost::to_lower(newgrp);
 
-    if (newgrp == "solar thermal")
+    for (const auto& [group, name] : groupToName)
     {
-        groupID = thermalSolar;
-        return;
+        if (newgrp == name)
+        {
+            groupID = group;
+            return;
+        }        
     }
-    if (newgrp == "solar pv")
-    {
-        groupID = PVSolar;
-        return;
-    }
-    if (newgrp == "solar rooftop")
-    {
-        groupID = rooftopSolar;
-        return;
-    }
-    if (newgrp == "wind onshore")
-    {
-        groupID = windOnShore;
-        return;
-    }
-    if (newgrp == "wind offshore")
-    {
-        groupID = windOffShore;
-        return;
-    }
-    if (newgrp == "other res 1")
-    {
-        groupID = renewableOther1;
-        return;
-    }
-    if (newgrp == "other res 2")
-    {
-        groupID = renewableOther2;
-        return;
-    }
-    if (newgrp == "other res 3")
-    {
-        groupID = renewableOther3;
-        return;
-    }
-    if (newgrp == "other res 4")
-    {
-        groupID = renewableOther4;
-        return;
-    }
+
     // assigning a default value
     groupID = renewableOther1;
 }
@@ -198,29 +175,10 @@ bool Data::RenewableCluster::integrityCheck()
 
 const char* Data::RenewableCluster::GroupName(enum RenewableGroup grp)
 {
-    switch (grp)
-    {
-    case windOffShore:
-        return "Wind offshore";
-    case windOnShore:
-        return "Wind onshore";
-    case thermalSolar:
-        return "Solar thermal";
-    case PVSolar:
-        return "Solar PV";
-    case rooftopSolar:
-        return "Solar rooftop";
-    case renewableOther1:
-        return "Other RES 1";
-    case renewableOther2:
-        return "Other RES 2";
-    case renewableOther3:
-        return "Other RES 3";
-    case renewableOther4:
-        return "Other RES 4";
-    case groupMax:
-        return "";
-    }
+    auto it = groupToName.find(grp);
+    if (it != groupToName.end())
+        return it->second;
+
     return "";
 }
 

--- a/src/libs/antares/study/parts/renewable/cluster.h
+++ b/src/libs/antares/study/parts/renewable/cluster.h
@@ -91,13 +91,6 @@ public:
 
     //! Set of renewable clusters
     using Set = std::set<RenewableCluster*, CompareClusterName>;
-
-    /*!
-    ** \brief Get the group name string
-    ** \return A valid CString
-    */
-    static const char* GroupName(enum RenewableGroup grp);
-
 public:
     //! \name Constructor & Destructor
     //@{


### PR DESCRIPTION
The problem is that the **group** of a renewable cluster is not read correctly when this group is an **other RES n**.
Let's look at the **area**'s list.ini : 

**input/renewables/clusters/area/list.ini**
```ini
[clstr-other-11]
name = clstr-other-11
group = Other RES 1
...

[clstr-other-21]
name = clstr-other-21
group = Other RES 2
...
```
Before the current change, Antares code base expected (notice the difference between **list.ini** content and the **expected strings)** : 
```C++
void Data::RenewableCluster::setGroup(Data::ClusterName newgrp)
{
    ... 
    if (newgrp == "other renewable 1")
    {
        groupID = renewableOther1;
        return;
    }
    if (newgrp == "other renewable 2")
    {
        groupID = renewableOther2;
        return;
    }
   ...
    // assigning a default value
    groupID = renewableOther1;
}
```
So a quick fix is made here.

Note that : 
- Nothing in the code base is done to prevent wrong input values : there are no raised exception or exit statement. 