### PR TITLE
Bump SimTest -> v8.8.2

### DIFF
--- a/simtest.json
+++ b/simtest.json
@@ -1,3 +1,3 @@
 {
-    "version": "v8.8.1"
+    "version": "v8.8.2"
 }


### PR DESCRIPTION
Because of a segfault and poor error handling on SimTest [fixed](https://github.com/AntaresSimulatorTeam/SimTest/compare/v8.8.2..v8.8.1), some results from SimTest@v8.8.1 are missing.

SimTest@v8.8.2 fixes most missing results, with 2 exceptions : hydroPricing and valid-hydro. These two have some failing studies related to infeasible problems caused by hydro hard bounds.