### PR TITLE
Reset hydro storage correctly

### DIFF
--- a/src/libs/antares/series/include/antares/series/series.h
+++ b/src/libs/antares/series/include/antares/series/series.h
@@ -77,6 +77,7 @@ public:
     double* operator[](uint32_t index);
 
     void reset();
+    void reset(uint32_t width, uint32_t height);
     void unloadFromMemory() const;
     void roundAllEntries();
     void resize(uint32_t timeSeriesCount, uint32_t timestepCount);

--- a/src/libs/antares/series/series.cpp
+++ b/src/libs/antares/series/series.cpp
@@ -102,6 +102,11 @@ void TimeSeries::reset()
     timeSeries.reset(1, HOURS_PER_YEAR);
 }
 
+void TimeSeries::reset(uint32_t width, uint32_t height)
+{
+    timeSeries.reset(width, height);
+}
+
 void TimeSeries::resize(uint32_t timeSeriesCount, uint32_t timestepCount)
 {
     timeSeries.resize(timeSeriesCount, timestepCount);

--- a/src/libs/antares/study/parts/hydro/series.cpp
+++ b/src/libs/antares/study/parts/hydro/series.cpp
@@ -122,7 +122,7 @@ bool DataSeriesHydro::loadFromFolder(Study& study, const AreaName& areaID, const
         logs.error() << "Hydro: `" << areaID
                      << "`: empty matrix detected. Fixing it with default values";
         ror.reset();
-        storage.reset();
+        storage.reset(1, DAYS_PER_YEAR);
         mingen.reset();
     }
     else
@@ -231,7 +231,7 @@ void DataSeriesHydro::markAsModified() const
 void DataSeriesHydro::reset()
 {
     ror.reset();
-    storage.reset();
+    storage.reset(1, DAYS_PER_YEAR);
     mingen.reset();
     count = 1;
 }


### PR DESCRIPTION
Fixed a bug in the GUI where storage size after reset was hour per year instead of day per year