### PR TITLE
Fix build for OL8

### DIFF
--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - develop
+      - fix/build-ol8
       - dependabot/*
 
   schedule:

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - develop
-      - fix/build-ol8
       - dependabot/*
 
   schedule:

--- a/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
+++ b/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
@@ -18,6 +18,8 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
+#include <list> // Fix for Boost < 1.67
+
 #define BOOST_TEST_MODULE test - end - to - end tests_binding_constraints
 #define BOOST_TEST_DYN_LINK
 #define WIN32_LEAN_AND_MEAN

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -18,6 +18,8 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
+#include <list> // Fix for Boost < 1.67
+
 #define BOOST_TEST_MODULE test - end - to - end tests
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/data/test_case.hpp>

--- a/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
+++ b/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
@@ -18,7 +18,7 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
-#include <list>
+#include <list> // Fix for Boost < 1.67
 
 #define BOOST_TEST_MODULE test - concurrency tests
 #define BOOST_TEST_DYN_LINK

--- a/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
+++ b/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
@@ -18,6 +18,8 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
+#include <list>
+
 #define BOOST_TEST_MODULE test - concurrency tests
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/data/test_case.hpp>

--- a/src/tests/src/libs/antares/writer/test_writer.cpp
+++ b/src/tests/src/libs/antares/writer/test_writer.cpp
@@ -18,6 +18,8 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
+#include <list> // Fix for Boost < 1.67
+
 #define BOOST_TEST_MODULE test - writer tests
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/data/test_case.hpp>

--- a/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
+++ b/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
@@ -18,6 +18,8 @@
  * You should have received a copy of the Mozilla Public Licence 2.0
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
+#include <list> // Fix for Boost < 1.67
+
 #define WIN32_LEAN_AND_MEAN
 #define BOOST_TEST_MODULE unfeasible_problem_analyzer
 #define BOOST_TEST_DYN_LINK


### PR DESCRIPTION
Boost < 1.67 has issues with the list header. Include it just before to avoid a compilation error.