### PR TITLE
Fixing hydro debug

### DIFF
--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -362,6 +362,7 @@ inline void HydroManagement::prepareDailyOptimalGenerations(
 
     if (debugData)
     {
+        dayYear = 0;
         for (uint month = 0; month != 12; ++month)
         {
             auto daysPerMonth = calendar_.months[month].days;
@@ -371,6 +372,7 @@ inline void HydroManagement::prepareDailyOptimalGenerations(
                 auto dYear = day + dayYear;
                 debugData->DailyTargetGen[dYear] = dailyTargetGen[dYear];
             }
+            dayYear += daysPerMonth;
         }
     }
 


### PR DESCRIPTION
Recall : **Hydro allocation** is done at the beginning of each MC year, and ends with a quantity of hydro energy for each day of the year. These daily quantities are to be used as daily hydro generations in the optimization problem.

The **hydro debug** functionality allows to print (if asked by user) on disk a **report** about **hydro allocation results**.

This hydro allocation report is broken (a crash comes up). It was broken since January 2023 (a commit can be supplied if needed).

This PR to fix this crash.
