### PR TITLE
Normalize simulation mode Expansion, fix logs

### DIFF
--- a/src/libs/antares/CMakeLists.txt
+++ b/src/libs/antares/CMakeLists.txt
@@ -26,7 +26,6 @@ set(SRC
     config.h
     constants.h
 	constants.cpp
-    xpansion.h
 	# Misc
 
 	locale.h

--- a/src/libs/antares/constants.h
+++ b/src/libs/antares/constants.h
@@ -28,7 +28,6 @@
 #ifndef __ANTARES_LIBS_CONSTANTS_H__
 #define __ANTARES_LIBS_CONSTANTS_H__
 
-#include "xpansion.h"
 #include <array>
 
 /*! Name of the app to use into logs */

--- a/src/libs/antares/exception/LoadingError.cpp
+++ b/src/libs/antares/exception/LoadingError.cpp
@@ -132,7 +132,7 @@ CommandLineArguments::CommandLineArguments(uint errors) :
 {
 }
 
-IncompatibleStudyModeForAdqPatch::IncompatibleStudyModeForAdqPatch() :
+IncompatibleSimulationModeForAdqPatch::IncompatibleSimulationModeForAdqPatch() :
  LoadingError("Adequacy Patch can only be used with Economy Simulation Mode")
 {
 }

--- a/src/libs/antares/exception/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/antares/exception/LoadingError.hpp
@@ -179,10 +179,10 @@ public:
     explicit CommandLineArguments(uint errors);
 };
 
-class IncompatibleStudyModeForAdqPatch : public LoadingError
+class IncompatibleSimulationModeForAdqPatch : public LoadingError
 {
 public:
-    IncompatibleStudyModeForAdqPatch();
+    IncompatibleSimulationModeForAdqPatch();
 };
 
 class NoAreaInsideAdqPatchMode : public LoadingError

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -937,7 +937,7 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
         ret = area.thermal.list.loadEconomicCosts(study, buffer) && ret;
 
         // In adequacy mode, all thermal clusters must be in 'mustrun' mode
-        if (study.usedByTheSolver && study.parameters.mode == stdmAdequacy)
+        if (study.usedByTheSolver && study.parameters.mode == SimulationMode::Adequacy)
             area.thermal.list.enableMustrunForEveryone();
     }
 

--- a/src/libs/antares/study/area/scratchpad.cpp
+++ b/src/libs/antares/study/area/scratchpad.cpp
@@ -72,7 +72,7 @@ AreaScratchpad::AreaScratchpad(const StudyRuntimeInfos& rinfos, Area& area)
                 sum += area.miscGen[w][h];
             miscGenSum[h] = sum;
         }
-        if (mode == Data::stdmAdequacy)
+        if (mode == Data::SimulationMode::Adequacy)
         {
             for (uint h = 0; h != area.miscGen.height; ++h)
                 miscGenSum[h] -= area.reserves[Data::fhrPrimaryReserve][h];

--- a/src/libs/antares/study/fwd.h
+++ b/src/libs/antares/study/fwd.h
@@ -97,21 +97,19 @@ enum StudyError
 };
 
 /*!
-** \brief Types of Study
+** \brief Types of Simulation
 */
-enum StudyMode
+enum class SimulationMode
 {
-    stdmUnknown = -1,
     //! Economic
-    stdmEconomy,
+    Economy,
     //! Adequacy (subset of the economy mode)
-    stdmAdequacy,
+    Adequacy,
     //! Expansion
-    stdmExpansion,
-    //! Max
-    stdmMax
-
-}; // enum StudyMode
+    Expansion,
+    //! Unknown simulation mode
+    Unknown
+};
 
 /*
 ** \brief Simplex optimizations

--- a/src/libs/antares/study/load-options.cpp
+++ b/src/libs/antares/study/load-options.cpp
@@ -44,7 +44,7 @@ StudyLoadOptions::StudyLoadOptions() :
  simplexOptimizationRange(sorUnknown),
  mpsToExport(false),
  ignoreConstraints(false),
- forceMode(stdmUnknown),
+ forceMode(SimulationMode::Unknown),
  enableParallel(false),
  forceParallel(false),
  maxNbYearsInParallel(0),
@@ -74,11 +74,11 @@ void StudyLoadOptions::checkForceSimulationMode()
         throw Error::InvalidSimulationMode();
     }
     if (forceExpansion)
-        forceMode = stdmExpansion;
+        forceMode = SimulationMode::Expansion;
     else if (forceEconomy)
-        forceMode = stdmEconomy;
+        forceMode = SimulationMode::Economy;
     else if (forceAdequacy)
-        forceMode = stdmAdequacy;
+        forceMode = SimulationMode::Adequacy;
 }
 } // namespace Data
 } // namespace Antares

--- a/src/libs/antares/study/load-options.h
+++ b/src/libs/antares/study/load-options.h
@@ -76,7 +76,7 @@ public:
     //! Ignore all constraints
     bool ignoreConstraints;
     //! Simulation mode
-    StudyMode forceMode;
+    SimulationMode forceMode;
 
     //! Enables the parallel computation of MC years
     bool enableParallel;

--- a/src/libs/antares/study/output.cpp
+++ b/src/libs/antares/study/output.cpp
@@ -89,7 +89,7 @@ private:
 } // anonymous namespace
 
 Output::Output(const AnyString& folder) :
- version(0), timestamp(0), mode(Data::stdmEconomy), menuID(-1), viewMenuID(-1), outputViewerID(-1)
+ version(0), timestamp(0), mode(Data::SimulationMode::Economy), menuID(-1), viewMenuID(-1), outputViewerID(-1)
 {
     loadFromFolder(folder);
 }
@@ -110,7 +110,7 @@ bool Output::loadFromFolder(const AnyString& folder)
     name.clear();
     path.clear();
     version = 0;
-    mode = Data::stdmUnknown;
+    mode = Data::SimulationMode::Unknown;
 
     // Load the INI file in memory
     IniFile ini;
@@ -152,7 +152,7 @@ bool Output::loadFromFolder(const AnyString& folder)
             {
                 if (p->key == "mode")
                 {
-                    StringToStudyMode(mode, p->value);
+                    StringToSimulationMode(mode, p->value);
                 }
                 else
                 {

--- a/src/libs/antares/study/output.h
+++ b/src/libs/antares/study/output.h
@@ -91,7 +91,7 @@ public:
     //! Date/time when the simulation has been launched
     int64_t timestamp;
     //! Mode (economy/adequacy/other)
-    Data::StudyMode mode;
+    Data::SimulationMode mode;
     //! Tag for storing a wx menu id
     int menuID;
     //! Tag for storing a wx menu id (from the menu `output`)

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -201,7 +201,7 @@ public:
     //! \name Mode
     //@{
     //! Mode of the study (adequacy, economy...)
-    StudyMode mode;
+    SimulationMode mode;
     //@}
 
     //! \name Horizon
@@ -537,18 +537,18 @@ private:
 }; // class Parameters
 
 /*!
-** \brief Convert a study mode (enum) into a human readable C-String
+** \brief Convert a simulation mode (enum) into a human readable C-String
 */
-const char* StudyModeToCString(StudyMode mode);
+const char* SimulationModeToCString(SimulationMode mode);
 
 /*!
-** \brief Convert a C-String (lowercase) into a study mode if possible
+** \brief Convert a C-String (lowercase) into a simulation mode if possible
 **
-** \param[out] mode The study mode. It will remain untouched if the conversion failed
+** \param[out] mode The simulation mode. It will remain untouched if the conversion failed
 ** \param Text An arbitrary Text (case insensitive)
 ** \return True if the conversion succeeded, false otherwise
 */
-bool StringToStudyMode(StudyMode& mode, Yuni::CString<20, false> text);
+bool StringToSimulationMode(SimulationMode& mode, Yuni::CString<20, false> text);
 
 } // namespace Antares::Data
 

--- a/src/libs/antares/study/parameters.h
+++ b/src/libs/antares/study/parameters.h
@@ -204,11 +204,6 @@ public:
     StudyMode mode;
     //@}
 
-    //! \name Expansion
-    //@{
-    //! Expansion flag
-    mutable bool expansion;
-
     //! \name Horizon
     //@{
     //! Horizon year

--- a/src/libs/antares/study/parameters/adq-patch-params.cpp
+++ b/src/libs/antares/study/parameters/adq-patch-params.cpp
@@ -169,11 +169,11 @@ void AdqPatchParams::saveToINI(IniFile& ini) const
     curtailmentSharing.addProperties(section);
 }
 
-bool AdqPatchParams::checkAdqPatchParams(const StudyMode studyMode,
+bool AdqPatchParams::checkAdqPatchParams(const SimulationMode simulationMode,
                                          const AreaList& areas,
                                          const bool includeHurdleCostParameters) const
 {
-    checkAdqPatchStudyModeEconomyOnly(studyMode);
+    checkAdqPatchSimulationModeEconomyOnly(simulationMode);
     checkAdqPatchContainsAdqPatchArea(areas);
     checkAdqPatchIncludeHurdleCost(includeHurdleCostParameters);
     checkAdqPatchDisabledLocalMatching();
@@ -182,10 +182,10 @@ bool AdqPatchParams::checkAdqPatchParams(const StudyMode studyMode,
 }
 
 // Adequacy Patch can only be used with Economy Study/Simulation Mode.
-void AdqPatchParams::checkAdqPatchStudyModeEconomyOnly(const StudyMode studyMode) const
+void AdqPatchParams::checkAdqPatchSimulationModeEconomyOnly(const SimulationMode simulationMode) const
 {
-    if (studyMode != StudyMode::stdmEconomy)
-        throw Error::IncompatibleStudyModeForAdqPatch();
+    if (simulationMode != SimulationMode::Economy)
+        throw Error::IncompatibleSimulationModeForAdqPatch();
 }
 
 // When Adequacy Patch is on at least one area must be inside Adequacy patch mode.

--- a/src/libs/antares/study/parameters/adq-patch-params.h
+++ b/src/libs/antares/study/parameters/adq-patch-params.h
@@ -116,12 +116,12 @@ struct AdqPatchParams
     void addExcludedVariables(std::vector<std::string>&) const;
     bool updateFromKeyValue(const Yuni::String& key, const Yuni::String& value);
     void saveToINI(IniFile& ini) const;
-    bool checkAdqPatchParams(const StudyMode studyMode,
+    bool checkAdqPatchParams(const SimulationMode simulationMode,
                              const AreaList& areas,
                              const bool includeHurdleCostParameters) const;
 
 
-    void checkAdqPatchStudyModeEconomyOnly(const StudyMode studyMode) const;
+    void checkAdqPatchSimulationModeEconomyOnly(const SimulationMode simulationMode) const;
     void checkAdqPatchContainsAdqPatchArea(const Antares::Data::AreaList& areas) const;
     void checkAdqPatchIncludeHurdleCost(const bool includeHurdleCost) const;
     void checkAdqPatchDisabledLocalMatching() const;

--- a/src/libs/antares/study/runtime/runtime.cpp
+++ b/src/libs/antares/study/runtime/runtime.cpp
@@ -143,7 +143,7 @@ void StudyRuntimeInfos::initializeRangeLimits(const Study& study, StudyRangeLimi
             // We have here too much hours, the interval will be reduced
             // Log Entry
             logs.info() << "    Partial week detected. Not allowed in "
-                        << StudyModeToCString(study.parameters.mode);
+                        << SimulationModeToCString(study.parameters.mode);
             logs.info() << "    Time interval that has been requested: " << (1 + a) << ".."
                         << (1 + b);
             // Reducing

--- a/src/libs/antares/study/runtime/runtime.h
+++ b/src/libs/antares/study/runtime/runtime.h
@@ -96,7 +96,7 @@ public:
     StudyRangeLimits rangeLimits;
 
     //! Mode of the simulation
-    StudyMode mode;
+    SimulationMode mode;
 
     //! The number of interconnections
     uint interconnectionsCount() const;

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -644,8 +644,10 @@ YString StudyCreateOutputPath(StudyMode mode,
     case stdmAdequacy:
         folderOutput += "adq";
         break;
-    case stdmUnknown:
     case stdmExpansion:
+        folderOutput += "exp";
+        break;
+    case stdmUnknown:
     case stdmMax:
         break;
     }

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -621,7 +621,7 @@ static std::string getOutputSuffix(ResultFormat fmt)
     }
 }
 
-YString StudyCreateOutputPath(StudyMode mode,
+YString StudyCreateOutputPath(SimulationMode mode,
                               ResultFormat fmt,
                               const YString& outputRoot,
                               const YString& label,
@@ -638,17 +638,16 @@ YString StudyCreateOutputPath(StudyMode mode,
 
     switch (mode)
     {
-    case stdmEconomy:
+    case SimulationMode::Economy:
         folderOutput += "eco";
         break;
-    case stdmAdequacy:
+    case SimulationMode::Adequacy:
         folderOutput += "adq";
         break;
-    case stdmExpansion:
+    case SimulationMode::Expansion:
         folderOutput += "exp";
         break;
-    case stdmUnknown:
-    case stdmMax:
+    case SimulationMode::Unknown:
         break;
     }
 
@@ -733,7 +732,7 @@ void Study::saveAboutTheStudy(Solver::IResultWriter& resultWriter)
     f << "[general]";
     f << "\nversion = " << (uint)Data::versionLatest;
     f << "\nname = " << simulationComments.name;
-    f << "\nmode = " << StudyModeToCString(parameters.mode);
+    f << "\nmode = " << SimulationModeToCString(parameters.mode);
     f << "\ndate = " << startTimeStr;
     f << "\ntitle = " << startTimeStr;
     f << "\ntimestamp = " << pStartTime;

--- a/src/libs/antares/study/study.h
+++ b/src/libs/antares/study/study.h
@@ -709,7 +709,7 @@ protected:
 */
 extern YString StudyIconFile;
 
-YString StudyCreateOutputPath(StudyMode mode,
+YString StudyCreateOutputPath(SimulationMode mode,
                               ResultFormat fmt,
                               const YString& folder,
                               const YString& label,

--- a/src/libs/antares/xpansion.h
+++ b/src/libs/antares/xpansion.h
@@ -1,4 +1,0 @@
-#pragma once
-
-/*! Enable / Disable the expansion mode */
-#define STUDY_MODE_EXPANSION 0

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -232,6 +232,7 @@ void Application::execute()
     switch (pStudy->runtime->mode)
     {
     case Data::stdmEconomy:
+    case Data::stdmExpansion:
         runSimulationInEconomicMode();
         break;
     case Data::stdmAdequacy:

--- a/src/solver/application.cpp
+++ b/src/solver/application.cpp
@@ -231,11 +231,11 @@ void Application::execute()
     // Run the simulation
     switch (pStudy->runtime->mode)
     {
-    case Data::stdmEconomy:
-    case Data::stdmExpansion:
+    case Data::SimulationMode::Economy:
+    case Data::SimulationMode::Expansion:
         runSimulationInEconomicMode();
         break;
-    case Data::stdmAdequacy:
+    case Data::SimulationMode::Adequacy:
         runSimulationInAdequacyMode();
         break;
     default:

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -376,7 +376,7 @@ bool HydroManagement::checkMinGeneration(uint year) const
     return ret;
 }
 
-void HydroManagement::prepareNetDemand(uint numSpace, uint year, Data::StudyMode mode)
+void HydroManagement::prepareNetDemand(uint numSpace, uint year, Data::SimulationMode mode)
 {
     areas_.each([this, &year, &numSpace, &mode](const Data::Area& area) {
         uint z = area.index;
@@ -403,7 +403,7 @@ void HydroManagement::prepareNetDemand(uint numSpace, uint year, Data::StudyMode
                 netdemand = + loadSeries[hour]
                             - windSeries[hour] - scratchpad.miscGenSum[hour]
                             - solarSeries[hour] - ror[hour]
-                            - ((mode != Data::stdmAdequacy) ? scratchpad.mustrunSum[hour]
+                            - ((mode != Data::SimulationMode::Adequacy) ? scratchpad.mustrunSum[hour]
                                                              : scratchpad.originalMustrunSum[hour]);
             }
 
@@ -412,7 +412,7 @@ void HydroManagement::prepareNetDemand(uint numSpace, uint year, Data::StudyMode
             {
                 netdemand = loadSeries[hour]
                             - scratchpad.miscGenSum[hour] - ror[hour]
-                            - ((mode != Data::stdmAdequacy) ? scratchpad.mustrunSum[hour]
+                            - ((mode != Data::SimulationMode::Adequacy) ? scratchpad.mustrunSum[hour]
                                                              : scratchpad.originalMustrunSum[hour]);
 
                 area.renewable.list.each([&](const Antares::Data::RenewableCluster& cluster) {

--- a/src/solver/hydro/management/management.h
+++ b/src/solver/hydro/management/management.h
@@ -135,7 +135,7 @@ private:
     //! check minimum generation is lower than available inflows
     bool checkMinGeneration(uint year) const;
     //! Prepare the net demand for each area
-    void prepareNetDemand(uint numSpace, uint year, Data::StudyMode mode);
+    void prepareNetDemand(uint numSpace, uint year, Data::SimulationMode mode);
     //! Prepare the effective demand for each area
     void prepareEffectiveDemand();
     //! Monthly Optimal generations

--- a/src/solver/optimisation/opt_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_optimisation_lineaire.cpp
@@ -110,8 +110,7 @@ bool runWeeklyOptimization(const OptimizationOptions& options,
                                  writer))
             return false;
 
-        if (problemeHebdo->ExportMPS != Data::mpsExportStatus::NO_EXPORT
-            || problemeHebdo->Expansion)
+        if (problemeHebdo->ExportMPS != Data::mpsExportStatus::NO_EXPORT)
         {
             double optimalSolutionCost
               = OPT_ObjectiveFunctionResult(problemeHebdo, numeroDeLIntervalle, optimizationNumber);

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -118,7 +118,7 @@ static void RecalculDesEchangesMoyens(Data::Study& study,
 
 void PrepareDataFromClustersInMustrunMode(Data::Study& study, uint numSpace, uint year)
 {
-    bool inAdequacy = (study.parameters.mode == Data::stdmAdequacy);
+    bool inAdequacy = (study.parameters.mode == Data::SimulationMode::Adequacy);
 
     for (uint i = 0; i < study.areas.size(); ++i)
     {

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -83,7 +83,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
 
     auto& parameters = study.parameters;
 
-    problem.Expansion = parameters.expansion;
+    problem.Expansion = (parameters.mode == Data::stdmExpansion);
     problem.firstWeekOfSimulation = false;
 
     problem.hydroHotStart

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -83,7 +83,7 @@ void SIM_InitialisationProblemeHebdo(Data::Study& study,
 
     auto& parameters = study.parameters;
 
-    problem.Expansion = (parameters.mode == Data::stdmExpansion);
+    problem.Expansion = (parameters.mode == Data::SimulationMode::Expansion);
     problem.firstWeekOfSimulation = false;
 
     problem.hydroHotStart

--- a/src/solver/variable/commons/rowBalance.h
+++ b/src/solver/variable/commons/rowBalance.h
@@ -166,7 +166,7 @@ public:
                        area->miscGen.entry[Data::fhhRowBalance],
                        sizeof(double) * height);
 
-        if (study->parameters.mode == Data::stdmAdequacy)
+        if (study->parameters.mode == Data::SimulationMode::Adequacy)
         {
             for (unsigned int h = 0; h != height; ++h)
                 pValuesForTheCurrentYear.hour[h]

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -63,7 +63,7 @@ void ThermalState::StateForAnArea::initializeFromArea(const Data::Area& area)
 State::State(Data::Study& s) :
  hourInTheSimulation(0u),
  dispatchableMargin(nullptr),
- studyMode(s.parameters.mode),
+ simulationMode(s.parameters.mode),
  unitCommitmentMode(s.parameters.unitCommitment.ucMode),
  study(s),
  thermal(s.areas),
@@ -108,7 +108,7 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex)
     {
         // otherwise from the solver (most of the time)
 
-        if (studyMode != Data::stdmAdequacy) // Economy
+        if (simulationMode != Data::SimulationMode::Adequacy) // Economy
         {
             thermalClusterPMinOfAGroup
               = problemeHebdo->PaliersThermiquesDuPays[area->index]
@@ -145,7 +145,7 @@ void State::initFromThermalClusterIndex(const uint clusterAreaWideIndex)
     }
     initFromThermalClusterIndexProduction(clusterAreaWideIndex);
 
-    if (studyMode != Data::stdmAdequacy)
+    if (simulationMode != Data::SimulationMode::Adequacy)
     {
         // Minimum power of a group of the cluster, one per year for each cluster - from the
         // solver

--- a/src/solver/variable/state.h
+++ b/src/solver/variable/state.h
@@ -206,8 +206,8 @@ public:
     //! Probleme Hebdo
     PROBLEME_HEBDO* problemeHebdo;
 
-    //! Study mode: economy / adequacy
-    Data::StudyMode studyMode;
+    //! Simulation mode: economy / adequacy / expansion
+    Data::SimulationMode simulationMode;
     //! Study unit commitment mode: fast(ucHeuristic) / accurate(ucMILP)
     Data::UnitCommitmentMode unitCommitmentMode;
     //! Reference to the original study

--- a/src/solver/variable/state.hxx
+++ b/src/solver/variable/state.hxx
@@ -76,20 +76,15 @@ inline void State::initFromAreaIndex(const unsigned int areaIndex, uint numSpace
 
     switch (studyMode)
     {
-    case Data::stdmEconomy:
-    {
-        hourlyResults = &problemeHebdo->ResultatsHoraires[areaIndex];
-        break;
-    }
     case Data::stdmAdequacy:
+    case Data::stdmEconomy:
+    case Data::stdmExpansion:
     {
         hourlyResults = &problemeHebdo->ResultatsHoraires[areaIndex];
         break;
     }
+
     case Data::stdmUnknown:
-        break;
-    case Data::stdmExpansion:
-        break;
     case Data::stdmMax:
         break;
     }

--- a/src/solver/variable/state.hxx
+++ b/src/solver/variable/state.hxx
@@ -74,18 +74,17 @@ inline void State::initFromAreaIndex(const unsigned int areaIndex, uint numSpace
     scratchpad = &area->scratchpad[numSpace];
     thermalCluster = nullptr;
 
-    switch (studyMode)
+    switch (simulationMode)
     {
-    case Data::stdmAdequacy:
-    case Data::stdmEconomy:
-    case Data::stdmExpansion:
+    case Data::SimulationMode::Adequacy:
+    case Data::SimulationMode::Economy:
+    case Data::SimulationMode::Expansion:
     {
         hourlyResults = &problemeHebdo->ResultatsHoraires[areaIndex];
         break;
     }
 
-    case Data::stdmUnknown:
-    case Data::stdmMax:
+    case Data::SimulationMode::Unknown:
         break;
     }
 }

--- a/src/solver/variable/surveyresults/surveyresults.cpp
+++ b/src/solver/variable/surveyresults/surveyresults.cpp
@@ -197,22 +197,17 @@ void SurveyResultsData::initialize(uint maxVariables)
 
     switch (study.parameters.mode)
     {
-    case Data::stdmEconomy:
-    {
-        matrix.resize(study.areas.size(), study.areas.size());
-        // The initialization will be done later
-        //::MatrixFill(&matrix, std::numeric_limits<double>::quiet_NaN());
-        break;
-    }
     case Data::stdmAdequacy:
+    case Data::stdmEconomy:
+    case Data::stdmExpansion:
     {
         matrix.resize(study.areas.size(), study.areas.size());
         // The initialization will be done later
         //::MatrixFill(&matrix, std::numeric_limits<double>::quiet_NaN());
         break;
     }
+
     case Data::stdmUnknown:
-    case Data::stdmExpansion:
     case Data::stdmMax:
         break;
     }

--- a/src/solver/variable/surveyresults/surveyresults.cpp
+++ b/src/solver/variable/surveyresults/surveyresults.cpp
@@ -197,9 +197,9 @@ void SurveyResultsData::initialize(uint maxVariables)
 
     switch (study.parameters.mode)
     {
-    case Data::stdmAdequacy:
-    case Data::stdmEconomy:
-    case Data::stdmExpansion:
+    case Data::SimulationMode::Adequacy:
+    case Data::SimulationMode::Economy:
+    case Data::SimulationMode::Expansion:
     {
         matrix.resize(study.areas.size(), study.areas.size());
         // The initialization will be done later
@@ -207,8 +207,7 @@ void SurveyResultsData::initialize(uint maxVariables)
         break;
     }
 
-    case Data::stdmUnknown:
-    case Data::stdmMax:
+    case Data::SimulationMode::Unknown:
         break;
     }
 }

--- a/src/tests/src/libs/antares/study/output-folder/study.cpp
+++ b/src/tests/src/libs/antares/study/output-folder/study.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_SUITE(s)
 
 BOOST_FIXTURE_TEST_CASE(economy_legacyfiles_emptylabel, Fixture)
 {
-    StudyMode mode = stdmEconomy;
+    SimulationMode mode = SimulationMode::Economy;
     ResultFormat fmt = legacyFilesDirectories;
     const YString label = "";
     const int64_t startTime = 1;
@@ -63,7 +63,7 @@ BOOST_FIXTURE_TEST_CASE(economy_legacyfiles_emptylabel, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(economy_legacyfiles_label_now, Fixture)
 {
-    StudyMode mode = stdmEconomy;
+    SimulationMode mode = SimulationMode::Economy;
     ResultFormat fmt = legacyFilesDirectories;
     const YString label = "test";
     const int64_t startTime = 1672391667;
@@ -75,7 +75,7 @@ BOOST_FIXTURE_TEST_CASE(economy_legacyfiles_label_now, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(adequacy_legacyfiles_label_now, Fixture)
 {
-    StudyMode mode = stdmAdequacy;
+    SimulationMode mode = SimulationMode::Adequacy;
     ResultFormat fmt = legacyFilesDirectories;
     const YString label = "test";
     const int64_t startTime = 1672391667;
@@ -93,7 +93,7 @@ BOOST_FIXTURE_TEST_CASE(adequacy_legacyfiles_label_now, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(adequacy_zip_label_now, Fixture)
 {
-    StudyMode mode = stdmAdequacy;
+    SimulationMode mode = SimulationMode::Adequacy;
     ResultFormat fmt = zipArchive;
     const YString label = "test";
     const int64_t startTime = 1672391667;

--- a/src/tests/src/solver/optimisation/adequacy_patch.cpp
+++ b/src/tests/src/solver/optimisation/adequacy_patch.cpp
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(calculateAreaFlowBalanceForOneTimeStep_outside_inside_Inclu
 BOOST_AUTO_TEST_CASE(check_valid_adq_param)
 {
     auto p = createParams();
-    BOOST_CHECK_NO_THROW(p.checkAdqPatchStudyModeEconomyOnly(Antares::Data::stdmEconomy));
+    BOOST_CHECK_NO_THROW(p.checkAdqPatchSimulationModeEconomyOnly(Antares::Data::SimulationMode::Economy));
     BOOST_CHECK_NO_THROW(p.checkAdqPatchIncludeHurdleCost(true));
     BOOST_CHECK_NO_THROW(p.checkAdqPatchDisabledLocalMatching());
 }
@@ -495,8 +495,8 @@ BOOST_AUTO_TEST_CASE(check_valid_adq_param)
 BOOST_AUTO_TEST_CASE(check_adq_param_wrong_mode)
 {
     auto p = createParams();
-    BOOST_CHECK_THROW(p.checkAdqPatchStudyModeEconomyOnly(Antares::Data::stdmAdequacy),
-            Error::IncompatibleStudyModeForAdqPatch);
+    BOOST_CHECK_THROW(p.checkAdqPatchSimulationModeEconomyOnly(Antares::Data::SimulationMode::Adequacy),
+            Error::IncompatibleSimulationModeForAdqPatch);
 }
 
 BOOST_AUTO_TEST_CASE(check_adq_param_wrong_hurdle_cost)

--- a/src/ui/simulator/application/main/refresh.cpp
+++ b/src/ui/simulator/application/main/refresh.cpp
@@ -41,9 +41,9 @@ namespace Antares
 {
 namespace Forms
 {
-struct CompareByStudyMode final
+struct CompareBySimulationMode final
 {
-    bool operator()(const Data::StudyMode a, const Data::StudyMode b) const
+    bool operator()(const Data::SimulationMode a, const Data::SimulationMode b) const
     {
         return b < a;
     }
@@ -117,14 +117,14 @@ void ApplWnd::refreshMenuOutput()
 
     // NOTE : in some rare cases, it may happen that two simulations have the
     // same timestamp
-    using StudyModeT = Data::StudyMode;
+    using SimulationModeT = Data::SimulationMode;
     using TemporalMap = std::map<int64_t, Data::Output::List, CompareByTimestamp>;
-    using Map = std::map<StudyModeT, TemporalMap, CompareByStudyMode>;
+    using Map = std::map<SimulationModeT, TemporalMap, CompareBySimulationMode>;
 
     // Getting the list of all available outputs
     const Data::Output::List& list = ListOfOutputsForTheCurrentStudy;
-    // The last study mode
-    Data::StudyMode lastMode = Data::stdmUnknown;
+    // The last simulation mode
+    Data::SimulationMode lastMode = Data::SimulationMode::Unknown;
 
     // Informations about the outputs
     Map map;
@@ -219,7 +219,7 @@ void ApplWnd::refreshMenuOutput()
 #ifndef YUNI_OS_WINDOWS
               (!more ? "images/16x16/minibullet_sel.png" : "images/16x16/minibullet.png"),
 #else
-              (((*i)->mode == Data::stdmEconomy) ? "images/misc/economy.png"
+              (((*i)->mode == Data::SimulationMode::Economy) ? "images/misc/economy.png"
                                                  : "images/misc/adequacy.png"),
 #endif
               s,
@@ -273,14 +273,14 @@ void ApplWnd::refreshMenuOutput()
                         // AppendTooManyItems(menu, more);
                         more = 0;
                     }
-                    // if (lastMode != Data::stdmUnknown)
+                    // if (lastMode != Data::SimulationMode::Unknown)
                     //	Menu::CreateEmptyItem(menu);
 
                     lastMode = (*i)->mode;
-                    if (lastMode == Data::stdmUnknown)
-                        lastMode = Data::stdmEconomy;
+                    if (lastMode == Data::SimulationMode::Unknown)
+                        lastMode = Data::SimulationMode::Economy;
                     Menu::CreateGroupItem(menu,
-                                          wxStringFromUTF8(StudyModeToCString(lastMode)),
+                                          wxStringFromUTF8(SimulationModeToCString(lastMode)),
                                           "images/16x16/empty.png");
                     total = 0;
                 }
@@ -308,7 +308,7 @@ void ApplWnd::refreshMenuOutput()
 #ifndef YUNI_OS_WINDOWS
                                                 "images/16x16/minibullet.png",
 #else
-                                                (((*i)->mode == Data::stdmEconomy)
+                                                (((*i)->mode == Data::SimulationMode::Economy)
                                                    ? "images/misc/economy.png"
                                                    : "images/misc/adequacy.png"),
 #endif

--- a/src/ui/simulator/windows/inspector/accumulator.hxx
+++ b/src/ui/simulator/windows/inspector/accumulator.hxx
@@ -187,25 +187,24 @@ struct PAreaColor
     }
 };
 
-struct PStudyMode
+struct PSimulationMode
 {
-    using Type = Data::StudyMode;
+    using Type = Data::SimulationMode;
     static Type Value(const Data::Study::Ptr& study)
     {
-        return (!(!study) ? study->parameters.mode : Data::stdmEconomy);
+        return (!(!study) ? study->parameters.mode : Data::SimulationMode::Economy);
     }
     static wxString ConvertToString(const Type v)
     {
         switch (v)
         {
-        case Data::stdmEconomy:
+        case Data::SimulationMode::Economy:
             return wxT("Economy");
-        case Data::stdmAdequacy:
+        case Data::SimulationMode::Adequacy:
             return wxT("Adequacy");
-        case Data::stdmExpansion:
+        case Data::SimulationMode::Expansion:
             return wxT("Expansion");
-        case Data::stdmUnknown:
-        case Data::stdmMax:
+        case Data::SimulationMode::Unknown:
             return wxEmptyString;
         }
         return wxEmptyString;

--- a/src/ui/simulator/windows/inspector/constants.cpp
+++ b/src/ui/simulator/windows/inspector/constants.cpp
@@ -1,4 +1,3 @@
-#include <antares/xpansion.h>
 #include "constants.h"
 
 namespace Antares
@@ -269,9 +268,7 @@ const wxChar* const calendarWeeks[] = {wxT("MON  -  SUN"),
 
 const wxChar* const studyMode[] = {wxT("Economy"),
                                    wxT("Adequacy"),
-#if STUDY_MODE_EXPANSION
                                    wxT("Expansion"),
-#endif
                                    nullptr};
 
 const wxChar* const adequacyPatchMode[] = {wxT("virtual area"),

--- a/src/ui/simulator/windows/inspector/constants.cpp
+++ b/src/ui/simulator/windows/inspector/constants.cpp
@@ -266,7 +266,7 @@ const wxChar* const calendarWeeks[] = {wxT("MON  -  SUN"),
                                        wxT("SUN  -  SAT"),
                                        nullptr};
 
-const wxChar* const studyMode[] = {wxT("Economy"),
+const wxChar* const simulationMode[] = {wxT("Economy"),
                                    wxT("Adequacy"),
                                    wxT("Expansion"),
                                    nullptr};

--- a/src/ui/simulator/windows/inspector/constants.h
+++ b/src/ui/simulator/windows/inspector/constants.h
@@ -44,7 +44,7 @@ extern const wxChar* const playlist[];
 extern const wxChar* const geographicTrimming[];
 extern const wxChar* const thematicTrimming[];
 
-extern const wxChar* const studyMode[];
+extern const wxChar* const simulationMode[];
 extern const wxChar* const adequacyPatchMode[];
 } // namespace Inspector
 } // namespace Window

--- a/src/ui/simulator/windows/inspector/frame.cpp
+++ b/src/ui/simulator/windows/inspector/frame.cpp
@@ -340,7 +340,7 @@ Frame::Frame(wxWindow* parent, bool allowAnyObject) :
     // --- STUDIES ---
     pPGStudyTitle = Group(pg, wxT("GENERAL PARAMETERS"), wxT("study.title"));
     pPGStudyGrpSimulation = Category(pg, wxT("Simulation"), wxT("study.context"));
-    pPGStudyMode = P_ENUM("Mode", "study.mode", studyMode);
+    pPGSimulationMode = P_ENUM("Mode", "study.mode", simulationMode);
     pPGStudyCalendarBegin = P_UINT("First day", "study.cal.begin");
     pPGStudyCalendarEnd = P_UINT("Last day", "study.cal.end");
     pg->SetPropertyEditor(pPGStudyCalendarBegin, wxPG_EDITOR(StudyCalendarBtnEditor));
@@ -743,7 +743,7 @@ void Frame::apply(const InspectorData::Ptr& data)
     if (!hide)
     {
         // Context
-        Accumulator<PStudyMode>::Apply(pPGStudyMode, data->studies);
+        Accumulator<PSimulationMode>::Apply(pPGSimulationMode, data->studies);
         Accumulator<PStudyHorizon>::Apply(pPGStudyHorizon, data->studies);
         Accumulator<PStudyCalendarMonth>::Apply(pPGStudyCalendarMonth, data->studies);
         Accumulator<PStudyCalendarWeek>::Apply(pPGStudyCalendarWeek, data->studies);

--- a/src/ui/simulator/windows/inspector/frame.h
+++ b/src/ui/simulator/windows/inspector/frame.h
@@ -149,7 +149,7 @@ private:
     wxPGProperty* pPGStudyGrpCalendar;
     wxPGProperty* pPGStudyMCScenarios;
     wxPGProperty* pPGStudyOutputProfile;
-    wxPGProperty* pPGStudyMode;
+    wxPGProperty* pPGSimulationMode;
     wxPGProperty* pPGStudyYears;
     wxPGProperty* pPGStudyCalendarBegin;
     wxPGProperty* pPGStudyCalendarEnd;

--- a/src/ui/simulator/windows/inspector/property.update.cpp
+++ b/src/ui/simulator/windows/inspector/property.update.cpp
@@ -1185,13 +1185,13 @@ bool InspectorGrid::onPropertyChanging_S(wxPGProperty*,
         wxStringToString(value.GetString(), s);
         s.toLower();
 
-        Data::StudyMode mode = Data::stdmUnknown;
+        Data::SimulationMode mode = Data::SimulationMode::Unknown;
         if (s == "economy" || s == "0")
-            mode = Data::stdmEconomy;
+            mode = Data::SimulationMode::Economy;
         else if (s == "adequacy" || s == "1")
-            mode = Data::stdmAdequacy;
+            mode = Data::SimulationMode::Adequacy;
         else
-            mode = Data::stdmEconomy;
+            mode = Data::SimulationMode::Economy;
 
         for (; i != end; ++i)
         {

--- a/src/ui/simulator/windows/output/panel/area-link.cpp
+++ b/src/ui/simulator/windows/output/panel/area-link.cpp
@@ -668,17 +668,16 @@ void Panel::loadDataFromFile()
     // Economy
     switch (output.mode)
     {
-    case Data::stdmEconomy:
+    case Data::SimulationMode::Economy:
         filename << output.path << SEP << "economy" << SEP;
         break;
-    case Data::stdmAdequacy:
+    case Data::SimulationMode::Adequacy:
         filename << output.path << SEP << "adequacy" << SEP;
         break;
-    case Data::stdmExpansion:
+    case Data::SimulationMode::Expansion:
         filename << output.path << SEP << "expansion" << SEP;
         break;
-    case Data::stdmUnknown:
-    case Data::stdmMax:
+    case Data::SimulationMode::Unknown:
         filename << output.path << SEP << "unknown" << SEP;
         break;
     }

--- a/src/ui/simulator/windows/output/panel/area-link.cpp
+++ b/src/ui/simulator/windows/output/panel/area-link.cpp
@@ -675,6 +675,8 @@ void Panel::loadDataFromFile()
         filename << output.path << SEP << "adequacy" << SEP;
         break;
     case Data::stdmExpansion:
+        filename << output.path << SEP << "expansion" << SEP;
+        break;
     case Data::stdmUnknown:
     case Data::stdmMax:
         filename << output.path << SEP << "unknown" << SEP;

--- a/src/ui/simulator/windows/output/provider/outputs.cpp
+++ b/src/ui/simulator/windows/output/provider/outputs.cpp
@@ -179,8 +179,10 @@ void Outputs::search(Spotlight::IItem::Vector& out,
             case Data::stdmAdequacy:
                 item->addTag("ADQ", 220, 192, 245);
                 break;
-            case Data::stdmUnknown:
             case Data::stdmExpansion:
+                item->addTag("EXP", 220, 192, 245);
+                break;
+            case Data::stdmUnknown:
             case Data::stdmMax:
                 item->addTag("...", 213, 213, 213);
             }

--- a/src/ui/simulator/windows/output/provider/outputs.cpp
+++ b/src/ui/simulator/windows/output/provider/outputs.cpp
@@ -173,17 +173,16 @@ void Outputs::search(Spotlight::IItem::Vector& out,
 
             switch (output->mode)
             {
-            case Data::stdmEconomy:
+            case Data::SimulationMode::Economy:
                 item->addTag("ECO", 162, 178, 197);
                 break;
-            case Data::stdmAdequacy:
+            case Data::SimulationMode::Adequacy:
                 item->addTag("ADQ", 220, 192, 245);
                 break;
-            case Data::stdmExpansion:
+            case Data::SimulationMode::Expansion:
                 item->addTag("EXP", 220, 192, 245);
                 break;
-            case Data::stdmUnknown:
-            case Data::stdmMax:
+            case Data::SimulationMode::Unknown:
                 item->addTag("...", 213, 213, 213);
             }
             int imgIndex = pComponent.imageIndexForOutput(output);

--- a/src/ui/simulator/windows/simulation/run.cpp
+++ b/src/ui/simulator/windows/simulation/run.cpp
@@ -217,7 +217,7 @@ Run::Run(wxWindow* parent, bool preproOnly) :
                    "images/32x32/run.png",
                    wxString(wxT("For the study `"))
                      << wxStringFromUTF8(study.header.caption) << wxT("`, ")
-                     << wxStringFromUTF8(Data::StudyModeToCString(study.parameters.mode))),
+                     << wxStringFromUTF8(Data::SimulationModeToCString(study.parameters.mode))),
                  0,
                  wxALL | wxEXPAND | wxFIXED_MINSIZE);
 
@@ -242,7 +242,7 @@ Run::Run(wxWindow* parent, bool preproOnly) :
     }
     {
         auto* lblMode = Antares::Component::CreateLabel(
-          pBigDaddy, wxStringFromUTF8(Data::StudyModeToCString(study.parameters.mode)));
+          pBigDaddy, wxStringFromUTF8(Data::SimulationModeToCString(study.parameters.mode)));
         wxFont f = lblMode->GetFont();
         f.SetWeight(wxFONTWEIGHT_BOLD);
         lblMode->SetFont(f);


### PR DESCRIPTION
## Goal of this PR
The goal of this PR is to **normalize mode Expansion**. Until now, it was a sort of hack for [antares-xpansion](https://github.com/AntaresSimulatorTeam/antares-xpansion).

Simulation mode Expansion is Economy, but with a single optimization instead of 2 optimizations + thermal heuristic for Economy / Adequacy.

## Functional changes
- Do not force the export of MPS files in Xpansion mode. MPS files still be enabled through the "include-exportmps" parameter, as usual
- Allow the export of simulation results (mc-ind & mc-all) in Xpansion mode. As usual, can be enabled through settings year-by-year and `synthesis`, with suffix "exp" for the output directory (e.g **20231117-0931exp**)
- Fix logs, display "Expansion" instead of "Economy"

## Technical changes
- Allow `Parameters::mode = stdmExpansion` (renamed `SimulationMode::Expansion`)
- Use `enum class` ("scoped enum") instead of C-style `enum`. Remove `stdmMax`
- Remove `bool Parameters::expansion`
- Remove file `xpansion.h` and constant `STUDY_MODE_EXPANSION`
- Factorize two `switch..case`
```diff
switch (a) {
 case A:
+case B:
   someCode(); 
  break;
-case B:
-  someCode();
-  break;  
}
```

## TODO
Generates tests results for new studies in mode expansion
https://github.com/AntaresSimulatorTeam/Antares_Simulator_Tests_NR/pull/10
