### PR TITLE
TS : generator : make it work for thermal [ANT-1852]

### DIFF
--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -41,6 +41,7 @@
 
 
 #include "hydro-final-reservoir-level-functions.h"
+namespace fs = std::filesystem;
 
 namespace Antares::Solver::Simulation
 {
@@ -488,11 +489,9 @@ void ISimulation<ImplementationType>::regenerateTimeSeries(uint year)
         if (refreshTSonCurrentYear)
         {
             auto clusters = getAllClustersToGen(study.areas, pData.haveToRefreshTSThermal);
-#define SEP Yuni::IO::Separator
-            const std::string savePath = std::string("ts-generator") + SEP + "thermal" + SEP + "mc-"
-                                         + std::to_string(year);
-#undef SEP
-            generateThermalTimeSeries(study, clusters, pResultWriter, savePath);
+            fs::path savePath = fs::path(study.folderOutput.to<std::string>()) / "ts-generator"
+                                / "thermal" / "mc-" / std::to_string(year);
+            generateThermalTimeSeries(study, clusters, savePath.string());
 
             // apply the spinning if we generated some in memory clusters
             for (auto* cluster: clusters)

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -649,6 +649,7 @@ bool generateThermalTimeSeries(Data::Study& study,
 
     for (auto* cluster: clusters)
     {
+        cluster->series.timeSeries.reset(study.parameters.nbTimeSeriesThermal, HOURS_PER_YEAR);
         AvailabilityTSGeneratorData tsGenerationData(cluster);
         generator.run(tsGenerationData);
     }
@@ -657,7 +658,7 @@ bool generateThermalTimeSeries(Data::Study& study,
     bool doWeWrite = archive && !study.parameters.noOutput;
     if (! doWeWrite)
     {
-        logs.info() << "Study parammeters such that we don't write thermal TS.";
+        logs.info() << "Study parameters forbid writing thermal TS.";
         return true;
     }
 

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -32,6 +32,7 @@
 #include "antares/study/simulation.h"
 
 #define SEP Yuni::IO::Separator
+namespace fs = std::filesystem;
 
 constexpr double FAILURE_RATE_EQ_1 = 0.999;
 
@@ -612,15 +613,6 @@ std::vector<Data::ThermalCluster*> getAllClustersToGen(const Data::AreaList& are
     return clusters;
 }
 
-void writeTStoDisk(Solver::IResultWriter& writer,
-                   const Matrix<>& series,
-                   const std::string& savePath)
-{
-    std::string buffer;
-    series.saveToBuffer(buffer, 0);
-    writer.addEntryFromBuffer(savePath, buffer);
-}
-
 void writeTStoDisk(const Matrix<>& series,
                    const std::filesystem::path savePath)
 {
@@ -637,7 +629,6 @@ void writeTStoDisk(const Matrix<>& series,
 
 bool generateThermalTimeSeries(Data::Study& study,
                                const std::vector<Data::ThermalCluster*>& clusters,
-                               Solver::IResultWriter& writer,
                                const std::string& savePath)
 {
     logs.info();
@@ -664,9 +655,11 @@ bool generateThermalTimeSeries(Data::Study& study,
 
     for (auto* cluster: clusters)
     {
-        std::string filePath = savePath + SEP + cluster->parentArea->id + SEP + cluster->id()
-                               + ".txt";
-        writeTStoDisk(writer, cluster->series.timeSeries, filePath);
+        auto areaName = cluster->parentArea->id.to<std::string>();
+        auto clusterName = cluster->id();
+        auto filePath = fs::path(savePath) / areaName / clusterName += ".txt";
+
+        writeTStoDisk(cluster->series.timeSeries, filePath.string());
     }
 
     return true;

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -111,7 +111,6 @@ bool GenerateTimeSeries(Data::Study& study, uint year, IResultWriter& writer);
 
 bool generateThermalTimeSeries(Data::Study& study,
                                const std::vector<Data::ThermalCluster*>& clusters,
-                               Solver::IResultWriter& writer,
                                const std::string& savePath);
 
 bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -103,14 +103,9 @@ int main(int argc, char* argv[])
         Antares::logs.error() << ex.what();
     }
 
-    Benchmarking::DurationCollector durationCollector;
-
-    auto resultWriter = Solver::resultWriterFactory(Data::ResultFormat::legacyFilesDirectories,
-                                                    study->folderOutput,
-                                                    nullptr,
-                                                    durationCollector);
-
-    const auto thermalSavePath = fs::path("ts-generator") / "thermal";
+    auto thermalSavePath = fs::path(settings.studyFolder) / "output" / FormattedTime("%Y%m%d-%H%M");
+    thermalSavePath /= "ts-generator";
+    thermalSavePath /= "thermal";
 
     // ============ THERMAL : Getting data for generating time-series =========
     std::vector<Data::ThermalCluster*> clusters;
@@ -137,7 +132,6 @@ int main(int argc, char* argv[])
 
     bool ret = TSGenerator::generateThermalTimeSeries(*study,
                                                       clusters,
-                                                      *resultWriter,
                                                       thermalSavePath.string());
 
     ret = linksTSgenerator.generate() && ret;


### PR DESCRIPTION
This PR addresses [this go-pro ticket](https://gopro-tickets.rte-france.com/browse/ANT-1852)

What was done : 
- **Cause of the crash** : allocate (give a size to) the storage containers supposed to receive the thermal TS  generation results
- Remove the use of **result writer**, too complicated (for example, it forces us to use a duration collector we don't need).
- Use of **std::filesystem** whenever possible

See helping **gitHub** comments inserted in sources. 