### PR TITLE
Enable $ delimiter for latex expressions

### DIFF
--- a/docs/javascript/mathjax.js
+++ b/docs/javascript/mathjax.js
@@ -1,0 +1,5 @@
+window.MathJax = {
+    tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']]
+    }
+};

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ extra_css:
 extra_javascript:
   - https://code.jquery.com/jquery-3.6.0.min.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - javascript/mathjax.js
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
 markdown_extensions:


### PR DESCRIPTION

Mathjax does not recognize simple $ signs as delimiter,
by default.
We add it to our configuration, to have consistent
interpretation of latex expressions between sphinx 
and mkdocs.