### PR TITLE
Remove remaining Yuni::Mutex, cleaning

### DIFF
--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -187,7 +187,7 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
           {
               auto& col = area.hydro.inflowPattern[0];
               bool errorInflow = false;
-              for (int day = 0; day < DAYS_PER_YEAR; day++)
+              for (unsigned int day = 0; day < DAYS_PER_YEAR; day++)
               {
                   if (col[day] < 0 && !errorInflow)
                   {
@@ -811,7 +811,7 @@ bool PartHydro::CheckDailyMaxEnergy(const AnyString& areaName)
     auto& colGen = dailyNbHoursAtGenPmax[0];
     auto& colPump = dailyNbHoursAtPumpPmax[0];
 
-    for (int day = 0; day < DAYS_PER_YEAR; day++)
+    for (unsigned int day = 0; day < DAYS_PER_YEAR; day++)
     {
         if (!errorEnergy && (colGen[day] < 0 || (colGen[day] > 24)))
         {

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -1120,7 +1120,7 @@ void Study::destroyAllWindTSGeneratorData()
 void Study::destroyAllThermalTSGeneratorData()
 {
     areas.each([&](Data::Area& area) {
-        for (const auto cluster : area.thermal.list.each_enabled_and_not_mustrun())
+        for (const auto& cluster : area.thermal.list.each_enabled_and_not_mustrun())
             FreeAndNil(cluster->prepro);
     });
 }

--- a/src/tools/vacuum/antares-study.cpp
+++ b/src/tools/vacuum/antares-study.cpp
@@ -357,10 +357,11 @@ void* AntaresStudy::userdataCreate(FSWalker::DispatchJobEvent& queue)
 
 void AntaresStudy::userdataDestroy(void* userdata)
 {
-    pMutex.lock();
-    bytesDeleted += ((UserData*)userdata)->bytesDeleted;
-    filesDeleted += ((UserData*)userdata)->filesDeleted;
-    foldersDeleted += ((UserData*)userdata)->foldersDeleted;
-    pMutex.unlock();
+    {
+        std::lock_guard lock(pMutex);
+        bytesDeleted += ((UserData*)userdata)->bytesDeleted;
+        filesDeleted += ((UserData*)userdata)->filesDeleted;
+        foldersDeleted += ((UserData*)userdata)->foldersDeleted;
+    }
     delete (UserData*)userdata;
 }

--- a/src/tools/vacuum/antares-study.h
+++ b/src/tools/vacuum/antares-study.h
@@ -21,7 +21,7 @@
 #ifndef __ANTARES_STUDY_H__
 #define __ANTARES_STUDY_H__
 
-#include <yuni/yuni.h>
+#include <mutex>
 #include <fswalker/fswalker.h>
 
 class AntaresStudy : public FSWalker::IExtension
@@ -51,7 +51,7 @@ public:
     uint64_t foldersDeleted;
 
 private:
-    Yuni::Mutex pMutex;
+    std::mutex pMutex;
     int64_t pDateLimit;
 
 }; // class AntaresStudy

--- a/src/tools/vacuum/modified-inode.cpp
+++ b/src/tools/vacuum/modified-inode.cpp
@@ -224,11 +224,12 @@ void ModifiedINode::userdataDestroy(void* userdata)
 
     if (userdata)
     {
-        pMutex.lock();
-        bytesDeleted += ((UserData*)userdata)->bytesDeleted;
-        filesDeleted += ((UserData*)userdata)->filesDeleted;
-        foldersDeleted += ((UserData*)userdata)->foldersDeleted;
-        pMutex.unlock();
+        {
+            std::lock_guard lock(pMutex);
+            bytesDeleted += ((UserData*)userdata)->bytesDeleted;
+            filesDeleted += ((UserData*)userdata)->filesDeleted;
+            foldersDeleted += ((UserData*)userdata)->foldersDeleted;
+        }
 
         // destroying the user data
         ((UserData*)userdata)->syncBeforeRelease();

--- a/src/tools/vacuum/modified-inode.h
+++ b/src/tools/vacuum/modified-inode.h
@@ -21,7 +21,7 @@
 #ifndef __MODIFIED_INODE_H__
 #define __MODIFIED_INODE_H__
 
-#include <yuni/yuni.h>
+#include <mutex>
 #include <fswalker/fswalker.h>
 
 class ModifiedINode : public FSWalker::IExtension
@@ -46,7 +46,7 @@ public:
     uint64_t foldersDeleted;
 
 private:
-    Yuni::Mutex pMutex;
+    std::mutex pMutex;
     int64_t pDateLimit;
     FSWalker::DispatchJobEvent pQueue;
 

--- a/src/tools/yby-aggregator/job.cpp
+++ b/src/tools/yby-aggregator/job.cpp
@@ -21,6 +21,7 @@
 
 #include "job.h"
 #include <antares/logs/logs.h>
+#include <mutex>
 #include "progress.h"
 
 using namespace Yuni;
@@ -31,7 +32,7 @@ static std::atomic<int> gNbJobs = 0;
 
 #define SEP IO::Separator
 
-Yuni::Mutex gResultsMutex;
+std::mutex gResultsMutex;
 
 bool JobFileReader::RemainJobsToExecute()
 {
@@ -278,7 +279,7 @@ bool JobFileReader::storeResults()
     if (!pLineCount)
         return false;
 
-    Yuni::MutexLocker locker(gResultsMutex);
+    std::lock_guard locker(gResultsMutex);
 
     // The total number of variables
     const uint nbVars = (uint)output->columns.size();


### PR DESCRIPTION
- #1780 
- Avoid int/uint comparison (g++-13 warning)
- Avoid copying `std::shared_ptr`, use reference instead (g++-13 warning)