### PR TITLE
Fix segfault caused by uninitialized `cluster.series.timeseriesNumbers`

### DIFF
--- a/src/libs/antares/study/parts/common/cluster_list.cpp
+++ b/src/libs/antares/study/parts/common/cluster_list.cpp
@@ -80,7 +80,7 @@ void ClusterList<ClusterT>::clear()
 template<class ClusterT>
 void ClusterList<ClusterT>::resizeAllTimeseriesNumbers(uint n)
 {
-    each([&](Cluster& cluster) { cluster.series.timeseriesNumbers.resize(1, n); });
+    each([&](Cluster& cluster) { cluster.series.timeseriesNumbers.reset(1, n); });
 }
 
 #define SEP IO::Separator


### PR DESCRIPTION
```cpp
void Area::resizeAllTimeseriesNumbers(uint nbYears) 
{ 
    assert(hydro.series and "series must not be nullptr !"); 

    load.series.timeseriesNumbers.reset(1, nbYears); 
    solar.series.timeseriesNumbers.reset(1, nbYears); 
    wind.series.timeseriesNumbers.reset(1, nbYears); 
    hydro.series->timeseriesNumbers.reset(1, nbYears); 
    for (auto& namedLink : links) 
    { 
        AreaLink* link = namedLink.second; 
        link->timeseriesNumbers.reset(1, nbYears); 
    } 
    thermal.resizeAllTimeseriesNumbers(nbYears); // resize is called here
    renewable.resizeAllTimeseriesNumbers(nbYears); // resize is called here
}
```