### PR TITLE
Add STS level constraint to suspect list for infeasible problem analysis

### DIFF
--- a/src/solver/infeasible-problem-analysis/constraint-slack-analysis.h
+++ b/src/solver/infeasible-problem-analysis/constraint-slack-analysis.h
@@ -24,7 +24,7 @@ private:
     void addSlackVariables(operations_research::MPSolver* problem);
 
     std::vector<const operations_research::MPVariable*> slackVariables_;
-    const std::string constraint_name_pattern = "^AreaHydroLevel::|::hourly::|::daily::|::weekly::|^FictiveLoads::";
+    const std::string constraint_name_pattern = "^AreaHydroLevel::|::hourly::|::daily::|::weekly::|^FictiveLoads::|^Level::";
 };
 
 } // namespace Antares::Optimization

--- a/src/solver/infeasible-problem-analysis/constraint.cpp
+++ b/src/solver/infeasible-problem-analysis/constraint.cpp
@@ -5,6 +5,10 @@
 #include <iomanip>
 #include <algorithm>
 
+namespace {
+    const std::string kUnknown;
+}
+
 namespace Antares
 {
 namespace Optimization
@@ -104,6 +108,8 @@ std::string Constraint::getTimeStepInYear() const
     case ConstraintType::fictitious_load:
     case ConstraintType::hydro_reservoir_level:
         return StringBetweenAngleBrackets (mItems.at(mItems.size()-2));
+    case ConstraintType::short_term_storage_level:
+        return StringBetweenAngleBrackets (mItems.at(mItems.size()-2));
     default:
         return "-1";
     }
@@ -132,6 +138,10 @@ ConstraintType Constraint::getType() const
     {
         return ConstraintType::hydro_reservoir_level;
     }
+    if (mItems.at(0) == "Level")
+    {
+        return ConstraintType::short_term_storage_level;
+    }
     return ConstraintType::none;
 }
 
@@ -144,8 +154,16 @@ std::string Constraint::getBindingConstraintName() const
     case ConstraintType::binding_constraint_weekly:
         return mItems.at(0);
     default:
-        return "<unknown>";
+        return kUnknown;
     }
+}
+
+std::string Constraint::getSTSName() const
+{
+  if (getType() == ConstraintType::short_term_storage_level)
+      return StringBetweenAngleBrackets(mItems.at(2));
+  else
+      return kUnknown;
 }
 
 std::string Constraint::prettyPrint() const
@@ -167,8 +185,11 @@ std::string Constraint::prettyPrint() const
     case ConstraintType::hydro_reservoir_level:
         return "Hydro reservoir constraint at area '" + getAreaName() + "' at hour "
                + getTimeStepInYear();
+    case ConstraintType::short_term_storage_level:
+        return "Short-term-storage reservoir constraint at area '" + getAreaName() + "' in STS '" + getSTSName() + "' at hour " + getTimeStepInYear();
+
     default:
-        return "<unknown>";
+        return kUnknown;
     }
 }
 } // namespace Optimization

--- a/src/solver/infeasible-problem-analysis/constraint.cpp
+++ b/src/solver/infeasible-problem-analysis/constraint.cpp
@@ -6,12 +6,10 @@
 #include <algorithm>
 
 namespace {
-    const std::string kUnknown;
+const std::string kUnknown = "<unknown>";
 }
 
-namespace Antares
-{
-namespace Optimization
+namespace Antares::Optimization
 {
 Constraint::Constraint(const std::string& input, const double slackValue) :
  mInput(input), mSlackValue(slackValue)
@@ -107,11 +105,10 @@ std::string Constraint::getTimeStepInYear() const
     case ConstraintType::binding_constraint_daily:
     case ConstraintType::fictitious_load:
     case ConstraintType::hydro_reservoir_level:
-        return StringBetweenAngleBrackets (mItems.at(mItems.size()-2));
     case ConstraintType::short_term_storage_level:
         return StringBetweenAngleBrackets (mItems.at(mItems.size()-2));
     default:
-        return "-1";
+        return kUnknown;
     }
 }
 
@@ -192,5 +189,4 @@ std::string Constraint::prettyPrint() const
         return kUnknown;
     }
 }
-} // namespace Optimization
-} // namespace Antares
+} // namespace Antares::Optimization

--- a/src/solver/infeasible-problem-analysis/constraint.h
+++ b/src/solver/infeasible-problem-analysis/constraint.h
@@ -14,6 +14,7 @@ enum class ConstraintType
     binding_constraint_weekly,
     fictitious_load,
     hydro_reservoir_level,
+    short_term_storage_level,
     none
 };
 
@@ -39,6 +40,7 @@ private:
 
     // Get specific items
     std::string getAreaName() const;
+    std::string getSTSName() const;
     std::string getTimeStepInYear() const;
     std::string getBindingConstraintName() const;
 };

--- a/src/solver/infeasible-problem-analysis/report.cpp
+++ b/src/solver/infeasible-problem-analysis/report.cpp
@@ -70,6 +70,11 @@ void InfeasibleProblemReport::logSuspiciousConstraints()
     {
         Antares::logs.error() << "* Last resort shedding status,";
     }
+    if (mTypes[ConstraintType::short_term_storage_level] > 0)
+    {
+        Antares::logs.error() << "* Short-term storage reservoir level impossible to manage. Please check inflows, lower & upper curves and initial level (if prescribed),";
+    }
+
     const unsigned int bcCount = mTypes[ConstraintType::binding_constraint_hourly]
                                  + mTypes[ConstraintType::binding_constraint_daily]
                                  + mTypes[ConstraintType::binding_constraint_weekly];


### PR DESCRIPTION
## Add STS level constraint to suspect list for infeasible problem analysis (slack variables)

In some cases, the data associated to STS objects can lead to infeasible problems.

This includes
    - Large inflows (no overflow is possible)
    - Large negative inflows (level can't be < 0)
    - Steep rule curves (energy can't be transferred fast enough because of PMAX constraints)

Most of these cases can be captured from the level equation, since it ties all of the above data.