### PR TITLE
Add tests on short-term storage/thermal cluster/renewable cluster removal

### DIFF
--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -79,16 +79,14 @@ BOOST_AUTO_TEST_SUITE(thermal_clusters_operations)
 
 BOOST_FIXTURE_TEST_CASE(thermal_cluster_add, OneAreaStudy)
 {
-    Study study;
-    Area& area = *study.areaAdd("A");
-    auto newCluster = std::make_shared<ThermalCluster>(&area);
+    auto newCluster = std::make_shared<ThermalCluster>(areaA);
     newCluster->setName("Cluster");
     BOOST_CHECK(newCluster->name() == "Cluster");
     BOOST_CHECK(newCluster->id() == "cluster");
 
-    area.thermal.list.add(newCluster);
-    BOOST_CHECK(area.thermal.list.find("cluster") == newCluster.get());
-    BOOST_CHECK(area.thermal.list.find("Cluster") == nullptr);
+    areaA->thermal.list.add(newCluster);
+    BOOST_CHECK(areaA->thermal.list.find("cluster") == newCluster.get());
+    BOOST_CHECK(areaA->thermal.list.find("Cluster") == nullptr);
 }
 
 /*!

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(area_add)
     const auto areaA = study.areaAdd("A");
     BOOST_CHECK(areaA != nullptr);
     BOOST_CHECK_EQUAL(areaA->name, "A");
-    BOOST_CHECK(areaA->id == "a");
+    BOOST_CHECK_EQUAL(areaA->id, "a");
 }
 
 BOOST_FIXTURE_TEST_CASE(area_rename, OneAreaStudy)
@@ -68,7 +68,7 @@ BOOST_FIXTURE_TEST_CASE(area_rename, OneAreaStudy)
 
 BOOST_FIXTURE_TEST_CASE(area_delete, OneAreaStudy)
 {
-    BOOST_CHECK(study.areas.size() == 1);
+    BOOST_CHECK_EQUAL(study.areas.size(), 1);
     BOOST_CHECK(study.areaDelete(areaA));
     BOOST_CHECK(study.areas.empty());
 }
@@ -81,12 +81,12 @@ BOOST_FIXTURE_TEST_CASE(thermal_cluster_add, OneAreaStudy)
 {
     auto newCluster = std::make_shared<ThermalCluster>(areaA);
     newCluster->setName("Cluster");
-    BOOST_CHECK(newCluster->name() == "Cluster");
-    BOOST_CHECK(newCluster->id() == "cluster");
+    BOOST_CHECK_EQUAL(newCluster->name(), "Cluster");
+    BOOST_CHECK_EQUAL(newCluster->id(), "cluster");
 
     areaA->thermal.list.add(newCluster);
-    BOOST_CHECK(areaA->thermal.list.find("cluster") == newCluster.get());
-    BOOST_CHECK(areaA->thermal.list.find("Cluster") == nullptr);
+    BOOST_CHECK_EQUAL(areaA->thermal.list.find("cluster"), newCluster.get());
+    BOOST_CHECK_EQUAL(areaA->thermal.list.find("Cluster"), nullptr);
 }
 
 /*!


### PR DESCRIPTION
For the `enabled` property, we depend on a "removal" mechanism. We must therefore check that this mechanism indeed works _ie_ removes disabled objects while retaining enabled objects.