### PR TITLE
Exclude src/ui from sonarQ analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.sources=src
 sonar.tests=src/tests
 sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=src/ext/**,src/tests/**
+sonar.exclusions=src/ext/**,src/tests/**,src/ui/**
 sonar.coverage.exclusions=src/ext/**,src/tests/**,src/analyzer/**,src/distrib/**,src/tools/**,src/ui/**
 
 sonar.cfamily.build-wrapper-output=_build/output


### PR DESCRIPTION
This should speed up analysis quite a bit. Since the UI component is deprecated and mostly untouched, there should no serious consequences to this eviction.