### PR TITLE
Fix compile warnings on Linux with g++>=10

### DIFF
--- a/src/ext/yuni/src/yuni/core/tree/n/treeN.hxx
+++ b/src/ext/yuni/src/yuni/core/tree/n/treeN.hxx
@@ -451,14 +451,17 @@ inline bool TreeN<T, TP, ChckP, ConvP>::isInvalidated()
     typename ThreadingPolicy::MutexLocker locker(*this);
     return isInvalidatedWL();
 }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvolatile"
 
 template<class T, template<class> class TP, template<class> class ChckP, class ConvP>
 inline void TreeN<T, TP, ChckP, ConvP>::addRef() const
 {
     typename ThreadingPolicy::MutexLocker locker(*this);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas" // g++-10 has no -Wvolatile, g++-13 does
+#pragma GCC diagnostic ignored "-Wvolatile"
     ++pRefCount;
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 }
 
 template<class T, template<class> class TP, template<class> class ChckP, class ConvP>
@@ -466,9 +469,13 @@ bool TreeN<T, TP, ChckP, ConvP>::release() const
 {
     typename ThreadingPolicy::MutexLocker locker(*this);
     assert(pRefCount > 0 and "TreeN: invalid reference count");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas" // g++-10 has no -Wvolatile, g++-13 does
+#pragma GCC diagnostic ignored "-Wvolatile"
     if (--pRefCount != 0)
         return false;
-
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
     // Early clean-up
     // The method 'release' must be const for good code design. But
     // we have to be properly detached from the parent node.
@@ -479,7 +486,7 @@ bool TreeN<T, TP, ChckP, ConvP>::release() const
         ref.clearWL();
     return true;
 }
-#pragma GCC diagnostic pop
+
 
 template<class T, template<class> class TP, template<class> class ChckP, class ConvP>
 inline bool TreeN<T, TP, ChckP, ConvP>::hasIntrusiveSmartPtr() const

--- a/src/ext/yuni/src/yuni/core/tree/n/treeN.hxx
+++ b/src/ext/yuni/src/yuni/core/tree/n/treeN.hxx
@@ -451,6 +451,8 @@ inline bool TreeN<T, TP, ChckP, ConvP>::isInvalidated()
     typename ThreadingPolicy::MutexLocker locker(*this);
     return isInvalidatedWL();
 }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvolatile"
 
 template<class T, template<class> class TP, template<class> class ChckP, class ConvP>
 inline void TreeN<T, TP, ChckP, ConvP>::addRef() const
@@ -477,6 +479,7 @@ bool TreeN<T, TP, ChckP, ConvP>::release() const
         ref.clearWL();
     return true;
 }
+#pragma GCC diagnostic pop
 
 template<class T, template<class> class TP, template<class> class ChckP, class ConvP>
 inline bool TreeN<T, TP, ChckP, ConvP>::hasIntrusiveSmartPtr() const

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -1463,7 +1463,6 @@ void AreaList::fixOrientationForAllInterconnections(BindingConstraintsRepository
                 // Reference to the link
                 auto& link = *(i->second);
                 // Asserts
-                assert(&link);
                 assert(link.from);
                 assert(link.with);
 

--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -306,7 +306,10 @@ bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(
         else if (bindingConstraint->operatorType() == BindingConstraint::opEquality)
             columnNumber = BindingConstraint::Column::columnEquality;
         else
+        {
             logs.error("Cannot load time series of type other that eq/gt/lt");
+            return false;
+        }
 
         bindingConstraint->RHSTimeSeries_.resize(1, height);
         bindingConstraint->RHSTimeSeries_.pasteToColumn(0, intermediate[columnNumber]);

--- a/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
@@ -227,12 +227,10 @@ bool BindingConstraintsRepository::internalSaveToFolder(BindingConstraintSaver::
     bool ret = true;
     uint index = 0;
     auto end = constraints_.end();
-    Yuni::ShortString64 text;
 
     for (auto i = constraints_.begin(); i != end; ++i, ++index)
     {
-        text = index;
-        env.section = ini.addSection(text);
+        env.section = ini.addSection(std::to_string(index));
         ret = Antares::Data::BindingConstraintSaver::saveToEnv(env, i->get()) && ret;
     }
 

--- a/src/libs/antares/study/parts/common/cluster_list.h
+++ b/src/libs/antares/study/parts/common/cluster_list.h
@@ -9,6 +9,9 @@
 #include <vector>
 #include <memory>
 
+
+
+
 namespace Antares
 {
 namespace Data

--- a/src/solver/infeasible-problem-analysis/report.h
+++ b/src/solver/infeasible-problem-analysis/report.h
@@ -5,7 +5,10 @@
 #include <map>
 
 #include "constraint.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "ortools/linear_solver/linear_solver.h"
+#pragma GCC diagnostic pop
 
 namespace Antares
 {

--- a/src/solver/infeasible-problem-analysis/unfeasibility-analysis.h
+++ b/src/solver/infeasible-problem-analysis/unfeasibility-analysis.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <memory>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "ortools/linear_solver/linear_solver.h"
+#pragma GCC diagnostic pop
 
 namespace Antares::Optimization
 {

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -106,7 +106,6 @@ static void RecalculDesEchangesMoyens(Data::Study& study,
     {
         const uint indx = i + PasDeTempsDebut;
         auto& ntcValues = problem.ValeursDeNTC[i];
-        assert(&ntcValues);
 
         for (uint j = 0; j < study.runtime->interconnectionsCount(); ++j)
         {

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -588,8 +588,6 @@ void SIM_RenseignementProblemeHebdo(const Study& study,
             double solarSeries = area.solar.series.getCoefficient(year, hourInYear);
             double rorSeries = area.hydro.series->ror.getCoefficient(year, hourInYear);
 
-            assert(&scratchpad);
-
             double& mustRunGen = problem.AllMustRunGeneration[hourInWeek].AllMustRunGenerationOfArea[k];
             if (parameters.renewableGeneration.isAggregated())
             {

--- a/src/solver/utils/include/antares/solver/utils/ortools_utils.h
+++ b/src/solver/utils/include/antares/solver/utils/ortools_utils.h
@@ -8,9 +8,7 @@
 // ignore unused parameters warnings from ortools
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-
 #include "ortools/linear_solver/linear_solver.h"
-
 #pragma GCC diagnostic pop
 
 #include "ortools_wrapper.h"

--- a/src/solver/utils/include/antares/solver/utils/ortools_utils.h
+++ b/src/solver/utils/include/antares/solver/utils/ortools_utils.h
@@ -5,7 +5,13 @@
 
 #include <antares/writer/i_writer.h>
 
+// ignore unused parameters warnings from ortools
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 #include "ortools/linear_solver/linear_solver.h"
+
+#pragma GCC diagnostic pop
 
 #include "ortools_wrapper.h"
 

--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -573,7 +573,8 @@ void MarkTheStudyAsModified(const Data::Study::Ptr& study)
     if (!(!study) and study == GetCurrentStudy())
         MarkTheStudyAsModified();
 }
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvolatile"
 void MarkTheStudyAsModified()
 {
     auto study = GetCurrentStudy();
@@ -596,7 +597,7 @@ void MarkTheStudyAsModified()
         }
     }
 }
-
+#pragma GCC diagnostic pop
 void ResetTheModifierState(bool v)
 {
     auto study = GetCurrentStudy();

--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -573,14 +573,17 @@ void MarkTheStudyAsModified(const Data::Study::Ptr& study)
     if (!(!study) and study == GetCurrentStudy())
         MarkTheStudyAsModified();
 }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvolatile"
 void MarkTheStudyAsModified()
 {
     auto study = GetCurrentStudy();
     if (!(!study))
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wvolatile"
         ++gInMemoryRevisionIncrement;
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
         if (!gStudyHasBeenModified)
         {
             gStudyHasBeenModified = true;
@@ -597,7 +600,7 @@ void MarkTheStudyAsModified()
         }
     }
 }
-#pragma GCC diagnostic pop
+
 void ResetTheModifierState(bool v)
 {
     auto study = GetCurrentStudy();

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/data.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/bindingconstraint/data.cpp
@@ -117,7 +117,7 @@ Date::Precision Data::precision()
     }
 }
 
-double Data::cellNumericValue(int x, int y) const
+double Data::cellNumericValue(int x, [[maybe_unused]] int y) const
 {
     if (!(!study))
     {
@@ -185,7 +185,7 @@ IRenderer::CellStyle Data::cellStyle(int, int y) const
     return ((y % 2) ? IRenderer::cellStyleDefaultAlternate : IRenderer::cellStyleDefault);
 }
 
-bool Data::cellValue(int x, int y, const String& value)
+bool Data::cellValue(int x, [[maybe_unused]]int y, const String& value)
 {
     if (!study)
         return false;


### PR DESCRIPTION
- Use `#pragma GCC diagnostic ignored` where needed, as narrow as possible
- Remove useless asserts
- Add a few `[[maybe_unused]]` where needed