### PR TITLE
Study version literal change from 870 to 890

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -908,7 +908,7 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
                 area, study.usedByTheSolver, study.gotFatalError);
         }
 
-        if (study.header.version < 870)
+        if (study.header.version < 890)
         {
             buffer.clear() << study.folderInput << SEP << "hydro";
 

--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -135,7 +135,7 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
           area.hydro.reservoirCapacity = 0.;
           area.hydro.pumpingEfficiency = 1.;
 
-          if (study.header.version >= 870)
+          if (study.header.version >= 890)
           {
               // GUI part patch :
               // We need to know, when estimating the RAM required by the solver, if the current

--- a/src/libs/antares/study/parts/hydro/series.cpp
+++ b/src/libs/antares/study/parts/hydro/series.cpp
@@ -355,7 +355,7 @@ void DataSeriesHydro::resizeTSinDeratedMode(bool derated,
         mingen.averageTimeseries();
     generationTScount_ = 1;
 
-    if (studyVersion >= 870)
+    if (studyVersion >= 890)
     {
         maxHourlyGenPower.averageTimeseries();
         maxHourlyPumpPower.averageTimeseries();

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
@@ -37,7 +37,7 @@ struct Fixture
         createFoldersAndFiles();
 
         // Instantiating neccessary studies parameters
-        study->header.version = 870;
+        study->header.version = 890;
         study->parameters.derated = false;
 
         //  Setting necessary paths
@@ -123,7 +123,7 @@ BOOST_FIXTURE_TEST_CASE(Testing_load_power_credits_both_matrix_equal_width_and_d
     bool ret = true;
     bool fatalError = false;
     study->parameters.derated = true;
-    unsigned int studyVersion = 870;
+    unsigned int studyVersion =890;
     bool usedBySolver = true;
 
     auto& maxHourlyGenPower = area_1->hydro.series->maxHourlyGenPower.timeSeries;

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
@@ -123,7 +123,7 @@ BOOST_FIXTURE_TEST_CASE(Testing_load_power_credits_both_matrix_equal_width_and_d
     bool ret = true;
     bool fatalError = false;
     study->parameters.derated = true;
-    unsigned int studyVersion =890;
+    unsigned int studyVersion = 890;
     bool usedBySolver = true;
 
     auto& maxHourlyGenPower = area_1->hydro.series->maxHourlyGenPower.timeSeries;


### PR DESCRIPTION
In CR23, loading of data is dependent on the study version, so because this CR23 will be part of the 8.9 release, literals that indicates study version must be changed from the 870 to the 890.