### PR TITLE
Fix enum deprecation warning for DataLevel

### DIFF
--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -232,7 +232,7 @@ void AllVariablesPrintInfo::computeMaxColumnsCountInReports()
     // it contains, and incrementing a counter with as many columns as the current variable can take
     // up at most in a report.
 
-    for (uint CDataLevel = 1; CDataLevel <= Category::maxDataLevel; CDataLevel *= 2)
+    for (uint CDataLevel = 1; CDataLevel <= Category::DataLevel::maxDataLevel; CDataLevel *= 2)
     {
         for (uint CFileLevel = 1; CFileLevel <= Category::maxFileLevel; CFileLevel *= 2)
         {
@@ -260,7 +260,7 @@ void AllVariablesPrintInfo::countSelectedAreaVars()
                                                 [](auto& p) {
                                                     return p.second.isPrinted()
                                                            && p.second.isPrintedOnDataLevel(
-                                                             Category::area);
+                                                             Category::DataLevel::area);
                                                 });
 }
 
@@ -271,7 +271,7 @@ void AllVariablesPrintInfo::countSelectedLinkVars()
                                                 [](auto& p) {
                                                     return p.second.isPrinted()
                                                            && p.second.isPrintedOnDataLevel(
-                                                             Category::link);
+                                                             Category::DataLevel::link);
                                                 });
 }
 

--- a/src/solver/variable/include/antares/solver/variable/adequacy/overallCost.h
+++ b/src/solver/variable/include/antares/solver/variable/adequacy/overallCost.h
@@ -64,7 +64,7 @@ struct VCardOverallCost
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/adequacy/spilledEnergy.h
+++ b/src/solver/variable/include/antares/solver/variable/adequacy/spilledEnergy.h
@@ -65,7 +65,7 @@ struct VCardSpilledEnergy
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/area.h
+++ b/src/solver/variable/include/antares/solver/variable/area.h
@@ -55,7 +55,7 @@ struct VCardAllAreas
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & Category::de,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/area.hxx
+++ b/src/solver/variable/include/antares/solver/variable/area.hxx
@@ -64,9 +64,9 @@ void Areas<NextT>::buildSurveyReport(SurveyResults& results,
                                      int precision) const
 {
     int count_int = count;
-    bool linkDataLevel = dataLevel & Category::link;
-    bool areaDataLevel = dataLevel & Category::area;
-    bool thermalAggregateDataLevel = dataLevel & Category::thermalAggregate;
+    bool linkDataLevel = dataLevel & Category::DataLevel::link;
+    bool areaDataLevel = dataLevel & Category::DataLevel::area;
+    bool thermalAggregateDataLevel = dataLevel & Category::DataLevel::thermalAggregate;
     if (count_int && (linkDataLevel || areaDataLevel || thermalAggregateDataLevel))
     {
         assert(results.data.area != NULL
@@ -76,7 +76,7 @@ void Areas<NextT>::buildSurveyReport(SurveyResults& results,
         auto& area = *results.data.area;
 
         // Filtering
-        if (0 == (dataLevel & Category::link)) // filter on all but links
+        if (0 == (dataLevel & Category::DataLevel::link)) // filter on all but links
         {
             switch (precision)
             {
@@ -126,9 +126,9 @@ void Areas<NextT>::buildAnnualSurveyReport(SurveyResults& results,
                                            uint numSpace) const
 {
     int count_int = count;
-    bool linkDataLevel = dataLevel & Category::link;
-    bool areaDataLevel = dataLevel & Category::area;
-    bool thermalAggregateDataLevel = dataLevel & Category::thermalAggregate;
+    bool linkDataLevel = dataLevel & Category::DataLevel::link;
+    bool areaDataLevel = dataLevel & Category::DataLevel::area;
+    bool thermalAggregateDataLevel = dataLevel & Category::DataLevel::thermalAggregate;
     if (count_int && (linkDataLevel || areaDataLevel || thermalAggregateDataLevel))
     {
         assert(results.data.area != NULL
@@ -137,7 +137,7 @@ void Areas<NextT>::buildAnnualSurveyReport(SurveyResults& results,
         auto& area = *results.data.area;
 
         // Filtering
-        if (0 == (dataLevel & Category::link)) // filter on all but links
+        if (0 == (dataLevel & Category::DataLevel::link)) // filter on all but links
         {
             switch (precision)
             {
@@ -191,7 +191,7 @@ void Areas<NextT>::buildDigest(SurveyResults& results, int digestLevel, int data
     int count_int = count;
     if (count_int)
     {
-        if (dataLevel & Category::area)
+        if (dataLevel & Category::DataLevel::area)
         {
             assert(pAreaCount == results.data.study.areas.size());
 

--- a/src/solver/variable/include/antares/solver/variable/bindConstraints.h
+++ b/src/solver/variable/include/antares/solver/variable/bindConstraints.h
@@ -54,7 +54,7 @@ struct VCardAllBindingConstraints
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::bindingConstraint,
+        categoryDataLevel = Category::DataLevel::bindingConstraint,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & Category::bc,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/bindConstraints.hxx
+++ b/src/solver/variable/include/antares/solver/variable/bindConstraints.hxx
@@ -36,7 +36,7 @@ void BindingConstraints<NextT>::buildSurveyReport(SurveyResults& results,
                                                   int fileLevel,
                                                   int precision) const
 {
-    if (bool bcDataLevel = dataLevel & Category::bindingConstraint; !bcDataLevel)
+    if (bool bcDataLevel = dataLevel & Category::DataLevel::bindingConstraint; !bcDataLevel)
     {
         return;
     }
@@ -56,7 +56,7 @@ void BindingConstraints<NextT>::buildAnnualSurveyReport(SurveyResults& results,
                                                         int precision,
                                                         uint numSpace) const
 {
-    if (bool bcDataLevel = dataLevel & Category::bindingConstraint; !bcDataLevel)
+    if (bool bcDataLevel = dataLevel & Category::DataLevel::bindingConstraint; !bcDataLevel)
     {
         return;
     }

--- a/src/solver/variable/include/antares/solver/variable/categories.h
+++ b/src/solver/variable/include/antares/solver/variable/categories.h
@@ -31,23 +31,21 @@ namespace Variable
 {
 namespace Category
 {
-enum DataLevel
+namespace DataLevel
 {
     //! Data that belong to a single area
-    area = 1,
+    constexpr uint8_t area = 1;
     //! Data that belong to a thermal dispatchable cluster
-    thermalAggregate = 2,
+    constexpr uint8_t thermalAggregate = 2;
     //! Data that belong to a link
-    link = 4,
+    constexpr uint8_t link = 4;
     //! Data that belong to a set
-    setOfAreas = 8,
+    constexpr uint8_t setOfAreas = 8;
     // Data belonging to a binding constraint
-    bindingConstraint = 16,
+    constexpr uint8_t bindingConstraint = 16;
     //! The maximum available level
-    maxDataLevel = 16,
-    //! All data level
-    allDataLevel = area | thermalAggregate | link | setOfAreas | bindingConstraint
-};
+    constexpr uint8_t maxDataLevel = 16;
+}
 
 enum File
 {
@@ -167,6 +165,7 @@ inline void DataLevelToStream(StreamT& out, int dataLevel)
 {
     switch (dataLevel)
     {
+    using namespace DataLevel;
     case area:
         out += "area";
         break;

--- a/src/solver/variable/include/antares/solver/variable/commons/hydro.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/hydro.h
@@ -66,7 +66,7 @@ struct VCardTimeSeriesValuesHydro
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/commons/join.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/join.h
@@ -61,7 +61,7 @@ struct VCardJoin
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/commons/links/links.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/links/links.h
@@ -64,7 +64,7 @@ struct VCardAllLinks
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/commons/links/links.hxx
+++ b/src/solver/variable/include/antares/solver/variable/commons/links/links.hxx
@@ -210,7 +210,7 @@ inline void Links<VariablePerLink>::buildSurveyReport(SurveyResults& results,
                                                       int precision) const
 {
     int count_int = count;
-    bool link_dataLevel = (dataLevel & Category::link);
+    bool link_dataLevel = (dataLevel & Category::DataLevel::link);
     if (count_int && link_dataLevel)
     {
         assert(results.data.link != NULL
@@ -268,7 +268,7 @@ inline void Links<VariablePerLink>::buildAnnualSurveyReport(SurveyResults& resul
                                                             uint numSpace) const
 {
     int count_int = count;
-    bool link_dataLevel = (dataLevel & Category::link);
+    bool link_dataLevel = (dataLevel & Category::DataLevel::link);
     if (count_int && link_dataLevel)
     {
         assert(results.data.link != NULL
@@ -426,8 +426,8 @@ void Links<VariablePerLink>::buildDigest(SurveyResults& results,
                                          int dataLevel) const
 {
     int count_int = count;
-    bool linkDataLevel = dataLevel & Category::link;
-    bool areaDataLevel = dataLevel & Category::area;
+    bool linkDataLevel = dataLevel & Category::DataLevel::link;
+    bool areaDataLevel = dataLevel & Category::DataLevel::area;
     if (count_int && (linkDataLevel || areaDataLevel))
     {
         if (not results.data.area->links.empty())
@@ -438,7 +438,7 @@ void Links<VariablePerLink>::buildDigest(SurveyResults& results,
                 results.data.link = i->second;
                 pLinks[results.data.link->indexForArea].buildDigest(results,
                                                                     digestLevel,
-                                                                    Category::link);
+                                                                    Category::DataLevel::link);
             }
         }
     }

--- a/src/solver/variable/include/antares/solver/variable/commons/load.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/load.h
@@ -67,7 +67,7 @@ struct VCardTimeSeriesValuesLoad
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/commons/miscGenMinusRowPSP.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/miscGenMinusRowPSP.h
@@ -64,7 +64,7 @@ struct VCardMiscGenMinusRowPSP
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/commons/psp.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/psp.h
@@ -64,7 +64,7 @@ struct VCardPSP
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/commons/rowBalance.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/rowBalance.h
@@ -64,7 +64,7 @@ struct VCardRowBalance
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/commons/solar.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/solar.h
@@ -66,7 +66,7 @@ struct VCardTimeSeriesValuesSolar
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/commons/spatial-aggregate.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/spatial-aggregate.h
@@ -126,7 +126,7 @@ struct VCardProxy
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::setOfAreas,
+        categoryDataLevel = Category::DataLevel::setOfAreas,
         //! File level (provided by the type of the results)
         categoryFileLevel = VCardOrigin::categoryFileLevel,
         //! Precision (views)
@@ -355,7 +355,7 @@ public:
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
         // Generate the Digest for the local results (districts part)
-        if (VCardType::columnCount != 0 && (VCardType::categoryDataLevel & Category::setOfAreas))
+        if (VCardType::columnCount != 0 && (VCardType::categoryDataLevel & Category::DataLevel::setOfAreas))
         {
             // Initializing pointer on variable non applicable and print stati arrays to beginning
             results.isPrinted = AncestorType::isPrinted;
@@ -376,7 +376,7 @@ public:
                                       int precision,
                                       uint numSpace) const
     {
-        if (VCardType::columnCount != 0 && (VCardType::categoryDataLevel & Category::setOfAreas))
+        if (VCardType::columnCount != 0 && (VCardType::categoryDataLevel & Category::DataLevel::setOfAreas))
         {
             // Initializing pointer on variable non applicable and print stati arrays to beginning
             results.isPrinted = AncestorType::isPrinted;

--- a/src/solver/variable/include/antares/solver/variable/commons/wind.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/wind.h
@@ -66,7 +66,7 @@ struct VCardTimeSeriesValuesWind
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -84,7 +84,7 @@ struct VCardSTSbyGroup
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/STStorageCashFlowByCluster.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STStorageCashFlowByCluster.h
@@ -55,7 +55,7 @@ struct VCardSTstorageCashFlowByCluster
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & Category::de_sts,
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/STStorageInjectionByCluster.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STStorageInjectionByCluster.h
@@ -55,7 +55,7 @@ struct VCardSTstorageInjectionByCluster
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::de_sts),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/STStorageLevelsByCluster.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STStorageLevelsByCluster.h
@@ -55,7 +55,7 @@ struct VCardSTstorageLevelsByCluster
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::de_sts),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/STStorageWithdrawalByCluster.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STStorageWithdrawalByCluster.h
@@ -55,7 +55,7 @@ struct VCardSTstorageWithdrawalByCluster
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::de_sts),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/avail-dispatchable-generation.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/avail-dispatchable-generation.h
@@ -65,7 +65,7 @@ struct VCardAvailableDispatchGen
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/balance.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/balance.h
@@ -66,7 +66,7 @@ struct VCardBalance
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -63,7 +63,7 @@ struct VCardBindingConstMarginCost
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::bindingConstraint,
+        categoryDataLevel = Category::DataLevel::bindingConstraint,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::bc),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchable-generation-margin.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchable-generation-margin.h
@@ -66,7 +66,7 @@ struct VCardDispatchableGenMargin
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -65,7 +65,7 @@ struct VCardDispatchableGeneration
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/domesticUnsuppliedEnergy.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/domesticUnsuppliedEnergy.h
@@ -66,7 +66,7 @@ struct VCardDomesticUnsuppliedEnergy
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/dtgMarginAfterCsr.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dtgMarginAfterCsr.h
@@ -59,7 +59,7 @@ struct VCardDtgMarginCsr
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/hydroCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/hydroCost.h
@@ -67,7 +67,7 @@ struct VCardHydroCost
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/hydrostorage.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/hydrostorage.h
@@ -65,7 +65,7 @@ struct VCardHydroStorage
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/inflow.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/inflow.h
@@ -65,7 +65,7 @@ struct VCardInflows
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/congestionFee.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/congestionFee.h
@@ -62,7 +62,7 @@ struct VCardCongestionFee
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/congestionFeeAbs.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/congestionFeeAbs.h
@@ -64,7 +64,7 @@ struct VCardCongestionFeeAbs
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/congestionProbability.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/congestionProbability.h
@@ -55,7 +55,7 @@ struct VCardCongestionProbability
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/flowLinear.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/flowLinear.h
@@ -62,7 +62,7 @@ struct VCardFlowLinear
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)
@@ -238,7 +238,7 @@ public:
 
     void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
-        if (dataLevel & Category::link)
+        if (dataLevel & Category::DataLevel::link)
         {
             if (digestLevel & Category::digestFlowLinear)
             {

--- a/src/solver/variable/include/antares/solver/variable/economy/links/flowLinearAbs.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/flowLinearAbs.h
@@ -64,7 +64,7 @@ struct VCardFlowLinearAbs
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/flowQuad.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/flowQuad.h
@@ -59,7 +59,7 @@ struct VCardFlowQuad
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)
@@ -224,7 +224,7 @@ public:
 
     void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
-        if (dataLevel & Category::link)
+        if (dataLevel & Category::DataLevel::link)
         {
             if (digestLevel & Category::digestFlowQuad)
             {

--- a/src/solver/variable/include/antares/solver/variable/economy/links/hurdleCosts.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/hurdleCosts.h
@@ -62,7 +62,7 @@ struct VCardHurdleCosts
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/loopFlow.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/loopFlow.h
@@ -59,7 +59,7 @@ struct VCardLoopFlow
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/marginalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/marginalCost.h
@@ -64,7 +64,7 @@ struct VCardMarginalCost
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::link,
+        categoryDataLevel = Category::DataLevel::link,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/localMatchingRuleViolations.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/localMatchingRuleViolations.h
@@ -56,7 +56,7 @@ struct VCardLMRViolations
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/lold.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/lold.h
@@ -66,7 +66,7 @@ struct VCardLOLD
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/lolp.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/lolp.h
@@ -62,7 +62,7 @@ struct VCardLOLP
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/max-mrg.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/max-mrg.h
@@ -65,7 +65,7 @@ struct VCardMARGE
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/nbOfDispatchedUnits.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/nbOfDispatchedUnits.h
@@ -69,7 +69,7 @@ struct VCardNbOfDispatchedUnits
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -62,7 +62,7 @@ struct VCardNbOfDispatchedUnitsByPlant
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::de),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/nonProportionalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/nonProportionalCost.h
@@ -69,7 +69,7 @@ struct VCardNonProportionalCost
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/npCostByDispatchablePlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/npCostByDispatchablePlant.h
@@ -62,7 +62,7 @@ struct VCardNonProportionalCostByDispatchablePlant
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::de),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/operatingCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/operatingCost.h
@@ -68,7 +68,7 @@ struct VCardOperatingCost
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/overallCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/overallCost.h
@@ -64,7 +64,7 @@ struct VCardOverallCost
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/overflow.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/overflow.h
@@ -65,7 +65,7 @@ struct VCardOverflow
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/price.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/price.h
@@ -65,7 +65,7 @@ struct VCardPrice
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/productionByDispatchablePlant.h
@@ -62,7 +62,7 @@ struct VCardProductionByDispatchablePlant
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::de),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/productionByRenewablePlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/productionByRenewablePlant.h
@@ -62,7 +62,7 @@ struct VCardProductionByRenewablePlant
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::de_res),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/profitByPlant.h
@@ -62,7 +62,7 @@ struct VCardProfitByPlant
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::de),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/pumping.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/pumping.h
@@ -65,7 +65,7 @@ struct VCardPumping
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -65,7 +65,7 @@ struct VCardRenewableGeneration
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/reservoirlevel.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/reservoirlevel.h
@@ -65,7 +65,7 @@ struct VCardReservoirLevel
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/spilledEnergy.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/spilledEnergy.h
@@ -65,7 +65,7 @@ struct VCardSpilledEnergy
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/spilledEnergyAfterCSR.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/spilledEnergyAfterCSR.h
@@ -60,7 +60,7 @@ struct VCardSpilledEnergyAfterCSR
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/thermalAirPollutantEmissions.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/thermalAirPollutantEmissions.h
@@ -60,7 +60,7 @@ struct VCardThermalAirPollutantEmissions
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/unsupliedEnergy.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/unsupliedEnergy.h
@@ -65,7 +65,7 @@ struct VCardUnsupliedEnergy
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/economy/waterValue.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/waterValue.h
@@ -65,7 +65,7 @@ struct VCardWaterValue
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
         //! Precision (views)

--- a/src/solver/variable/include/antares/solver/variable/setofareas.h
+++ b/src/solver/variable/include/antares/solver/variable/setofareas.h
@@ -57,7 +57,7 @@ struct VCardAllSetsOfAreas
     enum
     {
         //! Data Level
-        categoryDataLevel = Category::area,
+        categoryDataLevel = Category::DataLevel::area,
         //! File level (provided by the type of the results)
         categoryFileLevel = ResultsType::categoryFile & Category::de,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/setofareas.hxx
+++ b/src/solver/variable/include/antares/solver/variable/setofareas.hxx
@@ -213,7 +213,7 @@ inline void SetsOfAreas<NextT>::buildSurveyReport(SurveyResults& results,
                                                   int precision) const
 {
     int count_int = count;
-    bool setOfAreasDataLevel = dataLevel & Category::setOfAreas;
+    bool setOfAreasDataLevel = dataLevel & Category::DataLevel::setOfAreas;
     if (count_int && setOfAreasDataLevel)
     {
         pSetsOfAreas[results.data.setOfAreasIndex]->buildSurveyReport(results,
@@ -231,7 +231,7 @@ inline void SetsOfAreas<NextT>::buildAnnualSurveyReport(SurveyResults& results,
                                                         uint numSpace) const
 {
     int count_int = count;
-    bool setOfAreasDataLevel = dataLevel & Category::setOfAreas;
+    bool setOfAreasDataLevel = dataLevel & Category::DataLevel::setOfAreas;
     if (count_int && setOfAreasDataLevel)
     {
         pSetsOfAreas[results.data.setOfAreasIndex]->buildAnnualSurveyReport(results,
@@ -246,7 +246,7 @@ template<class NextT>
 void SetsOfAreas<NextT>::buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
 {
     int count_int = count;
-    bool setOfAreasDataLevel = dataLevel & Category::setOfAreas;
+    bool setOfAreasDataLevel = dataLevel & Category::DataLevel::setOfAreas;
     if (count_int && setOfAreasDataLevel)
     {
         // Reset

--- a/src/solver/variable/include/antares/solver/variable/storage/average.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/average.h
@@ -135,7 +135,7 @@ protected:
                                || (VCardT::categoryFileLevel & Category::de_res);
         const bool isBindingConstraint = VCardT::categoryFileLevel & Category::bc;
         const bool isDigest = digestLevel & Category::digestAllYears;
-        if ((dataLevel & Category::area || dataLevel & Category::setOfAreas) && isDigest
+        if ((dataLevel & Category::DataLevel::area || dataLevel & Category::DataLevel::setOfAreas) && isDigest
             && !isCluster && !isBindingConstraint)
         {
             assert(report.data.columnIndex < report.maxVariables && "Column index out of bounds");

--- a/src/solver/variable/include/antares/solver/variable/storage/raw.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/raw.h
@@ -135,7 +135,7 @@ protected:
     template<class VCardT>
     void buildDigest(SurveyResults& report, int digestLevel, int dataLevel) const
     {
-        if ((dataLevel & Category::area || dataLevel & Category::setOfAreas)
+        if ((dataLevel & Category::DataLevel::area || dataLevel & Category::DataLevel::setOfAreas)
             && digestLevel & Category::digestAllYears)
         {
             assert(report.data.columnIndex < report.maxVariables && "Column index out of bounds");

--- a/src/solver/variable/include/antares/solver/variable/surveyresults/reportbuilder.hxx
+++ b/src/solver/variable/include/antares/solver/variable/surveyresults/reportbuilder.hxx
@@ -80,7 +80,7 @@ struct BrowseAllVariables
     enum
     {
         nextFileLevel = (CFile * 2 > (int)Category::maxFileLevel) ? 1 : CFile * 2,
-        nextDataLevel = (CDataLevel * 2 > (int)Category::maxDataLevel) ? 1 : CDataLevel * 2,
+        nextDataLevel = (CDataLevel * 2 > (int)Category::DataLevel::maxDataLevel) ? 1 : CDataLevel * 2,
         currentValue = NextT::template Statistics < CDataLevel,
         CFile > ::count,
         nextValue = BrowseAllVariables < NextT,
@@ -103,11 +103,11 @@ struct BrowseAllVariables
 };
 
 template<class NextT>
-struct BrowseAllVariables<NextT, Category::maxDataLevel, Category::maxFileLevel>
+struct BrowseAllVariables<NextT, Category::DataLevel::maxDataLevel, Category::maxFileLevel>
 {
     enum
     {
-        maxValue = NextT::template Statistics < Category::maxDataLevel,
+        maxValue = NextT::template Statistics < Category::DataLevel::maxDataLevel,
         Category::maxFileLevel > ::count
     };
 
@@ -115,7 +115,7 @@ struct BrowseAllVariables<NextT, Category::maxDataLevel, Category::maxFileLevel>
     static void buildSurveyResults(const L& list, S& results)
     {
         // Exporting data for the current state
-        list.template buildSurveyResults<S, Category::maxDataLevel, Category::maxFileLevel>(
+        list.template buildSurveyResults<S, Category::DataLevel::maxDataLevel, Category::maxFileLevel>(
           results);
         // This is the final available state
     }
@@ -211,20 +211,20 @@ public:
     static void Run(const ListType& list, SurveyResults& results, unsigned int numSpace = 9999)
     {
         // Area - Thermal clusters - Links
-        if (CDataLevel & Category::area || CDataLevel & Category::link
-            || CDataLevel & Category::thermalAggregate)
+        if (CDataLevel & Category::DataLevel::area || CDataLevel & Category::DataLevel::link
+            || CDataLevel & Category::DataLevel::thermalAggregate)
         {
             RunForEachArea(list, results, numSpace);
         }
 
         // Set of Areas
-        if (CDataLevel & Category::setOfAreas)
+        if (CDataLevel & Category::DataLevel::setOfAreas)
         {
             RunForEachSetOfAreas(list, results, numSpace);
         }
 
         // Binding constraints level
-        if (CDataLevel & Category::bindingConstraint)
+        if (CDataLevel & Category::DataLevel::bindingConstraint)
         {
             RunForEachBindingConstraint(list, results, numSpace);
         }
@@ -242,11 +242,11 @@ public:
 
         // Digest file : areas part
         std::string digestBuffer;
-        list.buildDigest(results, Category::digestAllYears, Category::area);
+        list.buildDigest(results, Category::digestAllYears, Category::DataLevel::area);
         results.exportDigestAllYears(digestBuffer);
 
         // Degest file : districts part
-        list.buildDigest(results, Category::digestAllYears, Category::setOfAreas);
+        list.buildDigest(results, Category::digestAllYears, Category::DataLevel::setOfAreas);
         results.exportDigestAllYears(digestBuffer);
 
         // Digest: Flow linear (only if selected by user)
@@ -254,7 +254,7 @@ public:
         {
             logs.debug() << " . Digest, flow linear";
             results.data.matrix.fill(std::numeric_limits<double>::quiet_NaN());
-            list.buildDigest(results, Category::digestFlowLinear, Category::area);
+            list.buildDigest(results, Category::digestFlowLinear, Category::DataLevel::area);
             results.exportDigestMatrix("Links (FLOW LIN.)", digestBuffer);
         }
 
@@ -263,7 +263,7 @@ public:
         {
             logs.debug() << " . Digest, flow quad";
             results.data.matrix.fill(std::numeric_limits<double>::quiet_NaN());
-            list.buildDigest(results, Category::digestFlowQuad, Category::area);
+            list.buildDigest(results, Category::digestFlowQuad, Category::DataLevel::area);
             results.exportDigestMatrix("Links (FLOW QUAD.)", digestBuffer);
         }
         // THIS FILE IS DEPRECATED !!!
@@ -312,7 +312,7 @@ private:
             skipDirectory = skipDirectory || !selectedZonalVarsCount;
 
             // Generating the report for each area
-            if (CDataLevel & Category::area && !skipDirectory)
+            if (CDataLevel & Category::DataLevel::area && !skipDirectory)
             {
                 logs.info() << "Exporting results : " << area.name;
                 // The new output
@@ -323,12 +323,12 @@ private:
             }
 
             // Thermal clusters for the current area
-            if (CDataLevel & Category::thermalAggregate)
+            if (CDataLevel & Category::DataLevel::thermalAggregate)
             {
                 RunForEachThermalCluster(list, results, numSpace);
             }
             // Links
-            if (CDataLevel & Category::link && !area.links.empty())
+            if (CDataLevel & Category::DataLevel::link && !area.links.empty())
             {
                 RunForEachLink(list, results, numSpace);
             }
@@ -340,8 +340,8 @@ private:
                                          unsigned int numSpace)
     {
         // Only do something if there is at least one column to write somewhere
-        // See below: if (CDataLevel & Category::thermalAggregate)
-        if (VariablesStatsByDataLevel<NextT, Category::thermalAggregate>::count)
+        // See below: if (CDataLevel & Category::DataLevel::thermalAggregate)
+        if (VariablesStatsByDataLevel<NextT, Category::DataLevel::thermalAggregate>::count)
         {
             auto& area = *results.data.area;
             for (auto& cluster: area.thermal.list.each_enabled_and_not_mustrun())
@@ -371,7 +371,7 @@ private:
             return;
         }
 
-        int count_int = VariablesStatsByDataLevel<NextT, Category::link>::count;
+        int count_int = VariablesStatsByDataLevel<NextT, Category::DataLevel::link>::count;
         if (count_int)
         {
             auto& area = *results.data.area;
@@ -461,7 +461,7 @@ private:
         using namespace Yuni;
 
         // Generating the report for each binding constraint
-        if (CDataLevel & Category::bindingConstraint)
+        if (CDataLevel & Category::DataLevel::bindingConstraint)
         {
             logs.info() << "Exporting results : binding constraints";
             // The new output
@@ -474,7 +474,7 @@ private:
 }; // class SurveyReportBuilder
 
 template<bool GlobalT, class NextT>
-class SurveyReportBuilder<GlobalT, NextT, 2 * Category::maxDataLevel>
+class SurveyReportBuilder<GlobalT, NextT, 2 * Category::DataLevel::maxDataLevel>
 {
 public:
     using ListType = NextT;

--- a/src/solver/variable/include/antares/solver/variable/variable.hxx
+++ b/src/solver/variable/include/antares/solver/variable/variable.hxx
@@ -331,9 +331,9 @@ inline void IVariable<ChildT, NextT, VCardT>::buildDigest(SurveyResults& results
 {
     // Generate the Digest for the local results (areas part)
     if (VCardType::columnCount != 0
-        && (VCardType::categoryDataLevel & Category::setOfAreas
-            || VCardType::categoryDataLevel & Category::area
-            || VCardType::categoryDataLevel & Category::link))
+        && (VCardType::categoryDataLevel & Category::DataLevel::setOfAreas
+            || VCardType::categoryDataLevel & Category::DataLevel::area
+            || VCardType::categoryDataLevel & Category::DataLevel::link))
     {
         // Initializing pointer on variable non applicable and print stati arrays to beginning
         results.isPrinted = isPrinted;


### PR DESCRIPTION
On modern compilers (gcc>=11, clang>=17), this enum appears hundreds if not thousands of times because of templates, so it's very annoying.