### PR TITLE
[SONAR] Use 4 threads for analysis instead of 2

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,4 +17,4 @@ sonar.coverage.exclusions=src/ext/**,src/tests/**,src/analyzer/**,src/distrib/**
 
 sonar.cfamily.build-wrapper-output=_build/output
 sonar.coverageReportPaths=coverage.xml
-sonar.cfamily.threads=2
+sonar.cfamily.threads=4


### PR DESCRIPTION
GH hosted runners for Linux now have 4 threads and 16GB RAM, see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

This should speed up analysis a bit.