### PR TITLE
Fix 2 build warnings

### DIFF
--- a/src/solver/optimisation/LinearProblemMatrixStartUpCosts.cpp
+++ b/src/solver/optimisation/LinearProblemMatrixStartUpCosts.cpp
@@ -24,7 +24,6 @@
 **
 ** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
 */
-#pragma once
 #include "LinearProblemMatrixStartUpCosts.h"
 using namespace Antares::Data;
 

--- a/src/solver/optimisation/constraints/AbstractStartUpCostsGroup.cpp
+++ b/src/solver/optimisation/constraints/AbstractStartUpCostsGroup.cpp
@@ -1,5 +1,13 @@
 #include "AbstractStartUpCostsGroup.h"
 
+AbstractStartUpCostsGroup::AbstractStartUpCostsGroup(PROBLEME_HEBDO* problemeHebdo,
+                                                     bool simulation,
+                                                     ConstraintBuilder& builder) :
+  ConstraintGroup(problemeHebdo, builder), simulation_(simulation)
+{
+}
+
+
 StartUpCostsData AbstractStartUpCostsGroup::GetStartUpCostsDataFromProblemHebdo()
 {
     return {.PaliersThermiquesDuPays = problemeHebdo_->PaliersThermiquesDuPays,

--- a/src/solver/optimisation/constraints/AbstractStartUpCostsGroup.h
+++ b/src/solver/optimisation/constraints/AbstractStartUpCostsGroup.h
@@ -8,13 +8,11 @@ class AbstractStartUpCostsGroup : public ConstraintGroup
 public:
     AbstractStartUpCostsGroup(PROBLEME_HEBDO* problemeHebdo,
                               bool simulation,
-                              ConstraintBuilder& builder) :
-     simulation_(simulation), ConstraintGroup(problemeHebdo, builder)
-    {
-    }
+                              ConstraintBuilder& builder);
 
-        void BuildConstraints() = 0;
-
-    bool simulation_ = false;
+    virtual void BuildConstraints() = 0;
     StartUpCostsData GetStartUpCostsDataFromProblemHebdo();
+
+protected:
+    bool simulation_ = false;
 };


### PR DESCRIPTION
- `#pragma once` in .cpp file
- `-Wreorder` because member initialization is out of order