### PR TITLE
Fail if OR-Tools solver is not found

### DIFF
--- a/src/libs/antares/exception/LoadingError.cpp
+++ b/src/libs/antares/exception/LoadingError.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+#include <iomanip>
 #include "antares/exception/LoadingError.hpp"
 
 namespace Antares
@@ -41,8 +43,19 @@ InvalidSimulationMode::InvalidSimulationMode() :
 {
 }
 
-InvalidSolver::InvalidSolver(const std::string& solver) :
- LoadingError("Can't use solver '" + solver + "' : it does not match any available OR-Tools solver")
+static std::string InvalidSolverHelper(const std::string& solver, const std::list<std::string>& availableSolverList) {
+  std::ostringstream message;
+  message << "Can't use solver '" << solver << "' : it does not match any available OR-Tools solver. Possible choices are ";
+  for (const std::string& avail : availableSolverList)
+  {
+    bool last = &avail == &availableSolverList.back();
+    std::string sep = last ? "." : ", ";
+    message << std::quoted(avail) << sep;
+  }
+  return message.str();
+}
+
+InvalidSolver::InvalidSolver(const std::string& solver, const std::list<std::string>& availableSolverList) : LoadingError(InvalidSolverHelper(solver, availableSolverList))
 {
 }
 

--- a/src/libs/antares/exception/LoadingError.cpp
+++ b/src/libs/antares/exception/LoadingError.cpp
@@ -1,6 +1,5 @@
-#include <sstream>
-#include <iomanip>
 #include "antares/exception/LoadingError.hpp"
+#include <sstream>
 
 namespace Antares
 {
@@ -43,19 +42,18 @@ InvalidSimulationMode::InvalidSimulationMode() :
 {
 }
 
-static std::string InvalidSolverHelper(const std::string& solver, const std::list<std::string>& availableSolverList) {
+static std::string InvalidSolverHelper(const std::string& solver, const std::string& availableSolvers)
+{
   std::ostringstream message;
-  message << "Can't use solver '" << solver << "' : it does not match any available OR-Tools solver. Possible choices are ";
-  for (const std::string& avail : availableSolverList)
-  {
-    bool last = &avail == &availableSolverList.back();
-    std::string sep = last ? "." : ", ";
-    message << std::quoted(avail) << sep;
-  }
+  message
+    << "Can't use solver '"
+    << solver
+    << "' : it does not match any available OR-Tools solver. Possible choices are "
+    << availableSolvers;
   return message.str();
 }
 
-InvalidSolver::InvalidSolver(const std::string& solver, const std::list<std::string>& availableSolverList) : LoadingError(InvalidSolverHelper(solver, availableSolverList))
+InvalidSolver::InvalidSolver(const std::string& solver, const std::string& availableSolvers) : LoadingError(InvalidSolverHelper(solver, availableSolvers))
 {
 }
 

--- a/src/libs/antares/exception/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/antares/exception/LoadingError.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <stdexcept>
+#include <list>
 #include <map>
 
 #include <yuni/yuni.h>
@@ -131,7 +132,7 @@ public:
 class InvalidSolver : public LoadingError
 {
 public:
-    explicit InvalidSolver(const std::string& solver);
+    explicit InvalidSolver(const std::string& solver, const std::list<std::string>& availableSolverList);
 };
 
 class InvalidStudy : public LoadingError

--- a/src/libs/antares/exception/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/antares/exception/LoadingError.hpp
@@ -132,7 +132,7 @@ public:
 class InvalidSolver : public LoadingError
 {
 public:
-    explicit InvalidSolver(const std::string& solver, const std::list<std::string>& availableSolverList);
+    explicit InvalidSolver(const std::string& solver, const std::string& availableSolverList);
 };
 
 class InvalidStudy : public LoadingError

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -36,11 +36,7 @@ namespace
 {
 void printSolvers()
 {
-    std::cout << "Available solvers :" << std::endl;
-    for (const auto& solver : getAvailableOrtoolsSolverName())
-    {
-        std::cout << solver << std::endl;
-    }
+    std::cout << "Available solvers: " << availableOrToolsSolversString() << std::endl;
 }
 } // namespace
 

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -38,7 +38,6 @@
 #include <algorithm>
 
 #include "antares/solver/misc/options.h"
-#include "../config.h"
 
 #include "../../config.h"
 
@@ -52,20 +51,6 @@
 using namespace Yuni;
 using namespace Antares;
 using namespace Antares::Data;
-
-static std::string availableOrToolsSolversString()
-{
-    const std::list<std::string> availableSolverList = getAvailableOrtoolsSolverName();
-    std::string availableSolverListStr;
-    for (auto it = availableSolverList.begin(); it != availableSolverList.end(); it++)
-    {
-        availableSolverListStr += *it + ";";
-    }
-    // Remove last semicolumn
-    if (!availableSolverListStr.empty())
-        availableSolverListStr.pop_back();
-    return availableSolverListStr;
-}
 
 std::unique_ptr<GetOpt::Parser> CreateParser(Settings& settings,
                                              StudyLoadOptions& options)
@@ -279,7 +264,7 @@ void checkOrtoolsSolver(Data::StudyLoadOptions& options)
              != availableSolverList.end());
         if (!found)
         {
-            throw Error::InvalidSolver(options.ortoolsSolver, availableSolverList);
+            throw Error::InvalidSolver(options.ortoolsSolver, availableOrToolsSolversString());
         }
     }
 }

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -68,7 +68,7 @@ static std::string availableOrToolsSolversString()
 }
 
 std::unique_ptr<GetOpt::Parser> CreateParser(Settings& settings,
-                                             Antares::Data::StudyLoadOptions& options)
+                                             StudyLoadOptions& options)
 {
     settings.reset();
 
@@ -268,26 +268,18 @@ void checkAndCorrectSettingsAndOptions(Settings& settings, Data::StudyLoadOption
 
 void checkOrtoolsSolver(Data::StudyLoadOptions& options)
 {
-    std::string baseSolver = "sirius";
     if (options.ortoolsUsed)
     {
         const std::list<std::string> availableSolverList = getAvailableOrtoolsSolverName();
-        if (availableSolverList.empty())
-        {
-            throw Error::InvalidSolver(options.ortoolsSolver);
-        }
 
         // Check if solver is available
         bool found
           = (std::find(
                availableSolverList.begin(), availableSolverList.end(), options.ortoolsSolver)
              != availableSolverList.end());
-
         if (!found)
         {
-            logs.warning() << "Invalid ortools-solver option. Got '" << options.ortoolsSolver
-                           << "'. reset to " << baseSolver;
-            options.ortoolsSolver = baseSolver;
+            throw Error::InvalidSolver(options.ortoolsSolver, availableSolverList);
         }
     }
 }

--- a/src/solver/utils/include/antares/solver/utils/ortools_utils.h
+++ b/src/solver/utils/include/antares/solver/utils/ortools_utils.h
@@ -23,6 +23,12 @@ void ORTOOLS_EcrireJeuDeDonneesLineaireAuFormatMPS(MPSolver* solver,
 std::list<std::string> getAvailableOrtoolsSolverName();
 
 /*!
+ *  \brief Return a single string containing all solvers available, separated by a ", " and ending with a ".".
+ *
+ */
+std::string availableOrToolsSolversString();
+
+/*!
  *  \brief Create a MPSolver with correct linear or mixed variant
  *
  *  \return MPSolver

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -387,8 +387,20 @@ std::list<std::string> getAvailableOrtoolsSolverName()
         if (MPSolver::SupportsProblemType(solverType))
             result.push_back(solverName.first);
     }
-
     return result;
+}
+
+std::string availableOrToolsSolversString()
+{
+  const std::list<std::string> availableSolverList = getAvailableOrtoolsSolverName();
+  std::ostringstream solvers;
+  for (const std::string& avail : availableSolverList)
+  {
+    bool last = &avail == &availableSolverList.back();
+    std::string sep = last ? "." : ", ";
+    solvers << avail << sep;
+  }
+  return solvers.str();
 }
 
 MPSolver* MPSolverFactory(const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* probleme,


### PR DESCRIPTION
This change follows a discussion with @sylvlecl. According to him, falling back to Sirius without OR-Tools is not a desirable behavior since it can be misleading. For example, the user thinks they're using XPRESS, but since it's not available (missing licence, misplaced env variables, etc.), Antares Solver silently uses Sirius with a warning in the logs instead.

The choice has been made to refuse running the simulation when the user requests an unavailable solver, and to throw a nice error message

> [2023-12-27 10:17:30][solver][fatal] Can't use solver 'spx' : it does not match any available OR-Tools solver. Possible choices are coin, sirius, xpress.