### PR TITLE
Fix flawed concurrency test (concurrent write on non-atomic int)

### DIFF
--- a/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
+++ b/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(test_throw)
 BOOST_AUTO_TEST_CASE(test_future_set)
 {
     auto threadPool = createThreadPool(4);
-    int counter = 0;
+    std::atomic<int> counter = 0;
     Task incrementCounter = [&counter]() {
         counter++;
     };


### PR DESCRIPTION
Multiple threads writing to a non-atomic object is UB. Use `std::atomic` to guarantee result and fix broken test.

```
D:/a/Antares_Simulator/Antares_Simulator/src/tests/src/libs/antares/concurrency/test_concurrency.cpp(86): error: in "test_future_set": check counter == 10 has failed
```