### PR TITLE
Restore correct behavior when options -h/--list-solvers are provided

### DIFF
--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -63,7 +63,7 @@ Application::Application()
     resetProcessPriority();
 }
 
-void Application::parseCommandLine(Data::StudyLoadOptions& options)
+bool Application::parseCommandLine(Data::StudyLoadOptions& options)
 {
     auto parser = CreateParser(pSettings, options);
     auto ret = parser->operator()(pArgc, pArgv);
@@ -73,9 +73,9 @@ void Application::parseCommandLine(Data::StudyLoadOptions& options)
         throw Error::CommandLineArguments(parser->errors());
     case Yuni::GetOpt::ReturnCode::help:
         pStudy = nullptr;
-        return;
+        return false;
     default:
-        break;
+        return true;
     }
 }
 
@@ -336,9 +336,10 @@ void Application::prepare(int argc, char* argv[])
     // The parser contains references to members of pSettings and options,
     // don't de-allocate these.
 
-    parseCommandLine(options);
+    if (!parseCommandLine(options)) // --help
+        return;
 
-    if (!handleOptions(options)) // -h, --list-solvers, etc.
+    if (!handleOptions(options)) // --version, --list-solvers
        return;
 
     // Perform some checks

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -79,21 +79,22 @@ void Application::parseCommandLine(Data::StudyLoadOptions& options)
     }
 }
 
-void Application::handleOptions(const Data::StudyLoadOptions& options)
+bool Application::handleOptions(const Data::StudyLoadOptions& options)
 {
     if (options.displayVersion)
     {
         PrintVersionToStdCout();
         pStudy = nullptr;
-        return;
+        return false;
     }
 
     if (options.listSolvers)
     {
         printSolvers();
         pStudy = nullptr;
-        return;
+        return false;
     }
+    return true;
 }
 
 void Application::readDataForTheStudy(Data::StudyLoadOptions& options)
@@ -337,7 +338,8 @@ void Application::prepare(int argc, char* argv[])
 
     parseCommandLine(options);
 
-    handleOptions(options);
+    if (!handleOptions(options)) // -h, --list-solvers, etc.
+       return;
 
     // Perform some checks
     checkAndCorrectSettingsAndOptions(pSettings, options);

--- a/src/solver/application/include/antares/application/application.h
+++ b/src/solver/application/include/antares/application/application.h
@@ -124,9 +124,10 @@ private:
 
     void writeComment(Data::Study& study);
     void startSimulation(Data::StudyLoadOptions& options);
-    // Return false if the user requested help, available solvers, etc, true otherwise
+    // Return false if the user requested the version ,available solvers, etc, true otherwise
     bool handleOptions(const Data::StudyLoadOptions& options);
-    void parseCommandLine(Data::StudyLoadOptions& options);
+    // Return false if the user requested help, true otherwise
+    bool parseCommandLine(Data::StudyLoadOptions& options);
     void handleParserReturn(Yuni::GetOpt::Parser* parser);
     void postParametersChecks() const;
 }; // class Application

--- a/src/solver/application/include/antares/application/application.h
+++ b/src/solver/application/include/antares/application/application.h
@@ -124,7 +124,8 @@ private:
 
     void writeComment(Data::Study& study);
     void startSimulation(Data::StudyLoadOptions& options);
-    void handleOptions(const Data::StudyLoadOptions& options);
+    // Return false if the user requested help, available solvers, etc, true otherwise
+    bool handleOptions(const Data::StudyLoadOptions& options);
     void parseCommandLine(Data::StudyLoadOptions& options);
     void handleParserReturn(Yuni::GetOpt::Parser* parser);
     void postParametersChecks() const;


### PR DESCRIPTION
#2056 introduced a slight change of behavior : after this PR, when the user requests help (--help) or queries the available OR-Tools solvers (--list-solvers), a warning message is displayed after the requested information.

This is a bit annoying, so here is a fix.