### PR TITLE
Bump upload-artifact to v4, use unique names for artifacts

### DIFF
--- a/.github/workflows/build-userguide.yml
+++ b/.github/workflows/build-userguide.yml
@@ -58,7 +58,7 @@ jobs:
         echo "PDF_PATH_ASSET= [\"docs/pdf-doc-generation-with-sphinx/$PDF_NAME\"]" >> $GITHUB_ENV
 
     - name: user guide upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pdf-reference-guide
         path: ${{ env.PDF_PATH }}

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -120,13 +120,15 @@ jobs:
            cpack -G TGZ
 
     - name: Installer TGZ push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: targz
         path: _build/*.tar.gz
 
     - name: Installer RPM push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: rpm
         path: _build/*.rpm
 
     - name: Publish assets

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -119,13 +119,15 @@ jobs:
            cpack -G TGZ
 
     - name: Installer TGZ push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: targz
         path: _build/*.tar.gz
 
     - name: Installer RPM push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: rpm
         path: _build/*.rpm
 
     - name: Publish assets

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -145,7 +145,7 @@ jobs:
 
     - name: Upload logs for failed tests
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-log
         path: ${{ github.workspace }}/_build/Testing/Temporary/LastTest.log
@@ -277,13 +277,15 @@ jobs:
            rm -rf install
 
     - name: Installer archive upload push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: targz
         path: _build/*.tar.gz
 
     - name: Installer deb upload push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: deb
         path: _build/*.deb
 
 

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -190,7 +190,7 @@ jobs:
 
     - name: Upload build on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MPS-diff
         path: ${{ github.workspace }}/src/tests/mps
@@ -319,7 +319,7 @@ jobs:
 
     - name: Upload NSIS log on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: NSISError.log
         path: _build/_CPack_Packages/win64/NSIS/NSISOutput.log
@@ -330,8 +330,9 @@ jobs:
            cpack -G ZIP
 
     - name: Installer upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: installer
         path: _build/${{env.NSIS_NAME}}
 
     - name: Publish assets


### PR DESCRIPTION
[Migration doc](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)

Instead of one big large artifact (named "artifact"), we get multiple artifacts
![image](https://github.com/AntaresSimulatorTeam/Antares_Simulator/assets/26088210/f82bc529-5188-444a-a5c1-951beb43c220)

It may, or may not break the release process. **EDIT** Won't break, since **assets** are completely independent of **artifacts**.
```yml
    - name: Publish assets
      if: ${{ env.IS_RELEASE == 'true' }}
      env:
        GITHUB_TOKEN: ${{ github.token }}
        tag: ${{ github.event.inputs.release_tag }}
      run: |
        gh release upload "$tag" _build/*.tar.gz _build/*.deb
```
