### PR TITLE
Fix a few compilation warnings

### DIFF
--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -102,7 +102,7 @@ bool AreaLink::linkLoadTimeSeries_for_version_below_810(const AnyString& folder)
     }
 
     // Store data into link's data container
-    for (int h = 0; h < HOURS_PER_YEAR; h++)
+    for (unsigned int h = 0; h < HOURS_PER_YEAR; h++)
     {
         directCapacities[0][h] = tmpMatrix[0][h];
         indirectCapacities[0][h] = tmpMatrix[1][h];
@@ -502,7 +502,7 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
                 const double* indirectCapacities = link.indirectCapacities[indexTS];
 
                 // Checks on direct capacities
-                for (int h = 0; h < HOURS_PER_YEAR; h++)
+                for (unsigned int h = 0; h < HOURS_PER_YEAR; h++)
                 {
                     if (directCapacities[h] < 0.)
                     {
@@ -517,7 +517,7 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
                 }
 
                 // Checks on indirect capacities
-                for (int h = 0; h < HOURS_PER_YEAR; h++)
+                for (unsigned int h = 0; h < HOURS_PER_YEAR; h++)
                 {
                     if (indirectCapacities[h] < 0.)
                     {
@@ -532,7 +532,7 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
                 }
             }
             // Checks on hurdle costs
-            for (int h = 0; h < HOURS_PER_YEAR; h++)
+            for (unsigned int h = 0; h < HOURS_PER_YEAR; h++)
             {
                 if (directHurdlesCost[h] + indirectHurdlesCost[h] < 0)
                 {
@@ -544,7 +544,7 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const AnyStr
             }
 
             // Checks on P. shift min and max
-            for (int h = 0; h < HOURS_PER_YEAR; h++)
+            for (unsigned int h = 0; h < HOURS_PER_YEAR; h++)
             {
                 if (PShiftPlus[h] < PShiftMinus[h])
                 {

--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -191,7 +191,7 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
         {
             auto& col = area.hydro.inflowPattern[0];
             bool errorInflow = false;
-            for (int day = 0; day < DAYS_PER_YEAR; day++)
+            for (unsigned int day = 0; day < DAYS_PER_YEAR; day++)
             {
                 if (col[day] < 0 && !errorInflow)
                 {
@@ -204,7 +204,7 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
             auto& colMin = area.hydro.reservoirLevel[minimum];
             auto& colAvg = area.hydro.reservoirLevel[average];
             auto& colMax = area.hydro.reservoirLevel[maximum];
-            for (int day = 0; day < DAYS_PER_YEAR; day++)
+            for (unsigned int day = 0; day < DAYS_PER_YEAR; day++)
             {
                 if (!errorLevels
                     && (colMin[day] < 0 || colAvg[day] < 0 || colMin[day] > colMax[day]
@@ -219,7 +219,7 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
             for (int i = 0; i < 4; i++)
             {
                 auto& col = area.hydro.maxPower[i];
-                for (int day = 0; day < DAYS_PER_YEAR; day++)
+                for (unsigned int day = 0; day < DAYS_PER_YEAR; day++)
                 {
                     if (!errorPowers && (col[day] < 0 || (i % 2 /*column hours*/ && col[day] > 24)))
                     {


### PR DESCRIPTION
`HOURS_PER_YEAR` and `DAYS_PER_YEAR` were previously `#define`s, they have been converted to `const unsigned int`. This change created a few compilation warnings, which we fix in this PR.