### PR TITLE
Add possibility to release without running any tests

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -9,8 +9,8 @@ on:
       release_name:
         description: "Release name"
         required: true
-      run_tests:
-        description: "true/false"
+      run-tests:
+        description: "Run all tests (true/false)"
         required: true
 jobs:
     release:
@@ -29,3 +29,10 @@ jobs:
             body: |
               Please complete description
 
+
+    ubuntu:
+      name: Release - Ubuntu
+      needs: release
+      uses: ./github/workflows/ubuntu.yml
+      with:
+        run-tests: ${{ inputs.run_tests }}

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -14,7 +14,7 @@ on:
         required: true
 jobs:
     release:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       outputs:
         url: ${{ steps.create_release.outputs.upload_url }}
       steps:

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -33,6 +33,6 @@ jobs:
     ubuntu:
       name: Release - Ubuntu
       needs: release
-      uses: ./github/workflows/ubuntu.yml
+      uses: ./.github/workflows/ubuntu.yml
       with:
         run-tests: ${{ inputs.run_tests }}

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -1,0 +1,31 @@
+name: Create new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag"
+        required: true
+      release_name:
+        description: "Release name"
+        required: true
+      run_tests:
+        description: "true/false"
+        required: true
+jobs:
+    release:
+      runs-on: ubuntu-latest
+      outputs:
+        url: ${{ steps.create_release.outputs.upload_url }}
+      steps:
+        - name: Release creation
+          uses: actions/create-release@v1
+          id: create_release
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            tag_name: ${{ github.event.inputs.release_tag }}
+            release_name: ${{ github.event.inputs.release_name }}
+            body: |
+              Please complete description
+

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,15 +14,15 @@ on:
     - cron: '21 2 * * *'
   workflow_call:
     inputs:
-      run_tests:
+      run-tests:
         required: true
         type: boolean
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
   IS_RELEASE: ${{ github.event_name == 'workflow_call' }}
-  IS_PUSH: ${{ github.event_name == 'push' }}
-  RUN_EXTENDED_TESTS: ${{ github.event_name == 'schedule' || inputs.run_tests }}
+  RUN_SIMPLE_TESTS: ${{ github.event_name == 'push' || inputs.run-tests }}
+  RUN_EXTENDED_TESTS: ${{ github.event_name == 'schedule' || inputs.run-tests }}
 
 jobs:
 
@@ -122,7 +122,7 @@ jobs:
 
 
     - name: Run named mps tests
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{steps.simtest-version.outputs.prop}}
@@ -131,13 +131,13 @@ jobs:
         variant: "named-mps"
 
     - name: Run unfeasibility-related tests
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       run: |
            cd _build
            ctest -C Release --output-on-failure -R "^unfeasible$"
 
     - name: Run unit and end-to-end tests
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       run: |
            cd _build
            ctest -C ${{ matrix.buildtype }} --output-on-failure -L "unit|end-to-end"
@@ -158,7 +158,7 @@ jobs:
         path: ${{ github.workspace }}/_build/Testing/Temporary/LastTest.log
 
     - name: Run tests about infinity on BCs RHS
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{steps.simtest-version.outputs.prop}}
@@ -166,7 +166,7 @@ jobs:
         os: ${{ matrix.test-platform }}
 
     - name: Run MILP with CBC
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{steps.simtest-version.outputs.prop}}
@@ -175,7 +175,7 @@ jobs:
         os: ${{ matrix.test-platform }}
 
     - name: Run tests introduced in v860
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{steps.simtest-version.outputs.prop}}
@@ -183,7 +183,7 @@ jobs:
         os: ${{ matrix.test-platform }}
 
     - name: Run tests introduced in v870
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{steps.simtest-version.outputs.prop}}
@@ -191,7 +191,7 @@ jobs:
         os: ${{ matrix.test-platform }}
 
     - name: Run short-tests
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{steps.simtest-version.outputs.prop}}
@@ -199,7 +199,7 @@ jobs:
         os: ${{ matrix.test-platform }}
 
     - name: Run mps tests
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{steps.simtest-version.outputs.prop}}
@@ -207,7 +207,7 @@ jobs:
         os: ${{ matrix.test-platform }}
 
     - name: Run tests for adequacy patch (CSR)
-      if: ${{ env.IS_PUSH == 'true' }}
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{steps.simtest-version.outputs.prop}}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,8 +1,6 @@
 name: Ubuntu CI (push and/or release)
 
 on:
-  release:
-    types: [created]
   push:
     branches:
       - develop
@@ -14,12 +12,17 @@ on:
       - doc/*
   schedule:
     - cron: '21 2 * * *'
+  workflow_call:
+    inputs:
+      run_tests:
+        required: true
+        type: boolean
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
-  IS_RELEASE: ${{ github.event_name == 'release' && github.event.action == 'created' }}
+  IS_RELEASE: ${{ github.event_name == 'workflow_call' }}
   IS_PUSH: ${{ github.event_name == 'push' }}
-  RUN_EXTENDED_TESTS: ${{ github.event_name == 'schedule' || github.event_name == 'release' }}
+  RUN_EXTENDED_TESTS: ${{ github.event_name == 'schedule' || inputs.run_tests }}
 
 jobs:
 
@@ -290,7 +293,6 @@ jobs:
     - name: Download all artifacts
       if: ${{ env.IS_RELEASE == 'true' }}
       uses: actions/download-artifact@v3
-
 
     - name: Publish assets
       if: ${{ env.IS_RELEASE == 'true' }}


### PR DESCRIPTION
This is useful for releases where we know results will deviate from reference results.

# Currently
## Workflow when results change
1. Disable tests by commenting them in the YML workflows
2. Create a RC release
4. Generate new reference results
5. Uncomment tests in YML workflows
6. Create a definitive release with tests

## Workflow when results don't change
1. Generate new release with tests

# After
## Workflow when results change
1. Create release without running the tests
2. Create a RC release
3. Generate new reference results
4. Generate definitive release with tests

We save two steps (comment/uncomment).

## Workflow when results don't change
1. Generate new release with tests

# Note
It won't be possible to manually create a new release, all releases will have to be created using the `new_release.yml` workflow. This is because the condition for asset upload changes from `${{ github.event_name == 'release' && github.event.action == 'created' }}` to `${{ github.event_name == 'workflow_call' }}`.

# Reference
https://docs.github.com/en/actions/using-workflows/reusing-workflows 
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputsinput_idtype