### PR TITLE
Use `std::unordered_map` for tmpDataByArea_ (hydro ventilation)

### DIFF
--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -226,12 +226,9 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
                                                             uint y,
                                                             uint numSpace)
 {
-    uint z = area.index;
-    assert(z < areas_.size());
-
     auto const srcinflows = area.hydro.series->storage.getColumn(y);
 
-    auto& data = tmpDataByArea_[z];
+    auto& data = tmpDataByArea_[&area];
 
     auto& scratchpad = area.scratchpad[numSpace];
 
@@ -250,7 +247,7 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
     auto const& maxP = maxPower[Data::PartHydro::genMaxP];
     auto const& maxE = maxPower[Data::PartHydro::genMaxE];
 
-    auto& ventilationResults = ventilationResults_[z];
+    auto& ventilationResults = ventilationResults_[area.index];
 
     std::shared_ptr<DebugData> debugData(nullptr);
 
@@ -535,7 +532,7 @@ inline void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::St
         }
 
         uint firstDaySimu = parameters_.simulationDays.first;
-        state.problemeHebdo->previousSimulationFinalLevel[z]
+        state.problemeHebdo->previousSimulationFinalLevel[area.index]
           = ventilationResults.NiveauxReservoirsDebutJours[firstDaySimu] * reservoirCapacity;
 
         if (debugData)

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -434,8 +434,10 @@ void HydroManagement::prepareEffectiveDemand()
             auto realmonth = calendar_.months[month].realmonth;
 
             double effectiveDemand = 0;
-            area.hydro.allocation.eachNonNull([&]([[maybe_unused]] unsigned areaindex, double value) {
-                effectiveDemand += data.DLN[day] * value;
+            // area.hydro.allocation is indexed by area index
+            area.hydro.allocation.eachNonNull([&](unsigned areaIndex, double value) {
+                const auto* area = areas_.byIndex[areaIndex];
+                effectiveDemand += tmpDataByArea_[area].DLN[day] * value;
             });
 
             assert(!Math::NaN(effectiveDemand) && "nan value detected for effectiveDemand");

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -125,15 +125,14 @@ HydroManagement::HydroManagement(const Data::AreaList& areas,
     ventilationResults_.resize(areas_.size());
     for (uint areaIndex = 0; areaIndex < areas_.size(); ++areaIndex)
     {
-        auto& area = *areas_.byIndex[areaIndex];
-        size_t clusterCount = area.thermal.clusterCount();
+        auto* area = areas_.byIndex[areaIndex];
+        auto& ventilationResults = ventilationResults_[areaIndex];
 
-        ventilationResults_[areaIndex].HydrauliqueModulableQuotidien.assign(nbDaysPerYear, 0);
-
-        if (area.hydro.reservoirManagement)
+        ventilationResults.HydrauliqueModulableQuotidien.assign(nbDaysPerYear, 0);
+        if (area->hydro.reservoirManagement)
         {
-            ventilationResults_[areaIndex].NiveauxReservoirsDebutJours.assign(nbDaysPerYear, 0.);
-            ventilationResults_[areaIndex].NiveauxReservoirsFinJours.assign(nbDaysPerYear, 0.);
+            ventilationResults.NiveauxReservoirsDebutJours.assign(nbDaysPerYear, 0.);
+            ventilationResults.NiveauxReservoirsFinJours.assign(nbDaysPerYear, 0.);
         }
     }
 }
@@ -142,11 +141,9 @@ void HydroManagement::prepareInflowsScaling(uint year)
 {
     areas_.each([&](const Data::Area& area)
       {
-          uint z = area.index;
-
           auto const& srcinflows = area.hydro.series->storage.getColumn(year);
 
-          auto& data = tmpDataByArea_[z];
+          auto& data = tmpDataByArea_[&area];
           double totalYearInflows = 0.0;
 
           for (uint month = 0; month != 12; ++month)
@@ -192,8 +189,7 @@ void HydroManagement::minGenerationScaling(uint year)
       {
           auto const& srcmingen =  area.hydro.series->mingen.getColumn(year);
 
-          uint z = area.index;
-          auto& data = tmpDataByArea_[z];
+          auto& data = tmpDataByArea_[&area];
           double totalYearMingen = 0.0;
 
           for (uint month = 0; month != 12; ++month)
@@ -244,7 +240,7 @@ void HydroManagement::minGenerationScaling(uint year)
 
 bool HydroManagement::checkMonthlyMinGeneration(uint year, const Data::Area& area) const
 {
-    const auto& data = tmpDataByArea_[area.index];
+    const auto& data = tmpDataByArea_.at(&area);
     for (uint month = 0; month != 12; ++month)
     {
         uint realmonth = calendar_.months[month].realmonth;
@@ -264,7 +260,7 @@ bool HydroManagement::checkMonthlyMinGeneration(uint year, const Data::Area& are
 
 bool HydroManagement::checkYearlyMinGeneration(uint year, const Data::Area& area) const
 {
-    const auto& data = tmpDataByArea_[area.index];
+    const auto& data = tmpDataByArea_.at(&area);
     if (data.totalYearMingen > data.totalYearInflows)
     {
         // Yearly minimum generation <= Yearly inflows
@@ -379,14 +375,12 @@ bool HydroManagement::checkMinGeneration(uint year) const
 void HydroManagement::prepareNetDemand(uint numSpace, uint year, Data::SimulationMode mode)
 {
     areas_.each([this, &year, &numSpace, &mode](const Data::Area& area) {
-        uint z = area.index;
-
         auto& scratchpad = area.scratchpad[numSpace];
 
         const auto& rormatrix = area.hydro.series->ror;
         const auto* ror = rormatrix.getColumn(year);
 
-        auto& data = tmpDataByArea_[z];
+        auto& data = tmpDataByArea_[&area];
         const double* loadSeries = area.load.series.getColumn(year);
         const double* windSeries = area.wind.series.getColumn(year);
         const double* solarSeries = area.solar.series.getColumn(year);
@@ -431,9 +425,7 @@ void HydroManagement::prepareNetDemand(uint numSpace, uint year, Data::Simulatio
 void HydroManagement::prepareEffectiveDemand()
 {
     areas_.each([&](Data::Area& area) {
-        auto z = area.index;
-
-        auto& data = tmpDataByArea_[z];
+        auto& data = tmpDataByArea_[&area];
 
         for (uint day = 0; day != 365; ++day)
         {
@@ -442,8 +434,8 @@ void HydroManagement::prepareEffectiveDemand()
             auto realmonth = calendar_.months[month].realmonth;
 
             double effectiveDemand = 0;
-            area.hydro.allocation.eachNonNull([&](unsigned areaindex, double value) {
-                effectiveDemand += (tmpDataByArea_[areaindex]).DLN[day] * value;
+            area.hydro.allocation.eachNonNull([&]([[maybe_unused]] unsigned areaindex, double value) {
+                effectiveDemand += data.DLN[day] * value;
             });
 
             assert(!Math::NaN(effectiveDemand) && "nan value detected for effectiveDemand");
@@ -495,9 +487,6 @@ void HydroManagement::makeVentilation(double* randomReservoirLevel,
                                       uint y,
                                       uint numSpace)
 {
-    tmpDataByArea_.resize(areas_.size());
-    memset(tmpDataByArea_.data(), 0, sizeof(TmpDataByArea) * areas_.size());
-
     prepareInflowsScaling(y);
     minGenerationScaling(y);
     if (!checkMinGeneration(y))

--- a/src/solver/hydro/management/management.h
+++ b/src/solver/hydro/management/management.h
@@ -28,6 +28,7 @@
 #define __ANTARES_SOLVER_HYDRO_MANAGEMENT_MANAGEMENT_H__
 
 #include <yuni/yuni.h>
+#include <unordered_map>
 #include <antares/study/fwd.h>
 #include <antares/mersenne-twister/mersenne-twister.h>
 #include "../../simulation/sim_structure_donnees.h"
@@ -157,7 +158,7 @@ private:
 
 
 private:
-    std::vector<TmpDataByArea> tmpDataByArea_;
+    std::unordered_map<const Data::Area*, TmpDataByArea> tmpDataByArea_;
     const Data::AreaList& areas_;
     const Date::Calendar& calendar_;
     const Data::Parameters& parameters_;

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -146,9 +146,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
 {
     uint indexArea = 0;
     areas_.each([&](Data::Area& area) {
-        uint z = area.index;
-
-        auto& data = tmpDataByArea_[z];
+        auto& data = tmpDataByArea_[&area];
 
         auto& minLvl = area.hydro.reservoirLevel[Data::PartHydro::minimum];
         auto& maxLvl = area.hydro.reservoirLevel[Data::PartHydro::maximum];


### PR DESCRIPTION
## Why ?

Using a `std::vector` requires one 2 indirections **area -> index -> tmpData**

Using a `std::unordered_map`, we don't need to worry about indices anymore, we can just get **area -> tmpData**. 

**NOTES** 
- The AreaList shall never be resized after assigning the newly created map. Otherwise pointers used as keys would be invalid. This works because no areas are added/removed after loading a study.
- Replacing a `std::vector` by a `std::unordered_map` works because we don't rely on order. If we did, using pointers as map keys would produce unpredictable results.