### PR TITLE
For ST storage, set initial level at t=0 instead of t=167

### DIFF
--- a/src/libs/antares/study/parts/short-term-storage/series.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/series.cpp
@@ -203,7 +203,7 @@ bool Series::validateRuleCurves() const
     if (!validateUpperRuleCurve() || !validateLowerRuleCurve())
         return false;
 
-    for (int i = 0; i < HOURS_PER_YEAR; i++)
+    for (unsigned int i = 0; i < HOURS_PER_YEAR; i++)
     {
         if (lowerRuleCurve[i] > upperRuleCurve[i])
         {

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -190,7 +190,7 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
                 // 3. Levels
                 int varLevel = CorrespondanceVarNativesVarOptim.SIM_ShortTermStorage
                                  .LevelVariable[clusterGlobalIndex];
-                if (pdtHebdo == DernierPdtDeLIntervalle - 1 && !storage.initialLevelOptim)
+                if (pdtHebdo == 0 && !storage.initialLevelOptim)
                 {
                     Xmin[varLevel] = Xmax[varLevel]
                       = storage.reservoirCapacity * storage.initialLevel;

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -268,6 +268,7 @@ BOOST_AUTO_TEST_CASE(sts_initial_level)
 
     storages.push_back(sts);
 
+    // Fatal gen at h=1
     {
       auto& windTS = area->wind.series.timeSeries;
       TimeSeriesConfigurer(windTS)
@@ -276,6 +277,7 @@ BOOST_AUTO_TEST_CASE(sts_initial_level)
       windTS[0][1] = 100;
     }
 
+    // Fatal load at h=2
     {
       auto& loadTS = area->load.series.timeSeries;
       TimeSeriesConfigurer(loadTS)
@@ -283,6 +285,10 @@ BOOST_AUTO_TEST_CASE(sts_initial_level)
         .fillColumnWith(0, 0.);
       loadTS[0][2] = 100;
     }
+
+    // Usual values, avoid spillage & unsupplied energy
+    area->thermal.unsuppliedEnergyCost = 1.e3;
+    area->thermal.spilledEnergyCost = 1.;
 
 	simulation->create();
 	simulation->run();

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -247,3 +247,34 @@ BOOST_AUTO_TEST_CASE(error_on_wrong_hydro_data)
     BOOST_CHECK_THROW(simulation->run(), Antares::FatalError);
 }
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(ONE_AREA__ONE_STS_THERMAL_CLUSTER, StudyFixture)
+BOOST_AUTO_TEST_CASE(sts_initial_level)
+{
+    using namespace Antares::Data::ShortTermStorage;
+	setNumberMCyears(1);
+    auto& storages = area->shortTermStorage.storagesByIndex;
+    STStorageCluster sts;
+    auto& props = sts.properties;
+    props.name = "my-sts";
+    props.injectionNominalCapacity = 10;
+    props.withdrawalNominalCapacity = 10;
+    props.reservoirCapacity = 100;
+    props.efficiencyFactor = .9;
+    props.initialLevel = .443;
+    props.group = Group::PSP_open;
+    // Default values for series
+    sts.series->fillDefaultSeriesIfEmpty();
+
+    storages.push_back(sts);
+
+	simulation->create();
+	simulation->run();
+
+	OutputRetriever output(simulation->rawSimu());
+	BOOST_TEST(output.STSLevel_PSP_Open(area).hour(0) == props.initialLevel * props.reservoirCapacity.value(), tt::tolerance(0.001));
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+
+

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -268,6 +268,22 @@ BOOST_AUTO_TEST_CASE(sts_initial_level)
 
     storages.push_back(sts);
 
+    {
+      auto& windTS = area->wind.series.timeSeries;
+      TimeSeriesConfigurer(windTS)
+        .setColumnCount(1)
+        .fillColumnWith(0, 0.);
+      windTS[0][1] = 100;
+    }
+
+    {
+      auto& loadTS = area->load.series.timeSeries;
+      TimeSeriesConfigurer(loadTS)
+        .setColumnCount(1)
+        .fillColumnWith(0, 0.);
+      loadTS[0][2] = 100;
+    }
+
 	simulation->create();
 	simulation->run();
 

--- a/src/tests/end-to-end/utils/utils.cpp
+++ b/src/tests/end-to-end/utils/utils.cpp
@@ -96,7 +96,7 @@ averageResults OutputRetriever::overallCost(Area* area)
     return averageResults(result->avgdata);
 }
 
-averageResults STSLevel_PSP_Open(Area* area);
+averageResults OutputRetriever::STSLevel_PSP_Open(Area* area)
 {
     auto result = retrieveAreaResults<Variable::Economy::VCardShortTermStorage>(area);
     // PSP_open / Level, see STStorageOutputCaptions.cpp

--- a/src/tests/end-to-end/utils/utils.cpp
+++ b/src/tests/end-to-end/utils/utils.cpp
@@ -96,6 +96,14 @@ averageResults OutputRetriever::overallCost(Area* area)
     return averageResults(result->avgdata);
 }
 
+averageResults STSLevel_PSP_Open(Area* area);
+{
+    auto result = retrieveAreaResults<Variable::Economy::VCardShortTermStorage>(area);
+    // PSP_open / Level, see STStorageOutputCaptions.cpp
+    const unsigned int PSP_Open_Level = 2;
+    return result[area->index][PSP_Open_Level].avgdata;
+}
+
 averageResults OutputRetriever::load(Area* area)
 {
     auto result = retrieveAreaResults<Variable::Economy::VCardTimeSeriesValuesLoad>(area);
@@ -140,7 +148,7 @@ ScenarioBuilderRule::ScenarioBuilderRule(Study& study)
         study.parameters.useCustomScenario = true;
         study.parameters.activeRulesScenario = "Custom";
     }
- }
+}
 
 
 // =====================

--- a/src/tests/end-to-end/utils/utils.h
+++ b/src/tests/end-to-end/utils/utils.h
@@ -69,6 +69,7 @@ class OutputRetriever
 public:
     OutputRetriever(ISimulation<Economy>& simulation) : simulation_(simulation) {}
     averageResults overallCost(Area* area);
+    averageResults STSLevel_PSP_Open(Area* area);
     averageResults load(Area* area);
     averageResults flow(AreaLink* link);
     averageResults thermalGeneration(ThermalCluster* cluster);


### PR DESCRIPTION
Currently, as reported by @nikolaredstork, the initial level for ST storages is set at the **last** hour.

We need to set it at the **first** hour instead.

### Tests failures
- Some tests from valid-named-mps fail because the named MPS files are different. This is expected, actually timesteps 0 and 167 are swapped for the bounds of the level variable.
- Some tests from valid-v860 fail because the lower rule curve becomes too steep after this change in **area 2**.