### PR TITLE
Use `std::unique_ptr::operator->` rather than `std::unique_ptr::get` & raw pointers

### DIFF
--- a/src/analyzer/atsp/correlations.cpp
+++ b/src/analyzer/atsp/correlations.cpp
@@ -629,7 +629,7 @@ bool ATSP::computeMonthlyCorrelations()
     }
 
     // removing the mapping list
-    delete mapping;
+    delete[] mapping;
 
     return true;
 }

--- a/src/solver/optimisation/opt_alloc_probleme_a_optimiser.cpp
+++ b/src/solver/optimisation/opt_alloc_probleme_a_optimiser.cpp
@@ -88,7 +88,7 @@ void OPT_AllocateFromNumberOfVariableConstraints(PROBLEME_ANTARES_A_RESOUDRE* Pr
 
 static void optimisationAllocateProblem(PROBLEME_HEBDO* problemeHebdo, const int mxPaliers)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     int NombreDePasDeTempsPourUneOptimisation
       = problemeHebdo->NombreDePasDeTempsPourUneOptimisation;

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -107,7 +107,7 @@ static SimplexResult OPT_TryToCallSimplex(
         IResultWriter& writer
         )
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
     auto ProbSpx
       = (PROBLEME_SPX*)(ProblemeAResoudre->ProblemesSpx[(int)NumIntervalle]);
     auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[(int)NumIntervalle]);
@@ -304,7 +304,7 @@ bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
                          const OptPeriodStringGenerator& optPeriodStringGenerator,
                          IResultWriter& writer)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
     Optimization::PROBLEME_SIMPLEXE_NOMME Probleme(ProblemeAResoudre->NomDesVariables,
                                                    ProblemeAResoudre->NomDesContraintes,
                                                    ProblemeAResoudre->StatutDesVariables,

--- a/src/solver/optimisation/opt_construction_contraintes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_construction_contraintes_couts_demarrage.cpp
@@ -45,7 +45,7 @@ void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaireCoutsDeDemarrage(
   PROBLEME_HEBDO* problemeHebdo,
   bool Simulation)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     int nombreDePasDeTempsPourUneOptimisation
       = problemeHebdo->NombreDePasDeTempsPourUneOptimisation;

--- a/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_matrice_des_contraintes_cas_lineaire.cpp
@@ -54,7 +54,7 @@ using namespace Antares::Data;
 
 void OPT_ConstruireLaMatriceDesContraintesDuProblemeLineaire(PROBLEME_HEBDO* problemeHebdo, Solver::IResultWriter& writer)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     int nombreDePasDeTempsDUneJournee = problemeHebdo->NombreDePasDeTempsDUneJournee;
     int nombreDePasDeTempsPourUneOptimisation

--- a/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
+++ b/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
@@ -38,7 +38,7 @@ void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaireCoutsDeDemarra
   PROBLEME_HEBDO* problemeHebdo,
   bool Simulation)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     int nombreDePasDeTempsPourUneOptimisation
       = problemeHebdo->NombreDePasDeTempsPourUneOptimisation;

--- a/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
@@ -33,7 +33,7 @@
 
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(PROBLEME_HEBDO* problemeHebdo)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     int NombreDePasDeTempsPourUneOptimisation
       = problemeHebdo->NombreDePasDeTempsPourUneOptimisation;

--- a/src/solver/optimisation/opt_construction_variables_optimisees_quadratique.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_quadratique.cpp
@@ -37,7 +37,7 @@
 
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeQuadratique(PROBLEME_HEBDO* problemeHebdo)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
     assert(ProblemeAResoudre != NULL);
 
     int nombreDeVariables = 0;

--- a/src/solver/optimisation/opt_decompte_variables_et_contraintes.cpp
+++ b/src/solver/optimisation/opt_decompte_variables_et_contraintes.cpp
@@ -39,7 +39,7 @@ using namespace Antares;
 
 int OPT_DecompteDesVariablesEtDesContraintesDuProblemeAOptimiser(PROBLEME_HEBDO* problemeHebdo)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
     int nombreDePasDeTempsPourUneOptimisation
       = problemeHebdo->NombreDePasDeTempsPourUneOptimisation;
 

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -216,7 +216,7 @@ void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO* prob
                                                             const int DernierPdtDeLIntervalle,
                                                             const int optimizationNumber)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     std::vector<double*>& AdresseOuPlacerLaValeurDesVariablesOptimisees
       = ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees;

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp
@@ -43,7 +43,7 @@ using namespace Yuni;
 void OPT_InitialiserLesBornesDesVariablesDuProblemeQuadratique(PROBLEME_HEBDO* problemeHebdo,
                                                                int PdtHebdo)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     for (int i = 0; i < ProblemeAResoudre->NombreDeVariables; i++)
         ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees[i] = nullptr;

--- a/src/solver/optimisation/opt_gestion_des_bornes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_couts_demarrage.cpp
@@ -39,7 +39,7 @@ void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaireCoutsDeDemarrage(
   const int PremierPdtDeLIntervalle,
   const int DernierPdtDeLIntervalle)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
     int NombreDePasDeTempsPourUneOptimisation
       = problemeHebdo->NombreDePasDeTempsPourUneOptimisation;
 

--- a/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
@@ -85,7 +85,7 @@ void OPT_InitialiserLesCoutsLineaire(PROBLEME_HEBDO* problemeHebdo,
                                      const int PremierPdtDeLIntervalle,
                                      const int DernierPdtDeLIntervalle)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     int pdtJour = 0;
 

--- a/src/solver/optimisation/opt_gestion_des_couts_cas_quadratique.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_cas_quadratique.cpp
@@ -34,7 +34,7 @@
 
 void OPT_InitialiserLesCoutsQuadratiques(PROBLEME_HEBDO* problemeHebdo, int PdtHebdo)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     ProblemeAResoudre->CoutLineaire.assign(ProblemeAResoudre->NombreDeVariables, 0.);
 

--- a/src/solver/optimisation/opt_gestion_des_couts_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_couts_demarrage.cpp
@@ -38,7 +38,7 @@ void OPT_InitialiserLesCoutsLineaireCoutsDeDemarrage(PROBLEME_HEBDO* problemeHeb
                                                      const int PremierPdtDeLIntervalle,
                                                      const int DernierPdtDeLIntervalle)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
     std::vector<double>& CoutLineaire = ProblemeAResoudre->CoutLineaire;
 
     for (int pdtHebdo = PremierPdtDeLIntervalle, pdtJour = 0; pdtHebdo < DernierPdtDeLIntervalle;

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -64,7 +64,7 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
 {
     int weekFirstHour = problemeHebdo->weekInTheYear * 168;
 
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     std::vector<double>& SecondMembre = ProblemeAResoudre->SecondMembre;
 

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_quadratique.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_quadratique.cpp
@@ -34,7 +34,7 @@
 
 void OPT_InitialiserLeSecondMembreDuProblemeQuadratique(PROBLEME_HEBDO* problemeHebdo, int PdtHebdo)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
 
     for (uint32_t pays = 0; pays < problemeHebdo->NombreDePays - 1; pays++)
     {

--- a/src/solver/optimisation/opt_gestion_second_membre_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_couts_demarrage.cpp
@@ -42,7 +42,7 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaireCoutsDeDemarrage(PROBLEME_HE
                                                                      int PremierPdtDeLIntervalle,
                                                                      int DernierPdtDeLIntervalle)
 {
-    PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
     std::vector<double>& SecondMembre = ProblemeAResoudre->SecondMembre;
 
     std::vector<double*>& AdresseOuPlacerLaValeurDesCoutsMarginaux

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -52,7 +52,7 @@ void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options, const P
 
     int nbIntervalles = problemeHebdo->NombreDePasDeTemps / NombreDePasDeTempsPourUneOptimisation;
 
-    const PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre = problemeHebdo->ProblemeAResoudre.get();
+    const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
     if (!ProblemeAResoudre)
         return;
 


### PR DESCRIPTION
Using `std::unique_ptr::operator->` offers a bit more safety against the possible scenario

1. A raw pointer is obtained through `T* ptr = unique.get()`
2. Object `unique` is deleted, freeing the underlying memory
3. The caller de-references `ptr`, resulting in a segfault