### PR TITLE
Install gh at start of workflows for CentOS 7 & OracleLinux 8

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -64,6 +64,14 @@ jobs:
         yum install -y centos-release-scl
         yum install -y devtoolset-10-gcc*
 
+    - name: Install gh if needed
+      if: ${{ env.IS_RELEASE == 'true' }}
+      run: |
+           yum -y install dnf
+           dnf -y install 'dnf-command(config-manager)'
+           dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+           dnf -y install gh
+
     - name: Configure
       run: |
            source /opt/rh/devtoolset-10/enable
@@ -114,14 +122,6 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         path: _build/*.rpm
-
-    - name: Install gh
-      if: ${{ env.IS_RELEASE == 'true' }}
-      run: |
-           yum -y install dnf
-           dnf -y install 'dnf-command(config-manager)'
-           dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-           dnf -y install gh
 
     - name: Publish assets
       if: ${{ env.IS_RELEASE == 'true' }}

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -54,6 +54,13 @@ jobs:
       run: |
           pip3 install -r src/tests/examples/requirements.txt
 
+    - name: Install gh if needed
+      if: ${{ env.IS_RELEASE == 'true' }}
+      run: |
+           dnf -y install 'dnf-command(config-manager)'
+           dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+           dnf -y install gh
+
     - name: Configure
       run: |
            source /opt/rh/gcc-toolset-10/enable
@@ -103,13 +110,6 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         path: _build/*.rpm
-
-    - name: Install gh
-      if: ${{ env.IS_RELEASE == 'true' }}
-      run: |
-           dnf -y install 'dnf-command(config-manager)'
-           dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-           dnf -y install gh
 
     - name: Publish assets
       if: ${{ env.IS_RELEASE == 'true' }}


### PR DESCRIPTION
If the install fails, the process will end directly. This should avoid the following frustrating scenario in case of failure

```
[OK] Install g++10
[OK] Configure
[OK] Build
[KO] Install gh
[ ] Upload assets <= Not done, assets missing
```