### PR TITLE
Remove most uses of `IResultWriter::Ptr`, use ref instead

### DIFF
--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -183,7 +183,7 @@ bool AreaLink::loadTimeSeries(const Study& study, const AnyString& folder)
         return linkLoadTimeSeries_for_version_820_and_later(folder);
 }
 
-void AreaLink::storeTimeseriesNumbers(Solver::IResultWriter::Ptr writer) const
+void AreaLink::storeTimeseriesNumbers(Solver::IResultWriter& writer) const
 {
     Clob path;
     TSNumbersPredicate predicate;
@@ -193,7 +193,7 @@ void AreaLink::storeTimeseriesNumbers(Solver::IResultWriter::Ptr writer) const
          << SEP << with->id << ".txt";
 
     timeseriesNumbers.saveToBuffer(buffer, 0, true, predicate, true);
-    writer->addEntryFromBuffer(path.c_str(), buffer);
+    writer.addEntryFromBuffer(path.c_str(), buffer);
 }
 
 void AreaLink::detach()

--- a/src/libs/antares/study/area/links.h
+++ b/src/libs/antares/study/area/links.h
@@ -74,7 +74,7 @@ public:
 
     bool loadTimeSeries(const Study& study, const AnyString& folder);
 
-    void storeTimeseriesNumbers(Solver::IResultWriter::Ptr writer) const;
+    void storeTimeseriesNumbers(Solver::IResultWriter& writer) const;
 
     //! \name Area
     //@{

--- a/src/libs/antares/study/area/store-timeseries-numbers.cpp
+++ b/src/libs/antares/study/area/store-timeseries-numbers.cpp
@@ -48,7 +48,7 @@ struct TSNumbersPredicate
 };
 } // anonymous namespace
 
-static void genericStoreTimeseriesNumbers(Solver::IResultWriter::Ptr writer,
+static void genericStoreTimeseriesNumbers(Solver::IResultWriter& writer,
                                           const Matrix<uint32_t>& timeseriesNumbers,
                                           const String& id,
                                           const String& directory)
@@ -64,41 +64,41 @@ static void genericStoreTimeseriesNumbers(Solver::IResultWriter::Ptr writer,
                                    predicate, // predicate
                                    true);     // save even if all coeffs are zero
 
-    writer->addEntryFromBuffer(path.c_str(), buffer);
+    writer.addEntryFromBuffer(path.c_str(), buffer);
 }
 
-void storeTimeseriesNumbersForLoad(Solver::IResultWriter::Ptr writer, const Area& area)
+void storeTimeseriesNumbersForLoad(Solver::IResultWriter& writer, const Area& area)
 {
     genericStoreTimeseriesNumbers(writer, area.load.series->timeseriesNumbers, area.id, "load");
 }
 
-void storeTimeseriesNumbersForSolar(Solver::IResultWriter::Ptr writer, const Area& area)
+void storeTimeseriesNumbersForSolar(Solver::IResultWriter& writer, const Area& area)
 {
     genericStoreTimeseriesNumbers(writer, area.solar.series->timeseriesNumbers, area.id, "solar");
 }
 
-void storeTimeseriesNumbersForHydro(Solver::IResultWriter::Ptr writer, const Area& area)
+void storeTimeseriesNumbersForHydro(Solver::IResultWriter& writer, const Area& area)
 {
     genericStoreTimeseriesNumbers(writer, area.hydro.series->timeseriesNumbers, area.id, "hydro");
 }
 
-void storeTimeseriesNumbersForWind(Solver::IResultWriter::Ptr writer, const Area& area)
+void storeTimeseriesNumbersForWind(Solver::IResultWriter& writer, const Area& area)
 {
     genericStoreTimeseriesNumbers(writer, area.wind.series->timeseriesNumbers, area.id, "wind");
 }
 
-void storeTimeseriesNumbersForThermal(Solver::IResultWriter::Ptr writer, const Area& area)
+void storeTimeseriesNumbersForThermal(Solver::IResultWriter& writer, const Area& area)
 {
     area.thermal.list.storeTimeseriesNumbers(writer);
     area.thermal.mustrunList.storeTimeseriesNumbers(writer);
 }
 
-void storeTimeseriesNumbersForRenewable(Solver::IResultWriter::Ptr writer, const Area& area)
+void storeTimeseriesNumbersForRenewable(Solver::IResultWriter& writer, const Area& area)
 {
     area.renewable.list.storeTimeseriesNumbers(writer);
 }
 
-void storeTimeseriesNumbersForTransmissionCapacities(Solver::IResultWriter::Ptr writer, const Area& area)
+void storeTimeseriesNumbersForTransmissionCapacities(Solver::IResultWriter& writer, const Area& area)
 {
     // No links originating from this area
     // do not create an empty directory

--- a/src/libs/antares/study/area/store-timeseries-numbers.h
+++ b/src/libs/antares/study/area/store-timeseries-numbers.h
@@ -33,19 +33,19 @@
 namespace Antares::Data
 {
     template<int TimeSeriesT>
-    void singleAreaStoreTimeseriesNumbers(Solver::IResultWriter::Ptr writer, const Area& area);
+    void singleAreaStoreTimeseriesNumbers(Solver::IResultWriter& writer, const Area& area);
 
     template<int TimeSeriesT>
-    void storeTimeseriesNumbers(Solver::IResultWriter::Ptr writer, const AreaList& area);
+    void storeTimeseriesNumbers(Solver::IResultWriter& writer, const AreaList& area);
 
     // Store time-series numbers
-    void storeTimeseriesNumbersForLoad(Solver::IResultWriter::Ptr writer, const Area& area);
-    void storeTimeseriesNumbersForSolar(Solver::IResultWriter::Ptr writer, const Area& area);
-    void storeTimeseriesNumbersForWind(Solver::IResultWriter::Ptr writer, const Area& area);
-    void storeTimeseriesNumbersForHydro(Solver::IResultWriter::Ptr writer, const Area& area);
-    void storeTimeseriesNumbersForThermal(Solver::IResultWriter::Ptr writer, const Area& area);
-    void storeTimeseriesNumbersForRenewable(Solver::IResultWriter::Ptr writer, const Area& area);
-    void storeTimeseriesNumbersForTransmissionCapacities(Solver::IResultWriter::Ptr writer, const Area& area);
+    void storeTimeseriesNumbersForLoad(Solver::IResultWriter& writer, const Area& area);
+    void storeTimeseriesNumbersForSolar(Solver::IResultWriter& writer, const Area& area);
+    void storeTimeseriesNumbersForWind(Solver::IResultWriter& writer, const Area& area);
+    void storeTimeseriesNumbersForHydro(Solver::IResultWriter& writer, const Area& area);
+    void storeTimeseriesNumbersForThermal(Solver::IResultWriter& writer, const Area& area);
+    void storeTimeseriesNumbersForRenewable(Solver::IResultWriter& writer, const Area& area);
+    void storeTimeseriesNumbersForTransmissionCapacities(Solver::IResultWriter& writer, const Area& area);
 
 } //Antares::Data
 

--- a/src/libs/antares/study/area/store-timeseries-numbers.hxx
+++ b/src/libs/antares/study/area/store-timeseries-numbers.hxx
@@ -30,7 +30,7 @@
 namespace Antares::Data
 {
 template<int TimeSeriesT>
-void singleAreaStoreTimeseriesNumbers(Solver::IResultWriter::Ptr writer, const Area& area)
+void singleAreaStoreTimeseriesNumbers(Solver::IResultWriter& writer, const Area& area)
 {
     switch (TimeSeriesT)
     {
@@ -69,7 +69,7 @@ void singleAreaStoreTimeseriesNumbers(Solver::IResultWriter::Ptr writer, const A
 }
 
 template<int TimeSeriesT>
-void storeTimeseriesNumbers(Solver::IResultWriter::Ptr writer, const AreaList& area)
+void storeTimeseriesNumbers(Solver::IResultWriter& writer, const AreaList& area)
 {
     // Each area in the list
     area.each([&writer](const Area& a) { singleAreaStoreTimeseriesNumbers<TimeSeriesT>(writer, a); });

--- a/src/libs/antares/study/parts/common/cluster_list.cpp
+++ b/src/libs/antares/study/parts/common/cluster_list.cpp
@@ -163,7 +163,7 @@ void ClusterList<ClusterT>::resizeAllTimeseriesNumbers(uint n)
 #define SEP IO::Separator
 
 template<class ClusterT>
-void ClusterList<ClusterT>::storeTimeseriesNumbers(Solver::IResultWriter::Ptr writer) const
+void ClusterList<ClusterT>::storeTimeseriesNumbers(Solver::IResultWriter& writer) const
 {
     if (cluster.empty())
         return;
@@ -177,7 +177,7 @@ void ClusterList<ClusterT>::storeTimeseriesNumbers(Solver::IResultWriter::Ptr wr
                      << cluster.id() << ".txt";
         ts_content.clear(); // We must clear ts_content here, since saveToBuffer does not do it.
         cluster.series->timeseriesNumbers.saveToBuffer(ts_content, 0, true, predicate, true);
-        writer->addEntryFromBuffer(path.c_str(), ts_content);
+        writer.addEntryFromBuffer(path.c_str(), ts_content);
     });
 }
 

--- a/src/libs/antares/study/parts/common/cluster_list.h
+++ b/src/libs/antares/study/parts/common/cluster_list.h
@@ -186,7 +186,7 @@ public:
     */
     void resizeAllTimeseriesNumbers(uint n);
 
-    void storeTimeseriesNumbers(Solver::IResultWriter::Ptr writer) const;
+    void storeTimeseriesNumbers(Solver::IResultWriter& writer) const;
 
     //@}
 

--- a/src/libs/antares/study/progression/progression.cpp
+++ b/src/libs/antares/study/progression/progression.cpp
@@ -153,7 +153,7 @@ Progression::~Progression()
     pProgressMeter.stop();
 }
 
-bool Progression::saveToFile(const Yuni::String& filename, IResultWriter::Ptr writer)
+bool Progression::saveToFile(const Yuni::String& filename, IResultWriter& writer)
 {
     Yuni::Clob buffer;
     MutexLocker locker(pProgressMeter.mutex);
@@ -174,7 +174,7 @@ bool Progression::saveToFile(const Yuni::String& filename, IResultWriter::Ptr wr
             }
         }
     }
-    writer->addEntryFromBuffer(filename.c_str(), buffer);
+    writer.addEntryFromBuffer(filename.c_str(), buffer);
     logs.info() << LOG_UI_PROGRESSION_MAP << filename;
     return true;
 }

--- a/src/libs/antares/study/progression/progression.h
+++ b/src/libs/antares/study/progression/progression.h
@@ -143,7 +143,7 @@ public:
 
     void add(Section section, int nbTicks);
 
-    bool saveToFile(const Yuni::String& filename, IResultWriter::Ptr writer);
+    bool saveToFile(const Yuni::String& filename, IResultWriter& writer);
 
     void setNumberOfParallelYears(uint nb);
 

--- a/src/libs/antares/study/simulation.cpp
+++ b/src/libs/antares/study/simulation.cpp
@@ -68,13 +68,13 @@ bool SimulationComments::saveToFolder(const AnyString& folder) const
     return false;
 }
 
-void SimulationComments::saveUsingWriter(Solver::IResultWriter::Ptr writer,
+void SimulationComments::saveUsingWriter(Solver::IResultWriter& writer,
                                          const AnyString& folder) const
 {
     String b = folder;
     b << SEP << "comments.txt";
     std::string comments_copy = comments.c_str();
-    writer->addEntryFromBuffer(b.c_str(), comments_copy);
+    writer.addEntryFromBuffer(b.c_str(), comments_copy);
 }
 
 bool SimulationComments::loadFromFolder(const StudyLoadOptions& options)

--- a/src/libs/antares/study/simulation.h
+++ b/src/libs/antares/study/simulation.h
@@ -65,7 +65,7 @@ public:
     */
     bool saveToFolder(const AnyString& folder) const;
 
-    void saveUsingWriter(Solver::IResultWriter::Ptr writer, const AnyString& folder) const;
+    void saveUsingWriter(Solver::IResultWriter& writer, const AnyString& folder) const;
 
     //! Get (in bytes) the amount of memory used by the class
     uint64_t memoryUsage() const;

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -700,7 +700,7 @@ void Study::saveAboutTheStudy()
     path.reserve(1024);
 
     path.clear() << "about-the-study";
-    simulationComments.saveUsingWriter(resultWriter, path);
+    simulationComments.saveUsingWriter(*resultWriter, path);
 
     // Write the header as a reminder
     {
@@ -711,7 +711,8 @@ void Study::saveAboutTheStudy()
         std::string writeBuffer;
         ini.saveToString(writeBuffer);
 
-        resultWriter->addEntryFromBuffer(path.c_str(), writeBuffer);
+        if (resultWriter)
+            resultWriter->addEntryFromBuffer(path.c_str(), writeBuffer);
     }
 
     // Write parameters.ini
@@ -720,7 +721,8 @@ void Study::saveAboutTheStudy()
         dest << "about-the-study" << SEP << "parameters.ini";
 
         buffer.clear() << folderSettings << SEP << "generaldata.ini";
-        resultWriter->addEntryFromFile(dest.c_str(), buffer.c_str());
+        if (resultWriter)
+            resultWriter->addEntryFromFile(dest.c_str(), buffer.c_str());
     }
 
     // antares-output.info
@@ -737,7 +739,8 @@ void Study::saveAboutTheStudy()
     f << "\ntimestamp = " << pStartTime;
     f << "\n\n";
     auto output = f.str();
-    resultWriter->addEntryFromBuffer(path.c_str(), output);
+    if (resultWriter)
+        resultWriter->addEntryFromBuffer(path.c_str(), output);
 
     if (usedByTheSolver and !parameters.noOutput)
     {
@@ -751,7 +754,8 @@ void Study::saveAboutTheStudy()
                     buffer << "@ " << i->first << "\r\n";
             }
             areas.each([&](const Data::Area& area) { buffer << area.name << "\r\n"; });
-            resultWriter->addEntryFromBuffer(path.c_str(), buffer);
+            if (resultWriter)            
+                resultWriter->addEntryFromBuffer(path.c_str(), buffer);
         }
 
         // Write all available links as a reminder
@@ -759,7 +763,8 @@ void Study::saveAboutTheStudy()
             path.clear() << "about-the-study" << SEP << "links.txt";
             Yuni::Clob buffer;
             areas.saveLinkListToBuffer(buffer);
-            resultWriter->addEntryFromBuffer(path.c_str(), buffer);
+            if (resultWriter)
+                resultWriter->addEntryFromBuffer(path.c_str(), buffer);
         }
     }
 }

--- a/src/libs/antares/study/study.hxx
+++ b/src/libs/antares/study/study.hxx
@@ -39,7 +39,7 @@ inline bool Study::readonly() const
 template<unsigned int TimeSeriesT>
 inline void Study::storeTimeSeriesNumbers() const
 {
-    storeTimeseriesNumbers<TimeSeriesT>(resultWriter, areas);
+    storeTimeseriesNumbers<TimeSeriesT>(*resultWriter, areas);
 }
 
 template<enum TimeSeries TS>

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -169,7 +169,7 @@ void Application::prepare(int argc, char* argv[])
     {
         auto& filename = pStudy->buffer;
         filename.clear() << "about-the-study" << Yuni::IO::Separator << "map";
-        pStudy->progression.saveToFile(filename, pStudy->resultWriter);
+        pStudy->progression.saveToFile(filename, *pStudy->resultWriter);
         pStudy->progression.start();
     }
     else
@@ -384,8 +384,7 @@ void Application::readDataForTheStudy(Data::StudyLoadOptions& options)
             if (!pSettings.commentFile.empty())
             {
                 auto writer = pStudy->resultWriter;
-                if (writer)
-                    writer->addEntryFromFile(study.buffer.c_str(), pSettings.commentFile.c_str());
+                writer->addEntryFromFile(study.buffer.c_str(), pSettings.commentFile.c_str());
 
                 pSettings.commentFile.clear();
                 pSettings.commentFile.shrink();

--- a/src/solver/application.h
+++ b/src/solver/application.h
@@ -9,7 +9,6 @@
 #include "antares/infoCollection/StudyInfoCollector.h"
 
 #include <antares/writer/i_writer.h>
-
 #include <yuni/core/string.h>
 
 namespace Antares::Solver

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -97,7 +97,7 @@ struct DebugData
     std::array<double, 12> CoutTotal{0};
     std::array<double, 12> previousMonthWaste{0};
 
-    Solver::IResultWriter::Ptr pWriter;
+    Solver::IResultWriter& pWriter;
     const TmpDataByArea& data;
     const VENTILATION_HYDRO_RESULTS_BY_AREA& ventilationResults;
     const InflowsType& srcinflows;
@@ -107,7 +107,7 @@ struct DebugData
     const ReservoirLevelType& lowLevel;
     const double reservoirCapacity;
 
-    DebugData(Solver::IResultWriter::Ptr writer,
+    DebugData(Solver::IResultWriter& writer,
               const TmpDataByArea& data,
               const VENTILATION_HYDRO_RESULTS_BY_AREA& ventilationResults,
               const InflowsType& srcinflows,
@@ -150,7 +150,7 @@ struct DebugData
             buffer << '\n';
         }
         auto buffer_str = buffer.str();
-        pWriter->addEntryFromBuffer(path.str(), buffer_str);
+        pWriter.addEntryFromBuffer(path.str(), buffer_str);
     }
 
     void writeDailyDebugData(const Date::Calendar& calendar,
@@ -218,7 +218,7 @@ struct DebugData
             }
         }
         auto buffer_str = buffer.str();
-        pWriter->addEntryFromBuffer(path.str(), buffer_str);
+        pWriter.addEntryFromBuffer(path.str(), buffer_str);
     }
 };
 
@@ -260,7 +260,7 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
     
     std::shared_ptr<DebugData> debugData(nullptr);
 
-    if (parameters_.hydroDebug && resultWriter_)
+    if (parameters_.hydroDebug)
     {
         debugData = std::make_shared<DebugData>(resultWriter_,
                                                 data,

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -82,7 +82,7 @@ HydroManagement::HydroManagement(const Data::AreaList& areas,
                                  const Data::Parameters& params,
                                  const Date::Calendar& calendar,
                                  unsigned int maxNbYearsInParallel,
-                                 Solver::IResultWriter::Ptr resultWriter) :
+                                 Solver::IResultWriter& resultWriter) :
     areas_(areas),
     calendar_(calendar),
     parameters_(params),

--- a/src/solver/hydro/management/management.h
+++ b/src/solver/hydro/management/management.h
@@ -105,7 +105,7 @@ public:
                     const Data::Parameters& params,
                     const Date::Calendar& calendar,
                     unsigned int maxNbYearsInParallel,
-                    Solver::IResultWriter::Ptr resultWriter);
+                    Solver::IResultWriter& resultWriter);
 
     ~HydroManagement();
 
@@ -172,7 +172,7 @@ private:
     const Data::Parameters& parameters_;
     MersenneTwister random_;
     unsigned int maxNbYearsInParallel_ = 0;
-    Solver::IResultWriter::Ptr resultWriter_;
+    Solver::IResultWriter& resultWriter_;
 
     ALL_HYDRO_VENTILATION_RESULTS ventilationResults_;
 }; // class HydroManagement

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -247,7 +247,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
             assert(!Math::Infinite(data.MOL[realmonth]) && "infinite value detected for MOL");
         }
 #endif
-        if (parameters_.hydroDebug && resultWriter_)
+        if (parameters_.hydroDebug)
         {
             std::ostringstream buffer, path;
             path << "debug" << SEP << "solver" << SEP << (1 + y) << SEP << "monthly." << area.name
@@ -292,7 +292,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
                 buffer << '\n';
             }
             auto content = buffer.str();
-            resultWriter_->addEntryFromBuffer(path.str(), content);
+            resultWriter_.addEntryFromBuffer(path.str(), content);
         }
     });
 }

--- a/src/solver/simulation/BindingConstraintsTimeSeriesNumbersWriter.h
+++ b/src/solver/simulation/BindingConstraintsTimeSeriesNumbersWriter.h
@@ -13,11 +13,11 @@ namespace Antares::Solver::Simulation {
 class BindingConstraintsTimeSeriesNumbersWriter: public ITimeSeriesNumbersWriter {
 
 public:
-    explicit BindingConstraintsTimeSeriesNumbersWriter(std::shared_ptr<Antares::Solver::IResultWriter> resultWriter);
+    explicit BindingConstraintsTimeSeriesNumbersWriter(IResultWriter& resultWriter);
     BindingConstraintsTimeSeriesNumbersWriter() = default;
     void write(const Data::BindingConstraintGroupRepository &bindingConstraintGroupRepository) override;
 
 private:
-    std::shared_ptr<IResultWriter> writer_;
+    IResultWriter& writer_;
 };
 } // Simulation

--- a/src/solver/simulation/TimeSeriesNumbersWriter.cpp
+++ b/src/solver/simulation/TimeSeriesNumbersWriter.cpp
@@ -9,8 +9,8 @@
 #include <utility>
 
 namespace Antares::Solver::Simulation {
-BindingConstraintsTimeSeriesNumbersWriter::BindingConstraintsTimeSeriesNumbersWriter(std::shared_ptr<Antares::Solver::IResultWriter> writer)
-: writer_(std::move(writer))
+BindingConstraintsTimeSeriesNumbersWriter::BindingConstraintsTimeSeriesNumbersWriter(IResultWriter& writer)
+: writer_(writer)
 {
 
 }
@@ -27,7 +27,7 @@ namespace // anonymous
 } // anonymous namespace
 
 // TODO : remove duplication
-static void genericStoreTimeseriesNumbers(const Solver::IResultWriter::Ptr& writer,
+static void genericStoreTimeseriesNumbers(Solver::IResultWriter& writer,
                                           const Matrix<uint32_t>& timeseriesNumbers,
                                           const std::string& id,
                                           const std::string& directory)
@@ -43,7 +43,7 @@ static void genericStoreTimeseriesNumbers(const Solver::IResultWriter::Ptr& writ
                                    predicate, // predicate
                                    true);     // save even if all coeffs are zero
 
-    writer->addEntryFromBuffer(path.string(), buffer);
+    writer.addEntryFromBuffer(path.string(), buffer);
 }
 
 void BindingConstraintsTimeSeriesNumbersWriter::write(const Data::BindingConstraintGroupRepository &bindingConstraintGroupRepository) {

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -28,7 +28,6 @@
 #include "adequacy.h"
 #include <antares/exception/UnfeasibleProblemError.hpp>
 #include <antares/exception/AssertionError.hpp>
-#include "opt_time_writer.h"
 
 using namespace Yuni;
 using Antares::Constants::nbHoursInAWeek;
@@ -124,7 +123,8 @@ bool Adequacy::year(Progression::Task& progression,
                     yearRandomNumbers& randomForYear,
                     std::list<uint>& failedWeekList,
                     bool isFirstPerformedYearOfSimulation,
-                    const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
+                    const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults,
+                    OptimizationStatisticsWriter& optWriter)
 {
     // No failed week at year start
     failedWeekList.clear();
@@ -138,8 +138,6 @@ bool Adequacy::year(Progression::Task& progression,
     if (isFirstPerformedYearOfSimulation)
         pProblemesHebdo[numSpace].firstWeekOfSimulation = true;
     bool reinitOptim = true;
-
-    OptimizationStatisticsWriter optWriter(study.resultWriter, state.year);
 
     for (uint w = 0; w != pNbWeeks; ++w)
     {

--- a/src/solver/simulation/adequacy.h
+++ b/src/solver/simulation/adequacy.h
@@ -35,6 +35,7 @@
 
 #include "solver.h" // for definition of type yearRandomNumbers
 #include "antares/infoCollection/StudyInfoCollector.h"
+#include "opt_time_writer.h"
 
 namespace Antares::Solver::Simulation
 {
@@ -81,7 +82,8 @@ protected:
               yearRandomNumbers& randomForYear,
               std::list<uint>& failedWeekList,
               bool isFirstPerformedYearOfSimulation,
-              const ALL_HYDRO_VENTILATION_RESULTS&);
+              const ALL_HYDRO_VENTILATION_RESULTS&,
+              OptimizationStatisticsWriter& optWriter);
 
     void incrementProgression(Progression::Task& progression);
 

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -32,7 +32,6 @@
 #include "../optimisation/opt_fonctions.h"
 #include "../optimisation/adequacy_patch_csr/adq_patch_curtailment_sharing.h"
 #include "common-eco-adq.h"
-#include "opt_time_writer.h"
 
 using namespace Yuni;
 using Antares::Constants::nbHoursInAWeek;
@@ -119,7 +118,8 @@ bool Economy::year(Progression::Task& progression,
                    yearRandomNumbers& randomForYear,
                    std::list<uint>& failedWeekList,
                    bool isFirstPerformedYearOfSimulation,
-                   const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
+                   const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults,
+                   OptimizationStatisticsWriter& optWriter)
 {
     // No failed week at year start
     failedWeekList.clear();
@@ -133,8 +133,6 @@ bool Economy::year(Progression::Task& progression,
     if (isFirstPerformedYearOfSimulation)
         pProblemesHebdo[numSpace].firstWeekOfSimulation = true;
     bool reinitOptim = true;
-
-    OptimizationStatisticsWriter optWriter(study.resultWriter, state.year);
 
     for (uint w = 0; w != pNbWeeks; ++w)
     {

--- a/src/solver/simulation/economy.h
+++ b/src/solver/simulation/economy.h
@@ -36,6 +36,7 @@
 
 #include "solver.h" // for definition of type yearRandomNumbers
 #include "antares/infoCollection/StudyInfoCollector.h"
+#include "opt_time_writer.h"
 
 namespace Antares::Solver::Simulation
 {
@@ -82,7 +83,8 @@ protected:
               yearRandomNumbers& randomForYear,
               std::list<uint>& failedWeekList,
               bool isFirstPerformedYearOfSimulation,
-              const ALL_HYDRO_VENTILATION_RESULTS&);
+              const ALL_HYDRO_VENTILATION_RESULTS&,
+              OptimizationStatisticsWriter& optWriter);
 
     void incrementProgression(Progression::Task& progression);
 

--- a/src/solver/simulation/opt_time_writer.cpp
+++ b/src/solver/simulation/opt_time_writer.cpp
@@ -27,7 +27,7 @@
 #include "opt_time_writer.h"
 
 OptimizationStatisticsWriter::OptimizationStatisticsWriter(
-  Antares::Solver::IResultWriter::Ptr writer,
+  Antares::Solver::IResultWriter& writer,
   uint year) :
  pWriter(writer)
 {
@@ -49,6 +49,5 @@ void OptimizationStatisticsWriter::addTime(uint week, double opt_1_ms, double op
 
 void OptimizationStatisticsWriter::finalize()
 {
-    if (pWriter)
-        pWriter->addEntryFromBuffer(pFilename.c_str(), pBuffer);
+    pWriter.addEntryFromBuffer(pFilename.c_str(), pBuffer);
 }

--- a/src/solver/simulation/opt_time_writer.h
+++ b/src/solver/simulation/opt_time_writer.h
@@ -33,7 +33,7 @@
 class OptimizationStatisticsWriter
 {
 public:
-    OptimizationStatisticsWriter(Antares::Solver::IResultWriter::Ptr writer, uint year);
+    OptimizationStatisticsWriter(Antares::Solver::IResultWriter& writer, uint year);
     void addTime(uint week, double opt_1_ms, double opt_2_ms);
     void finalize();
 
@@ -41,5 +41,5 @@ private:
     void printHeader();
     Yuni::Clob pBuffer;
     Yuni::String pFilename;
-    Antares::Solver::IResultWriter::Ptr pWriter;
+    Antares::Solver::IResultWriter& pWriter;
 };

--- a/src/solver/simulation/solver.h
+++ b/src/solver/simulation/solver.h
@@ -173,7 +173,7 @@ public:
     //! The queue service that runs every set of parallel years
     std::shared_ptr<Yuni::Job::QueueService> pQueueService = nullptr;
     //! Result writer
-    Antares::Solver::IResultWriter::Ptr pResultWriter = nullptr;
+    Antares::Solver::IResultWriter& pResultWriter;
 
 }; // class ISimulation
 } // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/solver.utils.h
+++ b/src/solver/simulation/solver.utils.h
@@ -157,11 +157,8 @@ public:
         optimizationTime2.endStandardDeviation();
     };
 
-    void writeToOutput(IResultWriter::Ptr writer)
+    void writeToOutput(IResultWriter& writer)
     {
-        if (!writer)
-            return;
-
         writeSystemCostToOutput(writer);
         writeCriterionCostsToOutput(writer);
         writeOptimizationTimeToOutput(writer);
@@ -189,7 +186,7 @@ public:
     }
 
 private:
-    void writeSystemCostToOutput(IResultWriter::Ptr writer)
+    void writeSystemCostToOutput(IResultWriter& writer)
     {
         Yuni::Clob buffer;
         buffer << "EXP : " << round_to_closer_int(systemCost.costAverage) << "\n";
@@ -197,10 +194,10 @@ private:
         buffer << "MIN : " << round_to_closer_int(systemCost.costMin) << "\n";
         buffer << "MAX : " << round_to_closer_int(systemCost.costMax) << "\n";
 
-        writer->addEntryFromBuffer(systemCostFilename, buffer);
+        writer.addEntryFromBuffer(systemCostFilename, buffer);
     }
 
-    void writeCriterionCostsToOutput(IResultWriter::Ptr writer)
+    void writeCriterionCostsToOutput(IResultWriter& writer)
     {
         Yuni::Clob buffer;
         buffer << to_scientific(criterionCost1.costAverage) << "\n";
@@ -213,10 +210,10 @@ private:
         buffer << to_scientific(criterionCost2.costMin) << "\n";
         buffer << to_scientific(criterionCost2.costMax) << "\n";
 
-        writer->addEntryFromBuffer(criterionsCostsFilename, buffer);
+        writer.addEntryFromBuffer(criterionsCostsFilename, buffer);
     }
 
-    void writeOptimizationTimeToOutput(IResultWriter::Ptr writer)
+    void writeOptimizationTimeToOutput(IResultWriter& writer)
     {
         Yuni::Clob buffer;
         buffer << "First optimization :\n";
@@ -231,7 +228,7 @@ private:
         buffer << "MIN (ms) : " << optimizationTime2.costMin << "\n";
         buffer << "MAX (ms) : " << optimizationTime2.costMax << "\n";
 
-        writer->addEntryFromBuffer(optimizationTimeFilename, buffer);
+        writer.addEntryFromBuffer(optimizationTimeFilename, buffer);
     }
 
 public:

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -984,7 +984,7 @@ void TimeSeriesNumbers::StoreTimeSeriesNumbersIntoOuput(Data::Study& study)
         study.storeTimeSeriesNumbers<TimeSeries::timeSeriesRenewable>();
         study.storeTimeSeriesNumbers<TimeSeries::timeSeriesTransmissionCapacities>();
 
-        Simulation::BindingConstraintsTimeSeriesNumbersWriter ts_writer(study.resultWriter);
+        Simulation::BindingConstraintsTimeSeriesNumbersWriter ts_writer(*study.resultWriter);
         ts_writer.write(study.bindingConstraintsGroups);
     }
 }

--- a/src/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/generator.h
@@ -44,13 +44,13 @@ namespace TSGenerator
 ** \brief Regenerate the time-series
 */
 template<enum Data::TimeSeries T>
-bool GenerateTimeSeries(Data::Study& study, uint year, IResultWriter::Ptr writer);
+bool GenerateTimeSeries(Data::Study& study, uint year, IResultWriter& writer);
 
 bool GenerateThermalTimeSeries(Data::Study& study,
                                uint year,
                                bool globalThermalTSgeneration,
                                bool refresh,
-                               IResultWriter::Ptr writer);
+                               IResultWriter& writer);
 
 /*!
 ** \brief Destroy all TS Generators

--- a/src/solver/ts-generator/generator.hxx
+++ b/src/solver/ts-generator/generator.hxx
@@ -38,19 +38,19 @@ namespace TSGenerator
 {
 // forward declaration
 // Hydro - see hydro.cpp
-bool GenerateHydroTimeSeries(Data::Study& study, uint year, IResultWriter::Ptr writer);
+bool GenerateHydroTimeSeries(Data::Study& study, uint year, IResultWriter& writer);
 
 template<>
 inline bool GenerateTimeSeries<Data::timeSeriesHydro>(Data::Study& study,
                                                       uint year,
-                                                      IResultWriter::Ptr writer)
+                                                      IResultWriter& writer)
 {
     return GenerateHydroTimeSeries(study, year, writer);
 }
 
 // --- TS Generators using XCast ---
 template<enum Data::TimeSeries T>
-bool GenerateTimeSeries(Data::Study& study, uint year, IResultWriter::Ptr writer)
+bool GenerateTimeSeries(Data::Study& study, uint year, IResultWriter& writer)
 {
     auto* xcast = reinterpret_cast<XCast::XCast*>(
       study.cacheTSGenerator[Data::TimeSeriesBitPatternIntoIndex<T>::value]);

--- a/src/solver/ts-generator/hydro.cpp
+++ b/src/solver/ts-generator/hydro.cpp
@@ -76,7 +76,7 @@ static void PreproRoundAllEntriesPlusDerated(Data::Study& study)
     });
 }
 
-bool GenerateHydroTimeSeries(Data::Study& study, uint currentYear, IResultWriter::Ptr writer)
+bool GenerateHydroTimeSeries(Data::Study& study, uint currentYear, IResultWriter& writer)
 {
     logs.info() << "Generating the hydro time-series";
 
@@ -302,14 +302,14 @@ bool GenerateHydroTimeSeries(Data::Study& study, uint currentYear, IResultWriter
                     std::string buffer;
                     area.hydro.series->ror.saveToBuffer(buffer, precision);
                     output.clear() << study.buffer << SEP << "ror.txt";
-                    writer->addEntryFromBuffer(output.c_str(), buffer);
+                    writer.addEntryFromBuffer(output.c_str(), buffer);
                 }
 
                 {
                     std::string buffer;
                     area.hydro.series->storage.saveToBuffer(buffer, precision);
                     output.clear() << study.buffer << SEP << "storage.txt";
-                    writer->addEntryFromBuffer(output.c_str(), buffer);
+                    writer.addEntryFromBuffer(output.c_str(), buffer);
                 }
                 ++progression;
             });

--- a/src/solver/ts-generator/thermal.cpp
+++ b/src/solver/ts-generator/thermal.cpp
@@ -60,7 +60,7 @@ class GeneratorTempData final
 public:
     GeneratorTempData(Data::Study& study,
                       Solver::Progression::Task& progr,
-                      IResultWriter::Ptr writer);
+                      IResultWriter& writer);
 
     void prepareOutputFoldersForAllAreas(uint year);
 
@@ -96,46 +96,32 @@ private:
     MersenneTwister& rndgenerator;
 
     double AVP[366];
-
     enum
     {
-
         Log_size = 4000
     };
-
     int LOG[Log_size];
-
     int LOGP[Log_size];
 
     double lf[366];
     double lp[366];
-
     double ff[366];
-
     double pp[366];
-
     double af[366];
-
     double ap[366];
-
     double bf[366];
-
     double bp[366];
-
     double FPOW[366][102];
-
     double PPOW[366][102];
 
     String pTempFilename;
-
     Solver::Progression::Task& pProgression;
-
-    IResultWriter::Ptr pWriter;
+    IResultWriter& pWriter;
 };
 
 GeneratorTempData::GeneratorTempData(Data::Study& study,
                                      Solver::Progression::Task& progr,
-                                     IResultWriter::Ptr writer) :
+                                     IResultWriter& writer) :
     study(study),
     rndgenerator(study.runtime->random[Data::seedTsGenThermal]),
     pProgression(progr),
@@ -169,7 +155,7 @@ void GeneratorTempData::writeResultsToDisk(const Data::Area& area,
         std::string buffer;
         cluster.series->timeSeries.saveToBuffer(buffer, precision);
 
-        pWriter->addEntryFromBuffer(pTempFilename.c_str(), buffer);
+        pWriter.addEntryFromBuffer(pTempFilename.c_str(), buffer);
     }
 
     ++pProgression;
@@ -631,7 +617,7 @@ bool GenerateThermalTimeSeries(Data::Study& study,
                                uint year,
                                bool globalThermalTSgeneration,
                                bool refreshTSonCurrentYear,
-                               Antares::Solver::IResultWriter::Ptr writer)
+                               Antares::Solver::IResultWriter& writer)
 {
     logs.info();
     logs.info() << "Generating the thermal time-series";

--- a/src/solver/ts-generator/xcast/xcast.cpp
+++ b/src/solver/ts-generator/xcast/xcast.cpp
@@ -59,7 +59,7 @@ enum
     mu = Data::XCast::dataCoeffMu,
 };
 
-XCast::XCast(Data::Study& study, Data::TimeSeries ts, IResultWriter::Ptr writer) :
+XCast::XCast(Data::Study& study, Data::TimeSeries ts, IResultWriter& writer) :
  study(study),
  timeSeriesType(ts),
  pNeverInitialized(true),
@@ -98,7 +98,7 @@ void XCast::exportTimeSeriesToTheOutput(Progression::Task& progression, Predicat
             std::string buffer;
             predicate.matrix(area).saveToBuffer(buffer);
 
-            pWriter->addEntryFromBuffer(filename.c_str(), buffer);
+            pWriter.addEntryFromBuffer(filename.c_str(), buffer);
 
             ++progression;
         });

--- a/src/solver/ts-generator/xcast/xcast.h
+++ b/src/solver/ts-generator/xcast/xcast.h
@@ -74,7 +74,7 @@ public:
     /*!
     ** \brief Default constructor
     */
-    XCast(Data::Study& study, Data::TimeSeries ts, IResultWriter::Ptr writer);
+    XCast(Data::Study& study, Data::TimeSeries ts, IResultWriter& writer);
     /*!
     ** \brief Destructor
     */
@@ -250,7 +250,7 @@ private:
     //! Name of the current timeseries
     Yuni::CString<32, false> pTSName;
 
-    IResultWriter::Ptr pWriter;
+    IResultWriter& pWriter;
 }; // class XCast
 
 } // namespace XCast

--- a/src/solver/variable/container.h
+++ b/src/solver/variable/container.h
@@ -218,7 +218,7 @@ public:
     void exportSurveyResults(bool global,
                              const Yuni::String& output,
                              unsigned int numSpace,
-                             IResultWriter::Ptr writer);
+                             IResultWriter& writer);
 
     /*!
     ** \brief Ask to all variables to fullfil the digest

--- a/src/solver/variable/container.hxx
+++ b/src/solver/variable/container.hxx
@@ -317,7 +317,7 @@ template<class NextT>
 void List<NextT>::exportSurveyResults(bool global,
                                       const Yuni::String& output,
                                       unsigned int numSpace,
-                                      IResultWriter::Ptr writer)
+                                      IResultWriter& writer)
 {
     using namespace Antares;
 

--- a/src/solver/variable/surveyresults/data.h
+++ b/src/solver/variable/surveyresults/data.h
@@ -57,7 +57,7 @@ public:
     ** It is composed by several files to completely describe the system
     ** and provide a good support for Excel macros.
     */
-    void exportGridInfos(IResultWriter::Ptr writer);
+    void exportGridInfos(IResultWriter& writer);
 
 public:
     //! The current column index

--- a/src/solver/variable/surveyresults/reportbuilder.hxx
+++ b/src/solver/variable/surveyresults/reportbuilder.hxx
@@ -217,7 +217,7 @@ public:
         SurveyReportBuilder<GlobalT, NextT, nextDataLevel>::Run(list, results, numSpace);
     }
 
-    static void RunDigest(const ListType& list, SurveyResults& results, IResultWriter::Ptr writer)
+    static void RunDigest(const ListType& list, SurveyResults& results, IResultWriter& writer)
     {
         logs.info() << "Exporting digest...";
         logs.debug() << " . Digest, truncating file";
@@ -253,7 +253,7 @@ public:
         // THIS FILE IS DEPRECATED !!!
         YString digestFileName;
         digestFileName << results.data.originalOutput << SEP << "grid" << SEP << "digest.txt";
-        writer->addEntryFromBuffer(digestFileName.c_str(), digestBuffer);
+        writer.addEntryFromBuffer(digestFileName.c_str(), digestBuffer);
     }
 
 private:

--- a/src/solver/variable/surveyresults/surveyresults.cpp
+++ b/src/solver/variable/surveyresults/surveyresults.cpp
@@ -113,7 +113,7 @@ void InternalExportDigestLinksMatrix(const Data::Study& study,
 
 static void ExportGridInfosAreas(const Data::Study& study,
                                  const Yuni::String& originalOutput,
-                                 IResultWriter::Ptr writer)
+                                 IResultWriter& writer)
 {
     Clob out;
     Clob outLinks;
@@ -164,7 +164,7 @@ static void ExportGridInfosAreas(const Data::Study& study,
     auto add = [&writer, &originalOutput](const YString& filename, Clob&& buffer) {
         YString path;
         path << originalOutput << SEP << "grid" << SEP << filename;
-        writer->addEntryFromBuffer(path.c_str(), buffer);
+        writer.addEntryFromBuffer(path.c_str(), buffer);
     };
 
     add("areas.txt", std::move(out));
@@ -218,7 +218,7 @@ void SurveyResultsData::initialize(uint maxVariables)
     }
 }
 
-void SurveyResultsData::exportGridInfos(IResultWriter::Ptr writer)
+void SurveyResultsData::exportGridInfos(IResultWriter& writer)
 {
     output.clear();
     Solver::Variable::Private::ExportGridInfosAreas(study, originalOutput, writer);
@@ -490,7 +490,7 @@ static inline void WriteIndexHeaderToFileDescriptor(int precisionLevel,
 
 SurveyResults::SurveyResults(const Data::Study& s,
                              const String& o,
-                             IResultWriter::Ptr writer) :
+                             IResultWriter& writer) :
  data(s, o),
  yearByYearResults(false),
  isCurrentVarNA(nullptr),
@@ -738,7 +738,7 @@ void SurveyResults::saveToFile(int dataLevel, int fileLevel, int precisionLevel)
     }
 
     // mc-ind & mc-all
-    pResultWriter->addEntryFromBuffer(data.filename.c_str(), data.fileBuffer);
+    pResultWriter.addEntryFromBuffer(data.filename.c_str(), data.fileBuffer);
 }
 
 void SurveyResults::exportGridInfos()

--- a/src/solver/variable/surveyresults/surveyresults.h
+++ b/src/solver/variable/surveyresults/surveyresults.h
@@ -63,7 +63,7 @@ public:
     */
     SurveyResults(const Data::Study& s,
                   const Yuni::String& o,
-                  IResultWriter::Ptr writer);
+                  IResultWriter& writer);
     /*!
     ** \brief Destructor
     */
@@ -138,7 +138,7 @@ public:
     //! Same thing for print status (do we print the current output variable ?)
     bool* isPrinted;
     // File writer
-    IResultWriter::Ptr pResultWriter;
+    IResultWriter& pResultWriter;
 
 private:
     template<class StringT, class ConvertT, class PrecisionT>


### PR DESCRIPTION
- Remove most uses of `IResultWriter::Ptr`, use reference instead
- Pass `OptimizationStatisticsWriter` to `Adequacy::year` and `Economy::year`

See also #1601. This work is not about moving `resultWriter` away from `Study`, but it is somewhat related, and may help.