### PR TITLE
Remove state from hydro ventilation

### DIFF
--- a/src/solver/hydro/include/antares/solver/hydro/management/management.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/management.h
@@ -112,7 +112,6 @@ public:
 
     //! Perform the hydro ventilation
     void makeVentilation(double* randomReservoirLevel,
-                         Solver::Variable::State& state,
                          uint y,
                          Antares::Data::Area::ScratchMap& scratchmap);
 
@@ -152,12 +151,10 @@ private:
     // \return The total inflow for the whole year
     double prepareMonthlyTargetGenerations(Data::Area& area, TmpDataByArea& data);
 
-    void prepareDailyOptimalGenerations(Solver::Variable::State& state,
-                                        uint y,
+    void prepareDailyOptimalGenerations(uint y,
                                         Antares::Data::Area::ScratchMap& scratchmap);
 
-    void prepareDailyOptimalGenerations(Solver::Variable::State& state,
-                                        Data::Area& area,
+    void prepareDailyOptimalGenerations(Data::Area& area,
                                         uint y,
                                         Antares::Data::Area::ScratchMap& scratchmap);
 

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -40,7 +40,6 @@
 #include "antares/solver/hydro/daily2/h2o2_j_fonctions.h"
 #include "antares/solver/hydro/management/management.h"
 #include "antares/solver/simulation/sim_extern_variables_globales.h"
-#include "antares/solver/variable/state.h"
 
 using namespace Yuni;
 
@@ -220,10 +219,9 @@ struct DebugData
 };
 
 inline void HydroManagement::prepareDailyOptimalGenerations(
-  Solver::Variable::State& state,
-  Data::Area& area,
-  uint y,
-  Antares::Data::Area::ScratchMap& scratchmap)
+    Data::Area& area,
+    uint y,
+    Antares::Data::Area::ScratchMap& scratchmap)
 {
     const auto srcinflows = area.hydro.series->storage.getColumn(y);
 
@@ -546,10 +544,6 @@ inline void HydroManagement::prepareDailyOptimalGenerations(
             H2O2_J_Free(problem);
         }
 
-        uint firstDaySimu = parameters_.simulationDays.first;
-        state.problemeHebdo->previousSimulationFinalLevel[area.index]
-          = ventilationResults.NiveauxReservoirsDebutJours[firstDaySimu] * reservoirCapacity;
-
         if (debugData)
         {
             debugData->writeDailyDebugData(calendar_, initReservoirLvlMonth, y, area.name);
@@ -557,11 +551,10 @@ inline void HydroManagement::prepareDailyOptimalGenerations(
     }
 }
 
-void HydroManagement::prepareDailyOptimalGenerations(Solver::Variable::State& state,
-                                                     uint y,
+void HydroManagement::prepareDailyOptimalGenerations(uint y,
                                                      Antares::Data::Area::ScratchMap& scratchmap)
 {
     areas_.each([&](Data::Area& area)
-                { prepareDailyOptimalGenerations(state, area, y, scratchmap); });
+                { prepareDailyOptimalGenerations(area, y, scratchmap); });
 }
 } // namespace Antares

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -519,7 +519,6 @@ bool HydroManagement::checksOnGenerationPowerBounds(uint year) const
 }
 
 void HydroManagement::makeVentilation(double* randomReservoirLevel,
-                                      Solver::Variable::State& state,
                                       uint y,
                                       Antares::Data::Area::ScratchMap& scratchmap)
 {
@@ -534,7 +533,7 @@ void HydroManagement::makeVentilation(double* randomReservoirLevel,
     prepareEffectiveDemand();
 
     prepareMonthlyOptimalGenerations(randomReservoirLevel, y);
-    prepareDailyOptimalGenerations(state, y, scratchmap);
+    prepareDailyOptimalGenerations(y, scratchmap);
 }
 
 } // namespace Antares

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -136,7 +136,7 @@ bool Adequacy::year(Progression::Task& progression,
     currentProblem.year = state.year;
 
     PrepareRandomNumbers(study, currentProblem, randomForYear);
-    SetInitialHydroLevel(study, currentProblem, randomForYear);
+    SetInitialHydroLevel(study, currentProblem, hydroVentilationResults);
 
     state.startANewYear();
 

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -136,6 +136,7 @@ bool Adequacy::year(Progression::Task& progression,
     currentProblem.year = state.year;
 
     PrepareRandomNumbers(study, currentProblem, randomForYear);
+    SetInitialHydroLevel(study, currentProblem, randomForYear);
 
     state.startANewYear();
 

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -398,14 +398,16 @@ void PrepareRandomNumbers(Data::Study& study,
 
 void SetInitialHydroLevel(Data::Study& study,
                           PROBLEME_HEBDO& problem,
-                          yearRandomNumbers& randomForYear)
+                          const HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
 {
+    uint firstDaySimu = study.parameters.simulationDays.first;
     study.areas.each([&](Data::Area& area)
     {
         if (area.hydro.reservoirManagement)
         {
+            double capacity = area.hydro.reservoirCapacity;
             problem.previousSimulationFinalLevel[area.index] =
-                    randomForYear.pReservoirLevels[area.index] * area.hydro.reservoirCapacity;
+                hydroVentilationResults[area.index].NiveauxReservoirsDebutJours[firstDaySimu] * capacity;
         }
     });
 }

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -395,6 +395,18 @@ void PrepareRandomNumbers(Data::Study& study,
       });
 }
 
+
+void SetInitialHydroLevel(Data::Study& study,
+                          PROBLEME_HEBDO& problem,
+                          yearRandomNumbers& randomForYear)
+{
+    study.areas.each([&](Data::Area& area)
+    {
+        problem.previousSimulationFinalLevel[area.index] =
+                randomForYear.pReservoirLevels[area.index] * area.hydro.reservoirCapacity;
+    });
+}
+
 void BuildThermalPartOfWeeklyProblem(Data::Study& study,
                                      PROBLEME_HEBDO& problem,
                                      const int PasDeTempsDebut,

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -402,8 +402,11 @@ void SetInitialHydroLevel(Data::Study& study,
 {
     study.areas.each([&](Data::Area& area)
     {
-        problem.previousSimulationFinalLevel[area.index] =
-                randomForYear.pReservoirLevels[area.index] * area.hydro.reservoirCapacity;
+        if (area.hydro.reservoirManagement)
+        {
+            problem.previousSimulationFinalLevel[area.index] =
+                    randomForYear.pReservoirLevels[area.index] * area.hydro.reservoirCapacity;
+        }
     });
 }
 

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -126,7 +126,7 @@ bool Economy::year(Progression::Task& progression,
     currentProblem.year = state.year;
 
     PrepareRandomNumbers(study, currentProblem, randomForYear);
-    SetInitialHydroLevel(study, currentProblem, randomForYear);
+    SetInitialHydroLevel(study, currentProblem, hydroVentilationResults);
 
     state.startANewYear();
 

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -126,6 +126,7 @@ bool Economy::year(Progression::Task& progression,
     currentProblem.year = state.year;
 
     PrepareRandomNumbers(study, currentProblem, randomForYear);
+    SetInitialHydroLevel(study, currentProblem, randomForYear);
 
     state.startANewYear();
 

--- a/src/solver/simulation/include/antares/solver/simulation/common-eco-adq.h
+++ b/src/solver/simulation/include/antares/solver/simulation/common-eco-adq.h
@@ -56,6 +56,10 @@ void PrepareRandomNumbers(Data::Study& study,
                           PROBLEME_HEBDO& problem,
                           yearRandomNumbers& randomForYear);
 
+void SetInitialHydroLevel(Data::Study& study,
+                          PROBLEME_HEBDO& problem,
+                          yearRandomNumbers& randomForYear);
+
 void BuildThermalPartOfWeeklyProblem(Data::Study& study,
                                      PROBLEME_HEBDO& problem,
                                      const int PasDeTempsDebut,

--- a/src/solver/simulation/include/antares/solver/simulation/common-eco-adq.h
+++ b/src/solver/simulation/include/antares/solver/simulation/common-eco-adq.h
@@ -58,7 +58,7 @@ void PrepareRandomNumbers(Data::Study& study,
 
 void SetInitialHydroLevel(Data::Study& study,
                           PROBLEME_HEBDO& problem,
-                          yearRandomNumbers& randomForYear);
+                          const HYDRO_VENTILATION_RESULTS& hydroVentilationResults);
 
 void BuildThermalPartOfWeeklyProblem(Data::Study& study,
                                      PROBLEME_HEBDO& problem,

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -172,7 +172,6 @@ public:
             // 4 - Hydraulic ventilation
             pDurationCollector("hydro_ventilation") << [&] {
                 hydroManagement.makeVentilation(randomReservoirLevel,
-                                                state[numSpace],
                                                 y,
                                                 scratchmap);
             };


### PR DESCRIPTION
**State** type is passed to the hydro ventilation.
The object **state** is used by the hydro ventilation to reach the weekly optimization problem, in order to update the hydro initial level of a MC year.
This important update is hidden in the depth of the code whereas it should be more highlighted (when a year starts).
Furthermore, removing state alleviates a bit the hydro ventilation, already too complicated.

Eventually, removing dependency of class **HydroManagement** to **State** allows to : 
- highlight the update of hydro initial level when beginning a year
-  have class **HydroManagement** loose a dependency to **State**