### PR TITLE
Revert "Bump upload-artifact to v4, use unique names for artifacts"

### DIFF
--- a/.github/workflows/build-userguide.yml
+++ b/.github/workflows/build-userguide.yml
@@ -58,7 +58,7 @@ jobs:
         echo "PDF_PATH_ASSET= [\"docs/pdf-doc-generation-with-sphinx/$PDF_NAME\"]" >> $GITHUB_ENV
 
     - name: user guide upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: pdf-reference-guide
         path: ${{ env.PDF_PATH }}

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -120,15 +120,13 @@ jobs:
            cpack -G TGZ
 
     - name: Installer TGZ push
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
-        name: targz
         path: _build/*.tar.gz
 
     - name: Installer RPM push
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
-        name: rpm
         path: _build/*.rpm
 
     - name: Publish assets

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -119,15 +119,13 @@ jobs:
            cpack -G TGZ
 
     - name: Installer TGZ push
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
-        name: targz
         path: _build/*.tar.gz
 
     - name: Installer RPM push
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
-        name: rpm
         path: _build/*.rpm
 
     - name: Publish assets

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -145,7 +145,7 @@ jobs:
 
     - name: Upload logs for failed tests
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: test-log
         path: ${{ github.workspace }}/_build/Testing/Temporary/LastTest.log
@@ -277,15 +277,13 @@ jobs:
            rm -rf install
 
     - name: Installer archive upload push
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
-        name: targz
         path: _build/*.tar.gz
 
     - name: Installer deb upload push
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
-        name: deb
         path: _build/*.deb
 
 

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -190,7 +190,7 @@ jobs:
 
     - name: Upload build on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: MPS-diff
         path: ${{ github.workspace }}/src/tests/mps
@@ -319,7 +319,7 @@ jobs:
 
     - name: Upload NSIS log on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: NSISError.log
         path: _build/_CPack_Packages/win64/NSIS/NSISOutput.log
@@ -330,9 +330,8 @@ jobs:
            cpack -G ZIP
 
     - name: Installer upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
-        name: installer
         path: _build/${{env.NSIS_NAME}}
 
     - name: Publish assets


### PR DESCRIPTION
Reverts AntaresSimulatorTeam/Antares_Simulator#2076

OL8 & CentOS7 are incompatible with NodeJS 20. There seems to be no obvious solution.