### PR TITLE
Fix invalid index causing segfault in `test-study` test

### DIFF
--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -42,6 +42,8 @@ struct OneAreaStudy
     OneAreaStudy()
     {
         areaA = study.areaAdd("A");
+        study.parameters.simulationDays.first = 0;
+        study.parameters.simulationDays.end = 7;
     }
 
     Study study;


### PR DESCRIPTION
Line causing segfault 
https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/f2c87b68e0472e11c1344f5c5648a11adb559785/src/libs/antares/study/runtime/runtime.cpp#L130

The segfault occurs because by default, `study.parameters.simulationDays.end=0`, so we query index -1.