### PR TITLE
Use 50% as a default value for ST-storage property initiallevel

### DIFF
--- a/docs/reference-guide/13-file-format.md
+++ b/docs/reference-guide/13-file-format.md
@@ -1,5 +1,10 @@
 # Study format changes
 This is a list of all recent changes that came with new Antares Simulator features. The main goal of this document is to lower the costs of changing existing interfaces, both GUI and scripts.
+## v8.7.1
+### Input
+### Short-term storage
+If no value is specified for `initiallevel`, then a default value of 50% is used. Note that this value is used only if `initialleveloptim=false`, and that `false` is the default value for `initialleveloptim`.
+
 ## v8.7.0
 ### Input
 #### Scenarized RHS for binding constraints

--- a/src/libs/antares/study/parts/short-term-storage/properties.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/properties.cpp
@@ -99,7 +99,7 @@ bool Properties::loadKey(const IniFile::Property* p)
         return p->value.to<std::string>(this->name);
 
     if (p->key == "initiallevel")
-        return valueForOptional(this->initialLevel);
+        return p->value.to<double>(this->initialLevel);
 
     if (p->key == "initialleveloptim")
         return p->value.to<bool>(this->initialLevelOptim);
@@ -206,29 +206,16 @@ bool Properties::validate()
         efficiencyFactor = 1;
     }
 
-    // reset initialLevel value to show we're optimising it
-    if (initialLevelOptim)
+    if (initialLevel < 0)
     {
-        logs.info() << "Optimizing initial level";
-        initialLevel.reset();
+        logs.warning() << "initiallevel for cluster: " << name << " should be positive";
+        initialLevel = 0;
     }
 
-    if (!initialLevelOptim && !initialLevel.has_value())
-        logs.error() << "Initial level not optimized and no value provided, aborting";
-
-    if (initialLevel.has_value())
+    if (initialLevel > 1)
     {
-        if (initialLevel < 0)
-        {
-            logs.warning() << "initiallevel for cluster: " << name << " should be positive";
-            initialLevel = 0;
-        }
-
-        if (initialLevel > 1)
-        {
-            logs.warning() << "initiallevel for cluster: " << name << " should be inferior to 1";
-            initialLevel = 1;
-        }
+        logs.warning() << "initiallevel for cluster: " << name << " should be inferior to 1";
+        initialLevel = 1;
     }
 
     return true;

--- a/src/libs/antares/study/parts/short-term-storage/properties.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/properties.cpp
@@ -208,14 +208,16 @@ bool Properties::validate()
 
     if (initialLevel < 0)
     {
-        logs.warning() << "initiallevel for cluster: " << name << " should be positive";
-        initialLevel = 0;
+        initialLevel = initiallevelDefault;
+        logs.warning() << "initiallevel for cluster: " << name << " should be positive, value has been set to " << initialLevel;
+
     }
 
     if (initialLevel > 1)
     {
-        logs.warning() << "initiallevel for cluster: " << name << " should be inferior to 1";
-        initialLevel = 1;
+        initialLevel = initiallevelDefault;
+        logs.warning() << "initiallevel for cluster: " << name << " should be inferior to 1, value has been set to " << initialLevel;
+
     }
 
     return true;

--- a/src/libs/antares/study/parts/short-term-storage/properties.h
+++ b/src/libs/antares/study/parts/short-term-storage/properties.h
@@ -63,7 +63,7 @@ public:
     // Not optional   Reservoir capacity in MWh, >= 0
     std::optional<double> reservoirCapacity;
     // Initial level, <= 1
-    std::optional<double> initialLevel;
+    double initialLevel = 0;
     // Bool to optimise or not initial level
     bool initialLevelOptim = false;
     // Efficiency factor between 0 and 1

--- a/src/libs/antares/study/parts/short-term-storage/properties.h
+++ b/src/libs/antares/study/parts/short-term-storage/properties.h
@@ -63,7 +63,7 @@ public:
     // Not optional   Reservoir capacity in MWh, >= 0
     std::optional<double> reservoirCapacity;
     // Initial level, <= 1
-    double initialLevel = 0;
+    double initialLevel = initiallevelDefault;
     // Bool to optimise or not initial level
     bool initialLevelOptim = false;
     // Efficiency factor between 0 and 1
@@ -74,5 +74,7 @@ public:
     std::string name;
 
     static const std::map<std::string, enum Group> ST_STORAGE_PROPERTY_GROUP_ENUM;
+private:
+    static constexpr double initiallevelDefault = .5;
 };
 } // namespace Antares::Data::ShortTermStorage

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -190,10 +190,10 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                 // 3. Levels
                 int varLevel = CorrespondanceVarNativesVarOptim.SIM_ShortTermStorage
                                  .LevelVariable[clusterGlobalIndex];
-                if (pdtHebdo == DernierPdtDeLIntervalle - 1 && storage.initialLevel.has_value())
+                if (pdtHebdo == DernierPdtDeLIntervalle - 1 && !storage.initialLevelOptim)
                 {
                     Xmin[varLevel] = Xmax[varLevel]
-                      = storage.reservoirCapacity * storage.initialLevel.value();
+                      = storage.reservoirCapacity * storage.initialLevel;
                 }
                 else
                 {

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -62,6 +62,7 @@ static void importShortTermStorages(
             toInsert.injectionNominalCapacity = st->properties.injectionNominalCapacity.value();
             toInsert.withdrawalNominalCapacity = st->properties.withdrawalNominalCapacity.value();
             toInsert.initialLevel = st->properties.initialLevel;
+            toInsert.initialLevelOptim = st->properties.initialLevelOptim;
             toInsert.name = st->properties.name;
 
             toInsert.series = st->series;

--- a/src/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/sim_structure_probleme_economique.h
@@ -173,7 +173,8 @@ struct PROPERTIES
     double injectionNominalCapacity;
     double withdrawalNominalCapacity;
     double efficiency;
-    std::optional<double> initialLevel;
+    double initialLevel;
+    bool initialLevelOptim;
 
     std::shared_ptr<Antares::Data::ShortTermStorage::Series> series;
 


### PR DESCRIPTION
## Previous behavior
- If `initialleveloptim = true`, then `initiallevel` is ignored and so not required
- If `initialleveloptim = false`, then `initiallevel` is required

There is no default numerical value.

## New behavior
If `initiallevel` is required (`initialleveloptim = false`), it's default value is 0. If it is not provided by the user, then `initiallevel = 0` is used.

## In the code
Replace `std::optional<double>` with `double`, remove `has_value`, `value`, etc.

## To be applied to...
Branches 8.6.x and 8.7.x