### PR TITLE
Fix directory path for windows

### DIFF
--- a/src/libs/antares/writer/immediate_file_writer.cpp
+++ b/src/libs/antares/writer/immediate_file_writer.cpp
@@ -47,8 +47,7 @@ static bool prepareDirectoryHierarchy(const fs::path& root,
     fs::path fullPath = root / entryPath.relative_path();
     output = fullPath;
 
-    fs::path directory = fullPath;
-    directory.remove_filename();
+    fs::path directory = fullPath.parent_path();
     if (fs::exists(directory))
     {
         return true;

--- a/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
+++ b/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(BC_group_TestGroup_has_output_file)
 
     Benchmarking::DurationCollector durationCollector;
     auto resultWriter = resultWriterFactory(ResultFormat::legacyFilesDirectories,
-                                            working_tmp_dir.string(),
+                                            working_tmp_dir.string().c_str(),
                                             nullptr,
                                             durationCollector);
     fs::path bc_path = working_tmp_dir / "ts-numbers" / "bindingconstraints" / "TestGroup.txt";
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(BC_output_ts_numbers_file_for_each_group)
 
     Benchmarking::DurationCollector durationCollector;
     auto resultWriter = resultWriterFactory(ResultFormat::legacyFilesDirectories,
-                                            working_tmp_dir.string(),
+                                            working_tmp_dir.string().c_str(),
                                             nullptr,
                                             durationCollector);
 
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(BC_timeseries_numbers_store_values)
 
     Benchmarking::DurationCollector durationCollector;
     auto resultWriter = resultWriterFactory(ResultFormat::legacyFilesDirectories,
-                                            working_tmp_dir.string(),
+                                            working_tmp_dir.string().c_str(),
                                             nullptr,
                                             durationCollector);
 


### PR DESCRIPTION

**Analysis**

On windows:
```cpp
// this returns true as expected
fs::create_directories("/path/to/my/new/directory");

// thisreturns false because of trailing slash ???
fs::create_directories("/path/to/my/new/directory/");
```

It looks more or less like a bug of the STL ... the last slash is considered as "not created" which would explain it returns false ...

**The fix**

Use `parent_path` instead of `remove_filename`, to get the correct path of parent directory without the trailing slash.
