### PR TITLE
Remove export target

### DIFF
--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -52,7 +52,6 @@ set(TARGET_LIBS #No alias
         #
         signal-handling
         antares-solver-variable-info
-        minizip
 )
 
 install(TARGETS ${TARGET_LIBS}
@@ -87,10 +86,4 @@ install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/AntaresConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/AntaresConfigVersion.cmake"
         DESTINATION lib/cmake/Antares
-)
-
-# generate the export targets for the build tree
-export(EXPORT AntaresTargets
-        FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/AntaresTargets.cmake"
-        NAMESPACE Antares::
 )


### PR DESCRIPTION
Remove export directive.
Unnecessary and cause issue for supporting both fetch_content(DEPS) or find_package(DEPS)