### PR TITLE
Remove unused arrays & variables from `RESULTATS_HORAIRES`

### DIFF
--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -471,9 +471,6 @@ void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO* prob
                                                 .ValeursHorairesDeDefaillanceNegative[pdtHebdo]);
                 AdresseOuPlacerLaValeurDesVariablesOptimisees[var] = adresseDuResultat;
             }
-
-            problemeHebdo->ResultatsHoraires[pays].ValeursHorairesDeDefaillanceEnReserve[pdtHebdo]
-              = 0.0;
         }
     }
 

--- a/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
@@ -250,9 +250,6 @@ struct PDISP_ET_COUTS_HORAIRES_PAR_PALIER
 
     std::vector<double> CoutHoraireDeProductionDuPalierThermique;
 
-    std::vector<double> CoutHoraireDuPalierThermiqueUp;
-    std::vector<double> CoutHoraireDuPalierThermiqueDown;
-
     std::vector<int> NombreMaxDeGroupesEnMarcheDuPalierThermique;
     std::vector<int> NombreMinDeGroupesEnMarcheDuPalierThermique;
 };
@@ -302,8 +299,6 @@ struct ENERGIES_ET_PUISSANCES_HYDRAULIQUES
     double PenalisationDeLaVariationDeProductionHydrauliqueSurVariationMax;
 
     double WeeklyWaterValueStateRegular;
-    double WeeklyWaterValueStateUp;
-    double WeeklyWaterValueStateDown;
 
     bool TurbinageEntreBornes;
     bool SansHeuristique;
@@ -405,9 +400,6 @@ struct PRODUCTION_THERMIQUE_OPTIMALE
 {
     std::vector<double> ProductionThermiqueDuPalier;
 
-    std::vector<double> ProductionThermiqueDuPalierUp;
-    std::vector<double> ProductionThermiqueDuPalierDown;
-
     std::vector<double> NombreDeGroupesEnMarcheDuPalier;
     std::vector<double> NombreDeGroupesQuiDemarrentDuPalier;
 
@@ -423,20 +415,11 @@ struct RESULTATS_HORAIRES
     std::vector<int> ValeursHorairesLmrViolations; // adq patch lmr violations
     std::vector<double> ValeursHorairesSpilledEnergyAfterCSR; // adq patch spillage after CSR
     std::vector<double> ValeursHorairesDtgMrgCsr;             // adq patch DTG MRG after CSR
-    std::vector<double> ValeursHorairesDeDefaillancePositiveUp;
-    std::vector<double> ValeursHorairesDeDefaillancePositiveDown;
-    std::vector<double> ValeursHorairesDeDefaillancePositiveAny;
 
     std::vector<double> ValeursHorairesDeDefaillanceNegative;
-    std::vector<double> ValeursHorairesDeDefaillanceNegativeUp;
-    std::vector<double> ValeursHorairesDeDefaillanceNegativeDown;
-    std::vector<double> ValeursHorairesDeDefaillanceNegativeAny;
 
-    std::vector<double> ValeursHorairesDeDefaillanceEnReserve;
     std::vector<double> PompageHoraire;
     std::vector<double> TurbinageHoraire;
-    std::vector<double> TurbinageHoraireUp;
-    std::vector<double> TurbinageHoraireDown;
 
     std::vector<double> niveauxHoraires;
     std::vector<double> valeurH2oHoraire;

--- a/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
+++ b/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
@@ -387,26 +387,11 @@ void SIM_AllocateAreas(PROBLEME_HEBDO& problem,
                                                                                  0.); // adq patch
         problem.ResultatsHoraires[k].ValeursHorairesDtgMrgCsr.assign(NombreDePasDeTemps,
                                                                      0.); // adq patch
-        problem.ResultatsHoraires[k]
-          .ValeursHorairesDeDefaillancePositiveUp.assign(NombreDePasDeTemps, 0.);
-        problem.ResultatsHoraires[k]
-          .ValeursHorairesDeDefaillancePositiveDown.assign(NombreDePasDeTemps, 0.);
-        problem.ResultatsHoraires[k]
-          .ValeursHorairesDeDefaillancePositiveAny.assign(NombreDePasDeTemps, 0.);
+
         problem.ResultatsHoraires[k].ValeursHorairesDeDefaillanceNegative.assign(NombreDePasDeTemps,
                                                                                  0.);
-        problem.ResultatsHoraires[k]
-          .ValeursHorairesDeDefaillanceNegativeUp.assign(NombreDePasDeTemps, 0.);
-        problem.ResultatsHoraires[k]
-          .ValeursHorairesDeDefaillanceNegativeDown.assign(NombreDePasDeTemps, 0.);
-        problem.ResultatsHoraires[k]
-          .ValeursHorairesDeDefaillanceNegativeAny.assign(NombreDePasDeTemps, 0.);
-        problem.ResultatsHoraires[k]
-          .ValeursHorairesDeDefaillanceEnReserve.assign(NombreDePasDeTemps, 0.);
         problem.ResultatsHoraires[k].TurbinageHoraire.assign(NombreDePasDeTemps, 0.);
         problem.ResultatsHoraires[k].PompageHoraire.assign(NombreDePasDeTemps, 0.);
-        problem.ResultatsHoraires[k].TurbinageHoraireUp.assign(NombreDePasDeTemps, 0.);
-        problem.ResultatsHoraires[k].TurbinageHoraireDown.assign(NombreDePasDeTemps, 0.);
         problem.ResultatsHoraires[k].CoutsMarginauxHoraires.assign(NombreDePasDeTemps, 0.);
         problem.ResultatsHoraires[k].niveauxHoraires.assign(NombreDePasDeTemps, 0.);
         problem.ResultatsHoraires[k].valeurH2oHoraire.assign(NombreDePasDeTemps, 0.);
@@ -438,25 +423,12 @@ void SIM_AllocateAreas(PROBLEME_HEBDO& problem,
             problem.PaliersThermiquesDuPays[k]
               .PuissanceDisponibleEtCout[j]
               .NombreMinDeGroupesEnMarcheDuPalierThermique.assign(NombreDePasDeTemps, 0);
-
-            problem.PaliersThermiquesDuPays[k]
-              .PuissanceDisponibleEtCout[j]
-              .CoutHoraireDuPalierThermiqueUp.assign(NombreDePasDeTemps, 0.);
-            problem.PaliersThermiquesDuPays[k]
-              .PuissanceDisponibleEtCout[j]
-              .CoutHoraireDuPalierThermiqueDown.assign(NombreDePasDeTemps, 0.);
         }
         for (unsigned j = 0; j < NombreDePasDeTemps; j++)
         {
             problem.ResultatsHoraires[k].ProductionThermique[j].ProductionThermiqueDuPalier.assign(
               nbPaliers,
               0.);
-            problem.ResultatsHoraires[k]
-              .ProductionThermique[j]
-              .ProductionThermiqueDuPalierUp.assign(nbPaliers, 0.);
-            problem.ResultatsHoraires[k]
-              .ProductionThermique[j]
-              .ProductionThermiqueDuPalierDown.assign(nbPaliers, 0.);
             problem.ResultatsHoraires[k]
               .ProductionThermique[j]
               .NombreDeGroupesEnMarcheDuPalier.assign(nbPaliers, 0.);


### PR DESCRIPTION
Many `*Up`, `*Down`, `*Any` are unused. Remove them & allocations to simplify code and hopefully reduce memory footprint at runtime.