### PR TITLE
Lay the groundwork for Scenarization@POC

### DIFF
--- a/src/solver/optim/api/LinearProblemBuilder.cpp
+++ b/src/solver/optim/api/LinearProblemBuilder.cpp
@@ -11,8 +11,10 @@ void LinearProblemBuilder::addFiller(std::shared_ptr<LinearProblemFiller> filler
     fillers_.push_back(filler);
 }
 
-void LinearProblemBuilder::build(const LinearProblemData& data) {
-    if (built) {
+void LinearProblemBuilder::build(const LinearProblemData::YearView& data)
+{
+    if (built)
+    {
         // TODO
         throw;
     }
@@ -31,9 +33,11 @@ void LinearProblemBuilder::build(const LinearProblemData& data) {
     built = true;
 }
 
-void LinearProblemBuilder::update(const LinearProblemData& data) const {
+void LinearProblemBuilder::update(const LinearProblemData::YearView& data) const
+{
     // TODO : throw if timestamps have changed ?
-    if (!built) {
+    if (!built)
+    {
         // TODO
         throw;
     }
@@ -46,7 +50,8 @@ void LinearProblemBuilder::update(const LinearProblemData& data) const {
 MipSolution LinearProblemBuilder::solve(const operations_research::MPSolverParameters& param)
 {
     // TODO : move to new interface LinearProblemSolver ??
-    if (!built) {
+    if (!built)
+    {
         // TODO
         throw;
     }

--- a/src/solver/optim/api/include/antares/optim/api/LinearProblemBuilder.h
+++ b/src/solver/optim/api/include/antares/optim/api/LinearProblemBuilder.h
@@ -31,17 +31,18 @@
 
 namespace Antares::optim::api
 {
-    class LinearProblemBuilder final
-    {
-    private:
-        LinearProblem* linearProblem_;
-        std::vector<std::shared_ptr<LinearProblemFiller>> fillers_{};
-        bool built = false;
-    public:
-        explicit LinearProblemBuilder(LinearProblem& linearProblem) : linearProblem_(&linearProblem) {};
-        void addFiller(std::shared_ptr<LinearProblemFiller> filler);
-        void build(const LinearProblemData& data);
-        void update(const LinearProblemData& data) const;
-        MipSolution solve(const operations_research::MPSolverParameters& param);
-    };
-}
+class LinearProblemBuilder final
+{
+private:
+    LinearProblem* linearProblem_;
+    std::vector<std::shared_ptr<LinearProblemFiller>> fillers_{};
+    bool built = false;
+
+public:
+    explicit LinearProblemBuilder(LinearProblem& linearProblem) : linearProblem_(&linearProblem){};
+    void addFiller(std::shared_ptr<LinearProblemFiller> filler);
+    void build(const LinearProblemData::YearView& data);
+    void update(const LinearProblemData::YearView& data) const;
+    MipSolution solve(const operations_research::MPSolverParameters& param);
+};
+} // namespace Antares::optim::api

--- a/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
+++ b/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
@@ -42,14 +42,20 @@ public:
     {
     public:
         GroupedData() = default;
+
+        // One single scenario. Remove ?
         template<class T>
         GroupedData(const T& v) : values({v})
         {
         }
+
+        // One single scenario. Remove ?
         template<class T>
         GroupedData(T&& v) : values({v})
         {
         }
+
+        // Kept for compat. Remove ?
         template<class T>
         GroupedData(std::initializer_list<T> v) : values({v})
         {
@@ -98,7 +104,9 @@ public:
                                int timeResolutionInMinutes,
                                const ScalarDataDict& scalarData,
                                const TimedDataDict& timedData,
+                               // Default value = one single scenario, no groups
                                const GroupYearToIndex& groupToYear = {{"", {{0, 0}}}}) :
+
      timeStamps_(timeStamps),
      timeResolutionInMinutes_(timeResolutionInMinutes),
      scalarData_(scalarData),
@@ -107,7 +115,7 @@ public:
        // TODO: some coherence check on data
        // for example, check that timed data are all of same size = size of timeStamps_
      };
-    [[nodiscard]] std::vector<int> getTimeStamps() const
+    [[nodiscard]] const std::vector<int>& getTimeStamps() const
     {
         return timeStamps_;
     }
@@ -200,6 +208,7 @@ public:
         std::map<std::string, std::reference_wrapper<const std::vector<double>>> timedData_;
     };
 
+    // TODO cache for this ?
     YearView operator[](std::size_t year) const
     {
         return YearView(*this, year);

--- a/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
+++ b/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
@@ -109,9 +109,17 @@ public:
         return timeResolutionInMinutes_;
     }
 
+    // TODO use cache ?
     inline std::set<std::string> groups() const
     {
-        return {""}; // TODO iterate over scalarData and TimedData
+        std::set<std::string> groups;
+        for (const auto& [_, scalar] : scalarData_)
+            groups.insert(scalar.group);
+
+        for (const auto& [_, timed] : timedData_)
+            groups.insert(timed.group);
+
+        return groups;
     }
 
     struct Legacy

--- a/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
+++ b/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
@@ -208,8 +208,5 @@ public:
     // TODO: remove this when legacy support is dropped
     // TODO: meanwhile, instead of having a nested struct, create a daughter class?
     Legacy legacy;
-    // TODO[FOM] Move as argument ?
-    // TODO[FOM] No default value ?
-    unsigned int year_ = 0;
 };
 } // namespace Antares::optim::api

--- a/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
+++ b/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
@@ -28,6 +28,7 @@
 
 #include <utility>
 #include <vector>
+#include <functional>
 
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
@@ -54,11 +55,12 @@ public:
         {
         }
 
-        inline V operator[](std::size_t idx) const
+        inline V& operator[](std::size_t idx)
         {
             return values[idx];
         }
-        inline V& operator[](std::size_t idx)
+
+        inline const V& operator[](std::size_t idx) const
         {
             return values[idx];
         }
@@ -131,12 +133,12 @@ public:
                 unsigned tsIndex = data.groupYearToIndex_.at(group).at(year);
                 for (auto& [key, scalarData] : data.scalarData_)
                 {
-                    scalarData_.insert({key, scalarData[tsIndex]}); // TODO avoid copies
+                    scalarData_.insert({key, scalarData[tsIndex]});
                 }
 
                 for (auto& [key, timedData] : data.timedData_)
                 {
-                    timedData_.insert({key, timedData[tsIndex]}); // TODO avoid copies
+                    timedData_.insert({key, std::cref(timedData[tsIndex])});
                 }
             }
         }
@@ -174,7 +176,7 @@ public:
 
     private:
         std::map<std::string, double> scalarData_;
-        std::map<std::string, std::vector<double>> timedData_;
+        std::map<std::string, std::reference_wrapper<const std::vector<double>>> timedData_;
     };
 
     YearView operator[](std::size_t year) const

--- a/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
+++ b/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
@@ -55,6 +55,12 @@ public:
         {
         }
 
+        template<class T>
+        GroupedData(std::string group, std::initializer_list<T> values) :
+         group(group), values(values)
+        {
+        }
+
         inline V& operator[](std::size_t idx)
         {
             return values[idx];
@@ -91,12 +97,13 @@ public:
     explicit LinearProblemData(const std::vector<int>& timeStamps,
                                int timeResolutionInMinutes,
                                const ScalarDataDict& scalarData,
-                               const TimedDataDict& timedData) :
+                               const TimedDataDict& timedData,
+                               const GroupYearToIndex& groupToYear = {{"", {{0, 0}}}}) :
      timeStamps_(timeStamps),
      timeResolutionInMinutes_(timeResolutionInMinutes),
      scalarData_(scalarData),
      timedData_(timedData),
-     groupYearToIndex_({{"", {{0, 0}}}}){
+     groupYearToIndex_(groupToYear){
        // TODO: some coherence check on data
        // for example, check that timed data are all of same size = size of timeStamps_
      };
@@ -141,12 +148,18 @@ public:
                 unsigned tsIndex = data.groupYearToIndex_.at(group).at(year);
                 for (auto& [key, scalarData] : data.scalarData_)
                 {
-                    scalarData_.insert({key, scalarData[tsIndex]});
+                    if (scalarData.group == group)
+                    {
+                        scalarData_.insert({key, scalarData[tsIndex]});
+                    }
                 }
 
                 for (auto& [key, timedData] : data.timedData_)
                 {
-                    timedData_.insert({key, std::cref(timedData[tsIndex])});
+                    if (timedData.group == group)
+                    {
+                        timedData_.insert({key, std::cref(timedData[tsIndex])});
+                    }
                 }
             }
         }

--- a/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
+++ b/src/solver/optim/api/include/antares/optim/api/LinearProblemData.h
@@ -27,25 +27,32 @@
 #pragma once
 
 #include <utility>
-#include "antares/solver/simulation/sim_structure_probleme_economique.h"
+#include <vector>
 
-#include "vector"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 namespace Antares::optim::api
 {
     class LinearProblemData final
     {
+    public:
+        using ScalarDataDict = std::map<std::string, double>;
+
+        using TimedData = std::vector<double>;
+        using TimedDataDict = std::map<std::string, TimedData>;
+
     private:
         // TODO : timestamps or timesteps?
         std::vector<int> timeStamps_;
         int timeResolutionInMinutes_;
-        std::map<std::string, double> scalarData_;
-        std::map<std::string, std::vector<double>> timedData_;
+
+        ScalarDataDict scalarData_;
+        TimedDataDict timedData_;
         // TODO : handle scenarios, and data vectorized on scenarios, on time, or on both
     public:
         explicit LinearProblemData(const std::vector<int> &timeStamps, int timeResolutionInMinutes,
-                                   const std::map<std::string, double> &scalarData,
-                                   const std::map<std::string, std::vector<double>> &timedData) :
+                                   const ScalarDataDict& scalarData,
+                                   const TimedDataDict& timedData) :
                 timeStamps_(timeStamps), timeResolutionInMinutes_(timeResolutionInMinutes),
                 scalarData_(scalarData), timedData_(timedData)
         {
@@ -57,7 +64,7 @@ namespace Antares::optim::api
         [[nodiscard]] bool hasScalarData(const std::string& key) const { return scalarData_.contains(key); }
         [[nodiscard]] double getScalarData(const std::string& key) const { return scalarData_.at(key); }
         [[nodiscard]] bool hasTimedData(const std::string& key) const { return timedData_.contains(key); }
-        [[nodiscard]] const std::vector<double>& getTimedData(const std::string& key) const { return timedData_.at(key); }
+        [[nodiscard]] const TimedData& getTimedData(const std::string& key) const { return timedData_.at(key); }
 
         // TODO: remove this when legacy support is dropped
         // TODO: meanwhile, instead of having a nested struct, create a daughter class?

--- a/src/solver/optim/api/include/antares/optim/api/LinearProblemFiller.h
+++ b/src/solver/optim/api/include/antares/optim/api/LinearProblemFiller.h
@@ -31,20 +31,23 @@
 
 namespace Antares::optim::api
 {
-    class LinearProblemFiller
-    {
-    public:
-        virtual void addVariables(LinearProblem& problem, const LinearProblemData& data) = 0;
-        virtual void addConstraints(LinearProblem& problem, const LinearProblemData& data) = 0;
-        virtual void addObjective(LinearProblem& problem, const LinearProblemData& data) = 0;
-        virtual void update(LinearProblem& problem, const LinearProblemData& data) = 0;
-        // TODO : see if update is really needed in target solution
-        // Currently used to update the MIP from week to week by only changing LB/UB & coefs
-        // (see sim_structure_contrainte_economique.h & ApportNaturelHoraire)
-        // This may be dropped in the target solution (thus we'll have to re-create the MIP) for 2 reasons:
-        // - we may have to add/remove variables & constraints
-        // - OR-Tools does not allow changing the names of variables & constraints, which is necessary if we want the
-        //   variables & constraints to be indexed by the number of the week in the year
-        virtual ~LinearProblemFiller() = default;
-    };
-}
+class LinearProblemFiller
+{
+public:
+    virtual void addVariables(LinearProblem& problem, const LinearProblemData::YearView& data) = 0;
+    virtual void addConstraints(LinearProblem& problem, const LinearProblemData::YearView& data)
+      = 0;
+    virtual void addObjective(LinearProblem& problem, const LinearProblemData::YearView& data) = 0;
+    virtual void update(LinearProblem& problem, const LinearProblemData::YearView& data) = 0;
+    // TODO : see if update is really needed in target solution
+    // Currently used to update the MIP from week to week by only changing LB/UB & coefs
+    // (see sim_structure_contrainte_economique.h & ApportNaturelHoraire)
+    // This may be dropped in the target solution (thus we'll have to re-create the MIP) for 2
+    // reasons:
+    // - we may have to add/remove variables & constraints
+    // - OR-Tools does not allow changing the names of variables & constraints, which is necessary
+    // if we want the
+    //   variables & constraints to be indexed by the number of the week in the year
+    virtual ~LinearProblemFiller() = default;
+};
+} // namespace Antares::optim::api

--- a/src/solver/optim/impl/include/antares/optim/impl/LinearProblemImpl.h
+++ b/src/solver/optim/impl/include/antares/optim/impl/LinearProblemImpl.h
@@ -36,16 +36,28 @@ protected:
     operations_research::MPSolver* mpSolver{};
     // TODO: remove this constructor when legacy support is dropped
     LinearProblemImpl();
-public :
+
+public:
     LinearProblemImpl(bool isMip, const std::string& solverName);
-    operations_research::MPVariable& addNumVariable(std::string name, double lb, double ub) override;
-    operations_research::MPVariable& addIntVariable(std::string name, double lb, double ub) override;
+    operations_research::MPVariable& addNumVariable(std::string name,
+                                                    double lb,
+                                                    double ub) override;
+    operations_research::MPVariable& addIntVariable(std::string name,
+                                                    double lb,
+                                                    double ub) override;
     operations_research::MPVariable& getVariable(std::string name) override;
-    operations_research::MPConstraint& addConstraint(std::string name, double lb, double ub) override;
-    operations_research::MPConstraint& addBalanceConstraint(std::string name, double bound, std::string nodeName, int timestep) override;
+    operations_research::MPConstraint& addConstraint(std::string name,
+                                                     double lb,
+                                                     double ub) override;
+    operations_research::MPConstraint& addBalanceConstraint(std::string name,
+                                                            double bound,
+                                                            std::string nodeName,
+                                                            int timestep) override;
     operations_research::MPConstraint& getConstraint(std::string name) override;
-    void setObjectiveCoefficient(const operations_research::MPVariable& variable, double coefficient) override;
+    void setObjectiveCoefficient(const operations_research::MPVariable& variable,
+                                 double coefficient) override;
     void setMinimization(bool isMinim) override;
-    Antares::optim::api::MipSolution solve(const operations_research::MPSolverParameters& param) override;
+    Antares::optim::api::MipSolution solve(
+      const operations_research::MPSolverParameters& param) override;
     virtual ~LinearProblemImpl() override;
 };

--- a/src/solver/optimisation/LegacyLinearProblemFillerImpl.cpp
+++ b/src/solver/optimisation/LegacyLinearProblemFillerImpl.cpp
@@ -30,57 +30,64 @@
 
 using namespace Antares::optim::api;
 
-void LegacyLinearProblemFillerImpl::addVariables(LinearProblem& problem, const LinearProblemData& data)
+void LegacyLinearProblemFillerImpl::addVariables(LinearProblem& problem,
+                                                 const LinearProblemData::YearView& data)
 {
-    // For now, only one "fill" method is developed in order for the legacy problem to fill the ORTools matrix
-    // It is called here since addVariables is called first in problem builder
-    // If needed, we shall split it up in three functions
-    // Also, no "fill(linearProblem)" has been developed yet, so we are casting the linearProblem and fetching its
-    // underlying MPSolver object in order to fill it. If needed, we should change this in the future.
+    // For now, only one "fill" method is developed in order for the legacy problem to fill the
+    // ORTools matrix It is called here since addVariables is called first in problem builder If
+    // needed, we shall split it up in three functions Also, no "fill(linearProblem)" has been
+    // developed yet, so we are casting the linearProblem and fetching its underlying MPSolver
+    // object in order to fill it. If needed, we should change this in the future.
     Antares::Optimization::ProblemSimplexeNommeConverter converter("mock", legacyProblem_);
-    if (auto *legacyLinearProblem = dynamic_cast<LegacyLinearProblemImpl *>(&problem)) {
+    if (auto* legacyLinearProblem = dynamic_cast<LegacyLinearProblemImpl*>(&problem))
+    {
         converter.Fill(legacyLinearProblem->getMpSolver());
         declareBalanceConstraints(legacyLinearProblem, data.legacy);
-    } else {
+    }
+    else
+    {
         // throw
     }
 };
 
-void LegacyLinearProblemFillerImpl::addConstraints(LinearProblem& problem, const LinearProblemData& data)
-{
-// nothing to do: everything has been done in addVariables
+void LegacyLinearProblemFillerImpl::addConstraints(LinearProblem& problem,
+                                                   const LinearProblemData::YearView& data){
+  // nothing to do: everything has been done in addVariables
 };
 
-void LegacyLinearProblemFillerImpl::addObjective(LinearProblem& problem, const LinearProblemData& data)
+void LegacyLinearProblemFillerImpl::addObjective(LinearProblem& problem,
+                                                 const LinearProblemData::YearView& data)
 {
-// nothing to do: everything has been done in addVariables
+    // nothing to do: everything has been done in addVariables
 }
 
-void LegacyLinearProblemFillerImpl::update(LinearProblem& problem, const LinearProblemData& data)
+void LegacyLinearProblemFillerImpl::update(LinearProblem& problem,
+                                           const LinearProblemData::YearView& data)
 {
-// TODO
+    // TODO
 }
 
-// TODO move to class LegacyLinearProblem? Maybe simpler if we don't need the "update" method after all
+// TODO move to class LegacyLinearProblem? Maybe simpler if we don't need the "update" method after
+// all
 
-// Tell the LegacyLinearProblem what the balance constraints are, in order to be able to add new models to existing nodes
-void LegacyLinearProblemFillerImpl::declareBalanceConstraints(LegacyLinearProblemImpl *legacyLinearProblem,
-                                                              const LinearProblemData::Legacy& legacy)
+// Tell the LegacyLinearProblem what the balance constraints are, in order to be able to add new
+// models to existing nodes
+void LegacyLinearProblemFillerImpl::declareBalanceConstraints(
+  LegacyLinearProblemImpl* legacyLinearProblem,
+  const LinearProblemData::Legacy& legacy)
 {
-   const auto* solver = legacyLinearProblem->getMpSolver();
-   auto* constraintMapping = legacy.constraintMapping;
+    const auto* solver = legacyLinearProblem->getMpSolver();
+    auto* constraintMapping = legacy.constraintMapping;
 
-   for (unsigned int timestamp = 0; timestamp < constraintMapping->size(); timestamp++)
-   {
-       const auto& BalanceAtT = constraintMapping->at(timestamp).NumeroDeContrainteDesBilansPays;
-       for (unsigned areaIndex = 0; areaIndex < BalanceAtT.size(); areaIndex++)
-       {
-           int cnt = BalanceAtT[areaIndex];
-           operations_research::MPConstraint* constraint = solver->constraint(cnt);
-           legacyLinearProblem->declareBalanceConstraint(std::string(legacy.areaNames->at(areaIndex)), timestamp, constraint);
-       }
-   }
+    for (unsigned int timestamp = 0; timestamp < constraintMapping->size(); timestamp++)
+    {
+        const auto& BalanceAtT = constraintMapping->at(timestamp).NumeroDeContrainteDesBilansPays;
+        for (unsigned areaIndex = 0; areaIndex < BalanceAtT.size(); areaIndex++)
+        {
+            int cnt = BalanceAtT[areaIndex];
+            operations_research::MPConstraint* constraint = solver->constraint(cnt);
+            legacyLinearProblem->declareBalanceConstraint(
+              std::string(legacy.areaNames->at(areaIndex)), timestamp, constraint);
+        }
+    }
 }
-
-
-

--- a/src/solver/optimisation/LegacyLinearProblemFillerImpl.h
+++ b/src/solver/optimisation/LegacyLinearProblemFillerImpl.h
@@ -34,11 +34,19 @@ class LegacyLinearProblemFillerImpl final : public Antares::optim::api::LinearPr
 {
 private:
     const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* legacyProblem_;
-    static void declareBalanceConstraints(LegacyLinearProblemImpl* legacyLinearProblem, const LinearProblemData::Legacy& legacy);
+    static void declareBalanceConstraints(LegacyLinearProblemImpl* legacyLinearProblem,
+                                          const LinearProblemData::Legacy& legacy);
+
 public:
-    explicit LegacyLinearProblemFillerImpl(const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* legacyProblem) : legacyProblem_(legacyProblem) {};
-    void addVariables(Antares::optim::api::LinearProblem& problem, const Antares::optim::api::LinearProblemData& data) override;
-    void addConstraints(Antares::optim::api::LinearProblem& problem, const Antares::optim::api::LinearProblemData& data) override;
-    void addObjective(Antares::optim::api::LinearProblem& problem, const Antares::optim::api::LinearProblemData& data) override;
-    void update(Antares::optim::api::LinearProblem& problem, const Antares::optim::api::LinearProblemData& data) override;
+    explicit LegacyLinearProblemFillerImpl(
+      const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* legacyProblem) :
+     legacyProblem_(legacyProblem){};
+    void addVariables(Antares::optim::api::LinearProblem& problem,
+                      const Antares::optim::api::LinearProblemData::YearView& data) override;
+    void addConstraints(Antares::optim::api::LinearProblem& problem,
+                        const Antares::optim::api::LinearProblemData::YearView& data) override;
+    void addObjective(Antares::optim::api::LinearProblem& problem,
+                      const Antares::optim::api::LinearProblemData::YearView& data) override;
+    void update(Antares::optim::api::LinearProblem& problem,
+                const Antares::optim::api::LinearProblemData::YearView& data) override;
 };

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -96,19 +96,17 @@ struct SimplexResult
     mpsWriterFactory mps_writer_factory;
 };
 
-static SimplexResult OPT_TryToCallSimplex(
-        const OptimizationOptions& options,
-        PROBLEME_HEBDO* problemeHebdo,
-        Optimization::PROBLEME_SIMPLEXE_NOMME& Probleme,
-        const int NumIntervalle,
-        const int optimizationNumber,
-        const OptPeriodStringGenerator& optPeriodStringGenerator,
-        bool PremierPassage,
-        IResultWriter& writer)
+static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
+                                          PROBLEME_HEBDO* problemeHebdo,
+                                          Optimization::PROBLEME_SIMPLEXE_NOMME& Probleme,
+                                          const int NumIntervalle,
+                                          const int optimizationNumber,
+                                          const OptPeriodStringGenerator& optPeriodStringGenerator,
+                                          bool PremierPassage,
+                                          IResultWriter& writer)
 {
     const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
-    auto ProbSpx
-            = (PROBLEME_SPX*)(ProblemeAResoudre->ProblemesSpx[(int)NumIntervalle]);
+    auto ProbSpx = (PROBLEME_SPX*)(ProblemeAResoudre->ProblemesSpx[(int)NumIntervalle]);
     auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[(int)NumIntervalle]);
 
     const int opt = optimizationNumber - 1;
@@ -154,8 +152,9 @@ static SimplexResult OPT_TryToCallSimplex(
             if (options.useOrtools)
             {
                 // TODO comment gérer le update ??? => ajouter une méthode update à LinearProblem ?
-                ORTOOLS_ModifierLeVecteurCouts(
-                        solver, ProblemeAResoudre->CoutLineaire.data(), ProblemeAResoudre->NombreDeVariables);
+                ORTOOLS_ModifierLeVecteurCouts(solver,
+                                               ProblemeAResoudre->CoutLineaire.data(),
+                                               ProblemeAResoudre->NombreDeVariables);
                 ORTOOLS_ModifierLeVecteurSecondMembre(solver,
                                                       ProblemeAResoudre->SecondMembre.data(),
                                                       ProblemeAResoudre->Sens.data(),
@@ -168,8 +167,9 @@ static SimplexResult OPT_TryToCallSimplex(
             }
             else
             {
-                SPX_ModifierLeVecteurCouts(
-                        ProbSpx, ProblemeAResoudre->CoutLineaire.data(), ProblemeAResoudre->NombreDeVariables);
+                SPX_ModifierLeVecteurCouts(ProbSpx,
+                                           ProblemeAResoudre->CoutLineaire.data(),
+                                           ProblemeAResoudre->NombreDeVariables);
                 SPX_ModifierLeVecteurSecondMembre(ProbSpx,
                                                   ProblemeAResoudre->SecondMembre.data(),
                                                   ProblemeAResoudre->Sens.data(),
@@ -196,7 +196,7 @@ static SimplexResult OPT_TryToCallSimplex(
     Probleme.NombreDeTermesDesLignes = ProblemeAResoudre->NombreDeTermesDesLignes.data();
     Probleme.IndicesColonnes = ProblemeAResoudre->IndicesColonnes.data();
     Probleme.CoefficientsDeLaMatriceDesContraintes
-            = ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes.data();
+      = ProblemeAResoudre->CoefficientsDeLaMatriceDesContraintes.data();
     Probleme.Sens = ProblemeAResoudre->Sens.data();
     Probleme.SecondMembre = ProblemeAResoudre->SecondMembre.data();
 
@@ -204,7 +204,7 @@ static SimplexResult OPT_TryToCallSimplex(
 
     Probleme.TypeDePricing = PRICING_STEEPEST_EDGE;
 
-    Probleme.FaireDuScaling = ( PremierPassage ? OUI_SPX : NON_SPX );
+    Probleme.FaireDuScaling = (PremierPassage ? OUI_SPX : NON_SPX);
 
     Probleme.StrategieAntiDegenerescence = AGRESSIF;
 
@@ -226,7 +226,8 @@ static SimplexResult OPT_TryToCallSimplex(
     LinearProblemBuilder linearProblemBuilder(legacyLinearProblem);
     if (options.useOrtools)
     {
-        auto filler = std::make_shared<LegacyLinearProblemFillerImpl>(&Probleme); // TODO: merge this with LegacyLinearProblemImpl ?
+        auto filler = std::make_shared<LegacyLinearProblemFillerImpl>(
+          &Probleme); // TODO: merge this with LegacyLinearProblemImpl ?
         linearProblemBuilder.addFiller(filler);
         // TODO: we can add extra fillers here
         for (const auto& additionalFiller : gAdditionalFillers)
@@ -234,13 +235,15 @@ static SimplexResult OPT_TryToCallSimplex(
 
         // sinon renvoyer le builder ou le problem à une autre classe
         // Required for the balance constraint indices
-        gLinearProblemData.legacy.constraintMapping = &problemeHebdo->CorrespondanceCntNativesCntOptim;
+        gLinearProblemData.legacy.constraintMapping
+          = &problemeHebdo->CorrespondanceCntNativesCntOptim;
         gLinearProblemData.legacy.areaNames = &problemeHebdo->NomsDesPays;
         // TODO : add data here
-        linearProblemBuilder.build(gLinearProblemData);
+        linearProblemBuilder.build(gLinearProblemData[problemeHebdo->year]);
         solver = legacyLinearProblem.getMpSolver();
-        // TODO: because of LinearProblemImpl's destructor, when we exit this scope, the MPSolver instance is destroyed
-        // We have to work around this in order for the current "update" methods to work
+        // TODO: because of LinearProblemImpl's destructor, when we exit this scope, the MPSolver
+        // instance is destroyed We have to work around this in order for the current "update"
+        // methods to work
     }
     const std::string filename = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
 
@@ -258,10 +261,7 @@ static SimplexResult OPT_TryToCallSimplex(
     if (options.useOrtools)
     {
         const bool keepBasis = (optimizationNumber == PREMIERE_OPTIMISATION);
-        solver = ORTOOLS_Simplexe(&Probleme,
-                                  solver,
-                                  linearProblemBuilder,
-                                  keepBasis);
+        solver = ORTOOLS_Simplexe(&Probleme, solver, linearProblemBuilder, keepBasis);
         if (solver != nullptr)
         {
             ProblemeAResoudre->ProblemesSpx[NumIntervalle] = (void*)solver;
@@ -300,8 +300,9 @@ static SimplexResult OPT_TryToCallSimplex(
             {
                 logs.info() << " solver: resetting";
             }
-            return {.success=false, .timeMeasure=timeMeasure,
-                    .mps_writer_factory=mps_writer_factory};
+            return {.success = false,
+                    .timeMeasure = timeMeasure,
+                    .mps_writer_factory = mps_writer_factory};
         }
 
         else
@@ -309,8 +310,7 @@ static SimplexResult OPT_TryToCallSimplex(
             throw FatalError("Internal error: insufficient memory");
         }
     }
-    return {.success=true, .timeMeasure=timeMeasure,
-            .mps_writer_factory=mps_writer_factory};
+    return {.success = true, .timeMeasure = timeMeasure, .mps_writer_factory = mps_writer_factory};
 }
 
 bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
@@ -331,16 +331,27 @@ bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
 
     bool PremierPassage = true;
 
-    SimplexResult simplexResult =
-        OPT_TryToCallSimplex(options, problemeHebdo, Probleme, NumIntervalle, optimizationNumber,
-                optPeriodStringGenerator, PremierPassage, writer);
+    SimplexResult simplexResult = OPT_TryToCallSimplex(options,
+                                                       problemeHebdo,
+                                                       Probleme,
+                                                       NumIntervalle,
+                                                       optimizationNumber,
+                                                       optPeriodStringGenerator,
+                                                       PremierPassage,
+                                                       writer);
 
     if (!simplexResult.success)
     {
         // TODO : why ??
         PremierPassage = false;
-        simplexResult = OPT_TryToCallSimplex(options, problemeHebdo, Probleme,  NumIntervalle, optimizationNumber,
-                optPeriodStringGenerator, PremierPassage, writer);
+        simplexResult = OPT_TryToCallSimplex(options,
+                                             problemeHebdo,
+                                             Probleme,
+                                             NumIntervalle,
+                                             optimizationNumber,
+                                             optPeriodStringGenerator,
+                                             PremierPassage,
+                                             writer);
     }
 
     if (ProblemeAResoudre->ExistenceDUneSolution == OUI_SPX)
@@ -399,14 +410,16 @@ bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
         Probleme.SetUseNamedProblems(true);
 
         // Analyse d'infaisa en clonant le MPSolver existant => on peut ignorer ça pour l'instant
-        auto MPproblem = std::shared_ptr<MPSolver>(ProblemSimplexeNommeConverter(options.solverName, &Probleme).Convert());
+        auto MPproblem = std::shared_ptr<MPSolver>(
+          ProblemSimplexeNommeConverter(options.solverName, &Probleme).Convert());
 
         auto analyzer = makeUnfeasiblePbAnalyzer();
         analyzer->run(MPproblem.get());
         analyzer->printReport();
 
         auto mps_writer_on_error = simplexResult.mps_writer_factory.createOnOptimizationError();
-        const std::string filename = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
+        const std::string filename
+          = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
         mps_writer_on_error->runIfNeeded(writer, filename);
 
         return false;

--- a/src/tests/poc/include/simple/Balance.h
+++ b/src/tests/poc/include/simple/Balance.h
@@ -14,57 +14,70 @@ class Balance : public LinearProblemFiller
 private:
     string nodeName_;
     vector<shared_ptr<Battery>> batteries_; // sera remplacé par la notion de ports
-    vector<shared_ptr<Thermal>> thermals_; // sera remplacé par la notion de ports
+    vector<shared_ptr<Thermal>> thermals_;  // sera remplacé par la notion de ports
 public:
-    Balance(string nodeName, vector<shared_ptr<Battery>> batteries, vector<shared_ptr<Thermal>> thermals) :
-            nodeName_(std::move(nodeName)), batteries_(std::move(batteries)), thermals_(std::move(thermals)) {};
-    void addVariables(LinearProblem& problem, const LinearProblemData& data) override;
-    void addConstraints(LinearProblem& problem, const LinearProblemData& data) override;
-    void addObjective(LinearProblem& problem, const LinearProblemData& data) override;
-    void update(LinearProblem& problem, const LinearProblemData& data) override;
+    Balance(string nodeName,
+            vector<shared_ptr<Battery>> batteries,
+            vector<shared_ptr<Thermal>> thermals) :
+     nodeName_(std::move(nodeName)),
+     batteries_(std::move(batteries)),
+     thermals_(std::move(thermals)){};
+    void addVariables(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void addConstraints(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void addObjective(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void update(LinearProblem& problem, const LinearProblemData::YearView& data) override;
 };
 
-void Balance::addVariables(LinearProblem& problem, const LinearProblemData& data)
+void Balance::addVariables(LinearProblem& problem, const LinearProblemData::YearView& data)
 {
     // nothing to do
 }
 
-void Balance::addConstraints(LinearProblem& problem, const LinearProblemData& data)
+void Balance::addConstraints(LinearProblem& problem, const LinearProblemData::YearView& data)
 {
-    if (!data.hasTimedData("consumption_" + nodeName_)) {
+    if (!data.hasTimedData("consumption_" + nodeName_))
+    {
         throw;
     }
     auto consumption = data.getTimedData("consumption_" + nodeName_);
-    // <!> IMPORTANT : we have to use the convention -production = -consumption, in order to be compatible
-    // with the legacy code's balance constraint
-    for (auto ts : data.getTimeStamps()) {
-        auto balanceConstraint =
-                &problem.addBalanceConstraint("Balance_" + nodeName_ + "_" + to_string(ts), -consumption[ts], nodeName_, ts);
+    // <!> IMPORTANT : we have to use the convention -production = -consumption, in order to be
+    // compatible with the legacy code's balance constraint
+    for (auto ts : data.getTimeStamps())
+    {
+        auto balanceConstraint = &problem.addBalanceConstraint(
+          "Balance_" + nodeName_ + "_" + to_string(ts), -consumption[ts], nodeName_, ts);
 
-        for (const auto& battery : batteries_) {
+        for (const auto& battery : batteries_)
+        {
             auto p = &problem.getVariable(battery->getPVarName(ts));
             balanceConstraint->SetCoefficient(p, -1);
         }
-        for (const auto& thermal : thermals_) {
+        for (const auto& thermal : thermals_)
+        {
             auto p = &problem.getVariable(thermal->getPVarName(ts));
             balanceConstraint->SetCoefficient(p, -1);
         }
     }
 }
 
-void Balance::addObjective(Antares::optim::api::LinearProblem& problem, const LinearProblemData& data)
+void Balance::addObjective(Antares::optim::api::LinearProblem& problem,
+                           const LinearProblemData::YearView& data)
 {
     // nothing to do
 }
 
-void Balance::update(Antares::optim::api::LinearProblem& problem, const LinearProblemData& data)
+void Balance::update(Antares::optim::api::LinearProblem& problem,
+                     const LinearProblemData::YearView& data)
 {
-    if (!data.hasTimedData("consumption_" + nodeName_)) {
+    if (!data.hasTimedData("consumption_" + nodeName_))
+    {
         throw;
     }
     auto consumption = data.getTimedData("consumption_" + nodeName_);
-    for (auto ts : data.getTimeStamps()) {
-        auto balanceConstraint = &problem.getConstraint("Balance_" + nodeName_ + "_" + to_string(ts));
+    for (auto ts : data.getTimeStamps())
+    {
+        auto balanceConstraint
+          = &problem.getConstraint("Balance_" + nodeName_ + "_" + to_string(ts));
         balanceConstraint->SetLB(consumption[ts]);
         balanceConstraint->SetUB(consumption[ts]);
     }

--- a/src/tests/poc/include/simple/Battery.h
+++ b/src/tests/poc/include/simple/Battery.h
@@ -16,24 +16,28 @@ private:
     double maxStock_;
     vector<string> pVarNames;
     vector<string> stockVarNames;
-public:
-    Battery(string id, double maxP, double maxStock) : id_(std::move(id)), maxP_(maxP), maxStock_(maxStock)
-    {
 
-    };
-    void addVariables(LinearProblem& problem, const LinearProblemData& data) override;
-    void addConstraints(LinearProblem& problem, const LinearProblemData& data) override;
-    void addObjective(LinearProblem& problem, const LinearProblemData& data) override;
-    void update(LinearProblem& problem, const LinearProblemData& data) override;
+public:
+    Battery(string id, double maxP, double maxStock) :
+     id_(std::move(id)),
+     maxP_(maxP),
+     maxStock_(maxStock){
+
+     };
+    void addVariables(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void addConstraints(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void addObjective(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void update(LinearProblem& problem, const LinearProblemData::YearView& data) override;
     string getPVarName(int ts); // sera remplacé par la notion de ports
 };
 
-void Battery::addVariables(LinearProblem& problem, const LinearProblemData& data)
+void Battery::addVariables(LinearProblem& problem, const LinearProblemData::YearView& data)
 {
     auto timestamps = data.getTimeStamps();
     pVarNames.reserve(timestamps.size());
     stockVarNames.reserve(timestamps.size());
-    for (auto ts : timestamps) {
+    for (auto ts : timestamps)
+    {
         string pVarName = "P_" + id_ + "_" + to_string(ts);
         problem.addNumVariable(pVarName, -maxP_, maxP_);
         // - charge
@@ -46,13 +50,15 @@ void Battery::addVariables(LinearProblem& problem, const LinearProblemData& data
     }
 }
 
-void Battery::addConstraints(LinearProblem& problem, const LinearProblemData& data)
+void Battery::addConstraints(LinearProblem& problem, const LinearProblemData::YearView& data)
 {
-    if (!data.hasScalarData("initialStock_" + id_)) {
+    if (!data.hasScalarData("initialStock_" + id_))
+    {
         throw;
     }
     double initialStock = data.getScalarData("initialStock_" + id_);
-    for (auto ts : data.getTimeStamps()) {
+    for (auto ts : data.getTimeStamps())
+    {
         auto p = &problem.getVariable(pVarNames[ts]);
         auto e = &problem.getVariable(stockVarNames[ts]);
 
@@ -73,12 +79,14 @@ void Battery::addConstraints(LinearProblem& problem, const LinearProblemData& da
     }
 }
 
-void Battery::addObjective(Antares::optim::api::LinearProblem& problem, const LinearProblemData& data)
+void Battery::addObjective(Antares::optim::api::LinearProblem& problem,
+                           const LinearProblemData::YearView& data)
 {
     // nothing to do
 }
 
-void Battery::update(Antares::optim::api::LinearProblem& problem, const LinearProblemData& data)
+void Battery::update(Antares::optim::api::LinearProblem& problem,
+                     const LinearProblemData::YearView& data)
 {
     // nothing to do
 }

--- a/src/tests/poc/include/simple/ProductionPriceMinimization.h
+++ b/src/tests/poc/include/simple/ProductionPriceMinimization.h
@@ -13,35 +13,42 @@ class ProductionPriceMinimization : public LinearProblemFiller
 private:
     vector<shared_ptr<Thermal>> thermals_; // sera remplacé par la notion de ports
 public:
-    explicit ProductionPriceMinimization(vector<shared_ptr<Thermal>> thermals) : thermals_(std::move(thermals)) {};
-    void addVariables(LinearProblem& problem, const LinearProblemData& data) override;
-    void addConstraints(LinearProblem& problem, const LinearProblemData& data) override;
-    void addObjective(LinearProblem& problem, const LinearProblemData& data) override;
-    void update(LinearProblem& problem, const LinearProblemData& data) override;
+    explicit ProductionPriceMinimization(vector<shared_ptr<Thermal>> thermals) :
+     thermals_(std::move(thermals)){};
+    void addVariables(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void addConstraints(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void addObjective(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void update(LinearProblem& problem, const LinearProblemData::YearView& data) override;
 };
 
-void ProductionPriceMinimization::addVariables(LinearProblem& problem, const LinearProblemData& data)
+void ProductionPriceMinimization::addVariables(LinearProblem& problem,
+                                               const LinearProblemData::YearView& data)
 {
     // nothing to do
 }
 
-void ProductionPriceMinimization::addConstraints(LinearProblem& problem, const LinearProblemData& data)
+void ProductionPriceMinimization::addConstraints(LinearProblem& problem,
+                                                 const LinearProblemData::YearView& data)
 {
     // nothing to do
 }
 
-void ProductionPriceMinimization::addObjective(Antares::optim::api::LinearProblem& problem, const LinearProblemData& data)
+void ProductionPriceMinimization::addObjective(Antares::optim::api::LinearProblem& problem,
+                                               const LinearProblemData::YearView& data)
 {
     problem.setMinimization(true);
-    for (auto ts : data.getTimeStamps()) {
-        for (const auto& thermal : thermals_) {
+    for (auto ts : data.getTimeStamps())
+    {
+        for (const auto& thermal : thermals_)
+        {
             auto* p = &problem.getVariable(thermal->getPVarName(ts));
             problem.setObjectiveCoefficient(*p, thermal->getPCost(ts));
         }
     }
 }
 
-void ProductionPriceMinimization::update(Antares::optim::api::LinearProblem& problem, const LinearProblemData& data)
+void ProductionPriceMinimization::update(Antares::optim::api::LinearProblem& problem,
+                                         const LinearProblemData::YearView& data)
 {
     // nothing to do
 }

--- a/src/tests/poc/include/simple/Thermal.h
+++ b/src/tests/poc/include/simple/Thermal.h
@@ -15,44 +15,50 @@ private:
     double maxP_;
     vector<double> pCost_; // TODO : put in LinearProblemData ?
     vector<string> pVarNames;
+
 public:
     Thermal(string id, double maxP) : id_(std::move(id)), maxP_(maxP)
-    {}
-    void addVariables(LinearProblem& problem, const LinearProblemData& data) override;
-    void addConstraints(LinearProblem& problem, const LinearProblemData& data) override;
-    void addObjective(LinearProblem& problem, const LinearProblemData& data) override;
-    void update(LinearProblem& problem, const LinearProblemData& data) override;
+    {
+    }
+    void addVariables(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void addConstraints(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void addObjective(LinearProblem& problem, const LinearProblemData::YearView& data) override;
+    void update(LinearProblem& problem, const LinearProblemData::YearView& data) override;
 
     string getPVarName(int ts); // sera remplacé par la notion de ports
-    double getPCost(int ts); // sera remplacé par la notion de ports
+    double getPCost(int ts);    // sera remplacé par la notion de ports
 };
 
-void Thermal::addVariables(LinearProblem& problem, const LinearProblemData& data)
+void Thermal::addVariables(LinearProblem& problem, const LinearProblemData::YearView& data)
 {
     pVarNames.reserve(data.getTimeStamps().size());
-    for (auto ts : data.getTimeStamps()) {
+    for (auto ts : data.getTimeStamps())
+    {
         string pVarName = "P_" + id_ + "_" + to_string(ts);
         problem.addNumVariable(pVarName, 0, maxP_);
         pVarNames.push_back(pVarName);
     }
     // keep cost data for later (will be replaced with ports)
-    if (!data.hasTimedData("cost_" + id_)) {
+    if (!data.hasTimedData("cost_" + id_))
+    {
         throw;
     }
     pCost_ = data.getTimedData("cost_" + id_);
 }
 
-void Thermal::addConstraints(LinearProblem& problem, const LinearProblemData& data)
+void Thermal::addConstraints(LinearProblem& problem, const LinearProblemData::YearView& data)
 {
     // nothing to do
 }
 
-void Thermal::addObjective(Antares::optim::api::LinearProblem& problem, const LinearProblemData& data)
+void Thermal::addObjective(Antares::optim::api::LinearProblem& problem,
+                           const LinearProblemData::YearView& data)
 {
     // nothing to do
 }
 
-void Thermal::update(Antares::optim::api::LinearProblem& problem, const LinearProblemData& data)
+void Thermal::update(Antares::optim::api::LinearProblem& problem,
+                     const LinearProblemData::YearView& data)
 {
     // nothing to do
 }
@@ -66,4 +72,3 @@ double Thermal::getPCost(int ts)
 {
     return pCost_[ts];
 }
-

--- a/src/tests/poc/legacy-workflow/CMakeLists.txt
+++ b/src/tests/poc/legacy-workflow/CMakeLists.txt
@@ -32,9 +32,5 @@ target_include_directories(${EXECUTABLE_NAME}
 							)
 
 add_test(NAME poc-legacy-study COMMAND ${EXECUTABLE_NAME})
-set_property(TEST poc-legacy-study PROPERTY LABELS end-to-end)
+set_property(TEST poc-legacy-study PROPERTY LABELS poc)
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests/poc-legacy-study)
-
-# Storing tests-simple-study under the folder Unit-tests in the IDE
-
-#----------------------------------------------------------

--- a/src/tests/poc/new-workflow/CMakeLists.txt
+++ b/src/tests/poc/new-workflow/CMakeLists.txt
@@ -4,6 +4,10 @@ target_link_libraries(simple-test
         Antares::optim_api
         Antares::optim_impl
         ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+add_test(NAME simple-test COMMAND simple-test)
+set_property(TEST simple-test PROPERTY LABELS poc)
+
+
 
 add_executable(standard-test standard-test.cpp
 )
@@ -12,9 +16,16 @@ target_link_libraries(standard-test
         Antares::optim_impl
         ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
+add_test(NAME standard-test COMMAND standard-test)
+set_property(TEST standard-test PROPERTY LABELS poc)
+
+
 add_executable(scaling-test scaling-test.cpp
 )
 target_link_libraries(scaling-test
         Antares::optim_api
         Antares::optim_impl
         ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
+add_test(NAME scaling-test COMMAND scaling-test)
+set_property(TEST scaling-test PROPERTY LABELS poc)

--- a/src/tests/poc/new-workflow/scaling-test.cpp
+++ b/src/tests/poc/new-workflow/scaling-test.cpp
@@ -15,7 +15,7 @@ using namespace std;
 
 static constexpr std::array solverNames =
         {
-          //                "xpress",
+                "xpress",
                 "sirius",
                 "coin",
                 //"scip" // TODO activate this after adding tolerance

--- a/src/tests/poc/new-workflow/scaling-test.cpp
+++ b/src/tests/poc/new-workflow/scaling-test.cpp
@@ -13,23 +13,24 @@ namespace bdata = boost::unit_test::data;
 using namespace Antares::optim::api;
 using namespace std;
 
-static constexpr std::array solverNames =
-        {
-                "xpress",
-                "sirius",
-                "coin",
-                //"scip" // TODO activate this after adding tolerance
-        };
+static constexpr std::array solverNames = {
+  "xpress",
+  "sirius",
+  "coin",
+  //"scip" // TODO activate this after adding tolerance
+};
 
-static constexpr std::array timestepNumbers =
-        {
-                24, // 1 day
-                168, // 1 week
-                744, // 1 month
-                4380 // 6 months
-        };
+static constexpr std::array timestepNumbers = {
+  24,  // 1 day
+  168, // 1 week
+  744, // 1 month
+  4380 // 6 months
+};
 
-BOOST_DATA_TEST_CASE(test_scaling_simple_problem, bdata::make(solverNames)*bdata::make(timestepNumbers), solverName, nTimesteps)
+BOOST_DATA_TEST_CASE(test_scaling_simple_problem,
+                     bdata::make(solverNames) * bdata::make(timestepNumbers),
+                     solverName,
+                     nTimesteps)
 {
     int timeResolution = 60;
 
@@ -39,7 +40,8 @@ BOOST_DATA_TEST_CASE(test_scaling_simple_problem, bdata::make(solverNames)*bdata
 
     LinearProblemData::TimedDataDict timedData;
 
-    // Build increasing consumption vector beginning at 0 MW, and increasing by 1 MW at every timestep
+    // Build increasing consumption vector beginning at 0 MW, and increasing by 1 MW at every
+    // timestep
     std::vector<double> consumption(nTimesteps);
     std::iota(consumption.begin(), consumption.end(), 1);
     timedData.insert({"consumption_nodeA", consumption});
@@ -49,21 +51,25 @@ BOOST_DATA_TEST_CASE(test_scaling_simple_problem, bdata::make(solverNames)*bdata
     PortConnectionsManager portConnectionsManager;
 
     Component balance("balanceA", BALANCE, {}, {{"nodeName", "nodeA"}});
-    shared_ptr<ComponentFiller> balanceAFiller = make_shared<ComponentFiller>(balance, portConnectionsManager);
+    shared_ptr<ComponentFiller> balanceAFiller
+      = make_shared<ComponentFiller>(balance, portConnectionsManager);
     linearProblemBuilder.addFiller(balanceAFiller);
 
     Component priceMinim("priceMinim", PRICE_MINIM, {}, {});
-    shared_ptr<ComponentFiller> priceMinimFiller = make_shared<ComponentFiller>(priceMinim, portConnectionsManager);
+    shared_ptr<ComponentFiller> priceMinimFiller
+      = make_shared<ComponentFiller>(priceMinim, portConnectionsManager);
     linearProblemBuilder.addFiller(priceMinimFiller);
 
     // Create thermal production units
     // Every unit can produce up to 10 MW
     // Price is stable in time but increase for every unit
     int nUnits = ceil(1.0 * (nTimesteps - 1) / 10.0);
-    for (int i = 1; i <= nUnits; ++i) {
+    for (int i = 1; i <= nUnits; ++i)
+    {
         string id = "thermal" + to_string(i);
         Component thermal(id, THERMAL, {{"maxP", 10}}, {});
-        shared_ptr<ComponentFiller> thermalFiller = make_shared<ComponentFiller>(thermal, portConnectionsManager);
+        shared_ptr<ComponentFiller> thermalFiller
+          = make_shared<ComponentFiller>(thermal, portConnectionsManager);
         vector<double> cost(nTimesteps, 1.0 * i);
         timedData.insert({"cost_" + id, cost});
         linearProblemBuilder.addFiller(thermalFiller);
@@ -72,16 +78,19 @@ BOOST_DATA_TEST_CASE(test_scaling_simple_problem, bdata::make(solverNames)*bdata
     }
 
     LinearProblemData linearProblemData(timeStamps, timeResolution, {}, timedData);
-    linearProblemBuilder.build(linearProblemData);
+    const unsigned int year = 0;
+    linearProblemBuilder.build(linearProblemData[year]);
     auto solution = linearProblemBuilder.solve({});
 
-    for (int i = 1; i <= nUnits; ++i) {
-        string pVarNamePrefix  = "P_thermal" + to_string(i) + "_";
+    for (int i = 1; i <= nUnits; ++i)
+    {
+        string pVarNamePrefix = "P_thermal" + to_string(i) + "_";
         vector<string> pVarNames;
         pVarNames.reserve(nTimesteps);
         vector<double> expectedP;
         expectedP.reserve(nTimesteps);
-        for (int ts: timeStamps) {
+        for (int ts : timeStamps)
+        {
             pVarNames.push_back(pVarNamePrefix + to_string(ts));
             expectedP.push_back(min(10.0, max(0.0, consumption[ts] - (i - 1) * 10)));
         }

--- a/src/tests/poc/new-workflow/scaling-test.cpp
+++ b/src/tests/poc/new-workflow/scaling-test.cpp
@@ -37,7 +37,7 @@ BOOST_DATA_TEST_CASE(test_scaling_simple_problem, bdata::make(solverNames)*bdata
     std::vector<int> timeStamps(nTimesteps);
     std::iota(timeStamps.begin(), timeStamps.end(), 0);
 
-    std::map<std::string, std::vector<double>> timedData;
+    LinearProblemData::TimedDataDict timedData;
 
     // Build increasing consumption vector beginning at 0 MW, and increasing by 1 MW at every timestep
     std::vector<double> consumption(nTimesteps);

--- a/src/tests/poc/new-workflow/scaling-test.cpp
+++ b/src/tests/poc/new-workflow/scaling-test.cpp
@@ -15,7 +15,7 @@ using namespace std;
 
 static constexpr std::array solverNames =
         {
-                "xpress",
+          //                "xpress",
                 "sirius",
                 "coin",
                 //"scip" // TODO activate this after adding tolerance

--- a/src/tests/poc/new-workflow/simple-test.cpp
+++ b/src/tests/poc/new-workflow/simple-test.cpp
@@ -49,11 +49,11 @@ BOOST_DATA_TEST_CASE(test_oneWeek_oneNode_oneBattery_oneThermal,
             timeStamps, // TODO : move to LinearProblem ?
             timeResolution, // TODO : move to LinearProblem ?
             {
-                    {"initialStock_battery1", 0}
+                    {"initialStock_battery1", 0.}
             },
             {
-                    {"consumption_nodeA", {50, 50, 150, 120}},
-                    {"cost_thermal1",     {1,  3,  10,  8}}
+                    {"consumption_nodeA", {50., 50., 150., 120.}},
+                    {"cost_thermal1",     {1.,  3.,  10.,  8.}}
             });
     linearProblemBuilder.build(linearProblemData);
     auto solution = linearProblemBuilder.solve({});
@@ -104,12 +104,12 @@ BOOST_DATA_TEST_CASE(test_oneWeek_oneNode_oneBattery_twoThermals,
             timeStamps, // TODO : move to LinearProblem ?
             timeResolution, // TODO : move to LinearProblem ?
             {
-                    {"initialStock_battery1", 0}
+                    {"initialStock_battery1", 0.}
             },
             {
-                    {"consumption_nodeA", {0, 150, 150, 150}},
-                    {"cost_thermal1",     {1,  4,  8,  11}},
-                    {"cost_thermal2",     {2,  3,  10,  9}}
+                    {"consumption_nodeA", {0., 150., 150., 150.}},
+                    {"cost_thermal1",     {1.,  4.,  8.,  11.}},
+                    {"cost_thermal2",     {2.,  3.,  10.,  9.}}
             });
     linearProblemBuilder.build(linearProblemData);
     auto solution = linearProblemBuilder.solve({});

--- a/src/tests/poc/new-workflow/simple-test.cpp
+++ b/src/tests/poc/new-workflow/simple-test.cpp
@@ -18,7 +18,7 @@ using namespace Antares::optim::api;
 
 static constexpr std::array solverNames =
         {
-          //                "xpress",
+                "xpress",
                 "sirius",
                 "coin",
                 //"scip" // TODO activate this after adding tolerance

--- a/src/tests/poc/new-workflow/simple-test.cpp
+++ b/src/tests/poc/new-workflow/simple-test.cpp
@@ -18,7 +18,7 @@ using namespace Antares::optim::api;
 
 static constexpr std::array solverNames =
         {
-                "xpress",
+          //                "xpress",
                 "sirius",
                 "coin",
                 //"scip" // TODO activate this after adding tolerance

--- a/src/tests/poc/new-workflow/simple-test.cpp
+++ b/src/tests/poc/new-workflow/simple-test.cpp
@@ -16,16 +16,16 @@ namespace tt = boost::test_tools;
 namespace bdata = boost::unit_test::data;
 using namespace Antares::optim::api;
 
-static constexpr std::array solverNames =
-        {
-                "xpress",
-                "sirius",
-                "coin",
-                //"scip" // TODO activate this after adding tolerance
-        };
+static constexpr std::array solverNames = {
+  "xpress",
+  "sirius",
+  "coin",
+  //"scip" // TODO activate this after adding tolerance
+};
 
 BOOST_DATA_TEST_CASE(test_oneWeek_oneNode_oneBattery_oneThermal,
-                     bdata::make(solverNames), solverName)
+                     bdata::make(solverNames),
+                     solverName)
 {
     vector<int> timeStamps{0, 1, 2, 3};
     int timeResolution = 60;
@@ -46,39 +46,38 @@ BOOST_DATA_TEST_CASE(test_oneWeek_oneNode_oneBattery_oneThermal,
     linearProblemBuilder.addFiller(objective);
 
     LinearProblemData linearProblemData(
-            timeStamps, // TODO : move to LinearProblem ?
-            timeResolution, // TODO : move to LinearProblem ?
-            {
-                    {"initialStock_battery1", 0.}
-            },
-            {
-                    {"consumption_nodeA", {50., 50., 150., 120.}},
-                    {"cost_thermal1",     {1.,  3.,  10.,  8.}}
-            });
-    linearProblemBuilder.build(linearProblemData);
+      timeStamps,     // TODO : move to LinearProblem ?
+      timeResolution, // TODO : move to LinearProblem ?
+      {{"initialStock_battery1", 0.}},
+      {{"consumption_nodeA", {50., 50., 150., 120.}}, {"cost_thermal1", {1., 3., 10., 8.}}});
+    const unsigned int year = 0;
+    linearProblemBuilder.build(linearProblemData[year]);
     auto solution = linearProblemBuilder.solve({});
 
     // Consumption is greater than thermal maximum production in TS 2 & 3
     // So, the battery has to charge during tS 0 & 1
-    // Moreover, production cost is big during TS 2 & 3, so the battery has to charge up to its maximum during 0 & 1
-    // Consumption in 0 & 1 is 50 MW, so the battery can charge 50 MW x 2
-    // It must then discharge in 2 & 3, but mostly in 2 because thermal production cost is higher, while keeping 20 MW
-    // to achieve balance in 3 (consumption = 120, thermal production <= 100)
+    // Moreover, production cost is big during TS 2 & 3, so the battery has to charge up to its
+    // maximum during 0 & 1 Consumption in 0 & 1 is 50 MW, so the battery can charge 50 MW x 2 It
+    // must then discharge in 2 & 3, but mostly in 2 because thermal production cost is higher,
+    // while keeping 20 MW to achieve balance in 3 (consumption = 120, thermal production <= 100)
     // Thermal production must complete the rest. Thus, the expected power plans are:
     // Thermal : 100, 100, 70, 100
     // Battery : -50, -50, 80, 20
 
-    vector<double> actualThermalP = solution.getOptimalValues({"P_thermal1_0", "P_thermal1_1", "P_thermal1_2", "P_thermal1_3"});
+    vector<double> actualThermalP
+      = solution.getOptimalValues({"P_thermal1_0", "P_thermal1_1", "P_thermal1_2", "P_thermal1_3"});
     vector<double> expectedThermalP({100., 100., 70., 100.});
     BOOST_TEST(actualThermalP == expectedThermalP, tt::per_element()); // TODO add tolerance
 
-    vector<double> actualBatteryP = solution.getOptimalValues({"P_battery1_0", "P_battery1_1", "P_battery1_2", "P_battery1_3"});
+    vector<double> actualBatteryP
+      = solution.getOptimalValues({"P_battery1_0", "P_battery1_1", "P_battery1_2", "P_battery1_3"});
     vector<double> expectedBatteryP({-50, -50, 80, 20});
     BOOST_TEST(actualBatteryP == expectedBatteryP, tt::per_element()); // TODO add tolerance
 }
 
 BOOST_DATA_TEST_CASE(test_oneWeek_oneNode_oneBattery_twoThermals,
-                     bdata::make(solverNames), solverName)
+                     bdata::make(solverNames),
+                     solverName)
 {
     vector<int> timeStamps{0, 1, 2, 3};
     int timeResolution = 60;
@@ -100,38 +99,36 @@ BOOST_DATA_TEST_CASE(test_oneWeek_oneNode_oneBattery_twoThermals,
     linearProblemBuilder.addFiller(balance);
     linearProblemBuilder.addFiller(objective);
 
-    LinearProblemData linearProblemData(
-            timeStamps, // TODO : move to LinearProblem ?
-            timeResolution, // TODO : move to LinearProblem ?
-            {
-                    {"initialStock_battery1", 0.}
-            },
-            {
-                    {"consumption_nodeA", {0., 150., 150., 150.}},
-                    {"cost_thermal1",     {1.,  4.,  8.,  11.}},
-                    {"cost_thermal2",     {2.,  3.,  10.,  9.}}
-            });
-    linearProblemBuilder.build(linearProblemData);
+    LinearProblemData linearProblemData(timeStamps,     // TODO : move to LinearProblem ?
+                                        timeResolution, // TODO : move to LinearProblem ?
+                                        {{"initialStock_battery1", 0.}},
+                                        {{"consumption_nodeA", {0., 150., 150., 150.}},
+                                         {"cost_thermal1", {1., 4., 8., 11.}},
+                                         {"cost_thermal2", {2., 3., 10., 9.}}});
+    unsigned int year = 0;
+    linearProblemBuilder.build(linearProblemData[0]);
     auto solution = linearProblemBuilder.solve({});
 
     // Thermal production is cheap in TS 0, then very expensive.
-    // Battery must charge up to its max during TS 0, then discharge mostly when thermal production is most
-    // expensive (mostly in TS 3, then in TS 2). It is limited in power and stock, it can charge 180 MW in TS 0 and
-    // 20 MW in TS 2.
-    // Thermal production will complete the rest, following merit order imposed by their respective costs.
-    // Expected power plans are:
+    // Battery must charge up to its max during TS 0, then discharge mostly when thermal production
+    // is most expensive (mostly in TS 3, then in TS 2). It is limited in power and stock, it can
+    // charge 180 MW in TS 0 and 20 MW in TS 2. Thermal production will complete the rest, following
+    // merit order imposed by their respective costs. Expected power plans are:
     // - Battery: -180, -20, 50, 150
     // - Thermal1: 100, 70, 100, 0
     // - Thermal2: 80, 100, 0, 0
 
-    vector<double> actualBatteryP = solution.getOptimalValues({"P_battery1_0", "P_battery1_1", "P_battery1_2", "P_battery1_3"});
+    vector<double> actualBatteryP
+      = solution.getOptimalValues({"P_battery1_0", "P_battery1_1", "P_battery1_2", "P_battery1_3"});
     vector<double> expectedBatteryP({-180, -20, 50, 150});
     BOOST_TEST(actualBatteryP == expectedBatteryP, tt::per_element()); // TODO add tolerance
 
-    vector<double> actualThermal1P = solution.getOptimalValues({"P_thermal1_0", "P_thermal1_1", "P_thermal1_2", "P_thermal1_3"});
+    vector<double> actualThermal1P
+      = solution.getOptimalValues({"P_thermal1_0", "P_thermal1_1", "P_thermal1_2", "P_thermal1_3"});
     vector<double> expectedThermal1P({100, 70, 100, 0});
     BOOST_TEST(actualThermal1P == expectedThermal1P, tt::per_element()); // TODO add tolerance
-    vector<double> actualThermal2P = solution.getOptimalValues({"P_thermal2_0", "P_thermal2_1", "P_thermal2_2", "P_thermal2_3"});
+    vector<double> actualThermal2P
+      = solution.getOptimalValues({"P_thermal2_0", "P_thermal2_1", "P_thermal2_2", "P_thermal2_3"});
     vector<double> expectedThermal2P({80, 100, 0, 0});
     BOOST_TEST(actualThermal2P == expectedThermal2P, tt::per_element()); // TODO add tolerance
 }

--- a/src/tests/poc/new-workflow/standard-test.cpp
+++ b/src/tests/poc/new-workflow/standard-test.cpp
@@ -53,11 +53,11 @@ BOOST_DATA_TEST_CASE(test_std_oneWeek_oneNode_oneBattery_oneThermal,
             timeStamps, // TODO : move to LinearProblem ?
             timeResolution, // TODO : move to LinearProblem ?
             {
-                    {"initialStock_battery1", 0}
+                    {"initialStock_battery1", 0.}
             },
             {
-                    {"consumption_nodeA", {50, 50, 150, 120}},
-                    {"cost_thermal1",     {1,  3,  10,  8}}
+                    {"consumption_nodeA", {50., 50., 150., 120.}},
+                    {"cost_thermal1",     {1.,  3.,  10.,  8.}}
             });
     linearProblemBuilder.build(linearProblemData);
     auto solution = linearProblemBuilder.solve({});
@@ -119,12 +119,12 @@ BOOST_DATA_TEST_CASE(test_std_oneWeek_oneNode_oneBattery_twoThermals,
             timeStamps, // TODO : move to LinearProblem ?
             timeResolution, // TODO : move to LinearProblem ?
             {
-                    {"initialStock_battery1", 0}
+                    {"initialStock_battery1", 0.}
             },
             {
-                    {"consumption_nodeA", {0, 150, 150, 150}},
-                    {"cost_thermal1",     {1,  4,  8,  11}},
-                    {"cost_thermal2",     {2,  3,  10,  9}}
+                    {"consumption_nodeA", {0., 150., 150., 150.}},
+                    {"cost_thermal1",     {1.,  4.,  8.,  11.}},
+                    {"cost_thermal2",     {2.,  3.,  10.,  9.}}
             });
     linearProblemBuilder.build(linearProblemData);
     auto solution = linearProblemBuilder.solve({});

--- a/src/tests/poc/new-workflow/standard-test.cpp
+++ b/src/tests/poc/new-workflow/standard-test.cpp
@@ -14,7 +14,7 @@ using namespace Antares::optim::api;
 
 static constexpr std::array solverNames =
         {
-                "xpress",
+          //                "xpress",
                 "sirius",
                 "coin",
                 //"scip" // TODO activate this after adding tolerance

--- a/src/tests/poc/new-workflow/standard-test.cpp
+++ b/src/tests/poc/new-workflow/standard-test.cpp
@@ -12,16 +12,16 @@ namespace tt = boost::test_tools;
 namespace bdata = boost::unit_test::data;
 using namespace Antares::optim::api;
 
-static constexpr std::array solverNames =
-        {
-                "xpress",
-                "sirius",
-                "coin",
-                //"scip" // TODO activate this after adding tolerance
-        };
+static constexpr std::array solverNames = {
+  "xpress",
+  "sirius",
+  "coin",
+  //"scip" // TODO activate this after adding tolerance
+};
 
 BOOST_DATA_TEST_CASE(test_std_oneWeek_oneNode_oneBattery_oneThermal,
-                     bdata::make(solverNames), solverName)
+                     bdata::make(solverNames),
+                     solverName)
 {
     vector<int> timeStamps{0, 1, 2, 3};
     int timeResolution = 60;
@@ -50,39 +50,38 @@ BOOST_DATA_TEST_CASE(test_std_oneWeek_oneNode_oneBattery_oneThermal,
     portConnectionsManager.addConnection({priceMinimFiller, "cost"}, {batteryFiller, "cost"});
 
     LinearProblemData linearProblemData(
-            timeStamps, // TODO : move to LinearProblem ?
-            timeResolution, // TODO : move to LinearProblem ?
-            {
-                    {"initialStock_battery1", 0.}
-            },
-            {
-                    {"consumption_nodeA", {50., 50., 150., 120.}},
-                    {"cost_thermal1",     {1.,  3.,  10.,  8.}}
-            });
-    linearProblemBuilder.build(linearProblemData);
+      timeStamps,     // TODO : move to LinearProblem ?
+      timeResolution, // TODO : move to LinearProblem ?
+      {{"initialStock_battery1", 0.}},
+      {{"consumption_nodeA", {50., 50., 150., 120.}}, {"cost_thermal1", {1., 3., 10., 8.}}});
+    unsigned int year = 0;
+    linearProblemBuilder.build(linearProblemData[year]);
     auto solution = linearProblemBuilder.solve({});
 
     // Consumption is greater than thermal maximum production in TS 2 & 3
     // So, the battery has to charge during tS 0 & 1
-    // Moreover, production cost is big during TS 2 & 3, so the battery has to charge up to its maximum during 0 & 1
-    // Consumption in 0 & 1 is 50 MW, so the battery can charge 50 MW x 2
-    // It must then discharge in 2 & 3, but mostly in 2 because thermal production cost is higher, while keeping 20 MW
-    // to achieve balance in 3 (consumption = 120, thermal production <= 100)
+    // Moreover, production cost is big during TS 2 & 3, so the battery has to charge up to its
+    // maximum during 0 & 1 Consumption in 0 & 1 is 50 MW, so the battery can charge 50 MW x 2 It
+    // must then discharge in 2 & 3, but mostly in 2 because thermal production cost is higher,
+    // while keeping 20 MW to achieve balance in 3 (consumption = 120, thermal production <= 100)
     // Thermal production must complete the rest. Thus, the expected power plans are:
     // Thermal : 100, 100, 70, 100
     // Battery : -50, -50, 80, 20
 
-    vector<double> actualThermalP = solution.getOptimalValues({"P_thermal1_0", "P_thermal1_1", "P_thermal1_2", "P_thermal1_3"});
+    vector<double> actualThermalP
+      = solution.getOptimalValues({"P_thermal1_0", "P_thermal1_1", "P_thermal1_2", "P_thermal1_3"});
     vector<double> expectedThermalP({100., 100., 70., 100.});
     BOOST_TEST(actualThermalP == expectedThermalP, tt::per_element()); // TODO add tolerance
 
-    vector<double> actualBatteryP = solution.getOptimalValues({"P_battery1_0", "P_battery1_1", "P_battery1_2", "P_battery1_3"});
+    vector<double> actualBatteryP
+      = solution.getOptimalValues({"P_battery1_0", "P_battery1_1", "P_battery1_2", "P_battery1_3"});
     vector<double> expectedBatteryP({-50, -50, 80, 20});
     BOOST_TEST(actualBatteryP == expectedBatteryP, tt::per_element()); // TODO add tolerance
 }
 
 BOOST_DATA_TEST_CASE(test_std_oneWeek_oneNode_oneBattery_twoThermals,
-                     bdata::make(solverNames), solverName)
+                     bdata::make(solverNames),
+                     solverName)
 {
     vector<int> timeStamps{0, 1, 2, 3};
     int timeResolution = 60;
@@ -115,40 +114,39 @@ BOOST_DATA_TEST_CASE(test_std_oneWeek_oneNode_oneBattery_twoThermals,
     portConnectionsManager.addConnection({priceMinimFiller, "cost"}, {thermal2Filler, "cost"});
     portConnectionsManager.addConnection({priceMinimFiller, "cost"}, {batteryFiller, "cost"});
 
-    LinearProblemData linearProblemData(
-            timeStamps, // TODO : move to LinearProblem ?
-            timeResolution, // TODO : move to LinearProblem ?
-            {
-                    {"initialStock_battery1", 0.}
-            },
-            {
-                    {"consumption_nodeA", {0., 150., 150., 150.}},
-                    {"cost_thermal1",     {1.,  4.,  8.,  11.}},
-                    {"cost_thermal2",     {2.,  3.,  10.,  9.}}
-            });
-    linearProblemBuilder.build(linearProblemData);
+    LinearProblemData linearProblemData(timeStamps,     // TODO : move to LinearProblem ?
+                                        timeResolution, // TODO : move to LinearProblem ?
+                                        {{"initialStock_battery1", 0.}},
+                                        {{"consumption_nodeA", {0., 150., 150., 150.}},
+                                         {"cost_thermal1", {1., 4., 8., 11.}},
+                                         {"cost_thermal2", {2., 3., 10., 9.}}});
+    unsigned int year = 0;
+    linearProblemBuilder.build(linearProblemData[year]);
     auto solution = linearProblemBuilder.solve({});
 
     // Thermal production is cheap in TS 0, then very expensive.
-    // Battery must charge up to its max during TS 0, then discharge mostly when thermal production is most
-    // expensive (mostly in TS 3, then in TS 2). It is limited in power and stock, it can charge 180 MW in TS 0 and
-    // 20 MW in TS 2.
-    // Thermal production will complete the rest, following merit order imposed by their respective costs.
-    // Expected power plans are:
+    // Battery must charge up to its max during TS 0, then discharge mostly when thermal production
+    // is most expensive (mostly in TS 3, then in TS 2). It is limited in power and stock, it can
+    // charge 180 MW in TS 0 and 20 MW in TS 2. Thermal production will complete the rest, following
+    // merit order imposed by their respective costs. Expected power plans are:
     // - Battery: -180, -20, 50, 150
     // - Thermal1: 100, 70, 100, 0
     // - Thermal2: 80, 100, 0, 0
 
-    vector<double> actualBatteryP = solution.getOptimalValues({"P_battery1_0", "P_battery1_1", "P_battery1_2", "P_battery1_3"});
+    vector<double> actualBatteryP
+      = solution.getOptimalValues({"P_battery1_0", "P_battery1_1", "P_battery1_2", "P_battery1_3"});
     vector<double> expectedBatteryP({-180, -20, 50, 150});
     BOOST_TEST(actualBatteryP == expectedBatteryP, tt::per_element());
     // TODO add tolerance with boost version >= 1.73.0
-    //BOOST_TEST(actualBatteryP == expectedBatteryP, tt::tolerance( 1e-3 ) << "comparison to ground truth failed" << tt::per_element());
+    // BOOST_TEST(actualBatteryP == expectedBatteryP, tt::tolerance( 1e-3 ) << "comparison to ground
+    // truth failed" << tt::per_element());
 
-    vector<double> actualThermal1P = solution.getOptimalValues({"P_thermal1_0", "P_thermal1_1", "P_thermal1_2", "P_thermal1_3"});
+    vector<double> actualThermal1P
+      = solution.getOptimalValues({"P_thermal1_0", "P_thermal1_1", "P_thermal1_2", "P_thermal1_3"});
     vector<double> expectedThermal1P({100, 70, 100, 0});
     BOOST_TEST(actualThermal1P == expectedThermal1P, tt::per_element()); // TODO add tolerance
-    vector<double> actualThermal2P = solution.getOptimalValues({"P_thermal2_0", "P_thermal2_1", "P_thermal2_2", "P_thermal2_3"});
+    vector<double> actualThermal2P
+      = solution.getOptimalValues({"P_thermal2_0", "P_thermal2_1", "P_thermal2_2", "P_thermal2_3"});
     vector<double> expectedThermal2P({80, 100, 0, 0});
     BOOST_TEST(actualThermal2P == expectedThermal2P, tt::per_element()); // TODO add tolerance
 }

--- a/src/tests/poc/new-workflow/standard-test.cpp
+++ b/src/tests/poc/new-workflow/standard-test.cpp
@@ -14,7 +14,7 @@ using namespace Antares::optim::api;
 
 static constexpr std::array solverNames =
         {
-          //                "xpress",
+                "xpress",
                 "sirius",
                 "coin",
                 //"scip" // TODO activate this after adding tolerance


### PR DESCRIPTION
This PR works by introducing a new sub-class `LinearProblemData::YearView`. The role of this class is to reference the time-series / scalar data for a given year.

We build `YearView` instances using the following correspondences
```cpp
unsigned tsIndex = data.groupYearToIndex_.at(group).at(year);
double scalarDataForScenario = scalarData[tsIndex];
```

Then we replace most instances of `LinearProblemData` by `LinearProblemData::YearView` so that `addXXX` methods only see what they need to use.

Please note that at least 50% of changes is just formatting. Sorry about that.

### TODO
- [x] Construct groups
- [x] Add test with scenarized data & groups
- [ ] Make `LinearProblemBuilder` re-usable ?