### PR TITLE
Fix enum deprecation warning for FileLevel

### DIFF
--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -234,7 +234,7 @@ void AllVariablesPrintInfo::computeMaxColumnsCountInReports()
 
     for (uint CDataLevel = 1; CDataLevel <= Category::maxDataLevel; CDataLevel *= 2)
     {
-        for (uint CFileLevel = 1; CFileLevel <= Category::maxFileLevel; CFileLevel *= 2)
+        for (uint CFileLevel = 1; CFileLevel <= Category::FileLevel::maxFileLevel; CFileLevel *= 2)
         {
             uint currentColumnsCount = 0;
             for (auto& [name, variable]: allVarsPrintInfo)

--- a/src/solver/variable/include/antares/solver/variable/adequacy/overallCost.h
+++ b/src/solver/variable/include/antares/solver/variable/adequacy/overallCost.h
@@ -66,7 +66,7 @@ struct VCardOverallCost
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/adequacy/spilledEnergy.h
+++ b/src/solver/variable/include/antares/solver/variable/adequacy/spilledEnergy.h
@@ -67,7 +67,7 @@ struct VCardSpilledEnergy
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/area.h
+++ b/src/solver/variable/include/antares/solver/variable/area.h
@@ -57,7 +57,7 @@ struct VCardAllAreas
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & Category::de,
+        categoryFileLevel = ResultsType::categoryFile & Category::FileLevel::de,
         //! Indentation (GUI)
         nodeDepthForGUI = +1,
         //! Number of columns used by the variable (One ResultsType per column)

--- a/src/solver/variable/include/antares/solver/variable/bindConstraints.h
+++ b/src/solver/variable/include/antares/solver/variable/bindConstraints.h
@@ -56,7 +56,7 @@ struct VCardAllBindingConstraints
         //! Data Level
         categoryDataLevel = Category::bindingConstraint,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & Category::bc,
+        categoryFileLevel = ResultsType::categoryFile & Category::FileLevel::bc,
         //! Indentation (GUI)
         nodeDepthForGUI = +1,
         //! Number of columns used by the variable (One ResultsType per column)

--- a/src/solver/variable/include/antares/solver/variable/categories.h
+++ b/src/solver/variable/include/antares/solver/variable/categories.h
@@ -16,7 +16,7 @@
 ** Mozilla Public Licence 2.0 for more details.
 **
 ** You should have received a copy of the Mozilla Public Licence 2.0
-* along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #ifndef __SOLVER_VARIABLE_CATEGORIES_H__
 #define __SOLVER_VARIABLE_CATEGORIES_H__

--- a/src/solver/variable/include/antares/solver/variable/categories.h
+++ b/src/solver/variable/include/antares/solver/variable/categories.h
@@ -16,7 +16,7 @@
 ** Mozilla Public Licence 2.0 for more details.
 **
 ** You should have received a copy of the Mozilla Public Licence 2.0
-** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+* along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #ifndef __SOLVER_VARIABLE_CATEGORIES_H__
 #define __SOLVER_VARIABLE_CATEGORIES_H__
@@ -49,24 +49,24 @@ enum DataLevel
     allDataLevel = area | thermalAggregate | link | setOfAreas | bindingConstraint
 };
 
-enum File
+namespace FileLevel
 {
     //! Values of physical variables
-    va = 1,
+    constexpr uint8_t va = 1;
     //! Reference numbers
-    id = 2,
+    constexpr uint8_t id = 2;
     //! Detailed values regarding thermal generation
-    de = 4,
+    constexpr uint8_t de = 4;
     //! Detailed values regarding RES generation
-    de_res = 8,
+    constexpr uint8_t de_res = 8;
     //! Detailed values regarding binding constraints
-    bc = 16,
+    constexpr uint8_t bc = 16;
     //! Detailed values regarding short term storage
-    de_sts = 32,
+    constexpr uint8_t de_sts = 32;
     //! The maximum available value
-    maxFileLevel = 32,
+    constexpr uint8_t maxFileLevel = 32;
     //! All file level
-    allFile = va | id | de | de_res | bc | de_sts,
+    constexpr uint8_t allFile = va | id | de | de_res | bc | de_sts;
 };
 
 enum Precision
@@ -150,7 +150,7 @@ enum SpatialAggregatePostProcessing
 */
 static inline uint MaxDecimalPrecision(uint fileLevel)
 {
-    return (fileLevel != id) ? 2u : 0u;
+    return (fileLevel != FileLevel::id) ? 2u : 0u;
 }
 
 template<int Index, int Limit>
@@ -189,6 +189,7 @@ inline void FileLevelToStreamShort(StreamT& out, int fileLevel)
 {
     switch (fileLevel)
     {
+    using namespace FileLevel;
     case va:
         out += "va";
         break;
@@ -217,6 +218,7 @@ inline void FileLevelToStream(StreamT& out, int fileLevel)
 {
     switch (fileLevel)
     {
+    using namespace FileLevel;
     case va:
         out += "values";
         break;

--- a/src/solver/variable/include/antares/solver/variable/commons/hydro.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/hydro.h
@@ -68,7 +68,7 @@ struct VCardTimeSeriesValuesHydro
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/commons/join.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/join.h
@@ -63,7 +63,7 @@ struct VCardJoin
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/commons/load.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/load.h
@@ -69,7 +69,7 @@ struct VCardTimeSeriesValuesLoad
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/commons/miscGenMinusRowPSP.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/miscGenMinusRowPSP.h
@@ -66,7 +66,7 @@ struct VCardMiscGenMinusRowPSP
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/commons/psp.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/psp.h
@@ -66,7 +66,7 @@ struct VCardPSP
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/commons/rowBalance.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/rowBalance.h
@@ -66,7 +66,7 @@ struct VCardRowBalance
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/commons/solar.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/solar.h
@@ -68,7 +68,7 @@ struct VCardTimeSeriesValuesSolar
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/commons/wind.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/wind.h
@@ -68,7 +68,7 @@ struct VCardTimeSeriesValuesWind
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -86,7 +86,7 @@ struct VCardSTSbyGroup
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/STStorageCashFlowByCluster.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STStorageCashFlowByCluster.h
@@ -57,7 +57,7 @@ struct VCardSTstorageCashFlowByCluster
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & Category::de_sts,
+        categoryFileLevel = ResultsType::categoryFile & Category::FileLevel::de_sts,
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/STStorageInjectionByCluster.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STStorageInjectionByCluster.h
@@ -57,7 +57,7 @@ struct VCardSTstorageInjectionByCluster
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::de_sts),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::de_sts),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/STStorageLevelsByCluster.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STStorageLevelsByCluster.h
@@ -57,7 +57,7 @@ struct VCardSTstorageLevelsByCluster
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::de_sts),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::de_sts),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/STStorageWithdrawalByCluster.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STStorageWithdrawalByCluster.h
@@ -57,7 +57,7 @@ struct VCardSTstorageWithdrawalByCluster
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::de_sts),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::de_sts),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/avail-dispatchable-generation.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/avail-dispatchable-generation.h
@@ -67,7 +67,7 @@ struct VCardAvailableDispatchGen
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/balance.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/balance.h
@@ -68,7 +68,7 @@ struct VCardBalance
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -65,7 +65,7 @@ struct VCardBindingConstMarginCost
         //! Data Level
         categoryDataLevel = Category::bindingConstraint,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::bc),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::bc),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchable-generation-margin.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchable-generation-margin.h
@@ -68,7 +68,7 @@ struct VCardDispatchableGenMargin
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -67,7 +67,7 @@ struct VCardDispatchableGeneration
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/domesticUnsuppliedEnergy.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/domesticUnsuppliedEnergy.h
@@ -68,7 +68,7 @@ struct VCardDomesticUnsuppliedEnergy
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/dtgMarginAfterCsr.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dtgMarginAfterCsr.h
@@ -61,7 +61,7 @@ struct VCardDtgMarginCsr
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/hydroCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/hydroCost.h
@@ -69,7 +69,7 @@ struct VCardHydroCost
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/hydrostorage.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/hydrostorage.h
@@ -67,7 +67,7 @@ struct VCardHydroStorage
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/inflow.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/inflow.h
@@ -67,7 +67,7 @@ struct VCardInflows
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/congestionFee.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/congestionFee.h
@@ -64,7 +64,7 @@ struct VCardCongestionFee
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/congestionFeeAbs.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/congestionFeeAbs.h
@@ -66,7 +66,7 @@ struct VCardCongestionFeeAbs
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/congestionProbability.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/congestionProbability.h
@@ -57,7 +57,7 @@ struct VCardCongestionProbability
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/flowLinear.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/flowLinear.h
@@ -64,7 +64,7 @@ struct VCardFlowLinear
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/flowLinearAbs.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/flowLinearAbs.h
@@ -66,7 +66,7 @@ struct VCardFlowLinearAbs
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/flowQuad.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/flowQuad.h
@@ -61,7 +61,7 @@ struct VCardFlowQuad
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/hurdleCosts.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/hurdleCosts.h
@@ -64,7 +64,7 @@ struct VCardHurdleCosts
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/loopFlow.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/loopFlow.h
@@ -61,7 +61,7 @@ struct VCardLoopFlow
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/links/marginalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/marginalCost.h
@@ -66,7 +66,7 @@ struct VCardMarginalCost
         //! Data Level
         categoryDataLevel = Category::link,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/localMatchingRuleViolations.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/localMatchingRuleViolations.h
@@ -58,7 +58,7 @@ struct VCardLMRViolations
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/lold.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/lold.h
@@ -68,7 +68,7 @@ struct VCardLOLD
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/lolp.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/lolp.h
@@ -64,7 +64,7 @@ struct VCardLOLP
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/max-mrg.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/max-mrg.h
@@ -67,7 +67,7 @@ struct VCardMARGE
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/nbOfDispatchedUnits.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/nbOfDispatchedUnits.h
@@ -71,7 +71,7 @@ struct VCardNbOfDispatchedUnits
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/nbOfDispatchedUnitsByPlant.h
@@ -64,7 +64,7 @@ struct VCardNbOfDispatchedUnitsByPlant
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::de),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::de),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/nonProportionalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/nonProportionalCost.h
@@ -71,7 +71,7 @@ struct VCardNonProportionalCost
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/npCostByDispatchablePlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/npCostByDispatchablePlant.h
@@ -64,7 +64,7 @@ struct VCardNonProportionalCostByDispatchablePlant
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::de),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::de),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/operatingCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/operatingCost.h
@@ -70,7 +70,7 @@ struct VCardOperatingCost
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/overallCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/overallCost.h
@@ -66,7 +66,7 @@ struct VCardOverallCost
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/overflow.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/overflow.h
@@ -67,7 +67,7 @@ struct VCardOverflow
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/price.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/price.h
@@ -67,7 +67,7 @@ struct VCardPrice
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/productionByDispatchablePlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/productionByDispatchablePlant.h
@@ -64,7 +64,7 @@ struct VCardProductionByDispatchablePlant
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::de),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::de),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/productionByRenewablePlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/productionByRenewablePlant.h
@@ -64,7 +64,7 @@ struct VCardProductionByRenewablePlant
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::de_res),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::de_res),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/profitByPlant.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/profitByPlant.h
@@ -64,7 +64,7 @@ struct VCardProfitByPlant
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::de),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::de),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/pumping.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/pumping.h
@@ -67,7 +67,7 @@ struct VCardPumping
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -67,7 +67,7 @@ struct VCardRenewableGeneration
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/reservoirlevel.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/reservoirlevel.h
@@ -67,7 +67,7 @@ struct VCardReservoirLevel
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/spilledEnergy.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/spilledEnergy.h
@@ -67,7 +67,7 @@ struct VCardSpilledEnergy
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/spilledEnergyAfterCSR.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/spilledEnergyAfterCSR.h
@@ -62,7 +62,7 @@ struct VCardSpilledEnergyAfterCSR
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/thermalAirPollutantEmissions.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/thermalAirPollutantEmissions.h
@@ -62,7 +62,7 @@ struct VCardThermalAirPollutantEmissions
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/unsupliedEnergy.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/unsupliedEnergy.h
@@ -67,7 +67,7 @@ struct VCardUnsupliedEnergy
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/economy/waterValue.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/waterValue.h
@@ -67,7 +67,7 @@ struct VCardWaterValue
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & (Category::id | Category::va),
+        categoryFileLevel = ResultsType::categoryFile & (Category::FileLevel::id | Category::FileLevel::va),
         //! Precision (views)
         precision = Category::all,
         //! Indentation (GUI)

--- a/src/solver/variable/include/antares/solver/variable/info.h
+++ b/src/solver/variable/include/antares/solver/variable/info.h
@@ -415,9 +415,9 @@ struct VariableAccessor<ResultsT, Category::dynamicColumns>
     static bool setClusterCaption(SurveyResults& results, int fileLevel, uint idx)
     {
         assert(results.data.area && "Area is NULL");
-        const bool thermal_details = fileLevel & Category::de;
-        const bool renewable_details = fileLevel & Category::de_res;
-        const bool st_storage_details = fileLevel & Category::de_sts;
+        const bool thermal_details = fileLevel & Category::FileLevel::de;
+        const bool renewable_details = fileLevel & Category::FileLevel::de_res;
+        const bool st_storage_details = fileLevel & Category::FileLevel::de_sts;
 
         std::array<bool, 3> kind_of_details = {thermal_details,
                                                renewable_details,

--- a/src/solver/variable/include/antares/solver/variable/setofareas.h
+++ b/src/solver/variable/include/antares/solver/variable/setofareas.h
@@ -59,7 +59,7 @@ struct VCardAllSetsOfAreas
         //! Data Level
         categoryDataLevel = Category::area,
         //! File level (provided by the type of the results)
-        categoryFileLevel = ResultsType::categoryFile & Category::de,
+        categoryFileLevel = ResultsType::categoryFile & Category::FileLevel::de,
         //! Indentation (GUI)
         nodeDepthForGUI = +1,
         //! Number of columns used by the variable (One ResultsType per column)

--- a/src/solver/variable/include/antares/solver/variable/storage/average.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/average.h
@@ -33,7 +33,7 @@ namespace R
 {
 namespace AllYears
 {
-template<class NextT = Empty, int FileFilter = Variable::Category::allFile>
+template<class NextT = Empty, int FileFilter = Variable::Category::FileLevel::allFile>
 struct Average: public NextT
 {
 public:
@@ -45,7 +45,7 @@ public:
         //! The count if item in the list
         count = 1 + NextT::count,
 
-        categoryFile = NextT::categoryFile | Variable::Category::allFile,
+        categoryFile = NextT::categoryFile | Variable::Category::FileLevel::allFile,
     };
 
     struct Data
@@ -95,7 +95,7 @@ protected:
                            int fileLevel,
                            int precision) const
     {
-        if (!(fileLevel & Category::id))
+        if (!(fileLevel & Category::FileLevel::id))
         {
             switch (precision)
             {
@@ -131,9 +131,9 @@ protected:
     template<class VCardT>
     void buildDigest(SurveyResults& report, int digestLevel, int dataLevel) const
     {
-        const bool isCluster = (VCardT::categoryFileLevel & Category::de)
-                               || (VCardT::categoryFileLevel & Category::de_res);
-        const bool isBindingConstraint = VCardT::categoryFileLevel & Category::bc;
+        const bool isCluster = (VCardT::categoryFileLevel & Category::FileLevel::de)
+                               || (VCardT::categoryFileLevel & Category::FileLevel::de_res);
+        const bool isBindingConstraint = VCardT::categoryFileLevel & Category::FileLevel::bc;
         const bool isDigest = digestLevel & Category::digestAllYears;
         if ((dataLevel & Category::area || dataLevel & Category::setOfAreas) && isDigest
             && !isCluster && !isBindingConstraint)

--- a/src/solver/variable/include/antares/solver/variable/storage/fwd.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/fwd.h
@@ -36,10 +36,10 @@ namespace R
 {
 namespace AllYears
 {
-template<class NextT = Empty, int FileFilter = Variable::Category::allFile>
+template<class NextT = Empty, int FileFilter = Variable::Category::FileLevel::allFile>
 struct Raw;
 
-template<class NextT = Empty, int FileFilter = Variable::Category::allFile>
+template<class NextT = Empty, int FileFilter = Variable::Category::FileLevel::allFile>
 struct Or;
 
 } // namespace AllYears

--- a/src/solver/variable/include/antares/solver/variable/storage/intermediate.hxx
+++ b/src/solver/variable/include/antares/solver/variable/storage/intermediate.hxx
@@ -61,7 +61,7 @@ inline void IntermediateValues::buildAnnualSurveyReport(SurveyResults& report,
                                                         int fileLevel,
                                                         int precision) const
 {
-    if (!(fileLevel & Category::id))
+    if (!(fileLevel & Category::FileLevel::id))
     {
         switch (precision)
         {

--- a/src/solver/variable/include/antares/solver/variable/storage/minmax.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/minmax.h
@@ -50,7 +50,7 @@ public:
         //! The count if item in the list
         count = 1 + NextT::count,
 
-        categoryFile = NextT::categoryFile | Variable::Category::allFile,
+        categoryFile = NextT::categoryFile | Variable::Category::FileLevel::allFile,
     };
 
     //! Name of the filter
@@ -78,7 +78,7 @@ protected:
                            int fileLevel,
                            int precision) const
     {
-        if (fileLevel & Category::id)
+        if (fileLevel & Category::FileLevel::id)
         {
             switch (precision)
             {

--- a/src/solver/variable/include/antares/solver/variable/storage/raw.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/raw.h
@@ -39,7 +39,7 @@ namespace R
 {
 namespace AllYears
 {
-template<class NextT /*= Empty*/, int FileFilter /*= Variable::Category::allFile*/>
+template<class NextT /*= Empty*/, int FileFilter /*= Variable::Category::FileLevel::allFile*/>
 struct Raw: public NextT
 {
 public:
@@ -51,7 +51,7 @@ public:
         //! The count if item in the list
         count = 1 + NextT::count,
 
-        categoryFile = NextT::categoryFile | Variable::Category::allFile,
+        categoryFile = NextT::categoryFile | Variable::Category::FileLevel::allFile,
     };
 
     struct Data
@@ -99,7 +99,7 @@ protected:
                            int fileLevel,
                            int precision) const
     {
-        if (fileLevel & FileFilter && !(fileLevel & Category::id))
+        if (fileLevel & FileFilter && !(fileLevel & Category::FileLevel::id))
         {
             switch (precision)
             {

--- a/src/solver/variable/include/antares/solver/variable/storage/stdDeviation.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/stdDeviation.h
@@ -35,7 +35,7 @@ namespace R
 {
 namespace AllYears
 {
-template<class NextT = Empty, int FileFilter = Variable::Category::allFile>
+template<class NextT = Empty, int FileFilter = Variable::Category::FileLevel::allFile>
 struct StdDeviation: public NextT
 {
 public:
@@ -47,7 +47,7 @@ public:
         //! The count if item in the list
         count = 1 + NextT::count,
 
-        categoryFile = NextT::categoryFile | Variable::Category::allFile,
+        categoryFile = NextT::categoryFile | Variable::Category::FileLevel::allFile,
     };
 
     struct Data
@@ -137,7 +137,7 @@ protected:
                            int fileLevel,
                            int precision) const
     {
-        if (!(fileLevel & Category::id))
+        if (!(fileLevel & Category::FileLevel::id))
         {
             switch (precision)
             {

--- a/src/solver/variable/include/antares/solver/variable/surveyresults/reportbuilder.hxx
+++ b/src/solver/variable/include/antares/solver/variable/surveyresults/reportbuilder.hxx
@@ -53,7 +53,7 @@ struct VariablesStatsByDataLevel
 {
     enum
     {
-        nextFileLevel = (CFile * 2 > (int)Category::maxFileLevel) ? 1 : CFile * 2,
+        nextFileLevel = (CFile * 2 > (int)Category::FileLevel::maxFileLevel) ? 1 : CFile * 2,
         currentVariableCount = NextT::template Statistics < CDataLevel,
         CFile > ::count,
         nextVariableCount = VariablesStatsByDataLevel < NextT,
@@ -66,7 +66,7 @@ struct VariablesStatsByDataLevel
 };
 
 template<class NextT, int CDataLevel>
-struct VariablesStatsByDataLevel<NextT, CDataLevel, Category::maxFileLevel>
+struct VariablesStatsByDataLevel<NextT, CDataLevel, Category::FileLevel::maxFileLevel>
 {
     enum
     {
@@ -79,7 +79,7 @@ struct BrowseAllVariables
 {
     enum
     {
-        nextFileLevel = (CFile * 2 > (int)Category::maxFileLevel) ? 1 : CFile * 2,
+        nextFileLevel = (CFile * 2 > (int)Category::FileLevel::maxFileLevel) ? 1 : CFile * 2,
         nextDataLevel = (CDataLevel * 2 > (int)Category::maxDataLevel) ? 1 : CDataLevel * 2,
         currentValue = NextT::template Statistics < CDataLevel,
         CFile > ::count,
@@ -103,19 +103,19 @@ struct BrowseAllVariables
 };
 
 template<class NextT>
-struct BrowseAllVariables<NextT, Category::maxDataLevel, Category::maxFileLevel>
+struct BrowseAllVariables<NextT, Category::maxDataLevel, Category::FileLevel::maxFileLevel>
 {
     enum
     {
         maxValue = NextT::template Statistics < Category::maxDataLevel,
-        Category::maxFileLevel > ::count
+        Category::FileLevel::maxFileLevel > ::count
     };
 
     template<class L, class S>
     static void buildSurveyResults(const L& list, S& results)
     {
         // Exporting data for the current state
-        list.template buildSurveyResults<S, Category::maxDataLevel, Category::maxFileLevel>(
+        list.template buildSurveyResults<S, Category::maxDataLevel, Category::FileLevel::maxFileLevel>(
           results);
         // This is the final available state
     }
@@ -185,7 +185,7 @@ private:
 
 // Specialization for the final state (dummy)
 template<bool GlobalT, class NextT, int N>
-class SurveyReportBuilderFile<GlobalT, NextT, N, 2 * Category::maxFileLevel>
+class SurveyReportBuilderFile<GlobalT, NextT, N, 2 * Category::FileLevel::maxFileLevel>
 {
 public:
     using ListType = NextT;

--- a/src/solver/variable/include/antares/solver/variable/surveyresults/reportbuilder.hxx
+++ b/src/solver/variable/include/antares/solver/variable/surveyresults/reportbuilder.hxx
@@ -108,7 +108,7 @@ template<class NextT>
     enum
     {
         maxValue = NextT::template Statistics < Category::DataLevel::maxDataLevel,
-        Category::maxFileLevel > ::count
+        Category::FileLevel::maxFileLevel > ::count
     };
 
     template<class L, class S>


### PR DESCRIPTION
On modern compilers (gcc>=11, clang>=17), this enum appears hundreds if not thousands of times because of templates, so it's very annoying.