### PR TITLE
TS generator : refactor thermal part

### DIFF
--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -464,7 +464,7 @@ void ISimulation<ImplementationType>::regenerateTimeSeries(uint year)
 	    namespace fs = std::filesystem;
             fs::path savePath = fs::path(study.folderOutput.to<std::string>()) / "ts-generator"
                                 / "thermal" / "mc-" / std::to_string(year);
-            generateThermalTimeSeries(study, clusters, savePath.string());
+            generateThermalTimeSeries(study, clusters, savePath);
 
             // apply the spinning if we generated some in memory clusters
             for (auto* cluster: clusters)

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -464,7 +464,7 @@ void ISimulation<ImplementationType>::regenerateTimeSeries(uint year)
 	    namespace fs = std::filesystem;
             fs::path savePath = fs::path(study.folderOutput.to<std::string>()) / "ts-generator"
                                 / "thermal" / "mc-" / std::to_string(year);
-            generateThermalTimeSeries(study, clusters, savePath);
+            generateThermalTimeSeries(study, clusters, study.runtime->random[Data::seedTsGenThermal], savePath);
 
             // apply the spinning if we generated some in memory clusters
             for (auto* cluster: clusters)

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -461,10 +461,16 @@ void ISimulation<ImplementationType>::regenerateTimeSeries(uint year)
         if (refreshTSonCurrentYear)
         {
             auto clusters = getAllClustersToGen(study.areas, pData.haveToRefreshTSThermal);
-	    namespace fs = std::filesystem;
-            fs::path savePath = fs::path(study.folderOutput.to<std::string>()) / "ts-generator"
-                                / "thermal" / "mc-" / std::to_string(year);
-            generateThermalTimeSeries(study, clusters, study.runtime->random[Data::seedTsGenThermal], savePath);
+            generateThermalTimeSeries(study, clusters, study.runtime->random[Data::seedTsGenThermal]);
+
+            bool archive = study.parameters.timeSeriesToArchive & Data::timeSeriesThermal;
+            bool doWeWrite = archive && !study.parameters.noOutput;
+            if (doWeWrite)
+            {
+                fs::path savePath = fs::path(study.folderOutput.to<std::string>()) / "ts-generator"
+                                    / "thermal" / "mc-" / std::to_string(year);
+                writeThermalTimeSeries(clusters, savePath);
+            }
 
             // apply the spinning if we generated some in memory clusters
             for (auto* cluster: clusters)

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -612,8 +612,7 @@ void writeTStoDisk(const Matrix<>& series,
 
 bool generateThermalTimeSeries(Data::Study& study,
                                const std::vector<Data::ThermalCluster*>& clusters,
-                               MersenneTwister& thermalRandom,
-                               const fs::path& savePath)
+                               MersenneTwister& thermalRandom)
 {
     logs.info();
     logs.info() << "Generating the thermal time-series";
@@ -629,14 +628,12 @@ bool generateThermalTimeSeries(Data::Study& study,
         generator.run(tsGenerationData);
     }
 
-    bool archive = study.parameters.timeSeriesToArchive & Data::timeSeriesThermal;
-    bool doWeWrite = archive && !study.parameters.noOutput;
-    if (! doWeWrite)
-    {
-        logs.info() << "Study parameters forbid writing thermal TS.";
-        return true;
-    }
+    return true;
+}
 
+void writeThermalTimeSeries(const std::vector<Data::ThermalCluster*>& clusters,
+                            const fs::path& savePath)
+{
     for (auto* cluster: clusters)
     {
         auto areaName = cluster->parentArea->id.to<std::string>();
@@ -645,8 +642,6 @@ bool generateThermalTimeSeries(Data::Study& study,
 
         writeTStoDisk(cluster->series.timeSeries, filePath);
     }
-
-    return true;
 }
 
 // gp : we should try to add const identifiers before args here

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -19,20 +19,13 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <cmath>
-#include <sstream>
 #include <string>
 
 #include <antares/logs/logs.h>
 #include <antares/solver/ts-generator/generator.h>
 #include <antares/solver/ts-generator/law.h>
 #include <antares/study/study.h>
-#include <antares/writer/i_writer.h>
 #include <antares/io/file.h> // For Antares::IO::fileSetContent
-#include "antares/study/simulation.h"
-
-#define SEP Yuni::IO::Separator
-namespace fs = std::filesystem;
 
 constexpr double FAILURE_RATE_EQ_1 = 0.999;
 
@@ -619,7 +612,7 @@ void writeTStoDisk(const Matrix<>& series,
 
 bool generateThermalTimeSeries(Data::Study& study,
                                const std::vector<Data::ThermalCluster*>& clusters,
-                               const std::string& savePath)
+                               const fs::path& savePath)
 {
     logs.info();
     logs.info() << "Generating the thermal time-series";
@@ -647,7 +640,7 @@ bool generateThermalTimeSeries(Data::Study& study,
     {
         auto areaName = cluster->parentArea->id.to<std::string>();
         auto clusterName = cluster->id();
-        auto filePath = fs::path(savePath) / areaName / clusterName += ".txt";
+        auto filePath = savePath / areaName / clusterName += ".txt";
 
         writeTStoDisk(cluster->series.timeSeries, filePath);
     }
@@ -658,7 +651,7 @@ bool generateThermalTimeSeries(Data::Study& study,
 // gp : we should try to add const identifiers before args here
 bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
                             StudyParamsForLinkTS& generalParams,
-                            const std::string& savePath)
+                            const fs::path& savePath)
 {
     logs.info();
     logs.info() << "Generation of links time-series";
@@ -685,14 +678,14 @@ bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
         AvailabilityTSGeneratorData tsConfigDataDirect(link, ts, link.modulationCapacityDirect, link.namesPair.second);
         generator.run(tsConfigDataDirect);
 
-        auto filePath = fs::path(savePath) / link.namesPair.first / link.namesPair.second += "_direct.txt";
+        auto filePath = savePath / link.namesPair.first / link.namesPair.second += "_direct.txt";
         writeTStoDisk(ts.timeSeries, filePath);
 
         // === INDIRECT =======================
         AvailabilityTSGeneratorData tsConfigDataIndirect(link, ts, link.modulationCapacityIndirect, link.namesPair.second);
         generator.run(tsConfigDataIndirect);
 
-        filePath = fs::path(savePath) / link.namesPair.first / link.namesPair.second += "_indirect.txt";
+        filePath = savePath / link.namesPair.first / link.namesPair.second += "_indirect.txt";
         writeTStoDisk(ts.timeSeries, filePath);
     }
 

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -612,6 +612,7 @@ void writeTStoDisk(const Matrix<>& series,
 
 bool generateThermalTimeSeries(Data::Study& study,
                                const std::vector<Data::ThermalCluster*>& clusters,
+                               MersenneTwister& thermalRandom,
                                const fs::path& savePath)
 {
     logs.info();
@@ -619,7 +620,7 @@ bool generateThermalTimeSeries(Data::Study& study,
 
     auto generator = AvailabilityTSgenerator(study.parameters.derated,
                                              study.parameters.nbTimeSeriesThermal,
-                                             study.runtime->random[Data::seedTsGenThermal]);
+                                             thermalRandom);
 
     for (auto* cluster: clusters)
     {

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -649,7 +649,7 @@ bool generateThermalTimeSeries(Data::Study& study,
         auto clusterName = cluster->id();
         auto filePath = fs::path(savePath) / areaName / clusterName += ".txt";
 
-        writeTStoDisk(cluster->series.timeSeries, filePath.string());
+        writeTStoDisk(cluster->series.timeSeries, filePath);
     }
 
     return true;
@@ -681,22 +681,18 @@ bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
         Data::TimeSeries ts(fakeTSnumbers);
         ts.resize(generalParams.nbLinkTStoGenerate, HOURS_PER_YEAR);
 
-        // DIRECT
+        // === DIRECT =======================
         AvailabilityTSGeneratorData tsConfigDataDirect(link, ts, link.modulationCapacityDirect, link.namesPair.second);
-
         generator.run(tsConfigDataDirect);
 
-        std::string filePath = savePath + SEP + link.namesPair.first + SEP + link.namesPair.second
-                               + "_direct.txt";
+        auto filePath = fs::path(savePath) / link.namesPair.first / link.namesPair.second += "_direct.txt";
         writeTStoDisk(ts.timeSeries, filePath);
 
-        // INDIRECT
+        // === INDIRECT =======================
         AvailabilityTSGeneratorData tsConfigDataIndirect(link, ts, link.modulationCapacityIndirect, link.namesPair.second);
-
         generator.run(tsConfigDataIndirect);
 
-        filePath = savePath + SEP + link.namesPair.first + SEP + link.namesPair.second
-                               + "_indirect.txt";
+        filePath = fs::path(savePath) / link.namesPair.first / link.namesPair.second += "_indirect.txt";
         writeTStoDisk(ts.timeSeries, filePath);
     }
 

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -76,7 +76,7 @@ private:
 
     uint nbOfSeriesToGen_;
 
-    MersenneTwister& rndgenerator;
+    MersenneTwister& randomGenerator_;
 
     static constexpr int Log_size = 4000;
 
@@ -96,10 +96,10 @@ private:
 
 AvailabilityTSgenerator::AvailabilityTSgenerator(bool derated,
                                                  unsigned int nbOfSeriesToGen,
-                                                 MersenneTwister& rndGenerator):
+                                                 MersenneTwister& randomGenerator):
     derated(derated),
     nbOfSeriesToGen_(nbOfSeriesToGen),
-    rndgenerator(rndGenerator)
+    randomGenerator_(randomGenerator)
 {
 }
 
@@ -160,7 +160,7 @@ int AvailabilityTSgenerator::durationGenerator(Data::StatisticalLaw law,
         return expec;
     }
 
-    double rndnumber = rndgenerator.next();
+    double rndnumber = randomGenerator_.next();
 
     switch (law)
     {
@@ -372,7 +372,7 @@ void AvailabilityTSgenerator::run(AvailabilityTSGeneratorData& tsGenerationData)
 
             if (lf[dayInTheYear] > 0. && lf[dayInTheYear] <= FAILURE_RATE_EQ_1)
             {
-                A = rndgenerator.next();
+                A = randomGenerator_.next();
                 last = FPOW[dayInTheYear][AUN];
 
                 if (A > last)
@@ -408,7 +408,7 @@ void AvailabilityTSgenerator::run(AvailabilityTSGeneratorData& tsGenerationData)
                 }
 
                 last = PPOW[dayInTheYear][AUN_app];
-                A = rndgenerator.next();
+                A = randomGenerator_.next();
 
                 if (A > last)
                 {

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -74,7 +74,6 @@ namespace
 class AvailabilityTSgenerator final
 {
 public:
-    explicit AvailabilityTSgenerator(Data::Study&, unsigned, MersenneTwister&);
     explicit AvailabilityTSgenerator(bool, unsigned, MersenneTwister&);
 
     void run(AvailabilityTSGeneratorData&) const;
@@ -101,15 +100,6 @@ private:
                                std::array<double, 366>& B,
                                const T& duration) const;
 };
-
-AvailabilityTSgenerator::AvailabilityTSgenerator(Data::Study& study,
-                                                 unsigned nbOfSeriesToGen,
-                                                 MersenneTwister& rndGenerator):
-    derated(study.parameters.derated),
-    nbOfSeriesToGen_(nbOfSeriesToGen),
-    rndgenerator(rndGenerator)
-{
-}
 
 AvailabilityTSgenerator::AvailabilityTSgenerator(bool derated,
                                                  unsigned int nbOfSeriesToGen,
@@ -634,7 +624,7 @@ bool generateThermalTimeSeries(Data::Study& study,
     logs.info();
     logs.info() << "Generating the thermal time-series";
 
-    auto generator = AvailabilityTSgenerator(study,
+    auto generator = AvailabilityTSgenerator(study.parameters.derated,
                                              study.parameters.nbTimeSeriesThermal,
                                              study.runtime->random[Data::seedTsGenThermal]);
 

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -75,7 +75,6 @@ public:
     explicit AvailabilityTSGeneratorData(Data::ThermalCluster*);
 
     AvailabilityTSGeneratorData(LinkTSgenerationParams&,
-                                Data::TimeSeries&,
                                 Matrix<>& modulation,
                                 const std::string& name);
 
@@ -89,8 +88,6 @@ public:
     Data::StatisticalLaw& plannedLaw;
 
     Data::PreproAvailability* prepro;
-
-    Matrix<>& series;
 
     Matrix<>::ColumnType& modulationCapacity;
 

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -109,8 +109,10 @@ bool GenerateTimeSeries(Data::Study& study, uint year, IResultWriter& writer);
 
 bool generateThermalTimeSeries(Data::Study& study,
                                const std::vector<Data::ThermalCluster*>& clusters,
-                               MersenneTwister& thermalRandom,
-                               const fs::path& savePath);
+                               MersenneTwister& thermalRandom);
+
+void writeThermalTimeSeries(const std::vector<Data::ThermalCluster*>& clusters,
+                            const fs::path& savePath);
 
 bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
                             StudyParamsForLinkTS&,

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -50,7 +50,7 @@ struct LinkTSgenerationParams
 {
     LinkPair namesPair;
 
-    unsigned unitCount = 0;
+    unsigned unitCount = 1;
     double nominalCapacity = 0;
 
     double forcedVolatility = 0.;

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -109,6 +109,7 @@ bool GenerateTimeSeries(Data::Study& study, uint year, IResultWriter& writer);
 
 bool generateThermalTimeSeries(Data::Study& study,
                                const std::vector<Data::ThermalCluster*>& clusters,
+                               MersenneTwister& thermalRandom,
                                const fs::path& savePath);
 
 bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -24,15 +24,13 @@
 #include <yuni/yuni.h>
 
 #include <antares/series/series.h>
-#include <antares/solver/ts-generator/law.h>
 #include <antares/study/fwd.h>
 #include <antares/study/parameters.h>
 #include <antares/study/parts/thermal/cluster.h>
 #include <antares/study/study.h>
-#include <antares/writer/i_writer.h>
-
 #include "xcast/xcast.h"
 
+namespace fs = std::filesystem;
 using LinkPair = std::pair<std::string, std::string>;
 using LinkPairs = std::vector<LinkPair>;
 
@@ -111,11 +109,11 @@ bool GenerateTimeSeries(Data::Study& study, uint year, IResultWriter& writer);
 
 bool generateThermalTimeSeries(Data::Study& study,
                                const std::vector<Data::ThermalCluster*>& clusters,
-                               const std::string& savePath);
+                               const fs::path& savePath);
 
 bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
                             StudyParamsForLinkTS&,
-                            const std::string& savePath);
+                            const fs::path& savePath);
 
 std::vector<Data::ThermalCluster*> getAllClustersToGen(const Data::AreaList& areas,
                                                        bool globalThermalTSgeneration);

--- a/src/tools/ts-generator/include/antares/tools/ts-generator/tsGenerationOptions.h
+++ b/src/tools/ts-generator/include/antares/tools/ts-generator/tsGenerationOptions.h
@@ -26,4 +26,6 @@ bool parseOptions(int, char*[], Settings&);
 std::unique_ptr<Yuni::GetOpt::Parser> createTsGeneratorParser(Settings&);
 
 bool checkOptions(Settings& options);
+bool linkTSrequired(Settings& options);
+bool thermalTSrequired(Settings& options);
 }

--- a/src/tools/ts-generator/linksTSgenerator.cpp
+++ b/src/tools/ts-generator/linksTSgenerator.cpp
@@ -330,7 +330,7 @@ bool LinksTSgenerator::generate()
     saveTSpath /= "ts-generator";
     saveTSpath /= "links";
 
-    return generateLinkTimeSeries(linkList_, generalParams_, saveTSpath.string());
+    return generateLinkTimeSeries(linkList_, generalParams_, saveTSpath);
 }
 
 }

--- a/src/tools/ts-generator/linksTSgenerator.cpp
+++ b/src/tools/ts-generator/linksTSgenerator.cpp
@@ -226,7 +226,7 @@ void readPreproTimeSeries(std::vector<LinkTSgenerationParams>& linkList,
         fs::path sourceAreaDir = toLinksDir / sourceAreaName;
         if (! readLinkPreproTimeSeries(link, sourceAreaDir))
         {
-            logs.warning() << "Could not load all prepro data for link '"
+            logs.warning() << "Could not load all prepro/modulation data for link '"
                            << link.namesPair.first << "." << link.namesPair.second << "'";
         }
     }

--- a/src/tools/ts-generator/linksTSgenerator.cpp
+++ b/src/tools/ts-generator/linksTSgenerator.cpp
@@ -166,52 +166,56 @@ void readIniProperties(std::vector<LinkTSgenerationParams>& linkList, fs::path t
     }
 }
 
-    bool readLinkPreproTimeSeries(LinkTSgenerationParams& link,
-                                  fs::path sourceAreaDir)
+fs::path makePreproFile(const fs::path& preproFilePath, const std::string& changingEnd)
+{
+    auto to_return = preproFilePath;
+    to_return += changingEnd + ".txt";
+    return to_return;
+}
+
+bool readLinkPreproTimeSeries(LinkTSgenerationParams& link,
+                              fs::path sourceAreaDir)
+{
+    bool to_return = true;
+    const auto preproId = link.namesPair.first + "/" + link.namesPair.second;
+    link.prepro = std::make_unique<Data::PreproAvailability>(preproId, link.unitCount);
+
+    auto preproFileRoot = sourceAreaDir / "prepro" / link.namesPair.second;
+
+    // Testing files existence
+    auto preproFile = makePreproFile(preproFileRoot, "");
+    auto modulationDirectFile = makePreproFile(preproFileRoot, "_mod_direct");
+    auto modulationIndirectFile = makePreproFile(preproFileRoot, "_mod_indirect");
+    std::vector<fs::path> paths {preproFile, modulationDirectFile, modulationIndirectFile};
+    if (std::any_of(paths.begin(), paths.end(), [](auto& path) {return ! fs::exists(path);}))
     {
-        bool to_return = true;
-        const auto preproId = link.namesPair.first + "/" + link.namesPair.second;
-        link.prepro = std::make_unique<Data::PreproAvailability>(preproId, link.unitCount);
+        link.hasValidData = false;
+        return false;
+    }
 
-        auto preproFileRoot = sourceAreaDir / "prepro" / link.namesPair.second;
-
-        auto preproFile = preproFileRoot;
-        preproFile += ".txt";
-        if (fs::exists(preproFile))
-        {
-            to_return = link.prepro->data.loadFromCSVFile(
+    // Files loading
+    to_return = link.prepro->data.loadFromCSVFile(
                     preproFile.string(),
                     Data::PreproAvailability::preproAvailabilityMax,
                     DAYS_PER_YEAR)
-                        && link.prepro->validate()
-                        && to_return;
-        }
+                && link.prepro->validate()
+                && to_return;
 
-        auto modulationFileDirect = preproFileRoot;
-        modulationFileDirect += "_mod_direct.txt";
-        if (fs::exists(modulationFileDirect))
-        {
-            to_return = link.modulationCapacityDirect.loadFromCSVFile(
-                    modulationFileDirect.string(),
+    to_return = link.modulationCapacityDirect.loadFromCSVFile(
+                    modulationDirectFile.string(),
                     1,
                     HOURS_PER_YEAR)
-                        && to_return;
-        }
+                && to_return;
 
-        auto modulationFileIndirect = preproFileRoot;
-        modulationFileIndirect += "_mod_indirect.txt";
-        if (fs::exists(modulationFileIndirect))
-        {
-            to_return = link.modulationCapacityIndirect.loadFromCSVFile(
-                    modulationFileIndirect.string(),
+    to_return = link.modulationCapacityIndirect.loadFromCSVFile(
+                    modulationIndirectFile.string(),
                     1,
                     HOURS_PER_YEAR)
-                        && to_return;
-        }
-        // Makes it possible to skip a link's TS generation when time comes
-        link.hasValidData = link.hasValidData && to_return;
-        return to_return;
-    }
+                && to_return;
+
+    link.hasValidData = link.hasValidData && to_return;
+    return to_return;
+}
 
 void readPreproTimeSeries(std::vector<LinkTSgenerationParams>& linkList,
                           fs::path toLinksDir)

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -39,23 +39,23 @@ std::vector<Data::ThermalCluster*> getClustersToGen(Data::AreaList& areas,
                                                     const std::string& clustersToGen)
 {
     std::vector<Data::ThermalCluster*> clusters;
-    const auto ids = splitStringIntoPairs(clustersToGen, ';', '.');
+    const auto pairsAreaCluster = splitStringIntoPairs(clustersToGen, ';', '.');
 
-    for (const auto& [areaID, clusterID]: ids)
+    for (const auto& [areaName, clusterName]: pairsAreaCluster)
     {
-        logs.info() << "Searching for area: " << areaID << " and cluster: " << clusterID;
+        logs.info() << "Searching for area: " << areaName << " and cluster: " << clusterName;
 
-        auto* area = areas.find(areaID);
+        auto* area = areas.find(areaName);
         if (!area)
         {
-            logs.warning() << "Area not found: " << areaID;
+            logs.warning() << "Area not found: " << areaName;
             continue;
         }
 
-        auto* cluster = area->thermal.list.findInAll(clusterID);
+        auto* cluster = area->thermal.list.findInAll(clusterName);
         if (!cluster)
         {
-            logs.warning() << "Cluster not found: " << clusterID;
+            logs.warning() << "Cluster not found: " << clusterName;
             continue;
         }
 

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -22,8 +22,6 @@
 #include <memory>
 #include <string>
 
-#include <antares/checks/checkLoadedInputData.h>
-#include <antares/exception/LoadingError.hpp>
 #include <antares/logs/logs.h>
 #include <antares/solver/ts-generator/generator.h>
 #include <antares/study/study.h>
@@ -92,15 +90,6 @@ int main(int argc, char* argv[])
     study->initializeRuntimeInfos();
     // Forces the writing of generated TS into the study's output sub-folder
     study->parameters.timeSeriesToArchive |= Antares::Data::timeSeriesThermal;
-
-    try
-    {
-        Antares::Check::checkMinStablePower(true, study->areas);
-    }
-    catch (Error::InvalidParametersForThermalClusters& ex)
-    {
-        Antares::logs.error() << ex.what();
-    }
 
     auto thermalSavePath = fs::path(settings.studyFolder) / "output" / FormattedTime("%Y%m%d-%H%M");
     thermalSavePath /= "ts-generator";

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -22,15 +22,12 @@
 #include <memory>
 #include <string>
 
-#include <antares/benchmarking/DurationCollector.h>
 #include <antares/checks/checkLoadedInputData.h>
 #include <antares/exception/LoadingError.hpp>
 #include <antares/logs/logs.h>
 #include <antares/solver/ts-generator/generator.h>
 #include <antares/study/study.h>
 #include <antares/utils/utils.h>
-#include <antares/writer/result_format.h>
-#include <antares/writer/writer_factory.h>
 
 #include "antares/tools/ts-generator/tsGenerationOptions.h"
 #include "antares/tools/ts-generator/linksTSgenerator.h"
@@ -133,7 +130,7 @@ int main(int argc, char* argv[])
 
     bool ret = TSGenerator::generateThermalTimeSeries(*study,
                                                       clusters,
-                                                      thermalSavePath.string());
+                                                      thermalSavePath);
 
     ret = linksTSgenerator.generate() && ret;
 

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -41,21 +41,21 @@ std::vector<Data::ThermalCluster*> getClustersToGen(Data::AreaList& areas,
     std::vector<Data::ThermalCluster*> clusters;
     const auto pairsAreaCluster = splitStringIntoPairs(clustersToGen, ';', '.');
 
-    for (const auto& [areaName, clusterName]: pairsAreaCluster)
+    for (const auto& [areaID, clusterID]: pairsAreaCluster)
     {
-        logs.info() << "Searching for area: " << areaName << " and cluster: " << clusterName;
+        logs.info() << "Searching for area: " << areaID << " and cluster: " << clusterID;
 
-        auto* area = areas.find(areaName);
+        auto* area = areas.find(areaID);
         if (!area)
         {
-            logs.warning() << "Area not found: " << areaName;
+            logs.warning() << "Area not found: " << areaID;
             continue;
         }
 
-        auto* cluster = area->thermal.list.findInAll(clusterName);
+        auto* cluster = area->thermal.list.findInAll(clusterID);
         if (!cluster)
         {
-            logs.warning() << "Cluster not found: " << clusterName;
+            logs.warning() << "Cluster not found: " << clusterID;
             continue;
         }
 

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, char* argv[])
     if (! checkOptions(settings))
         return 1;
 
+    // ============ THERMAL : Getting data for generating time-series =========
     auto study = std::make_shared<Data::Study>(true);
     Data::StudyLoadOptions studyOptions;
     studyOptions.prepareOutput = true;
@@ -92,7 +93,7 @@ int main(int argc, char* argv[])
     }
 
     study->initializeRuntimeInfos();
-    // Force the writing of generated TS into output/YYYYMMDD-HHSSeco/ts-generator/thermal[/mc-0]
+    // Forces the writing of generated TS into the study's output sub-folder
     study->parameters.timeSeriesToArchive |= Antares::Data::timeSeriesThermal;
 
     try
@@ -108,7 +109,6 @@ int main(int argc, char* argv[])
     thermalSavePath /= "ts-generator";
     thermalSavePath /= "thermal";
 
-    // ============ THERMAL : Getting data for generating time-series =========
     std::vector<Data::ThermalCluster*> clusters;
     if (settings.allThermal)
     {
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
     {
         logs.debug() << c->id();
     }
-
+    // ========================================================================
 
 
     LinksTSgenerator linksTSgenerator(settings);

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -104,11 +104,6 @@ int main(int argc, char* argv[])
     {
         clusters = getClustersToGen(study->areas, settings.thermalListToGen);
     }
-
-    for (auto& c: clusters)
-    {
-        logs.debug() << c->id();
-    }
     // ========================================================================
 
 

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -79,20 +79,11 @@ int main(int argc, char* argv[])
     // ============ THERMAL : Getting data for generating time-series =========
     auto study = std::make_shared<Data::Study>(true);
     Data::StudyLoadOptions studyOptions;
-    studyOptions.prepareOutput = true;
-
     if (!study->loadFromFolder(settings.studyFolder, studyOptions))
     {
         logs.error() << "Invalid study given to the generator";
         return 1;
     }
-
-    // Forces the writing of generated TS into the study's output sub-folder
-    study->parameters.timeSeriesToArchive |= Antares::Data::timeSeriesThermal;
-
-    auto thermalSavePath = fs::path(settings.studyFolder) / "output" / FormattedTime("%Y%m%d-%H%M");
-    thermalSavePath /= "ts-generator";
-    thermalSavePath /= "thermal";
 
     std::vector<Data::ThermalCluster*> clusters;
     if (settings.allThermal)
@@ -105,7 +96,6 @@ int main(int argc, char* argv[])
     }
     // ========================================================================
 
-
     LinksTSgenerator linksTSgenerator(settings);
     linksTSgenerator.extractData();
 
@@ -115,8 +105,13 @@ int main(int argc, char* argv[])
 
     bool ret = TSGenerator::generateThermalTimeSeries(*study,
                                                       clusters,
-                                                      thermalRandom,
-                                                      thermalSavePath);
+                                                      thermalRandom);
+
+    auto thermalSavePath = fs::path(settings.studyFolder) / "output" / FormattedTime("%Y%m%d-%H%M");
+    thermalSavePath /= "ts-generator";
+    thermalSavePath /= "thermal";
+
+    writeThermalTimeSeries(clusters, thermalSavePath);
 
     ret = linksTSgenerator.generate() && ret;
 

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -87,7 +87,6 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    study->initializeRuntimeInfos();
     // Forces the writing of generated TS into the study's output sub-folder
     study->parameters.timeSeriesToArchive |= Antares::Data::timeSeriesThermal;
 
@@ -111,9 +110,12 @@ int main(int argc, char* argv[])
     linksTSgenerator.extractData();
 
     // ============ TS Generation =============================================
+    MersenneTwister thermalRandom;
+    thermalRandom.reset(study->parameters.seed[Data::seedTsGenThermal]);
 
     bool ret = TSGenerator::generateThermalTimeSeries(*study,
                                                       clusters,
+                                                      thermalRandom,
                                                       thermalSavePath);
 
     ret = linksTSgenerator.generate() && ret;

--- a/src/tools/ts-generator/tsGenerationOptions.cpp
+++ b/src/tools/ts-generator/tsGenerationOptions.cpp
@@ -63,4 +63,12 @@ bool checkOptions(Settings& options)
     return true;
 }
 
+bool linkTSrequired(Settings& options)
+{
+    return options.allLinks || !options.linksListToGen.empty();
+}
+bool thermalTSrequired(Settings& options)
+{
+    return options.allThermal || !options.thermalListToGen.empty();
+}
 }


### PR DESCRIPTION
Aim of this PR : see the title.

What was done (see helping **gitHub** comments in this PR) : 
- simplifications : 
  - [x] Standardizing TS generation with link TS : remove a constructor in a class containing data for TS generation.
  - [x] Remove use of **RuntimeInfos** in **main.cpp** (many code lines used to be called there, just to get a random generator).
  - [x] Remove check on min stable power, useless.
  - [x] Function that actually generates the TS no longer takes the TS to be generated as argument, but returns it.
  - [x] **TS generator** code no longer contains code related to whether we should skip the TS writing on disk. It writes, that'all. This kind of code belongs to **solver**, not to **TS generator**.
  - [x] Use **std::filesystem** whenever possible instead of **Yuni**
  
- Unwanted behavior correction : 
  - [x] Execute links or thermal TS generation code only depending on user requirements : indeed, thermal TS generation still needs the whole study to be loaded, but link TS generation does not (it retrieves from study only the required data). Being forced to load the study if only link TS generation is required is a clear performance issue. We avoid that here.
  - [x] When data files required to generate TS (modulation files & prepro files) don't exist, we used to ignore it (this can lead to a crash). We now raise an error before TS generation time comes. 
- Moving code : _to be completed_  