### PR TITLE
Remove TS links from solver

### DIFF
--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -306,14 +306,12 @@ AreaLink* AreaAddLinkBetweenAreas(Area* area, Area* with, bool warning)
 namespace // anonymous
 {
 
-bool isPropertyUsedForLinkTSgeneration(const std::string key)
+bool isPropertyUsedForLinkTSgeneration(const std::string& key)
 {
     std::array<std::string, 7> listKeys
         = {"unitcount", "nominalcapacity", "law.planned", "law.forced",
            "volatility.planned", "volatility.forced", "force-no-generation"};
-    if (std::find(listKeys.begin(), listKeys.end(), key) != listKeys.end())
-        return true;
-    return false;
+    return std::find(listKeys.begin(), listKeys.end(), key) != listKeys.end();
 }
 
 bool AreaLinksInternalLoadFromProperty(AreaLink& link, const String& key, const String& value)
@@ -459,13 +457,9 @@ bool AreaLinksInternalLoadFromProperty(AreaLink& link, const String& key, const 
         link.filterYearByYear = stringIntoDatePrecision(value);
         return true;
     }
-    if (isPropertyUsedForLinkTSgeneration(key.to<std::string>()))
-    {
-        // Properties used by TS generator only.
-        // We just skip them (otherwise : reading error)
-        return true;
-    }
-    return false;
+    // Properties used by TS generator only.
+    // We just skip them (otherwise : reading error)
+    return isPropertyUsedForLinkTSgeneration(key.to<std::string>());
 }
 
 [[noreturn]] void logLinkDataCheckError(const AreaLink& link, const String& msg, int hour)
@@ -508,7 +502,7 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* areaList, Area* area, const
     for (auto* s = ini.firstSection; s; s = s->next)
     {
         // Getting the name of the area
-        std::string targetAreaName = transformNameIntoID(s->name);
+        const std::string targetAreaName = transformNameIntoID(s->name);
 
         // Trying to find it
         Area* targetArea = AreaListLFind(areaList, targetAreaName.c_str());

--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -510,7 +510,6 @@ bool handleTSGenKey(Data::LinkTsGeneration& out,
                     const std::string& key,
                     const String& value)
 {
-
     if (key == "unitcount")
     {
         return value.to<uint>(out.unitCount);

--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -23,10 +23,7 @@
 
 #include <filesystem>
 #include <limits>
-
-#include <boost/algorithm/string/case_conv.hpp>
-
-#include <yuni/yuni.h>
+#include <array>
 
 #include <antares/exception/LoadingError.hpp>
 #include <antares/logs/logs.h>
@@ -309,6 +306,16 @@ AreaLink* AreaAddLinkBetweenAreas(Area* area, Area* with, bool warning)
 namespace // anonymous
 {
 
+bool isPropertyUsedForLinkTSgeneration(const std::string key)
+{
+    std::array<std::string, 7> listKeys
+        = {"unitcount", "nominalcapacity", "law.planned", "law.forced",
+           "volatility.planned", "volatility.forced", "force-no-generation"};
+    if (std::find(listKeys.begin(), listKeys.end(), key) != listKeys.end())
+        return true;
+    return false;
+}
+
 bool AreaLinksInternalLoadFromProperty(AreaLink& link, const String& key, const String& value)
 {
     if (key == "hurdles-cost")
@@ -450,6 +457,12 @@ bool AreaLinksInternalLoadFromProperty(AreaLink& link, const String& key, const 
     if (key == "filter-year-by-year")
     {
         link.filterYearByYear = stringIntoDatePrecision(value);
+        return true;
+    }
+    if (isPropertyUsedForLinkTSgeneration(key.to<std::string>()))
+    {
+        // Properties used by TS generator only.
+        // We just skip them (otherwise : reading error)
         return true;
     }
     return false;

--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -572,7 +572,7 @@ bool AreaLinksInternalLoadFromProperty(AreaLink& link, const String& key, const 
 }
 } // anonymous namespace
 
-bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const fs::path& folder, bool loadTSGen)
+bool AreaLinksLoadFromFolder(Study& study, AreaList* areaList, Area* area, const fs::path& folder, bool loadTSGen)
 {
     // Assert
     assert(area);
@@ -594,16 +594,16 @@ bool AreaLinksLoadFromFolder(Study& study, AreaList* l, Area* area, const fs::pa
     for (auto* s = ini.firstSection; s; s = s->next)
     {
         // Getting the name of the area
-        std::string buffer = transformNameIntoID(s->name);
+        std::string targetAreaName = transformNameIntoID(s->name);
 
         // Trying to find it
-        Area* linkedWith = AreaListLFind(l, buffer.c_str());
-        if (!linkedWith)
+        Area* targetArea = AreaListLFind(areaList, targetAreaName.c_str());
+        if (!targetArea)
         {
             logs.error() << '`' << s->name << "`: Impossible to find the area";
             continue;
         }
-        AreaLink* lnk = AreaAddLinkBetweenAreas(area, linkedWith);
+        AreaLink* lnk = AreaAddLinkBetweenAreas(area, targetArea);
         if (!lnk)
         {
             logs.error() << "Impossible to create a link between two areas";

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -881,7 +881,7 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
     // Links
     {
         fs::path folder = fs::path(study.folderInput.c_str()) / "links" / area.id.c_str();
-        ret = AreaLinksLoadFromFolder(study, list, &area, folder, options.linksLoadTSGen) && ret;
+        ret = AreaLinksLoadFromFolder(study, list, &area, folder) && ret;
     }
 
     // UI

--- a/src/libs/antares/study/cleaner/cleaner-v20.cpp
+++ b/src/libs/antares/study/cleaner/cleaner-v20.cpp
@@ -362,7 +362,7 @@ bool listOfFilesAnDirectoriesToKeep(StudyCleaningInfos* infos)
                 logs.verbosityLevel = Logs::Verbosity::Warning::level;
                 // load all links
                 buffer.clear() << infos->folder << "/input/links/" << area->id;
-                if (not AreaLinksLoadFromFolder(*study, arealist, area, buffer.c_str(), false))
+                if (not AreaLinksLoadFromFolder(*study, arealist, area, buffer.c_str()))
                 {
                     delete arealist;
                     delete study;

--- a/src/libs/antares/study/fwd.cpp
+++ b/src/libs/antares/study/fwd.cpp
@@ -53,8 +53,6 @@ const char* SeedToCString(SeedIndex seed)
         return "Noise on virtual Hydro costs";
     case seedHydroManagement:
         return "Initial reservoir levels";
-    case seedTsGenLinks:
-        return "Links time-series generation";
     case seedMax:
         return "";
     }
@@ -87,8 +85,6 @@ const char* SeedToID(SeedIndex seed)
         return "seed-hydro-costs";
     case seedHydroManagement:
         return "seed-initial-reservoir-levels";
-    case seedTsGenLinks:
-        return "seed-tsgen-links";
     case seedMax:
         return "";
     }

--- a/src/libs/antares/study/include/antares/study/area/area.h
+++ b/src/libs/antares/study/include/antares/study/area/area.h
@@ -727,8 +727,7 @@ AreaLink* AreaAddLinkBetweenAreas(Area* area, Area* with, bool warning = true);
 bool AreaLinksLoadFromFolder(Study& s,
                              AreaList* l,
                              Area* area,
-                             const std::filesystem::path& folder,
-                             bool loadTSGen);
+                             const std::filesystem::path& folder);
 
 /*!
 ** \brief Save interconnections of a given area into a folder (`input/areas/[area]/ntc`)

--- a/src/libs/antares/study/include/antares/study/area/links.h
+++ b/src/libs/antares/study/include/antares/study/area/links.h
@@ -71,8 +71,6 @@ public:
 
     bool loadTimeSeries(const StudyVersion& version, const AnyString& folder);
 
-    bool loadTSGenTimeSeries(const std::filesystem::path& folder);
-
     void storeTimeseriesNumbers(Solver::IResultWriter& writer) const;
 
     //! \name Area

--- a/src/libs/antares/study/include/antares/study/area/links.h
+++ b/src/libs/antares/study/include/antares/study/area/links.h
@@ -206,9 +206,6 @@ public:
     int linkWidth;
 
     friend struct CompareLinkName;
-
-    LinkTsGeneration tsGeneration;
-
 }; // class AreaLink
 
 struct CompareLinkName final

--- a/src/libs/antares/study/include/antares/study/fwd.h
+++ b/src/libs/antares/study/include/antares/study/fwd.h
@@ -361,8 +361,6 @@ enum SeedIndex
     seedHydroCosts,
     //! Seed - Hydro management
     seedHydroManagement,
-    //! The seed for links
-    seedTsGenLinks,
     //! The number of seeds
     seedMax,
 };

--- a/src/libs/antares/study/include/antares/study/load-options.h
+++ b/src/libs/antares/study/include/antares/study/load-options.h
@@ -53,9 +53,6 @@ public:
     //! Force the year-by-year flag
     bool forceYearByYear;
 
-    //! Load data associated to link TS generation
-    bool linksLoadTSGen = false;
-
     //! Force the derated mode
     bool forceDerated;
 

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -258,8 +258,6 @@ public:
     uint nbTimeSeriesThermal;
     //! Nb of timeSeries : Solar
     uint nbTimeSeriesSolar;
-    //! Nb of timeSeries : Links
-    uint nbLinkTStoGenerate = 1;
     //@}
 
     //! \name Time-series refresh

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -530,7 +530,9 @@ static bool SGDIntLoadFamily_General(Parameters& d,
     }
     if (key == "nbtimeserieslinks")
     {
-        return value.to<uint>(d.nbLinkTStoGenerate);
+        // This data is among solver data, but is useless while running a simulation
+        // Only by TS generator. We skip it here (otherwise, we get a reading error).
+        return true;
     }
     // Interval values
     if (key == "refreshintervalload")
@@ -1026,10 +1028,6 @@ static bool SGDIntLoadFamily_SeedsMersenneTwister(Parameters& d,
             {
                 return value.to<uint>(d.seed[seedTsGenSolar]);
             }
-            if (key == "seed_links")
-            {
-                return value.to<uint>(d.seed[seedTsGenLinks]);
-            }
             if (key == "seed_timeseriesnumbers")
             {
                 return value.to<uint>(d.seed[seedTimeseriesNumbers]);
@@ -1045,6 +1043,10 @@ static bool SGDIntLoadFamily_SeedsMersenneTwister(Parameters& d,
                 {
                     return value.to<uint>(d.seed[sd]);
                 }
+            }
+            if (key == "seed-tsgen-links")
+            {
+                return true; // Useless for solver, belongs to TS generator
             }
         }
     }
@@ -1766,7 +1768,6 @@ void Parameters::saveToINI(IniFile& ini) const
         section->add("nbTimeSeriesWind", nbTimeSeriesWind);
         section->add("nbTimeSeriesThermal", nbTimeSeriesThermal);
         section->add("nbTimeSeriesSolar", nbTimeSeriesSolar);
-        section->add("nbtimeserieslinks", nbLinkTStoGenerate);
 
         // Refresh
         ParametersSaveTimeSeries(section, "refreshTimeSeries", timeSeriesToRefresh);

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -621,23 +621,6 @@ std::vector<Data::ThermalCluster*> getAllClustersToGen(const Data::AreaList& are
     return clusters;
 }
 
-listOfLinks getAllLinksToGen(Data::AreaList& areas)
-{
-    listOfLinks links;
-
-    areas.each(
-      [&links](const Data::Area& area)
-      {
-          std::ranges::for_each(area.links, [&links](auto& l)
-                                {
-                                    if (!l.second->tsGeneration.forceNoGeneration)
-                                        links.push_back(l.second);
-                                });
-      });
-
-    return links;
-}
-
 void writeResultsToDisk(const Data::Study& study,
                         Solver::IResultWriter& writer,
                         const Matrix<>& series,

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -75,10 +75,7 @@ class AvailabilityTSGeneratorData
 {
 public:
     explicit AvailabilityTSGeneratorData(Data::ThermalCluster*);
-    AvailabilityTSGeneratorData(Data::LinkTsGeneration&,
-                                Data::TimeSeries&,
-                                Matrix<>& modulation,
-                                const std::string& name);
+
     AvailabilityTSGeneratorData(LinkTSgenerationParams&,
                                 Data::TimeSeries&,
                                 Matrix<>& modulation,
@@ -117,11 +114,6 @@ bool generateThermalTimeSeries(Data::Study& study,
                                Solver::IResultWriter& writer,
                                const std::string& savePath);
 
-bool generateLinkTimeSeries(Data::Study& study,
-                            const listOfLinks& links,
-                            Solver::IResultWriter& writer,
-                            const std::string& savePath);
-
 bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
                             StudyParamsForLinkTS&,
                             const std::string& savePath);
@@ -129,7 +121,6 @@ bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
 std::vector<Data::ThermalCluster*> getAllClustersToGen(const Data::AreaList& areas,
                                                        bool globalThermalTSgeneration);
 
-listOfLinks getAllLinksToGen(Data::AreaList& areas);
 
 /*!
 ** \brief Destroy all TS Generators

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -33,13 +33,53 @@
 
 #include "xcast/xcast.h"
 
+using LinkPair = std::pair<std::string, std::string>;
+using LinkPairs = std::vector<LinkPair>;
+
 namespace Antares::TSGenerator
 {
+
+struct StudyParamsForLinkTS
+{
+    unsigned int nbLinkTStoGenerate = 1;
+    bool derated = false;
+    // gp : we will have a problem with that if seed-tsgen-links not set in
+    // gp : generaldata.ini. In that case, our default value is wrong.
+    MersenneTwister random;
+};
+
+struct LinkTSgenerationParams
+{
+    LinkPair namesPair;
+
+    unsigned unitCount = 0;
+    double nominalCapacity = 0;
+
+    double forcedVolatility = 0.;
+    double plannedVolatility = 0.;
+
+    Data::StatisticalLaw forcedLaw = Data::LawUniform;
+    Data::StatisticalLaw plannedLaw = Data::LawUniform;
+
+    std::unique_ptr<Data::PreproAvailability> prepro;
+
+    Matrix<> modulationCapacityDirect;
+    Matrix<> modulationCapacityIndirect;
+
+    bool forceNoGeneration = false;
+    bool hasValidData = true;
+};
+
+
 class AvailabilityTSGeneratorData
 {
 public:
     explicit AvailabilityTSGeneratorData(Data::ThermalCluster*);
     AvailabilityTSGeneratorData(Data::LinkTsGeneration&,
+                                Data::TimeSeries&,
+                                Matrix<>& modulation,
+                                const std::string& name);
+    AvailabilityTSGeneratorData(LinkTSgenerationParams&,
                                 Data::TimeSeries&,
                                 Matrix<>& modulation,
                                 const std::string& name);
@@ -80,6 +120,10 @@ bool generateThermalTimeSeries(Data::Study& study,
 bool generateLinkTimeSeries(Data::Study& study,
                             const listOfLinks& links,
                             Solver::IResultWriter& writer,
+                            const std::string& savePath);
+
+bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
+                            StudyParamsForLinkTS&,
                             const std::string& savePath);
 
 std::vector<Data::ThermalCluster*> getAllClustersToGen(const Data::AreaList& areas,

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/prepro.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/prepro.h
@@ -114,28 +114,6 @@ public:
     YString id;
     unsigned int unitCount;
 }; // class PreproAvailability
-
-struct LinkTsGeneration
-{
-    unsigned unitCount = 0;
-    double nominalCapacity = 0;
-
-    double forcedVolatility = 0.;
-    double plannedVolatility = 0.;
-
-    Data::StatisticalLaw forcedLaw = LawUniform;
-    Data::StatisticalLaw plannedLaw = LawUniform;
-
-    std::unique_ptr<Data::PreproAvailability> prepro;
-
-    Matrix<> modulationCapacityDirect;
-    Matrix<> modulationCapacityIndirect;
-
-    bool valid = false;
-
-    bool forceNoGeneration = false;
-};
-
 } // namespace Antares::Data
 
 #endif // __ANTARES_LIBS_STUDY_PARTS_THERMAL_PREPRO_HXX__

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -114,28 +114,6 @@ std::vector<Data::ThermalCluster*> getClustersToGen(Data::AreaList& areas,
     return clusters;
 }
 
-TSGenerator::listOfLinks getLinksToGen(Data::AreaList& areas, const std::string& linksToGen)
-{
-    TSGenerator::listOfLinks links;
-    const auto ids = splitStringIntoPairs(linksToGen, ';', '.');
-
-    for (const auto& [areaFromID, areaWithID]: ids)
-    {
-        logs.info() << "Searching for link: " << areaFromID << "/" << areaWithID;
-
-        auto* link = areas.findLink(areaFromID, areaWithID);
-        if (!link)
-        {
-            logs.warning() << "Link not found: " << areaFromID << "/" << areaWithID;
-            continue;
-        }
-
-        links.emplace_back(link);
-    }
-
-    return links;
-}
-
 // =====  New code for TS generation links ====================================
 
 std::vector<std::string> extractTargetAreas(fs::path sourceLinkDir)

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -234,13 +234,13 @@ StudyParamsForLinkTS readGeneralParamsForLinksTS(fs::path studyDir)
 
 std::vector<LinkTSgenerationParams> CreateLinkList(const LinkPairs& linksFromCmdLine)
 {
-    std::vector<LinkTSgenerationParams> to_return(linksFromCmdLine.size());
-    // gp : following loop should be improved : we shouldn't need an index
-    unsigned int index = 0;
+    std::vector<LinkTSgenerationParams> to_return;
+    to_return.reserve(linksFromCmdLine.size());
     for (const auto& link_pair : linksFromCmdLine)
     {
-        to_return[index].namesPair = link_pair;
-        index++;
+        LinkTSgenerationParams params;
+        params.namesPair = link_pair;
+        to_return.push_back(std::move(params));
     }
     return to_return;
 }

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -222,11 +222,10 @@ bool readLinkGeneralProperty(StudyParamsForLinkTS& params,
     if (key == "seed-tsgen-links")
     {
         unsigned int seed {0};
-        if (value.to<unsigned int>(seed))
-        {
-            params.random.reset(seed);
-            return true;
-        }
+        if (! value.to<unsigned int>(seed))
+            return false;
+        params.random.reset(seed);
+        return true;
     }
     return true; // gp : should we return true here ?
 }

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -425,14 +425,6 @@ std::string DateAndTime()
     Yuni::DateTime::TimestampToString(to_return, "%Y%m%d-%H%M", now);
     return to_return.to<std::string>();
 }
-
-bool GenerateLinkTS(std::vector<LinkTSgenerationParams>& linkList,
-                    fs::path outputPath)
-{
-
-    return true;
-}
-
 // ============================================================================
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
The aim of this PR is removing from **Antares solver** the code related to TS generation associated to **links** capacity.
It follows PR #1986 

Note that : 
- Loading the study is now no longer required to generate TS associated to links.
- Handling errors related to each link's TS generation was simplified : 
  For a link, if we meet a problem while loading data required to generated its TS, a **warning** is raised and the TS generation for this link will be skipped.

What was done : 
- Reading data for links TS generation :  
   We now don't need the study to be loaded in order to generate TS. 
   Some new code retrieves data from study
- Generating TS associated to links : 
  Code of base branch was adapted to use data having a different format.
- Code related to link TS generation in **solver** was removed.
  An exception though : due to new data (related to links TS generation) next to data consumed by solver, we had to keep special skipping code for it, otherwise we get reading errors.   
