### PR TITLE
Use VCPKG to install boost, also on Linux

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 # Interface library to facilitate addition of WIN32_LEAN_AND_MEAN flag
 add_library(antares-unit-test INTERFACE)
 target_link_libraries(antares-unit-test INTERFACE Boost::boost)
-target_compile_definitions(antares-unit-test INTERFACE $<$<BOOL:${WIN32}>:-DWIN32_LEAN_AND_MEAN>)
+target_compile_definitions(antares-unit-test INTERFACE $<$<BOOL:${WIN32}>:WIN32_LEAN_AND_MEAN>)
 
 
 # Make found targets globally available.

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -4,6 +4,12 @@ project(unit_tests_antares VERSION 1.0)
 
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
+# Interface library to facilitate addition of WIN32_LEAN_AND_MEAN flag
+add_library(antares-unit-test INTERFACE)
+target_link_libraries(antares-unit-test INTERFACE Boost::boost)
+target_compile_definitions(antares-unit-test INTERFACE $<$<BOOL:${WIN32}>:-DWIN32_LEAN_AND_MEAN>)
+
+
 # Make found targets globally available.
 if (Boost_FOUND)
     set_target_properties(Boost::unit_test_framework PROPERTIES IMPORTED_GLOBAL TRUE)

--- a/src/tests/end-to-end/binding_constraints/CMakeLists.txt
+++ b/src/tests/end-to-end/binding_constraints/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(tests-binding_constraints
 target_link_libraries(tests-binding_constraints
         PRIVATE
         test_utils
-        Boost::unit_test_framework
+        Boost::boost Boost::disable_autolinking
         model_antares
         antares-solver-simulation
         antares-solver-hydro

--- a/src/tests/end-to-end/binding_constraints/CMakeLists.txt
+++ b/src/tests/end-to-end/binding_constraints/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(tests-binding_constraints
 target_link_libraries(tests-binding_constraints
         PRIVATE
         test_utils
-        Boost::boost Boost::disable_autolinking
+        antares-unit-test
         model_antares
         antares-solver-simulation
         antares-solver-hydro

--- a/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
+++ b/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
@@ -19,10 +19,9 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test - end - to - end tests_binding_constraints
-#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "utils.h"
 

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -19,9 +19,8 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test - end - to - end tests
-#define BOOST_TEST_DYN_LINK
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "utils.h"
 

--- a/src/tests/src/libs/antares/CMakeLists.txt
+++ b/src/tests/src/libs/antares/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(tests-matrix-save
 						PRIVATE
 							matrix
 							yuni-static-core
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							antares-core
 )
 
@@ -96,7 +96,7 @@ target_link_libraries(tests-matrix-load
 						PRIVATE
 							matrix
 							yuni-static-core
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							antares-core
 )
 
@@ -111,7 +111,7 @@ set_property(TEST load-matrix PROPERTY LABELS unit)
 add_executable(test-utils test_utils.cpp)
 target_link_libraries(test-utils
 		PRIVATE
-		Boost::boost Boost::disable_autolinking
+		antares-unit-test
 		Antares::utils
 		yuni-static-core
 )

--- a/src/tests/src/libs/antares/CMakeLists.txt
+++ b/src/tests/src/libs/antares/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(tests-matrix-save
 						PRIVATE
 							matrix
 							yuni-static-core
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							antares-core
 )
 
@@ -96,7 +96,7 @@ target_link_libraries(tests-matrix-load
 						PRIVATE
 							matrix
 							yuni-static-core
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							antares-core
 )
 
@@ -111,7 +111,7 @@ set_property(TEST load-matrix PROPERTY LABELS unit)
 add_executable(test-utils test_utils.cpp)
 target_link_libraries(test-utils
 		PRIVATE
-		Boost::unit_test_framework
+		Boost::boost Boost::disable_autolinking
 		Antares::utils
 		yuni-static-core
 )

--- a/src/tests/src/libs/antares/array/tests-matrix-load.cpp
+++ b/src/tests/src/libs/antares/array/tests-matrix-load.cpp
@@ -19,7 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test - lib - antares - matrix tests
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
@@ -29,7 +28,7 @@
 #include <iostream>
 #include <stdio.h>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 namespace utf = boost::unit_test;
 

--- a/src/tests/src/libs/antares/array/tests-matrix-save.cpp
+++ b/src/tests/src/libs/antares/array/tests-matrix-save.cpp
@@ -19,13 +19,12 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test - lib - antares - matrix tests
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
 #include "tests-matrix-save.h"
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 namespace utf = boost::unit_test;
 

--- a/src/tests/src/libs/antares/benchmarking/CMakeLists.txt
+++ b/src/tests/src/libs/antares/benchmarking/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(${PROJ} PRIVATE test_duration_collector.cpp)
 target_link_libraries(${PROJ}
         PRIVATE
         Antares::benchmarking
-        Boost::boost Boost::disable_autolinking
+        antares-unit-test
 )
 
 add_test(NAME ${PROJ} COMMAND ${PROJ})

--- a/src/tests/src/libs/antares/benchmarking/CMakeLists.txt
+++ b/src/tests/src/libs/antares/benchmarking/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(${PROJ} PRIVATE test_duration_collector.cpp)
 target_link_libraries(${PROJ}
         PRIVATE
         Antares::benchmarking
-        Boost::unit_test_framework
+        Boost::boost Boost::disable_autolinking
 )
 
 add_test(NAME ${PROJ} COMMAND ${PROJ})

--- a/src/tests/src/libs/antares/benchmarking/test_duration_collector.cpp
+++ b/src/tests/src/libs/antares/benchmarking/test_duration_collector.cpp
@@ -20,11 +20,10 @@
 */
 
 #define BOOST_TEST_MODULE study
-#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
 #include <thread>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/benchmarking/DurationCollector.h>
 #include <antares/benchmarking/timer.h>

--- a/src/tests/src/libs/antares/concurrency/CMakeLists.txt
+++ b/src/tests/src/libs/antares/concurrency/CMakeLists.txt
@@ -4,7 +4,7 @@ target_sources(test-concurrency PRIVATE test_concurrency.cpp)
 
 target_link_libraries(test-concurrency
 						PRIVATE
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							Antares::concurrency
 )
 

--- a/src/tests/src/libs/antares/concurrency/CMakeLists.txt
+++ b/src/tests/src/libs/antares/concurrency/CMakeLists.txt
@@ -4,7 +4,7 @@ target_sources(test-concurrency PRIVATE test_concurrency.cpp)
 
 target_link_libraries(test-concurrency
 						PRIVATE
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							Antares::concurrency
 )
 

--- a/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
+++ b/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
@@ -19,9 +19,8 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test - concurrency tests
-#define BOOST_TEST_DYN_LINK
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "antares/concurrency/concurrency.h"
 

--- a/src/tests/src/libs/antares/study/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/CMakeLists.txt
@@ -15,7 +15,7 @@ target_sources(test-study PRIVATE test_study.cpp)
 target_link_libraries(test-study
         PRIVATE
         Antares::study
-        Boost::unit_test_framework
+        Boost::boost Boost::disable_autolinking
 )
 
 add_test(NAME test-study COMMAND test-study)

--- a/src/tests/src/libs/antares/study/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/CMakeLists.txt
@@ -15,7 +15,7 @@ target_sources(test-study PRIVATE test_study.cpp)
 target_link_libraries(test-study
         PRIVATE
         Antares::study
-        Boost::boost Boost::disable_autolinking
+        antares-unit-test
 )
 
 add_test(NAME test-study COMMAND test-study)

--- a/src/tests/src/libs/antares/study/area/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/area/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(test-save-link-properties
 )
 target_link_libraries(test-save-link-properties
 						PRIVATE
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							model_antares
 )
 # Linux
@@ -49,7 +49,7 @@ target_include_directories(test-save-area-optimization-ini
 )
 target_link_libraries(test-save-area-optimization-ini
 						PRIVATE
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							model_antares
 )
 

--- a/src/tests/src/libs/antares/study/area/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/area/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(test-save-link-properties
 )
 target_link_libraries(test-save-link-properties
 						PRIVATE
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							model_antares
 )
 # Linux
@@ -49,7 +49,7 @@ target_include_directories(test-save-area-optimization-ini
 )
 target_link_libraries(test-save-area-optimization-ini
 						PRIVATE
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							model_antares
 )
 

--- a/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
@@ -19,7 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test save area optimization.ini
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
@@ -27,7 +26,7 @@
 #include <fstream>
 #include <string>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/study/area/constants.h>
 #include <antares/study/filter.h>

--- a/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
@@ -19,7 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test save link properties.ini
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
@@ -29,7 +28,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/study/filter.h>
 #include <antares/study/study.h>

--- a/src/tests/src/libs/antares/study/constraint/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/constraint/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(test_constraint
 target_link_libraries(test_constraint
         PRIVATE
         test_utils_unit
-        Boost::unit_test_framework
+        Boost::boost Boost::disable_autolinking
         Antares::study
         )
 		
@@ -29,7 +29,7 @@ add_executable(test_groups
 target_link_libraries(test_groups
         PRIVATE
         test_utils_unit
-        Boost::unit_test_framework
+        Boost::boost Boost::disable_autolinking
         Antares::study
         )
 

--- a/src/tests/src/libs/antares/study/constraint/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/constraint/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(test_constraint
 target_link_libraries(test_constraint
         PRIVATE
         test_utils_unit
-        Boost::boost Boost::disable_autolinking
+        antares-unit-test
         Antares::study
         )
 		
@@ -29,7 +29,7 @@ add_executable(test_groups
 target_link_libraries(test_groups
         PRIVATE
         test_utils_unit
-        Boost::boost Boost::disable_autolinking
+        antares-unit-test
         Antares::study
         )
 

--- a/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
@@ -24,13 +24,12 @@
 
 #define WIN32_LEAN_AND_MEAN
 #define BOOST_TEST_MODULE binding_constraints
-#define BOOST_TEST_DYN_LINK
 
 #include <files-system.h>
 #include <filesystem>
 #include <fstream>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/study/study.h>
 #include "antares/study/area/area.h"

--- a/src/tests/src/libs/antares/study/constraint/test_group.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_group.cpp
@@ -22,14 +22,13 @@
 // Created by marechaljas on 28/06/23.
 //
 #define BOOST_TEST_MODULE binding_constraints_groups
-#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
 #include <files-system.h>
 #include <filesystem>
 #include <fstream>
 #include <memory>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "antares/study/study.h"
 

--- a/src/tests/src/libs/antares/study/output-folder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/output-folder/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(test-folder-output
 
 target_link_libraries(test-folder-output
     				  PRIVATE
-					  Boost::unit_test_framework
+					  Boost::boost Boost::disable_autolinking
 				      Antares::study
 )
 

--- a/src/tests/src/libs/antares/study/output-folder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/output-folder/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(test-folder-output
 
 target_link_libraries(test-folder-output
     				  PRIVATE
-					  Boost::boost Boost::disable_autolinking
+					  antares-unit-test
 				      Antares::study
 )
 

--- a/src/tests/src/libs/antares/study/output-folder/study.cpp
+++ b/src/tests/src/libs/antares/study/output-folder/study.cpp
@@ -19,7 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE output folder
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
@@ -28,7 +27,7 @@
 #include <fstream>
 #include <string>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/study/study.h>
 

--- a/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(parameters-tests ${SRC_PARAMETERS_TESTS})
 
 target_link_libraries(parameters-tests
                       PRIVATE
-                      Boost::unit_test_framework
+                      Boost::boost Boost::disable_autolinking
                       Antares::study
 )
 

--- a/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(parameters-tests ${SRC_PARAMETERS_TESTS})
 
 target_link_libraries(parameters-tests
                       PRIVATE
-                      Boost::boost Boost::disable_autolinking
+                      antares-unit-test
                       Antares::study
 )
 

--- a/src/tests/src/libs/antares/study/parameters/parameters-tests.cpp
+++ b/src/tests/src/libs/antares/study/parameters/parameters-tests.cpp
@@ -19,13 +19,12 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE "test parameters"
-#define BOOST_TEST_DYN_LINK
 
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/study/study.h>
 

--- a/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(test-hydro-reader ${SRC_HYDRO_READER})
 
 target_link_libraries(test-hydro-reader
 	PRIVATE
-	Boost::boost Boost::disable_autolinking
+	antares-unit-test
 	Antares::study
 	test_utils_unit
 )
@@ -29,7 +29,7 @@ add_executable(test-hydro-series ${SRC_HYDRO_SERIES})
 
 target_link_libraries(test-hydro-series
 	PRIVATE
-	Boost::boost Boost::disable_autolinking
+	antares-unit-test
 	Antares::study
 	test_utils_unit
 )

--- a/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(test-hydro-reader ${SRC_HYDRO_READER})
 
 target_link_libraries(test-hydro-reader
 	PRIVATE
-	Boost::unit_test_framework
+	Boost::boost Boost::disable_autolinking
 	Antares::study
 	test_utils_unit
 )
@@ -29,7 +29,7 @@ add_executable(test-hydro-series ${SRC_HYDRO_SERIES})
 
 target_link_libraries(test-hydro-series
 	PRIVATE
-	Boost::unit_test_framework
+	Boost::boost Boost::disable_autolinking
 	Antares::study
 	test_utils_unit
 )

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
@@ -1,11 +1,10 @@
 #define BOOST_TEST_MODULE test hydro series
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
 #include <files-system.h>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/array/matrix.h>
 #include <antares/study/study.h>

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
@@ -1,11 +1,10 @@
 #define BOOST_TEST_MODULE test hydro reader
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
 #include <files-system.h>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/array/matrix.h>
 #include <antares/study/study.h>

--- a/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(test-sc-builder-file-read-line
 
 target_link_libraries(test-sc-builder-file-read-line
 						PRIVATE
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							model_antares
 )
 # Linux
@@ -50,7 +50,7 @@ target_include_directories(test-sc-builder-file-save
 
 target_link_libraries(test-sc-builder-file-save
   PRIVATE
-						Boost::unit_test_framework
+						Boost::boost Boost::disable_autolinking
 						model_antares
 )
 

--- a/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(test-sc-builder-file-read-line
 
 target_link_libraries(test-sc-builder-file-read-line
 						PRIVATE
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							model_antares
 )
 # Linux
@@ -50,7 +50,7 @@ target_include_directories(test-sc-builder-file-save
 
 target_link_libraries(test-sc-builder-file-save
   PRIVATE
-						Boost::boost Boost::disable_autolinking
+						antares-unit-test
 						model_antares
 )
 

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
@@ -19,11 +19,10 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test read scenario - builder.dat
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/study/scenario-builder/rules.h>
 #include <antares/study/study.h>

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -19,12 +19,11 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test save scenario - builder.dat
-#define BOOST_TEST_DYN_LINK
 #include <filesystem>
 #include <fstream>
 #include <string>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/study/scenario-builder/rules.h>
 #include <antares/study/scenario-builder/sets.h>

--- a/src/tests/src/libs/antares/study/series/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/series/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(timeseries-tests ${SRC_TIMESERIES_TESTS})
 
 target_link_libraries(timeseries-tests
                       PRIVATE
-                      Boost::unit_test_framework
+                      Boost::boost Boost::disable_autolinking
                       Antares::series
 )
 

--- a/src/tests/src/libs/antares/study/series/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/series/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(timeseries-tests ${SRC_TIMESERIES_TESTS})
 
 target_link_libraries(timeseries-tests
                       PRIVATE
-                      Boost::boost Boost::disable_autolinking
+                      antares-unit-test
                       Antares::series
 )
 

--- a/src/tests/src/libs/antares/study/series/timeseries-tests.cpp
+++ b/src/tests/src/libs/antares/study/series/timeseries-tests.cpp
@@ -19,11 +19,10 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE "test time series"
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/series/series.h>
 

--- a/src/tests/src/libs/antares/study/short-term-storage-input/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(short-term-storage-input
 
 target_link_libraries(short-term-storage-input
 						PRIVATE
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							model_antares
 )
 # Linux

--- a/src/tests/src/libs/antares/study/short-term-storage-input/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(short-term-storage-input
 
 target_link_libraries(short-term-storage-input
 						PRIVATE
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							model_antares
 )
 # Linux

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -19,14 +19,13 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE "test short term storage"
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
 #include <filesystem>
 #include <fstream>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <yuni/io/file.h>
 

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -20,9 +20,8 @@
 */
 
 #define BOOST_TEST_MODULE study
-#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "antares/study/study.h"
 

--- a/src/tests/src/libs/antares/study/thermal-price-definition/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(thermal-price-definition
 
 target_link_libraries(thermal-price-definition
 						PRIVATE
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							checks
 							Antares::study
 							Antares::exception

--- a/src/tests/src/libs/antares/study/thermal-price-definition/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(thermal-price-definition
 
 target_link_libraries(thermal-price-definition
 						PRIVATE
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							checks
 							Antares::study
 							Antares::exception

--- a/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
@@ -19,14 +19,13 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE "test thermal price definition"
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
 #include <filesystem>
 #include <fstream>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <yuni/io/file.h>
 

--- a/src/tests/src/libs/antares/test_utils.cpp
+++ b/src/tests/src/libs/antares/test_utils.cpp
@@ -19,10 +19,9 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test utils
-#define BOOST_TEST_DYN_LINK
 #include <string>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/utils/utils.h>
 

--- a/src/tests/src/libs/antares/writer/CMakeLists.txt
+++ b/src/tests/src/libs/antares/writer/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(test-writer PRIVATE test_writer.cpp)
 
 target_link_libraries(test-writer
 	PRIVATE
-		Boost::unit_test_framework
+		Boost::boost Boost::disable_autolinking
 		Antares::result_writer
 		test_utils_unit
 		MINIZIP::minizip-ng

--- a/src/tests/src/libs/antares/writer/CMakeLists.txt
+++ b/src/tests/src/libs/antares/writer/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(test-writer PRIVATE test_writer.cpp)
 
 target_link_libraries(test-writer
 	PRIVATE
-		Boost::boost Boost::disable_autolinking
+		antares-unit-test
 		Antares::result_writer
 		test_utils_unit
 		MINIZIP::minizip-ng

--- a/src/tests/src/libs/antares/writer/test_writer.cpp
+++ b/src/tests/src/libs/antares/writer/test_writer.cpp
@@ -19,9 +19,8 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test - writer tests
-#define BOOST_TEST_DYN_LINK
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "yuni/job/queue/service.h"
 

--- a/src/tests/src/solver/infeasible-problem-analysis/CMakeLists.txt
+++ b/src/tests/src/solver/infeasible-problem-analysis/CMakeLists.txt
@@ -4,7 +4,7 @@ target_sources(test-unfeasible-problem-analyzer
 		test-unfeasible-problem-analyzer.cpp)
 target_link_libraries(test-unfeasible-problem-analyzer
 		PRIVATE
-		Boost::boost Boost::disable_autolinking
+		antares-unit-test
 		infeasible_problem_analysis
 		ortools::ortools
 )

--- a/src/tests/src/solver/infeasible-problem-analysis/CMakeLists.txt
+++ b/src/tests/src/solver/infeasible-problem-analysis/CMakeLists.txt
@@ -4,7 +4,7 @@ target_sources(test-unfeasible-problem-analyzer
 		test-unfeasible-problem-analyzer.cpp)
 target_link_libraries(test-unfeasible-problem-analyzer
 		PRIVATE
-		Boost::unit_test_framework
+		Boost::boost Boost::disable_autolinking
 		infeasible_problem_analysis
 		ortools::ortools
 )

--- a/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
+++ b/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
@@ -20,11 +20,10 @@
  */
 #define WIN32_LEAN_AND_MEAN
 #define BOOST_TEST_MODULE unfeasible_problem_analyzer
-#define BOOST_TEST_DYN_LINK
 
 #include <boost/test/data/dataset.hpp>
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include "antares/solver/infeasible-problem-analysis/constraint-slack-analysis.h"
 #include "antares/solver/infeasible-problem-analysis/unfeasible-pb-analyzer.h"

--- a/src/tests/src/solver/optimisation/CMakeLists.txt
+++ b/src/tests/src/solver/optimisation/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(${EXECUTABLE_NAME}
 
 target_link_libraries(${EXECUTABLE_NAME}
                       PRIVATE
-                      Boost::boost Boost::disable_autolinking
+                      antares-unit-test
                       model_antares
  					  array
 )

--- a/src/tests/src/solver/optimisation/CMakeLists.txt
+++ b/src/tests/src/solver/optimisation/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(${EXECUTABLE_NAME}
 
 target_link_libraries(${EXECUTABLE_NAME}
                       PRIVATE
-                      Boost::unit_test_framework
+                      Boost::boost Boost::disable_autolinking
                       model_antares
  					  array
 )

--- a/src/tests/src/solver/optimisation/adequacy_patch.cpp
+++ b/src/tests/src/solver/optimisation/adequacy_patch.cpp
@@ -19,7 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test adequacy patch functions
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
@@ -27,7 +26,7 @@
 #include <tuple>
 #include <vector>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/exception/LoadingError.hpp>
 #include <antares/solver/simulation/adequacy_patch_runtime_data.h>

--- a/src/tests/src/solver/simulation/CMakeLists.txt
+++ b/src/tests/src/solver/simulation/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(tests-ts-numbers
 target_link_libraries(tests-ts-numbers
 						PRIVATE
                             Antares::utils
-							Boost::unit_test_framework
+							Boost::boost Boost::disable_autolinking
 							model_antares
 							antares-solver-simulation
 							antares-solver-ts-generator
@@ -43,7 +43,7 @@ add_executable(test-store-timeseries-number ${SRC_STORE_TS})
 
 target_link_libraries(test-store-timeseries-number
 		PRIVATE
-		Boost::unit_test_framework
+		Boost::boost Boost::disable_autolinking
         test_utils_unit
 		antares-solver-simulation
 		Antares::study
@@ -71,7 +71,7 @@ add_executable(test-time_series ${SRC_STORE_TS})
 
 target_link_libraries(test-time_series
 		PRIVATE
-		Boost::unit_test_framework
+		Boost::boost Boost::disable_autolinking
         test_utils_unit
 		antares-solver-simulation
 		Antares::study

--- a/src/tests/src/solver/simulation/CMakeLists.txt
+++ b/src/tests/src/solver/simulation/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(tests-ts-numbers
 target_link_libraries(tests-ts-numbers
 						PRIVATE
                             Antares::utils
-							Boost::boost Boost::disable_autolinking
+							antares-unit-test
 							model_antares
 							antares-solver-simulation
 							antares-solver-ts-generator
@@ -43,7 +43,7 @@ add_executable(test-store-timeseries-number ${SRC_STORE_TS})
 
 target_link_libraries(test-store-timeseries-number
 		PRIVATE
-		Boost::boost Boost::disable_autolinking
+		antares-unit-test
         test_utils_unit
 		antares-solver-simulation
 		Antares::study
@@ -71,7 +71,7 @@ add_executable(test-time_series ${SRC_STORE_TS})
 
 target_link_libraries(test-time_series
 		PRIVATE
-		Boost::boost Boost::disable_autolinking
+		antares-unit-test
         test_utils_unit
 		antares-solver-simulation
 		Antares::study

--- a/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
+++ b/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
@@ -22,14 +22,13 @@
 // Created by marechaljas on 15/03/23.
 //
 #define BOOST_TEST_MODULE store - timeseries - number
-#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
 
 #include <files-system.h>
 #include <filesystem>
 #include <fstream>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/benchmarking/DurationCollector.h>
 #include <antares/writer/result_format.h>

--- a/src/tests/src/solver/simulation/test-time_series.cpp
+++ b/src/tests/src/solver/simulation/test-time_series.cpp
@@ -22,14 +22,13 @@
 // Created by marechaljas on 07/04/23.
 //
 #define BOOST_TEST_MODULE rhsTimeSeries
-#define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN
 
 #include <files-system.h>
 #include <filesystem>
 #include <fstream>
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/study/study.h>
 

--- a/src/tests/src/solver/simulation/tests-ts-numbers.cpp
+++ b/src/tests/src/solver/simulation/tests-ts-numbers.cpp
@@ -19,13 +19,12 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test solver simulation things
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
 #include <algorithm> // std::adjacent_find
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/solver/simulation/timeseries-numbers.h>
 #include <antares/utils/utils.h>

--- a/src/tests/src/solver/utils/CMakeLists.txt
+++ b/src/tests/src/solver/utils/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(${EXECUTABLE_NAME}
 
 target_link_libraries(${EXECUTABLE_NAME}
                       PRIVATE
-                      Boost::boost Boost::disable_autolinking
+                      antares-unit-test
                       ortools::ortools
                       Antares::solverUtils
 )

--- a/src/tests/src/solver/utils/CMakeLists.txt
+++ b/src/tests/src/solver/utils/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(${EXECUTABLE_NAME}
 
 target_link_libraries(${EXECUTABLE_NAME}
                       PRIVATE
-                      Boost::unit_test_framework
+                      Boost::boost Boost::disable_autolinking
                       ortools::ortools
                       Antares::solverUtils
 )

--- a/src/tests/src/solver/utils/basis_status.cpp
+++ b/src/tests/src/solver/utils/basis_status.cpp
@@ -19,11 +19,10 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE test adequacy patch functions
-#define BOOST_TEST_DYN_LINK
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 #include <antares/solver/utils/basis_status.h>
 

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -13,12 +13,10 @@
       "platform": "windows"
     },
     {
-      "name": "boost-test",
-      "platform": "windows"
+      "name": "boost-test"
     },
     {
-      "name": "boost-algorithm",
-      "platform": "windows"
+      "name": "boost-algorithm"
     },
     {
       "name": "minizip-ng",


### PR DESCRIPTION
This will allow us to easily select the boost version we want, independently from the OS.

In order to simplify things, this PR includes the **following change**
 - use header version of boost test

**Why**
currently, we use the dynamic link version. This implies to install boost test as a dynamic library, independently of other libraries.
This is feasible with VCPKG with a custom "triplet".
However, the use of this dynamic library has shown more issues than benefits:
- the actual benefits in size and build time are completely negligible
- the fact that we need the dynamic link version si hidden: if a user installs the static version, he will not understand why tests don't run. By using the header version, we ensure the tests will work in any case.