### PR TITLE
Fix naming conflict with target `config`

### DIFF
--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(PROJ antares-config)
-set(PROJ_ALIAS config)
 set(HEADERS
         include/antares/config/config.h
 )
@@ -10,7 +9,7 @@ set(SRC_CONFIG
 source_group("config" FILES ${SRC_CONFIG})
 
 add_library(${PROJ} ${SRC_CONFIG}) #Memory conflict with absl memory when building deps https://github.com/AntaresSimulatorTeam/Antares_Simulator/issues/1589
-add_library(Antares::config ALIAS ${PROJ_ALIAS})
+add_library(Antares::config ALIAS ${PROJ})
 
 target_include_directories(${PROJ}
         PUBLIC

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(PROJ config)
+set(PROJ antares-config)
+set(PROJ_ALIAS config)
 set(HEADERS
         include/antares/config/config.h
 )
@@ -9,7 +10,7 @@ set(SRC_CONFIG
 source_group("config" FILES ${SRC_CONFIG})
 
 add_library(${PROJ} ${SRC_CONFIG}) #Memory conflict with absl memory when building deps https://github.com/AntaresSimulatorTeam/Antares_Simulator/issues/1589
-add_library(Antares::config ALIAS ${PROJ})
+add_library(Antares::config ALIAS ${PROJ_ALIAS})
 
 target_include_directories(${PROJ}
         PUBLIC

--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -48,7 +48,7 @@ set(TARGET_LIBS #No alias
         StudyUtils
         stdcxx
         inifile
-        config
+        antares-config
         #
         signal-handling
         antares-solver-variable-info


### PR DESCRIPTION
- Keep Antares::config for public use
- Internally, use antares-config