### PR TITLE
CR23 Modification : Unit tests refactoring

### DIFF
--- a/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
@@ -1,21 +1,8 @@
-# Useful variables definitions
-set(src_libs_antares_study "${CMAKE_SOURCE_DIR}/libs/antares/study")
-set(src_libs_antares "${CMAKE_SOURCE_DIR}/libs/antares")
-set(src_test_utils "${CMAKE_SOURCE_DIR}/tests/src/utils")
-
-
 # Hydro data reader
 set(SRC_HYDRO_READER
 	test-hydroreader-class.cpp)
 
 add_executable(test-hydro-reader ${SRC_HYDRO_READER})
-
-target_include_directories(test-hydro-reader
-	PRIVATE
-	"${src_libs_antares_study}"
-	"${src_libs_antares}/array/antares/array"
-	"${src_test_utils}"
-)
 
 target_link_libraries(test-hydro-reader
 	PRIVATE
@@ -40,19 +27,10 @@ set(SRC_HYDRO_SERIES
 
 add_executable(test-hydro-series ${SRC_HYDRO_SERIES})
 
-target_include_directories(test-hydro-series
-	PRIVATE
-	"${src_libs_antares_study}"
-	"${src_libs_antares}/array/antares/array"
-	"${src_libs_antares}/exception/antares/exception"
-	"${src_test_utils}"
-)
-
 target_link_libraries(test-hydro-series
 	PRIVATE
 	Boost::unit_test_framework
 	Antares::study
-	Antares::exception
 	test_utils_unit
 )
 

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
@@ -1,11 +1,11 @@
 #define BOOST_TEST_MODULE test hydro series
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
 #include <boost/test/included/unit_test.hpp>
-#include <study.h>
-#include <LoadingError.hpp>
-#include <matrix.h>
+#include <antares/study/study.h>
+#include <antares/array/matrix.h>
 #include <files-system.h>
 
 #define SEP "/"

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
@@ -1,10 +1,11 @@
-#define BOOST_TEST_MODULE test data transfer
+#define BOOST_TEST_MODULE test hydro reader
+#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
 #include <boost/test/included/unit_test.hpp>
-#include <study.h>
-#include <matrix.h>
+#include <antares/study/study.h>
+#include <antares/array/matrix.h>
 #include <files-system.h>
 
 #define SEP "/"
@@ -12,8 +13,8 @@
 using namespace Antares::Data;
 namespace fs = std::filesystem;
 
-bool equalDailyMaxPowerAsHourlyTs(const Matrix<double, int32_t>::ColumnType& hourlyColumn,
-                                        const Matrix<double>::ColumnType& dailyColumn)
+bool equalDailyMaxPowerAsHourlyTs(const Matrix<double>::ColumnType& hourlyColumn,
+                                  const Matrix<double>::ColumnType& dailyColumn)
 {
     uint hour = 0;
     uint day = 0;


### PR DESCRIPTION
1. Linking boost test library dynamically with unit tests .exe files.
2. Modifying function arguments due to implementation of the `TimeSeries `class.
3. Discarding unnecessary usage of `target_include_directories` CMake function.