### PR TITLE
Fix segfault encountered when importing logs

### DIFF
--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -456,8 +456,9 @@ Application::~Application()
     {
         logs.info() << LOG_UI_SOLVER_DONE;
 
-        // Copy the log file
-        if (!pStudy->parameters.noOutput) {
+        // Copy the log file if a result writer is available
+        if (!pStudy->parameters.noOutput && resultWriter)
+        {
             pStudy->importLogsToOutputFolder(*resultWriter);
         }
 

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -305,7 +305,7 @@ void Application::readDataForTheStudy(Data::StudyLoadOptions& options)
     // Load the study from a folder
     Benchmarking::Timer timer;
 
-    std::exception_ptr eptr;
+    std::exception_ptr loadingException;
     try
     {
         if (study.loadFromFolder(pSettings.studyFolder, options) && !study.gotFatalError)
@@ -335,7 +335,7 @@ void Application::readDataForTheStudy(Data::StudyLoadOptions& options)
     }
     catch (...)
     {
-        eptr = std::current_exception();
+        loadingException = std::current_exception();
     }
     // This settings can only be enabled from the solver
     // Prepare the output for the study
@@ -347,9 +347,9 @@ void Application::readDataForTheStudy(Data::StudyLoadOptions& options)
     // Some checks may have failed, but we need a writer to copy the logs
     // to the output directory
     // So we wait until we have initialized the writer to rethrow
-    if (eptr)
+    if (loadingException)
     {
-        std::rethrow_exception(eptr);
+        std::rethrow_exception(loadingException);
     }
 
     Antares::Solver::initializeSignalHandlers(resultWriter);


### PR DESCRIPTION
If an exception is thrown during the loading of the study, the `resultWriter` is `nullptr`. When trying to call `pStudy->importLogsToOutputFolder`, we get a segfault.

I did the following 2 changes to fix this
- Check that `resultWriter` is a valid pointer before de-referencing it. This is enough to avoid segfaults, but then logs are not imported in the output directory, which is not satisfactory for diagnosis. We can still find it in the study/logs/ directory though.
- Better handle exceptions that are thrown during the loading. Whenever an exception is thrown, wait until we have a writer to re-throw it. This way the logs can be imported into the output directory.

The original segfault can be triggered by setting the direct capacity for a link to a value < 0.