### PR TITLE
Remove temporary MSVC flag used to mitigate runner issue

### DIFF
--- a/src/cmake/common-settings.cmake
+++ b/src/cmake/common-settings.cmake
@@ -11,7 +11,7 @@ if (NOT WIN32)
 	set(COMMON_GCC_FLAGS "${COMMON_GCC_FLAGS} -Werror=return-type")
 endif()
 set(COMMON_MSVC_FLAGS "/W3 /MP4")
-set(COMMON_MSVC_FLAGS "${COMMON_MSVC_FLAGS} /we4715 /we4716 /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR") #adding no return or no return for all code paths as errors
+set(COMMON_MSVC_FLAGS "${COMMON_MSVC_FLAGS} /we4715 /we4716") #adding no return or no return for all code paths as errors
 set(ADDITIONAL_C_FLAGS " -Wconversion -Wmissing-prototypes -Wstrict-prototypes")
 set(ADDITIONAL_C_FLAGS "${ADDITIONAL_C_FLAGS} -Wmissing-noreturn -Wpacked -Wredundant-decls -Wbad-function-cast -W -Wcast-align -Wcast-qual -Wsign-compare -fno-exceptions -Wdeclaration-after-statement")
 


### PR DESCRIPTION
Revert "Add `/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` to fix segfault #2151 

This reverts commit a121c7571a4b6e7fed2904b325aa8127dd25261e.

https://github.com/actions/runner-images/issues/10004