### PR TITLE
Fix `RUN_EXTENDED_TESTS` being overriden at job level

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -32,7 +32,6 @@ jobs:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
       ORTOOLS_DIR: ${{ github.workspace }}/or-tools
-      RUN_EXTENDED_TESTS: ${{ github.event_name == 'schedule'}}
       os: windows-latest
       test-platform: windows-2022
       vcpkgPackages: wxwidgets boost-test


### PR DESCRIPTION
`RUN_EXTENDED_TESTS` is defined at the root level, and is overriden at the job level.

Keep only the definition at the root level.