### PR TITLE
Fix wrong year number in logs upon failed year

### DIFF
--- a/src/solver/simulation/solver.hxx
+++ b/src/solver/simulation/solver.hxx
@@ -1018,7 +1018,7 @@ void ISimulation<Impl>::loopThroughYears(uint firstYear,
             if (failed)
             {
                 std::ostringstream msg;
-                msg << "Year " << year << " has failed in the previous set of parallel year.";
+                msg << "Year " << year + 1 << " has failed in the previous set of parallel year.";
                 throw FatalError(msg.str());
             }
         }


### PR DESCRIPTION
Inconsistent year numbers are displayed because different conventions are used for year indexing. The developer indexing starts from 0, while user indexing starts at 1.

## Log extract before
```
[2023-10-03 20:32:11][solver][infos] Year(s) 14 
[2023-10-03 20:32:11][solver][fatal] Year 13 has failed in the previous set of parallel year.
```

## Log extract after
```
[2023-10-03 20:32:11][solver][infos] Year(s) 14 
[2023-10-03 20:32:11][solver][fatal] Year 14 has failed in the previous set of parallel year.
```