### PR TITLE
HydroMaxReader class refactor

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -913,7 +913,7 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
             buffer.clear() << study.folderInput << SEP << "hydro";
 
             HydroMaxTimeSeriesReader reader;
-            ret = reader(buffer, area, study.usedByTheSolver) && ret;
+            ret = reader.read(buffer, area, study.usedByTheSolver) && ret;
         }
 
         if (study.header.version >= 870)

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -912,8 +912,8 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
         {
             buffer.clear() << study.folderInput << SEP << "hydro";
 
-            HydroMaxTimeSeriesReader reader;
-            ret = reader.read(buffer, area, study.usedByTheSolver) && ret;
+            HydroMaxTimeSeriesReader reader(area.hydro, area.id.to<std::string>(), area.name.to<std::string>());
+            ret = reader.read(buffer, study.usedByTheSolver) && ret;
         }
 
         if (study.header.version >= 870)

--- a/src/libs/antares/study/parts/hydro/hydromaxtimeseriesreader.cpp
+++ b/src/libs/antares/study/parts/hydro/hydromaxtimeseriesreader.cpp
@@ -122,7 +122,7 @@ void HydroMaxTimeSeriesReader::copyDailyMaxPumpingEnergy(Area& area) const
     dailyNbHoursAtPumpPmax.pasteToColumn(0, dailyMaxPumpE);
 }
 
-bool HydroMaxTimeSeriesReader::operator()(const AnyString& folder, Area& area, bool usedBySolver)
+bool HydroMaxTimeSeriesReader::read(const AnyString& folder, Area& area, bool usedBySolver)
 {
     bool ret = true;
 

--- a/src/libs/antares/study/parts/hydro/hydromaxtimeseriesreader.h
+++ b/src/libs/antares/study/parts/hydro/hydromaxtimeseriesreader.h
@@ -43,8 +43,9 @@ class HydroMaxTimeSeriesReader
 public:
     HydroMaxTimeSeriesReader();
 
-    bool operator()(const AnyString& folder, Area& area, bool usedBySolver);
+    bool read(const AnyString& folder, Area& area, bool usedBySolver);
 
+private:
     Matrix<double, double> dailyMaxPumpAndGen;
 
     enum powerDailyE
@@ -59,7 +60,6 @@ public:
         pumpMaxE,
     };
 
-private:
     /**
      * \brief Loading deprecated files
      *  This function provides reading from deprecated files which

--- a/src/libs/antares/study/parts/hydro/hydromaxtimeseriesreader.h
+++ b/src/libs/antares/study/parts/hydro/hydromaxtimeseriesreader.h
@@ -41,9 +41,9 @@ namespace Antares::Data
 class HydroMaxTimeSeriesReader
 {
 public:
-    HydroMaxTimeSeriesReader();
+    HydroMaxTimeSeriesReader(PartHydro& hydro, std::string areaID, std::string areaName);
 
-    bool read(const AnyString& folder, Area& area, bool usedBySolver);
+    bool read(const AnyString& folder, bool usedBySolver);
 
 private:
     Matrix<double, double> dailyMaxPumpAndGen;
@@ -60,13 +60,16 @@ private:
         pumpMaxE,
     };
 
+    PartHydro& hydro_;
+    std::string areaID_;
+    std::string areaName_;
+
     /**
      * \brief Loading deprecated files
      *  This function provides reading from deprecated files which
      *  contains daily maximum generation/pumping power and energy data.
      */
     bool loadDailyMaxPowersAndEnergies(const AnyString& folder,
-                                       const Area& area,
                                        bool usedBySolver);
 
     /**
@@ -74,9 +77,9 @@ private:
      *  These functions provides coping of energy data loaded
      *  from deprecated file.
      */
-    void copyDailyMaxEnergy(Area& area) const;
-    void copyDailyMaxGenerationEnergy(Area& area) const;
-    void copyDailyMaxPumpingEnergy(Area& area) const;
+    void copyDailyMaxEnergy() const;
+    void copyDailyMaxGenerationEnergy() const;
+    void copyDailyMaxPumpingEnergy() const;
 };
 } // namespace Antares::Data
 

--- a/src/libs/antares/study/parts/hydro/hydromaxtimeseriesreader.h
+++ b/src/libs/antares/study/parts/hydro/hydromaxtimeseriesreader.h
@@ -45,9 +45,6 @@ public:
 
     bool read(const AnyString& folder, bool usedBySolver);
 
-private:
-    Matrix<double, double> dailyMaxPumpAndGen;
-
     enum powerDailyE
     {
         //! Generated max power
@@ -59,6 +56,9 @@ private:
         // Pumping max Energy
         pumpMaxE,
     };
+
+private:
+    Matrix<double, double> dailyMaxPumpAndGen;
 
     PartHydro& hydro_;
     std::string areaID_;

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
@@ -66,16 +66,16 @@ struct Fixture
         // Create necessary folders and files for these two areas
         createFoldersAndFiles();
 
-        auto& gen = dailyMaxPumpAndGen[0U];
+        auto& gen = dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::genMaxP];
         fillColumnWithSpecialEnds(gen, 300., DAYS_PER_YEAR);
 
-        auto& pump = dailyMaxPumpAndGen[2U];
+        auto& pump = dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::pumpMaxP];
         fillColumnWithSpecialEnds(pump, 200., DAYS_PER_YEAR);
 
-        auto& hoursGen = dailyMaxPumpAndGen[1U];
+        auto& hoursGen = dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::genMaxE];
         fillColumnWithSpecialEnds(hoursGen, 20., DAYS_PER_YEAR);
 
-        auto& hoursPump = dailyMaxPumpAndGen[3U];
+        auto& hoursPump = dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::pumpMaxE];
         fillColumnWithSpecialEnds(hoursPump, 14., DAYS_PER_YEAR);
 
         std::string buffer;
@@ -164,10 +164,10 @@ BOOST_FIXTURE_TEST_CASE(Testing_support_for_old_studies, Fixture)
     auto& genE = area_1->hydro.dailyNbHoursAtGenPmax[0];
     auto& pumpE = area_1->hydro.dailyNbHoursAtPumpPmax[0];
 
-    auto& genPReader = dailyMaxPumpAndGen[0U];
-    auto& pumpPReader = dailyMaxPumpAndGen[2U];
-    auto& genEReader = dailyMaxPumpAndGen[1U];
-    auto& pumpEReader = dailyMaxPumpAndGen[3U];
+    auto& genPReader = dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::genMaxP];
+    auto& pumpPReader = dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::pumpMaxP];
+    auto& genEReader = dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::genMaxE];
+    auto& pumpEReader = dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::pumpMaxE];
 
     buffer.clear();
     buffer = base_folder + SEP + hydro_folder;

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
@@ -55,11 +55,13 @@ struct Fixture
     Fixture()
     {
         study = std::make_shared<Study>(true);
-        reader = std::make_shared<HydroMaxTimeSeriesReader>();
+
         // Add areas
         area_1 = study->areaAdd("Area1");
         study->areas.rebuildIndexes();
         dailyMaxPumpAndGen.reset(4U, DAYS_PER_YEAR);
+        reader = std::make_shared<HydroMaxTimeSeriesReader>(
+          area_1->hydro, area_1->id.to<std::string>(), area_1->name.to<std::string>());
 
         // Create necessary folders and files for these two areas
         createFoldersAndFiles();
@@ -81,7 +83,6 @@ struct Fixture
         buffer = base_folder + SEP + hydro_folder + SEP + common_folder + SEP + capacity_folder
                  + SEP + maxpower + area_1->id.c_str() + ".txt";
         dailyMaxPumpAndGen.saveToCSVFile(buffer, 2);
-
     }
 
     void createFoldersAndFiles()
@@ -170,7 +171,7 @@ BOOST_FIXTURE_TEST_CASE(Testing_support_for_old_studies, Fixture)
 
     buffer.clear();
     buffer = base_folder + SEP + hydro_folder;
-    ret = reader->read(buffer, *area_1, study->usedByTheSolver) && ret;
+    ret = reader->read(buffer, study->usedByTheSolver) && ret;
 
     BOOST_CHECK(ret);
     BOOST_CHECK(equalDailyMaxPowerAsHourlyTs(genP, genPReader));

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
@@ -59,33 +59,29 @@ struct Fixture
         // Add areas
         area_1 = study->areaAdd("Area1");
         study->areas.rebuildIndexes();
+        dailyMaxPumpAndGen.reset(4U, DAYS_PER_YEAR);
 
         // Create necessary folders and files for these two areas
         createFoldersAndFiles();
 
-        auto& gen = reader->dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::genMaxP];
+        auto& gen = dailyMaxPumpAndGen[0U];
         fillColumnWithSpecialEnds(gen, 300., DAYS_PER_YEAR);
 
-        auto& pump = reader->dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::pumpMaxP];
+        auto& pump = dailyMaxPumpAndGen[2U];
         fillColumnWithSpecialEnds(pump, 200., DAYS_PER_YEAR);
 
-        auto& hoursGen = reader->dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::genMaxE];
+        auto& hoursGen = dailyMaxPumpAndGen[1U];
         fillColumnWithSpecialEnds(hoursGen, 20., DAYS_PER_YEAR);
 
-        auto& hoursPump = reader->dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::pumpMaxE];
+        auto& hoursPump = dailyMaxPumpAndGen[3U];
         fillColumnWithSpecialEnds(hoursPump, 14., DAYS_PER_YEAR);
 
         std::string buffer;
         buffer.clear();
         buffer = base_folder + SEP + hydro_folder + SEP + common_folder + SEP + capacity_folder
                  + SEP + maxpower + area_1->id.c_str() + ".txt";
-        reader->dailyMaxPumpAndGen.saveToCSVFile(buffer, 2);
+        dailyMaxPumpAndGen.saveToCSVFile(buffer, 2);
 
-        // Reset columns
-        reader->dailyMaxPumpAndGen.fillColumn(HydroMaxTimeSeriesReader::genMaxP, 0.);
-        reader->dailyMaxPumpAndGen.fillColumn(HydroMaxTimeSeriesReader::pumpMaxP, 0.);
-        reader->dailyMaxPumpAndGen.fillColumn(HydroMaxTimeSeriesReader::genMaxE, 24.);
-        reader->dailyMaxPumpAndGen.fillColumn(HydroMaxTimeSeriesReader::pumpMaxE, 24.);
     }
 
     void createFoldersAndFiles()
@@ -147,6 +143,7 @@ struct Fixture
     std::string maxpower = "maxpower_";
     std::string maxHourlyGenPower = "maxHourlyGenPower.txt";
     std::string maxHourlyPumpPower = "maxHourlyPumpPower.txt";
+    Matrix<double> dailyMaxPumpAndGen;
 
     ~Fixture()
     {
@@ -166,14 +163,14 @@ BOOST_FIXTURE_TEST_CASE(Testing_support_for_old_studies, Fixture)
     auto& genE = area_1->hydro.dailyNbHoursAtGenPmax[0];
     auto& pumpE = area_1->hydro.dailyNbHoursAtPumpPmax[0];
 
-    auto& genPReader = reader->dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::genMaxP];
-    auto& pumpPReader = reader->dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::pumpMaxP];
-    auto& genEReader = reader->dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::genMaxE];
-    auto& pumpEReader = reader->dailyMaxPumpAndGen[HydroMaxTimeSeriesReader::pumpMaxE];
+    auto& genPReader = dailyMaxPumpAndGen[0U];
+    auto& pumpPReader = dailyMaxPumpAndGen[2U];
+    auto& genEReader = dailyMaxPumpAndGen[1U];
+    auto& pumpEReader = dailyMaxPumpAndGen[3U];
 
     buffer.clear();
     buffer = base_folder + SEP + hydro_folder;
-    ret = (*reader)(buffer, *area_1, study->usedByTheSolver) && ret;
+    ret = reader->read(buffer, *area_1, study->usedByTheSolver) && ret;
 
     BOOST_CHECK(ret);
     BOOST_CHECK(equalDailyMaxPowerAsHourlyTs(genP, genPReader));


### PR DESCRIPTION
This PR is open for the purpose of refactoring `HydroMaxReaderClass`.

- [x] Declaring `dailyMaxPumpAndGen` matrix and `powerDailyE` enum as private.
- [x] Discarding overloaded operator () and switching it with `read` function.
- [x] Discarding passing reference to area to the `read` function.