### PR TITLE
Version : fix build conflict with GNU flags

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - develop
-      - fix/*
   schedule:
     - cron: '21 2 * * *'
   workflow_call:

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - develop
+      - fix/*
   schedule:
     - cron: '21 2 * * *'
   workflow_call:

--- a/src/libs/antares/study/version.cpp
+++ b/src/libs/antares/study/version.cpp
@@ -165,9 +165,6 @@ bool StudyVersion::isSupported(bool verbose) const
     if (std::ranges::find(::supportedVersions, *this) != ::supportedVersions.end())
         return true;
 
-    if (verbose)
-        logs.error() << "Version: " << toString() << " not supported";
-
     if (*this > latest() && verbose)
     {
         logs.error() << "Maximum study version supported: " << ::supportedVersions.back().toString();

--- a/src/libs/antares/study/version.cpp
+++ b/src/libs/antares/study/version.cpp
@@ -147,7 +147,7 @@ bool StudyVersion::fromString(const std::string& versionStr)
 
 std::string StudyVersion::toString() const
 {
-    return std::to_string(major) + "." + std::to_string(minor);
+    return std::to_string(major_) + "." + std::to_string(minor_);
 }
 
 StudyVersion StudyVersion::latest()

--- a/src/libs/antares/study/version.h
+++ b/src/libs/antares/study/version.h
@@ -39,7 +39,7 @@ public:
     auto operator<=>(const StudyVersion&) const = default;
 
     constexpr StudyVersion() = default;
-    constexpr StudyVersion(unsigned major_, unsigned minor_) : major(major_), minor(minor_) {}
+    constexpr StudyVersion(unsigned major, unsigned minor) : major_(major), minor_(minor) {}
     ~StudyVersion() = default;
 
     bool isSupported(bool verbose) const;
@@ -52,7 +52,7 @@ public:
     static StudyVersion unknown();
 
 private:
-    unsigned major = 0;
-    unsigned minor = 0;
+    unsigned major_ = 0;
+    unsigned minor_ = 0;
 };
 } // namespace Antares::Data


### PR DESCRIPTION
### Build on CentOS 7
```
In file included from /usr/include/sys/types.h:222,
                 from /__w/Antares_Simulator/Antares_Simulator/src/ext/yuni/src/yuni/../yuni/core/system/stdint.h:26,
                 from /__w/Antares_Simulator/Antares_Simulator/src/ext/yuni/src/yuni/../yuni/yuni.h:26,
                 from /__w/Antares_Simulator/Antares_Simulator/src/libs/antares/solver.cpp:22:
/__w/Antares_Simulator/Antares_Simulator/src/libs/antares/study/version.h: In constructor 'constexpr Antares::Data::StudyVersion::StudyVersion(unsigned int, unsigned int)':
/__w/Antares_Simulator/Antares_Simulator/src/libs/antares/study/version.h:42:64: error: class 'Antares::Data::StudyVersion' does not have any field named 'gnu_dev_major'
   42 |     constexpr StudyVersion(unsigned major_, unsigned minor_) : major(major_), minor(minor_) {}
      |                                                                ^~~~~
compilation terminated due to -Wfatal-errors.
```
See https://github.com/AntaresSimulatorTeam/Antares_Simulator/actions/runs/7754855599/job/21149035653

### Error message
Also remove misleading error message
[2024-02-02 12:45:21][solver][error] Study version 900 is not supported by this version of antares-solver
[2024-02-02 12:45:21][solver][error] Studies in version <7.0 are no longer supported. Please upgrade it first if it's the case
~~[2024-02-02 12:45:21][solver][error] Version: 0.0 not supported~~
[2024-02-02 12:45:21][solver][fatal] The folder `/home/florian/Downloads/short-tests/001 One node - passive` does not seem to be a valid study
[2024-02-02 12:45:21][solver][fatal] Aborting now. (warning: no file log available)