### PR TITLE
Fix adq patch regression

### DIFF
--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
@@ -30,6 +30,7 @@
 #include "../simulation/simulation.h"
 #include "../simulation/adequacy_patch_runtime_data.h"
 #include "antares/study/fwd.h"
+#include "../simulation/common-eco-adq.h"
 
 using namespace Antares::Data::AdequacyPatch;
 using Antares::Constants::nbHoursInAWeek;
@@ -46,7 +47,10 @@ AdequacyPatchOptimization::AdequacyPatchOptimization(const Antares::Data::Study&
 {
 }
 
-void AdequacyPatchOptimization::solve(uint weekInTheYear, int hourInTheYear)
+void AdequacyPatchOptimization::solve(uint weekInTheYear, 
+                                      int hourInTheYear,
+                                      const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults,
+                                      double** thermalNoises)
 {
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = true;
     OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_);
@@ -63,6 +67,12 @@ void AdequacyPatchOptimization::solve(uint weekInTheYear, int hourInTheYear)
                     problemeHebdo_->ResultatsHoraires[pays].ValeursHorairesDENS.end(), 0);
     }
     
+    ::SIM_RenseignementProblemeHebdo(study_, *problemeHebdo_, weekInTheYear,
+        thread_number_, hourInTheYear, hydroVentilationResults);
+
+    Simulation::BuildThermalPartOfWeeklyProblem(study_, *problemeHebdo_,
+        thread_number_, hourInTheYear, thermalNoises);
+
     OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_);
 }
 

--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.h
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.h
@@ -47,7 +47,10 @@ public:
                                        IResultWriter& writer);
 
     ~AdequacyPatchOptimization() override = default;
-    void solve(uint weekInTheYear, int hourInTheYear) override;
+    void solve(uint weekInTheYear,
+               int hourInTheYear,
+               const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults,
+               double** thermalNoises) override;
 private:
     const Antares::Data::Study& study_;
 };

--- a/src/solver/optimisation/base_weekly_optimization.h
+++ b/src/solver/optimisation/base_weekly_optimization.h
@@ -31,13 +31,18 @@
 #include "../simulation/sim_structure_donnees.h"
 #include "../simulation/sim_structure_probleme_economique.h"
 #include <antares/study/parameters/adq-patch-params.h>
+#include "../hydro/management.h"
 
 namespace Antares::Solver::Optimization
 {
 class WeeklyOptimization
 {
 public:
-    virtual void solve(uint weekInTheYear, int hourInTheYear) = 0;
+    virtual void solve(uint weekInTheYear,
+                       int hourInTheYear,
+                       const ALL_HYDRO_VENTILATION_RESULTS& hydroVentilationResults,
+                       double** thermalNoises) = 0;
+
     virtual ~WeeklyOptimization() = default;
     static std::unique_ptr<WeeklyOptimization> create(const Antares::Data::Study& study,
                                                       const OptimizationOptions& options,
@@ -52,8 +57,9 @@ protected:
                                 Antares::Data::AdequacyPatch::AdqPatchParams&, 
                                 uint numSpace,
                                 IResultWriter& writer);
+
     Antares::Solver::Optimization::OptimizationOptions options_;
-    PROBLEME_HEBDO* const problemeHebdo_ = nullptr;
+    PROBLEME_HEBDO* problemeHebdo_ = nullptr;
     Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams_;
     const uint thread_number_ = 0;
     IResultWriter& writer_;

--- a/src/solver/optimisation/weekly_optimization.cpp
+++ b/src/solver/optimisation/weekly_optimization.cpp
@@ -39,7 +39,7 @@ DefaultWeeklyOptimization::DefaultWeeklyOptimization(const OptimizationOptions& 
 {
 }
 
-void DefaultWeeklyOptimization::solve(uint, int)
+void DefaultWeeklyOptimization::solve(uint, int, const ALL_HYDRO_VENTILATION_RESULTS&, double**)
 {
     OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_);
 }

--- a/src/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/weekly_optimization.h
@@ -41,6 +41,6 @@ public:
                                      uint numSpace,
                                      IResultWriter& writer);
     ~DefaultWeeklyOptimization() override = default;
-    void solve(uint, int) override;
+    void solve(uint, int, const ALL_HYDRO_VENTILATION_RESULTS&, double**) override;
 };
 } // namespace Antares::Solver::Optimization

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -382,7 +382,7 @@ void PrepareRandomNumbers(Data::Study& study,
     });
 }
 
-void BuildThermalPartOfWeeklyProblem(Data::Study& study,
+void BuildThermalPartOfWeeklyProblem(const Data::Study& study,
                                      PROBLEME_HEBDO& problem,
                                      uint numSpace,
                                      const int PasDeTempsDebut,

--- a/src/solver/simulation/common-eco-adq.h
+++ b/src/solver/simulation/common-eco-adq.h
@@ -62,7 +62,7 @@ void PrepareRandomNumbers(Data::Study& study,
                           PROBLEME_HEBDO& problem,
                           yearRandomNumbers& randomForYear);
 
-void BuildThermalPartOfWeeklyProblem(Data::Study& study,
+void BuildThermalPartOfWeeklyProblem(const Data::Study& study,
                                      PROBLEME_HEBDO& problem,
                                      uint numSpace,
                                      const int PasDeTempsDebut,

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -154,7 +154,10 @@ bool Economy::year(Progression::Task& progression,
 
         try
         {
-            weeklyOptProblems_[numSpace]->solve(w, hourInTheYear);
+            weeklyOptProblems_[numSpace]->solve(w, 
+                                                hourInTheYear,
+                                                hydroVentilationResults,
+                                                randomForYear.pThermalNoisesByArea);
 
             // Runs all the post processes in the list of post-process commands
             optRuntimeData opt_runtime_data(state.year, w, hourInTheYear);


### PR DESCRIPTION
This PR intends to fix [gopro ticket 1155](https://gopro-tickets.rte-france.com/browse/ANT-1155).

Note that : 
- Note a special branch **branch-v8.8.0** was created so that this PR can be based on it. It seems that basing a PR on a tag is impossible.
- the fix was derived from the first commit where the regression occurs (which is somewhere in between **v8.7.0** and **v8.8.0**). Apparently there are conflict with tag v8.8.0.
- This fix is a **dirty quick hack** : its purpose is to demonstrate the cause of an **adequacy patch** regression, introduced when removing a global variable. This PR mainly consists in restoring a call to function **SIM_RenseignementProblemeHebdo**.
- Carrying data required by this call turns out to be difficult, the resulting code is uglier than it was : optimization abstract method **solve(...)** has now more arguments that are not used in all derived implementation classes, specially the default class. 
- If we decide to integrate these changes to **develop** branch, we need remove the previous identified flaws. That said, we may not need to apply this fix to develop : @JMJ-rte opinion is that adequacy patch isolation first step should be skipped, so we won't need a new call to **SIM_RenseignementProblemeHebdo**
- We validated this fix by running the study supplied in **ticket 1155** while asking mps files printings, and comparing them (a use of **md5sum** is enough).
- This regression was not caught sooner because there seems to be no associated test. We should have a test validating this. 
