### PR TITLE
Format code using clang-format==18.3.1

### DIFF
--- a/src/analyzer/atsp/load.cpp
+++ b/src/analyzer/atsp/load.cpp
@@ -59,7 +59,7 @@ bool ATSP::loadFromINIFile(const String& filename)
             if (section->name == ".general")
             {
                 IniFile::Property* p = section->firstProperty;
-                for (; p; p = p->next)
+                for (; p ; p = p->next)
                 {
                     key = p->key;
                     key.toLower();

--- a/src/analyzer/atsp/load.cpp
+++ b/src/analyzer/atsp/load.cpp
@@ -59,7 +59,7 @@ bool ATSP::loadFromINIFile(const String& filename)
             if (section->name == ".general")
             {
                 IniFile::Property* p = section->firstProperty;
-                for (; p ; p = p->next)
+                for (; p; p = p->next)
                 {
                     key = p->key;
                     key.toLower();

--- a/src/format-code.sh
+++ b/src/format-code.sh
@@ -4,7 +4,7 @@ if [ $# -eq 0 ]
 then
     # No arguments: format all
     SOURCE_DIRS="analyzer/ libs/ solver/ tools/ config/ tests/ packaging/"
-    SOURCE_FILES=$(find $SOURCE_DIRS -regextype egrep -regex ".*/*\.(c|cxx|cpp|cc|h|hxx|hpp)$")
+    SOURCE_FILES=$(find $SOURCE_DIRS -regextype egrep -regex ".*/*\.(c|cxx|cpp|cc|h|hxx|hpp)$" ! -path '*/antlr-interface/*')
 else
     # Format files provided as arguments
     SOURCE_FILES="$@"

--- a/src/libs/antares/antlr-interface/ExprBaseVisitor.cpp
+++ b/src/libs/antares/antlr-interface/ExprBaseVisitor.cpp
@@ -1,7 +1,4 @@
 
 // Generated from Expr.g4 by ANTLR 4.13.1
 
-
 #include "ExprBaseVisitor.h"
-
-

--- a/src/libs/antares/antlr-interface/ExprBaseVisitor.cpp
+++ b/src/libs/antares/antlr-interface/ExprBaseVisitor.cpp
@@ -1,4 +1,7 @@
 
 // Generated from Expr.g4 by ANTLR 4.13.1
 
+
 #include "ExprBaseVisitor.h"
+
+

--- a/src/libs/antares/antlr-interface/ExprBaseVisitor.h
+++ b/src/libs/antares/antlr-interface/ExprBaseVisitor.h
@@ -3,78 +3,88 @@
 
 #pragma once
 
-
-#include "antlr4-runtime.h"
 #include "ExprVisitor.h"
-
+#include "antlr4-runtime.h"
 
 /**
  * This class provides an empty implementation of ExprVisitor, which can be
  * extended to create a visitor which only needs to handle a subset of the available methods.
  */
-class  ExprBaseVisitor : public ExprVisitor {
+class ExprBaseVisitor: public ExprVisitor
+{
 public:
+    virtual std::any visitFullexpr(ExprParser::FullexprContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitFullexpr(ExprParser::FullexprContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitShift(ExprParser::ShiftContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitShift(ExprParser::ShiftContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitIdentifier(ExprParser::IdentifierContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitIdentifier(ExprParser::IdentifierContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitNegation(ExprParser::NegationContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitNegation(ExprParser::NegationContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitExpression(ExprParser::ExpressionContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitExpression(ExprParser::ExpressionContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitComparison(ExprParser::ComparisonContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitComparison(ExprParser::ComparisonContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitAddsub(ExprParser::AddsubContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitAddsub(ExprParser::AddsubContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitPortField(ExprParser::PortFieldContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitPortField(ExprParser::PortFieldContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitMuldiv(ExprParser::MuldivContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitMuldiv(ExprParser::MuldivContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitNumber(ExprParser::NumberContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitNumber(ExprParser::NumberContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitTimeIndex(ExprParser::TimeIndexContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitTimeIndex(ExprParser::TimeIndexContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitTimeShift(ExprParser::TimeShiftContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitTimeShift(ExprParser::TimeShiftContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitFunction(ExprParser::FunctionContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitFunction(ExprParser::FunctionContext *ctx) override {
-    return visitChildren(ctx);
-  }
+    virtual std::any visitTimeShiftRange(ExprParser::TimeShiftRangeContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 
-  virtual std::any visitTimeShiftRange(ExprParser::TimeShiftRangeContext *ctx) override {
-    return visitChildren(ctx);
-  }
-
-  virtual std::any visitTimeRange(ExprParser::TimeRangeContext *ctx) override {
-    return visitChildren(ctx);
-  }
-
-
+    virtual std::any visitTimeRange(ExprParser::TimeRangeContext* ctx) override
+    {
+        return visitChildren(ctx);
+    }
 };
-

--- a/src/libs/antares/antlr-interface/ExprBaseVisitor.h
+++ b/src/libs/antares/antlr-interface/ExprBaseVisitor.h
@@ -3,88 +3,78 @@
 
 #pragma once
 
-#include "ExprVisitor.h"
+
 #include "antlr4-runtime.h"
+#include "ExprVisitor.h"
+
 
 /**
  * This class provides an empty implementation of ExprVisitor, which can be
  * extended to create a visitor which only needs to handle a subset of the available methods.
  */
-class ExprBaseVisitor: public ExprVisitor
-{
+class  ExprBaseVisitor : public ExprVisitor {
 public:
-    virtual std::any visitFullexpr(ExprParser::FullexprContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
 
-    virtual std::any visitShift(ExprParser::ShiftContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitFullexpr(ExprParser::FullexprContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitIdentifier(ExprParser::IdentifierContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitShift(ExprParser::ShiftContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitNegation(ExprParser::NegationContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitIdentifier(ExprParser::IdentifierContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitExpression(ExprParser::ExpressionContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitNegation(ExprParser::NegationContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitComparison(ExprParser::ComparisonContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitExpression(ExprParser::ExpressionContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitAddsub(ExprParser::AddsubContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitComparison(ExprParser::ComparisonContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitPortField(ExprParser::PortFieldContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitAddsub(ExprParser::AddsubContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitMuldiv(ExprParser::MuldivContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitPortField(ExprParser::PortFieldContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitNumber(ExprParser::NumberContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitMuldiv(ExprParser::MuldivContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitTimeIndex(ExprParser::TimeIndexContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitNumber(ExprParser::NumberContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitTimeShift(ExprParser::TimeShiftContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitTimeIndex(ExprParser::TimeIndexContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitFunction(ExprParser::FunctionContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitTimeShift(ExprParser::TimeShiftContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitTimeShiftRange(ExprParser::TimeShiftRangeContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitFunction(ExprParser::FunctionContext *ctx) override {
+    return visitChildren(ctx);
+  }
 
-    virtual std::any visitTimeRange(ExprParser::TimeRangeContext* ctx) override
-    {
-        return visitChildren(ctx);
-    }
+  virtual std::any visitTimeShiftRange(ExprParser::TimeShiftRangeContext *ctx) override {
+    return visitChildren(ctx);
+  }
+
+  virtual std::any visitTimeRange(ExprParser::TimeRangeContext *ctx) override {
+    return visitChildren(ctx);
+  }
+
+
 };
+

--- a/src/libs/antares/antlr-interface/ExprLexer.cpp
+++ b/src/libs/antares/antlr-interface/ExprLexer.cpp
@@ -1,238 +1,177 @@
 
 // Generated from Expr.g4 by ANTLR 4.13.1
 
+
 #include "ExprLexer.h"
 
-using namespace antlr4;
 
 using namespace antlr4;
 
-namespace
-{
 
-struct ExprLexerStaticData final
-{
-    ExprLexerStaticData(std::vector<std::string> ruleNames,
-                        std::vector<std::string> channelNames,
-                        std::vector<std::string> modeNames,
-                        std::vector<std::string> literalNames,
-                        std::vector<std::string> symbolicNames):
-        ruleNames(std::move(ruleNames)),
-        channelNames(std::move(channelNames)),
-        modeNames(std::move(modeNames)),
-        literalNames(std::move(literalNames)),
+
+using namespace antlr4;
+
+namespace {
+
+struct ExprLexerStaticData final {
+  ExprLexerStaticData(std::vector<std::string> ruleNames,
+                          std::vector<std::string> channelNames,
+                          std::vector<std::string> modeNames,
+                          std::vector<std::string> literalNames,
+                          std::vector<std::string> symbolicNames)
+      : ruleNames(std::move(ruleNames)), channelNames(std::move(channelNames)),
+        modeNames(std::move(modeNames)), literalNames(std::move(literalNames)),
         symbolicNames(std::move(symbolicNames)),
-        vocabulary(this->literalNames, this->symbolicNames)
-    {
-    }
+        vocabulary(this->literalNames, this->symbolicNames) {}
 
-    ExprLexerStaticData(const ExprLexerStaticData&) = delete;
-    ExprLexerStaticData(ExprLexerStaticData&&) = delete;
-    ExprLexerStaticData& operator=(const ExprLexerStaticData&) = delete;
-    ExprLexerStaticData& operator=(ExprLexerStaticData&&) = delete;
+  ExprLexerStaticData(const ExprLexerStaticData&) = delete;
+  ExprLexerStaticData(ExprLexerStaticData&&) = delete;
+  ExprLexerStaticData& operator=(const ExprLexerStaticData&) = delete;
+  ExprLexerStaticData& operator=(ExprLexerStaticData&&) = delete;
 
-    std::vector<antlr4::dfa::DFA> decisionToDFA;
-    antlr4::atn::PredictionContextCache sharedContextCache;
-    const std::vector<std::string> ruleNames;
-    const std::vector<std::string> channelNames;
-    const std::vector<std::string> modeNames;
-    const std::vector<std::string> literalNames;
-    const std::vector<std::string> symbolicNames;
-    const antlr4::dfa::Vocabulary vocabulary;
-    antlr4::atn::SerializedATNView serializedATN;
-    std::unique_ptr<antlr4::atn::ATN> atn;
+  std::vector<antlr4::dfa::DFA> decisionToDFA;
+  antlr4::atn::PredictionContextCache sharedContextCache;
+  const std::vector<std::string> ruleNames;
+  const std::vector<std::string> channelNames;
+  const std::vector<std::string> modeNames;
+  const std::vector<std::string> literalNames;
+  const std::vector<std::string> symbolicNames;
+  const antlr4::dfa::Vocabulary vocabulary;
+  antlr4::atn::SerializedATNView serializedATN;
+  std::unique_ptr<antlr4::atn::ATN> atn;
 };
 
 ::antlr4::internal::OnceFlag exprlexerLexerOnceFlag;
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
 static thread_local
 #endif
-  ExprLexerStaticData* exprlexerLexerStaticData
-  = nullptr;
+ExprLexerStaticData *exprlexerLexerStaticData = nullptr;
 
-void exprlexerLexerInitialize()
-{
+void exprlexerLexerInitialize() {
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
-    if (exprlexerLexerStaticData != nullptr)
-    {
-        return;
-    }
+  if (exprlexerLexerStaticData != nullptr) {
+    return;
+  }
 #else
-    assert(exprlexerLexerStaticData == nullptr);
+  assert(exprlexerLexerStaticData == nullptr);
 #endif
-    auto staticData = std::make_unique<ExprLexerStaticData>(
-      std::vector<std::string>{"T__0",       "T__1",          "T__2",   "T__3",     "T__4",
-                               "T__5",       "T__6",          "T__7",   "T__8",     "DIGIT",
-                               "CHAR",       "CHAR_OR_DIGIT", "NUMBER", "TIME",     "IDENTIFIER",
-                               "COMPARISON", "ADDSUB",        "MULDIV", "LBRACKET", "RBRACKET",
-                               "WS"},
-      std::vector<std::string>{"DEFAULT_TOKEN_CHANNEL", "HIDDEN"},
-      std::vector<std::string>{"DEFAULT_MODE"},
-      std::vector<std::string>{"",
-                               "'+'",
-                               "'-'",
-                               "'/'",
-                               "'*'",
-                               "'.'",
-                               "'('",
-                               "')'",
-                               "','",
-                               "'..'",
-                               "",
-                               "'t'",
-                               "",
-                               "",
-                               "",
-                               "",
-                               "'['",
-                               "']'"},
-      std::vector<std::string>{"",
-                               "",
-                               "",
-                               "",
-                               "",
-                               "",
-                               "",
-                               "",
-                               "",
-                               "",
-                               "NUMBER",
-                               "TIME",
-                               "IDENTIFIER",
-                               "COMPARISON",
-                               "ADDSUB",
-                               "MULDIV",
-                               "LBRACKET",
-                               "RBRACKET",
-                               "WS"});
-    static const int32_t serializedATNSegment[] = {
-      4,   0,   18,  111, 6,  -1, 2,   0,   7,   0,   2,   1,   7,  1,   2,   2,   7,  2,   2,
-      3,   7,   3,   2,   4,  7,  4,   2,   5,   7,   5,   2,   6,  7,   6,   2,   7,  7,   7,
-      2,   8,   7,   8,   2,  9,  7,   9,   2,   10,  7,   10,  2,  11,  7,   11,  2,  12,  7,
-      12,  2,   13,  7,   13, 2,  14,  7,   14,  2,   15,  7,   15, 2,   16,  7,   16, 2,   17,
-      7,   17,  2,   18,  7,  18, 2,   19,  7,   19,  2,   20,  7,  20,  1,   0,   1,  0,   1,
-      1,   1,   1,   1,   2,  1,  2,   1,   3,   1,   3,   1,   4,  1,   4,   1,   5,  1,   5,
-      1,   6,   1,   6,   1,  7,  1,   7,   1,   8,   1,   8,   1,  8,   1,   9,   1,  9,   1,
-      10,  1,   10,  1,   11, 1,  11,  3,   11,  69,  8,   11,  1,  12,  4,   12,  72, 8,   12,
-      11,  12,  12,  12,  73, 1,  12,  1,   12,  4,   12,  78,  8,  12,  11,  12,  12, 12,  79,
-      3,   12,  82,  8,   12, 1,  13,  1,   13,  1,   14,  1,   14, 5,   14,  88,  8,  14,  10,
-      14,  12,  14,  91,  9,  14, 1,   15,  1,   15,  1,   15,  1,  15,  1,   15,  3,  15,  98,
-      8,   15,  1,   16,  1,  16, 1,   17,  1,   17,  1,   18,  1,  18,  1,   19,  1,  19,  1,
-      20,  1,   20,  1,   20, 1,  20,  0,   0,   21,  1,   1,   3,  2,   5,   3,   7,  4,   9,
-      5,   11,  6,   13,  7,  15, 8,   17,  9,   19,  0,   21,  0,  23,  0,   25,  10, 27,  11,
-      29,  12,  31,  13,  33, 14, 35,  15,  37,  16,  39,  17,  41, 18,  1,   0,   5,  1,   0,
-      48,  57,  3,   0,   65, 90, 95,  95,  97,  122, 2,   0,   43, 43,  45,  45,  2,  0,   42,
-      42,  47,  47,  3,   0,  9,  10,  13,  13,  32,  32,  114, 0,  1,   1,   0,   0,  0,   0,
-      3,   1,   0,   0,   0,  0,  5,   1,   0,   0,   0,   0,   7,  1,   0,   0,   0,  0,   9,
-      1,   0,   0,   0,   0,  11, 1,   0,   0,   0,   0,   13,  1,  0,   0,   0,   0,  15,  1,
-      0,   0,   0,   0,   17, 1,  0,   0,   0,   0,   25,  1,   0,  0,   0,   0,   27, 1,   0,
-      0,   0,   0,   29,  1,  0,  0,   0,   0,   31,  1,   0,   0,  0,   0,   33,  1,  0,   0,
-      0,   0,   35,  1,   0,  0,  0,   0,   37,  1,   0,   0,   0,  0,   39,  1,   0,  0,   0,
-      0,   41,  1,   0,   0,  0,  1,   43,  1,   0,   0,   0,   3,  45,  1,   0,   0,  0,   5,
-      47,  1,   0,   0,   0,  7,  49,  1,   0,   0,   0,   9,   51, 1,   0,   0,   0,  11,  53,
-      1,   0,   0,   0,   13, 55, 1,   0,   0,   0,   15,  57,  1,  0,   0,   0,   17, 59,  1,
-      0,   0,   0,   19,  62, 1,  0,   0,   0,   21,  64,  1,   0,  0,   0,   23,  68, 1,   0,
-      0,   0,   25,  71,  1,  0,  0,   0,   27,  83,  1,   0,   0,  0,   29,  85,  1,  0,   0,
-      0,   31,  97,  1,   0,  0,  0,   33,  99,  1,   0,   0,   0,  35,  101, 1,   0,  0,   0,
-      37,  103, 1,   0,   0,  0,  39,  105, 1,   0,   0,   0,   41, 107, 1,   0,   0,  0,   43,
-      44,  5,   43,  0,   0,  44, 2,   1,   0,   0,   0,   45,  46, 5,   45,  0,   0,  46,  4,
-      1,   0,   0,   0,   47, 48, 5,   47,  0,   0,   48,  6,   1,  0,   0,   0,   49, 50,  5,
-      42,  0,   0,   50,  8,  1,  0,   0,   0,   51,  52,  5,   46, 0,   0,   52,  10, 1,   0,
-      0,   0,   53,  54,  5,  40, 0,   0,   54,  12,  1,   0,   0,  0,   55,  56,  5,  41,  0,
-      0,   56,  14,  1,   0,  0,  0,   57,  58,  5,   44,  0,   0,  58,  16,  1,   0,  0,   0,
-      59,  60,  5,   46,  0,  0,  60,  61,  5,   46,  0,   0,   61, 18,  1,   0,   0,  0,   62,
-      63,  7,   0,   0,   0,  63, 20,  1,   0,   0,   0,   64,  65, 7,   1,   0,   0,  65,  22,
-      1,   0,   0,   0,   66, 69, 3,   21,  10,  0,   67,  69,  3,  19,  9,   0,   68, 66,  1,
-      0,   0,   0,   68,  67, 1,  0,   0,   0,   69,  24,  1,   0,  0,   0,   70,  72, 3,   19,
-      9,   0,   71,  70,  1,  0,  0,   0,   72,  73,  1,   0,   0,  0,   73,  71,  1,  0,   0,
-      0,   73,  74,  1,   0,  0,  0,   74,  81,  1,   0,   0,   0,  75,  77,  5,   46, 0,   0,
-      76,  78,  3,   19,  9,  0,  77,  76,  1,   0,   0,   0,   78, 79,  1,   0,   0,  0,   79,
-      77,  1,   0,   0,   0,  79, 80,  1,   0,   0,   0,   80,  82, 1,   0,   0,   0,  81,  75,
-      1,   0,   0,   0,   81, 82, 1,   0,   0,   0,   82,  26,  1,  0,   0,   0,   83, 84,  5,
-      116, 0,   0,   84,  28, 1,  0,   0,   0,   85,  89,  3,   21, 10,  0,   86,  88, 3,   23,
-      11,  0,   87,  86,  1,  0,  0,   0,   88,  91,  1,   0,   0,  0,   89,  87,  1,  0,   0,
-      0,   89,  90,  1,   0,  0,  0,   90,  30,  1,   0,   0,   0,  91,  89,  1,   0,  0,   0,
-      92,  98,  5,   61,  0,  0,  93,  94,  5,   62,  0,   0,   94, 98,  5,   61,  0,  0,   95,
-      96,  5,   60,  0,   0,  96, 98,  5,   61,  0,   0,   97,  92, 1,   0,   0,   0,  97,  93,
-      1,   0,   0,   0,   97, 95, 1,   0,   0,   0,   98,  32,  1,  0,   0,   0,   99, 100, 7,
-      2,   0,   0,   100, 34, 1,  0,   0,   0,   101, 102, 7,   3,  0,   0,   102, 36, 1,   0,
-      0,   0,   103, 104, 5,  91, 0,   0,   104, 38,  1,   0,   0,  0,   105, 106, 5,  93,  0,
-      0,   106, 40,  1,   0,  0,  0,   107, 108, 7,   4,   0,   0,  108, 109, 1,   0,  0,   0,
-      109, 110, 6,   20,  0,  0,  110, 42,  1,   0,   0,   0,   7,  0,   68,  73,  79, 81,  89,
-      97,  1,   6,   0,   0};
-    staticData->serializedATN = antlr4::atn::SerializedATNView(serializedATNSegment,
-                                                               sizeof(serializedATNSegment)
-                                                                 / sizeof(serializedATNSegment[0]));
-
-    antlr4::atn::ATNDeserializer deserializer;
-    staticData->atn = deserializer.deserialize(staticData->serializedATN);
-
-    const size_t count = staticData->atn->getNumberOfDecisions();
-    staticData->decisionToDFA.reserve(count);
-    for (size_t i = 0; i < count; i++)
-    {
-        staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
+  auto staticData = std::make_unique<ExprLexerStaticData>(
+    std::vector<std::string>{
+      "T__0", "T__1", "T__2", "T__3", "T__4", "T__5", "T__6", "T__7", "T__8", 
+      "DIGIT", "CHAR", "CHAR_OR_DIGIT", "NUMBER", "TIME", "IDENTIFIER", 
+      "COMPARISON", "ADDSUB", "MULDIV", "LBRACKET", "RBRACKET", "WS"
+    },
+    std::vector<std::string>{
+      "DEFAULT_TOKEN_CHANNEL", "HIDDEN"
+    },
+    std::vector<std::string>{
+      "DEFAULT_MODE"
+    },
+    std::vector<std::string>{
+      "", "'+'", "'-'", "'/'", "'*'", "'.'", "'('", "')'", "','", "'..'", 
+      "", "'t'", "", "", "", "", "'['", "']'"
+    },
+    std::vector<std::string>{
+      "", "", "", "", "", "", "", "", "", "", "NUMBER", "TIME", "IDENTIFIER", 
+      "COMPARISON", "ADDSUB", "MULDIV", "LBRACKET", "RBRACKET", "WS"
     }
-    exprlexerLexerStaticData = staticData.release();
+  );
+  static const int32_t serializedATNSegment[] = {
+  	4,0,18,111,6,-1,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,
+  	6,2,7,7,7,2,8,7,8,2,9,7,9,2,10,7,10,2,11,7,11,2,12,7,12,2,13,7,13,2,14,
+  	7,14,2,15,7,15,2,16,7,16,2,17,7,17,2,18,7,18,2,19,7,19,2,20,7,20,1,0,
+  	1,0,1,1,1,1,1,2,1,2,1,3,1,3,1,4,1,4,1,5,1,5,1,6,1,6,1,7,1,7,1,8,1,8,1,
+  	8,1,9,1,9,1,10,1,10,1,11,1,11,3,11,69,8,11,1,12,4,12,72,8,12,11,12,12,
+  	12,73,1,12,1,12,4,12,78,8,12,11,12,12,12,79,3,12,82,8,12,1,13,1,13,1,
+  	14,1,14,5,14,88,8,14,10,14,12,14,91,9,14,1,15,1,15,1,15,1,15,1,15,3,15,
+  	98,8,15,1,16,1,16,1,17,1,17,1,18,1,18,1,19,1,19,1,20,1,20,1,20,1,20,0,
+  	0,21,1,1,3,2,5,3,7,4,9,5,11,6,13,7,15,8,17,9,19,0,21,0,23,0,25,10,27,
+  	11,29,12,31,13,33,14,35,15,37,16,39,17,41,18,1,0,5,1,0,48,57,3,0,65,90,
+  	95,95,97,122,2,0,43,43,45,45,2,0,42,42,47,47,3,0,9,10,13,13,32,32,114,
+  	0,1,1,0,0,0,0,3,1,0,0,0,0,5,1,0,0,0,0,7,1,0,0,0,0,9,1,0,0,0,0,11,1,0,
+  	0,0,0,13,1,0,0,0,0,15,1,0,0,0,0,17,1,0,0,0,0,25,1,0,0,0,0,27,1,0,0,0,
+  	0,29,1,0,0,0,0,31,1,0,0,0,0,33,1,0,0,0,0,35,1,0,0,0,0,37,1,0,0,0,0,39,
+  	1,0,0,0,0,41,1,0,0,0,1,43,1,0,0,0,3,45,1,0,0,0,5,47,1,0,0,0,7,49,1,0,
+  	0,0,9,51,1,0,0,0,11,53,1,0,0,0,13,55,1,0,0,0,15,57,1,0,0,0,17,59,1,0,
+  	0,0,19,62,1,0,0,0,21,64,1,0,0,0,23,68,1,0,0,0,25,71,1,0,0,0,27,83,1,0,
+  	0,0,29,85,1,0,0,0,31,97,1,0,0,0,33,99,1,0,0,0,35,101,1,0,0,0,37,103,1,
+  	0,0,0,39,105,1,0,0,0,41,107,1,0,0,0,43,44,5,43,0,0,44,2,1,0,0,0,45,46,
+  	5,45,0,0,46,4,1,0,0,0,47,48,5,47,0,0,48,6,1,0,0,0,49,50,5,42,0,0,50,8,
+  	1,0,0,0,51,52,5,46,0,0,52,10,1,0,0,0,53,54,5,40,0,0,54,12,1,0,0,0,55,
+  	56,5,41,0,0,56,14,1,0,0,0,57,58,5,44,0,0,58,16,1,0,0,0,59,60,5,46,0,0,
+  	60,61,5,46,0,0,61,18,1,0,0,0,62,63,7,0,0,0,63,20,1,0,0,0,64,65,7,1,0,
+  	0,65,22,1,0,0,0,66,69,3,21,10,0,67,69,3,19,9,0,68,66,1,0,0,0,68,67,1,
+  	0,0,0,69,24,1,0,0,0,70,72,3,19,9,0,71,70,1,0,0,0,72,73,1,0,0,0,73,71,
+  	1,0,0,0,73,74,1,0,0,0,74,81,1,0,0,0,75,77,5,46,0,0,76,78,3,19,9,0,77,
+  	76,1,0,0,0,78,79,1,0,0,0,79,77,1,0,0,0,79,80,1,0,0,0,80,82,1,0,0,0,81,
+  	75,1,0,0,0,81,82,1,0,0,0,82,26,1,0,0,0,83,84,5,116,0,0,84,28,1,0,0,0,
+  	85,89,3,21,10,0,86,88,3,23,11,0,87,86,1,0,0,0,88,91,1,0,0,0,89,87,1,0,
+  	0,0,89,90,1,0,0,0,90,30,1,0,0,0,91,89,1,0,0,0,92,98,5,61,0,0,93,94,5,
+  	62,0,0,94,98,5,61,0,0,95,96,5,60,0,0,96,98,5,61,0,0,97,92,1,0,0,0,97,
+  	93,1,0,0,0,97,95,1,0,0,0,98,32,1,0,0,0,99,100,7,2,0,0,100,34,1,0,0,0,
+  	101,102,7,3,0,0,102,36,1,0,0,0,103,104,5,91,0,0,104,38,1,0,0,0,105,106,
+  	5,93,0,0,106,40,1,0,0,0,107,108,7,4,0,0,108,109,1,0,0,0,109,110,6,20,
+  	0,0,110,42,1,0,0,0,7,0,68,73,79,81,89,97,1,6,0,0
+  };
+  staticData->serializedATN = antlr4::atn::SerializedATNView(serializedATNSegment, sizeof(serializedATNSegment) / sizeof(serializedATNSegment[0]));
+
+  antlr4::atn::ATNDeserializer deserializer;
+  staticData->atn = deserializer.deserialize(staticData->serializedATN);
+
+  const size_t count = staticData->atn->getNumberOfDecisions();
+  staticData->decisionToDFA.reserve(count);
+  for (size_t i = 0; i < count; i++) { 
+    staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
+  }
+  exprlexerLexerStaticData = staticData.release();
 }
 
-} // namespace
-
-ExprLexer::ExprLexer(CharStream* input):
-    Lexer(input)
-{
-    ExprLexer::initialize();
-    _interpreter = new atn::LexerATNSimulator(this,
-                                              *exprlexerLexerStaticData->atn,
-                                              exprlexerLexerStaticData->decisionToDFA,
-                                              exprlexerLexerStaticData->sharedContextCache);
 }
 
-ExprLexer::~ExprLexer()
-{
-    delete _interpreter;
+ExprLexer::ExprLexer(CharStream *input) : Lexer(input) {
+  ExprLexer::initialize();
+  _interpreter = new atn::LexerATNSimulator(this, *exprlexerLexerStaticData->atn, exprlexerLexerStaticData->decisionToDFA, exprlexerLexerStaticData->sharedContextCache);
 }
 
-std::string ExprLexer::getGrammarFileName() const
-{
-    return "Expr.g4";
+ExprLexer::~ExprLexer() {
+  delete _interpreter;
 }
 
-const std::vector<std::string>& ExprLexer::getRuleNames() const
-{
-    return exprlexerLexerStaticData->ruleNames;
+std::string ExprLexer::getGrammarFileName() const {
+  return "Expr.g4";
 }
 
-const std::vector<std::string>& ExprLexer::getChannelNames() const
-{
-    return exprlexerLexerStaticData->channelNames;
+const std::vector<std::string>& ExprLexer::getRuleNames() const {
+  return exprlexerLexerStaticData->ruleNames;
 }
 
-const std::vector<std::string>& ExprLexer::getModeNames() const
-{
-    return exprlexerLexerStaticData->modeNames;
+const std::vector<std::string>& ExprLexer::getChannelNames() const {
+  return exprlexerLexerStaticData->channelNames;
 }
 
-const dfa::Vocabulary& ExprLexer::getVocabulary() const
-{
-    return exprlexerLexerStaticData->vocabulary;
+const std::vector<std::string>& ExprLexer::getModeNames() const {
+  return exprlexerLexerStaticData->modeNames;
 }
 
-antlr4::atn::SerializedATNView ExprLexer::getSerializedATN() const
-{
-    return exprlexerLexerStaticData->serializedATN;
+const dfa::Vocabulary& ExprLexer::getVocabulary() const {
+  return exprlexerLexerStaticData->vocabulary;
 }
 
-const atn::ATN& ExprLexer::getATN() const
-{
-    return *exprlexerLexerStaticData->atn;
+antlr4::atn::SerializedATNView ExprLexer::getSerializedATN() const {
+  return exprlexerLexerStaticData->serializedATN;
 }
 
-void ExprLexer::initialize()
-{
+const atn::ATN& ExprLexer::getATN() const {
+  return *exprlexerLexerStaticData->atn;
+}
+
+
+
+
+void ExprLexer::initialize() {
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
-    exprlexerLexerInitialize();
+  exprlexerLexerInitialize();
 #else
-    ::antlr4::internal::call_once(exprlexerLexerOnceFlag, exprlexerLexerInitialize);
+  ::antlr4::internal::call_once(exprlexerLexerOnceFlag, exprlexerLexerInitialize);
 #endif
 }

--- a/src/libs/antares/antlr-interface/ExprLexer.cpp
+++ b/src/libs/antares/antlr-interface/ExprLexer.cpp
@@ -1,177 +1,238 @@
 
 // Generated from Expr.g4 by ANTLR 4.13.1
 
-
 #include "ExprLexer.h"
 
+using namespace antlr4;
 
 using namespace antlr4;
 
+namespace
+{
 
-
-using namespace antlr4;
-
-namespace {
-
-struct ExprLexerStaticData final {
-  ExprLexerStaticData(std::vector<std::string> ruleNames,
-                          std::vector<std::string> channelNames,
-                          std::vector<std::string> modeNames,
-                          std::vector<std::string> literalNames,
-                          std::vector<std::string> symbolicNames)
-      : ruleNames(std::move(ruleNames)), channelNames(std::move(channelNames)),
-        modeNames(std::move(modeNames)), literalNames(std::move(literalNames)),
+struct ExprLexerStaticData final
+{
+    ExprLexerStaticData(std::vector<std::string> ruleNames,
+                        std::vector<std::string> channelNames,
+                        std::vector<std::string> modeNames,
+                        std::vector<std::string> literalNames,
+                        std::vector<std::string> symbolicNames):
+        ruleNames(std::move(ruleNames)),
+        channelNames(std::move(channelNames)),
+        modeNames(std::move(modeNames)),
+        literalNames(std::move(literalNames)),
         symbolicNames(std::move(symbolicNames)),
-        vocabulary(this->literalNames, this->symbolicNames) {}
+        vocabulary(this->literalNames, this->symbolicNames)
+    {
+    }
 
-  ExprLexerStaticData(const ExprLexerStaticData&) = delete;
-  ExprLexerStaticData(ExprLexerStaticData&&) = delete;
-  ExprLexerStaticData& operator=(const ExprLexerStaticData&) = delete;
-  ExprLexerStaticData& operator=(ExprLexerStaticData&&) = delete;
+    ExprLexerStaticData(const ExprLexerStaticData&) = delete;
+    ExprLexerStaticData(ExprLexerStaticData&&) = delete;
+    ExprLexerStaticData& operator=(const ExprLexerStaticData&) = delete;
+    ExprLexerStaticData& operator=(ExprLexerStaticData&&) = delete;
 
-  std::vector<antlr4::dfa::DFA> decisionToDFA;
-  antlr4::atn::PredictionContextCache sharedContextCache;
-  const std::vector<std::string> ruleNames;
-  const std::vector<std::string> channelNames;
-  const std::vector<std::string> modeNames;
-  const std::vector<std::string> literalNames;
-  const std::vector<std::string> symbolicNames;
-  const antlr4::dfa::Vocabulary vocabulary;
-  antlr4::atn::SerializedATNView serializedATN;
-  std::unique_ptr<antlr4::atn::ATN> atn;
+    std::vector<antlr4::dfa::DFA> decisionToDFA;
+    antlr4::atn::PredictionContextCache sharedContextCache;
+    const std::vector<std::string> ruleNames;
+    const std::vector<std::string> channelNames;
+    const std::vector<std::string> modeNames;
+    const std::vector<std::string> literalNames;
+    const std::vector<std::string> symbolicNames;
+    const antlr4::dfa::Vocabulary vocabulary;
+    antlr4::atn::SerializedATNView serializedATN;
+    std::unique_ptr<antlr4::atn::ATN> atn;
 };
 
 ::antlr4::internal::OnceFlag exprlexerLexerOnceFlag;
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
 static thread_local
 #endif
-ExprLexerStaticData *exprlexerLexerStaticData = nullptr;
+  ExprLexerStaticData* exprlexerLexerStaticData
+  = nullptr;
 
-void exprlexerLexerInitialize() {
+void exprlexerLexerInitialize()
+{
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
-  if (exprlexerLexerStaticData != nullptr) {
-    return;
-  }
-#else
-  assert(exprlexerLexerStaticData == nullptr);
-#endif
-  auto staticData = std::make_unique<ExprLexerStaticData>(
-    std::vector<std::string>{
-      "T__0", "T__1", "T__2", "T__3", "T__4", "T__5", "T__6", "T__7", "T__8", 
-      "DIGIT", "CHAR", "CHAR_OR_DIGIT", "NUMBER", "TIME", "IDENTIFIER", 
-      "COMPARISON", "ADDSUB", "MULDIV", "LBRACKET", "RBRACKET", "WS"
-    },
-    std::vector<std::string>{
-      "DEFAULT_TOKEN_CHANNEL", "HIDDEN"
-    },
-    std::vector<std::string>{
-      "DEFAULT_MODE"
-    },
-    std::vector<std::string>{
-      "", "'+'", "'-'", "'/'", "'*'", "'.'", "'('", "')'", "','", "'..'", 
-      "", "'t'", "", "", "", "", "'['", "']'"
-    },
-    std::vector<std::string>{
-      "", "", "", "", "", "", "", "", "", "", "NUMBER", "TIME", "IDENTIFIER", 
-      "COMPARISON", "ADDSUB", "MULDIV", "LBRACKET", "RBRACKET", "WS"
+    if (exprlexerLexerStaticData != nullptr)
+    {
+        return;
     }
-  );
-  static const int32_t serializedATNSegment[] = {
-  	4,0,18,111,6,-1,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,
-  	6,2,7,7,7,2,8,7,8,2,9,7,9,2,10,7,10,2,11,7,11,2,12,7,12,2,13,7,13,2,14,
-  	7,14,2,15,7,15,2,16,7,16,2,17,7,17,2,18,7,18,2,19,7,19,2,20,7,20,1,0,
-  	1,0,1,1,1,1,1,2,1,2,1,3,1,3,1,4,1,4,1,5,1,5,1,6,1,6,1,7,1,7,1,8,1,8,1,
-  	8,1,9,1,9,1,10,1,10,1,11,1,11,3,11,69,8,11,1,12,4,12,72,8,12,11,12,12,
-  	12,73,1,12,1,12,4,12,78,8,12,11,12,12,12,79,3,12,82,8,12,1,13,1,13,1,
-  	14,1,14,5,14,88,8,14,10,14,12,14,91,9,14,1,15,1,15,1,15,1,15,1,15,3,15,
-  	98,8,15,1,16,1,16,1,17,1,17,1,18,1,18,1,19,1,19,1,20,1,20,1,20,1,20,0,
-  	0,21,1,1,3,2,5,3,7,4,9,5,11,6,13,7,15,8,17,9,19,0,21,0,23,0,25,10,27,
-  	11,29,12,31,13,33,14,35,15,37,16,39,17,41,18,1,0,5,1,0,48,57,3,0,65,90,
-  	95,95,97,122,2,0,43,43,45,45,2,0,42,42,47,47,3,0,9,10,13,13,32,32,114,
-  	0,1,1,0,0,0,0,3,1,0,0,0,0,5,1,0,0,0,0,7,1,0,0,0,0,9,1,0,0,0,0,11,1,0,
-  	0,0,0,13,1,0,0,0,0,15,1,0,0,0,0,17,1,0,0,0,0,25,1,0,0,0,0,27,1,0,0,0,
-  	0,29,1,0,0,0,0,31,1,0,0,0,0,33,1,0,0,0,0,35,1,0,0,0,0,37,1,0,0,0,0,39,
-  	1,0,0,0,0,41,1,0,0,0,1,43,1,0,0,0,3,45,1,0,0,0,5,47,1,0,0,0,7,49,1,0,
-  	0,0,9,51,1,0,0,0,11,53,1,0,0,0,13,55,1,0,0,0,15,57,1,0,0,0,17,59,1,0,
-  	0,0,19,62,1,0,0,0,21,64,1,0,0,0,23,68,1,0,0,0,25,71,1,0,0,0,27,83,1,0,
-  	0,0,29,85,1,0,0,0,31,97,1,0,0,0,33,99,1,0,0,0,35,101,1,0,0,0,37,103,1,
-  	0,0,0,39,105,1,0,0,0,41,107,1,0,0,0,43,44,5,43,0,0,44,2,1,0,0,0,45,46,
-  	5,45,0,0,46,4,1,0,0,0,47,48,5,47,0,0,48,6,1,0,0,0,49,50,5,42,0,0,50,8,
-  	1,0,0,0,51,52,5,46,0,0,52,10,1,0,0,0,53,54,5,40,0,0,54,12,1,0,0,0,55,
-  	56,5,41,0,0,56,14,1,0,0,0,57,58,5,44,0,0,58,16,1,0,0,0,59,60,5,46,0,0,
-  	60,61,5,46,0,0,61,18,1,0,0,0,62,63,7,0,0,0,63,20,1,0,0,0,64,65,7,1,0,
-  	0,65,22,1,0,0,0,66,69,3,21,10,0,67,69,3,19,9,0,68,66,1,0,0,0,68,67,1,
-  	0,0,0,69,24,1,0,0,0,70,72,3,19,9,0,71,70,1,0,0,0,72,73,1,0,0,0,73,71,
-  	1,0,0,0,73,74,1,0,0,0,74,81,1,0,0,0,75,77,5,46,0,0,76,78,3,19,9,0,77,
-  	76,1,0,0,0,78,79,1,0,0,0,79,77,1,0,0,0,79,80,1,0,0,0,80,82,1,0,0,0,81,
-  	75,1,0,0,0,81,82,1,0,0,0,82,26,1,0,0,0,83,84,5,116,0,0,84,28,1,0,0,0,
-  	85,89,3,21,10,0,86,88,3,23,11,0,87,86,1,0,0,0,88,91,1,0,0,0,89,87,1,0,
-  	0,0,89,90,1,0,0,0,90,30,1,0,0,0,91,89,1,0,0,0,92,98,5,61,0,0,93,94,5,
-  	62,0,0,94,98,5,61,0,0,95,96,5,60,0,0,96,98,5,61,0,0,97,92,1,0,0,0,97,
-  	93,1,0,0,0,97,95,1,0,0,0,98,32,1,0,0,0,99,100,7,2,0,0,100,34,1,0,0,0,
-  	101,102,7,3,0,0,102,36,1,0,0,0,103,104,5,91,0,0,104,38,1,0,0,0,105,106,
-  	5,93,0,0,106,40,1,0,0,0,107,108,7,4,0,0,108,109,1,0,0,0,109,110,6,20,
-  	0,0,110,42,1,0,0,0,7,0,68,73,79,81,89,97,1,6,0,0
-  };
-  staticData->serializedATN = antlr4::atn::SerializedATNView(serializedATNSegment, sizeof(serializedATNSegment) / sizeof(serializedATNSegment[0]));
-
-  antlr4::atn::ATNDeserializer deserializer;
-  staticData->atn = deserializer.deserialize(staticData->serializedATN);
-
-  const size_t count = staticData->atn->getNumberOfDecisions();
-  staticData->decisionToDFA.reserve(count);
-  for (size_t i = 0; i < count; i++) { 
-    staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
-  }
-  exprlexerLexerStaticData = staticData.release();
-}
-
-}
-
-ExprLexer::ExprLexer(CharStream *input) : Lexer(input) {
-  ExprLexer::initialize();
-  _interpreter = new atn::LexerATNSimulator(this, *exprlexerLexerStaticData->atn, exprlexerLexerStaticData->decisionToDFA, exprlexerLexerStaticData->sharedContextCache);
-}
-
-ExprLexer::~ExprLexer() {
-  delete _interpreter;
-}
-
-std::string ExprLexer::getGrammarFileName() const {
-  return "Expr.g4";
-}
-
-const std::vector<std::string>& ExprLexer::getRuleNames() const {
-  return exprlexerLexerStaticData->ruleNames;
-}
-
-const std::vector<std::string>& ExprLexer::getChannelNames() const {
-  return exprlexerLexerStaticData->channelNames;
-}
-
-const std::vector<std::string>& ExprLexer::getModeNames() const {
-  return exprlexerLexerStaticData->modeNames;
-}
-
-const dfa::Vocabulary& ExprLexer::getVocabulary() const {
-  return exprlexerLexerStaticData->vocabulary;
-}
-
-antlr4::atn::SerializedATNView ExprLexer::getSerializedATN() const {
-  return exprlexerLexerStaticData->serializedATN;
-}
-
-const atn::ATN& ExprLexer::getATN() const {
-  return *exprlexerLexerStaticData->atn;
-}
-
-
-
-
-void ExprLexer::initialize() {
-#if ANTLR4_USE_THREAD_LOCAL_CACHE
-  exprlexerLexerInitialize();
 #else
-  ::antlr4::internal::call_once(exprlexerLexerOnceFlag, exprlexerLexerInitialize);
+    assert(exprlexerLexerStaticData == nullptr);
+#endif
+    auto staticData = std::make_unique<ExprLexerStaticData>(
+      std::vector<std::string>{"T__0",       "T__1",          "T__2",   "T__3",     "T__4",
+                               "T__5",       "T__6",          "T__7",   "T__8",     "DIGIT",
+                               "CHAR",       "CHAR_OR_DIGIT", "NUMBER", "TIME",     "IDENTIFIER",
+                               "COMPARISON", "ADDSUB",        "MULDIV", "LBRACKET", "RBRACKET",
+                               "WS"},
+      std::vector<std::string>{"DEFAULT_TOKEN_CHANNEL", "HIDDEN"},
+      std::vector<std::string>{"DEFAULT_MODE"},
+      std::vector<std::string>{"",
+                               "'+'",
+                               "'-'",
+                               "'/'",
+                               "'*'",
+                               "'.'",
+                               "'('",
+                               "')'",
+                               "','",
+                               "'..'",
+                               "",
+                               "'t'",
+                               "",
+                               "",
+                               "",
+                               "",
+                               "'['",
+                               "']'"},
+      std::vector<std::string>{"",
+                               "",
+                               "",
+                               "",
+                               "",
+                               "",
+                               "",
+                               "",
+                               "",
+                               "",
+                               "NUMBER",
+                               "TIME",
+                               "IDENTIFIER",
+                               "COMPARISON",
+                               "ADDSUB",
+                               "MULDIV",
+                               "LBRACKET",
+                               "RBRACKET",
+                               "WS"});
+    static const int32_t serializedATNSegment[] = {
+      4,   0,   18,  111, 6,  -1, 2,   0,   7,   0,   2,   1,   7,  1,   2,   2,   7,  2,   2,
+      3,   7,   3,   2,   4,  7,  4,   2,   5,   7,   5,   2,   6,  7,   6,   2,   7,  7,   7,
+      2,   8,   7,   8,   2,  9,  7,   9,   2,   10,  7,   10,  2,  11,  7,   11,  2,  12,  7,
+      12,  2,   13,  7,   13, 2,  14,  7,   14,  2,   15,  7,   15, 2,   16,  7,   16, 2,   17,
+      7,   17,  2,   18,  7,  18, 2,   19,  7,   19,  2,   20,  7,  20,  1,   0,   1,  0,   1,
+      1,   1,   1,   1,   2,  1,  2,   1,   3,   1,   3,   1,   4,  1,   4,   1,   5,  1,   5,
+      1,   6,   1,   6,   1,  7,  1,   7,   1,   8,   1,   8,   1,  8,   1,   9,   1,  9,   1,
+      10,  1,   10,  1,   11, 1,  11,  3,   11,  69,  8,   11,  1,  12,  4,   12,  72, 8,   12,
+      11,  12,  12,  12,  73, 1,  12,  1,   12,  4,   12,  78,  8,  12,  11,  12,  12, 12,  79,
+      3,   12,  82,  8,   12, 1,  13,  1,   13,  1,   14,  1,   14, 5,   14,  88,  8,  14,  10,
+      14,  12,  14,  91,  9,  14, 1,   15,  1,   15,  1,   15,  1,  15,  1,   15,  3,  15,  98,
+      8,   15,  1,   16,  1,  16, 1,   17,  1,   17,  1,   18,  1,  18,  1,   19,  1,  19,  1,
+      20,  1,   20,  1,   20, 1,  20,  0,   0,   21,  1,   1,   3,  2,   5,   3,   7,  4,   9,
+      5,   11,  6,   13,  7,  15, 8,   17,  9,   19,  0,   21,  0,  23,  0,   25,  10, 27,  11,
+      29,  12,  31,  13,  33, 14, 35,  15,  37,  16,  39,  17,  41, 18,  1,   0,   5,  1,   0,
+      48,  57,  3,   0,   65, 90, 95,  95,  97,  122, 2,   0,   43, 43,  45,  45,  2,  0,   42,
+      42,  47,  47,  3,   0,  9,  10,  13,  13,  32,  32,  114, 0,  1,   1,   0,   0,  0,   0,
+      3,   1,   0,   0,   0,  0,  5,   1,   0,   0,   0,   0,   7,  1,   0,   0,   0,  0,   9,
+      1,   0,   0,   0,   0,  11, 1,   0,   0,   0,   0,   13,  1,  0,   0,   0,   0,  15,  1,
+      0,   0,   0,   0,   17, 1,  0,   0,   0,   0,   25,  1,   0,  0,   0,   0,   27, 1,   0,
+      0,   0,   0,   29,  1,  0,  0,   0,   0,   31,  1,   0,   0,  0,   0,   33,  1,  0,   0,
+      0,   0,   35,  1,   0,  0,  0,   0,   37,  1,   0,   0,   0,  0,   39,  1,   0,  0,   0,
+      0,   41,  1,   0,   0,  0,  1,   43,  1,   0,   0,   0,   3,  45,  1,   0,   0,  0,   5,
+      47,  1,   0,   0,   0,  7,  49,  1,   0,   0,   0,   9,   51, 1,   0,   0,   0,  11,  53,
+      1,   0,   0,   0,   13, 55, 1,   0,   0,   0,   15,  57,  1,  0,   0,   0,   17, 59,  1,
+      0,   0,   0,   19,  62, 1,  0,   0,   0,   21,  64,  1,   0,  0,   0,   23,  68, 1,   0,
+      0,   0,   25,  71,  1,  0,  0,   0,   27,  83,  1,   0,   0,  0,   29,  85,  1,  0,   0,
+      0,   31,  97,  1,   0,  0,  0,   33,  99,  1,   0,   0,   0,  35,  101, 1,   0,  0,   0,
+      37,  103, 1,   0,   0,  0,  39,  105, 1,   0,   0,   0,   41, 107, 1,   0,   0,  0,   43,
+      44,  5,   43,  0,   0,  44, 2,   1,   0,   0,   0,   45,  46, 5,   45,  0,   0,  46,  4,
+      1,   0,   0,   0,   47, 48, 5,   47,  0,   0,   48,  6,   1,  0,   0,   0,   49, 50,  5,
+      42,  0,   0,   50,  8,  1,  0,   0,   0,   51,  52,  5,   46, 0,   0,   52,  10, 1,   0,
+      0,   0,   53,  54,  5,  40, 0,   0,   54,  12,  1,   0,   0,  0,   55,  56,  5,  41,  0,
+      0,   56,  14,  1,   0,  0,  0,   57,  58,  5,   44,  0,   0,  58,  16,  1,   0,  0,   0,
+      59,  60,  5,   46,  0,  0,  60,  61,  5,   46,  0,   0,   61, 18,  1,   0,   0,  0,   62,
+      63,  7,   0,   0,   0,  63, 20,  1,   0,   0,   0,   64,  65, 7,   1,   0,   0,  65,  22,
+      1,   0,   0,   0,   66, 69, 3,   21,  10,  0,   67,  69,  3,  19,  9,   0,   68, 66,  1,
+      0,   0,   0,   68,  67, 1,  0,   0,   0,   69,  24,  1,   0,  0,   0,   70,  72, 3,   19,
+      9,   0,   71,  70,  1,  0,  0,   0,   72,  73,  1,   0,   0,  0,   73,  71,  1,  0,   0,
+      0,   73,  74,  1,   0,  0,  0,   74,  81,  1,   0,   0,   0,  75,  77,  5,   46, 0,   0,
+      76,  78,  3,   19,  9,  0,  77,  76,  1,   0,   0,   0,   78, 79,  1,   0,   0,  0,   79,
+      77,  1,   0,   0,   0,  79, 80,  1,   0,   0,   0,   80,  82, 1,   0,   0,   0,  81,  75,
+      1,   0,   0,   0,   81, 82, 1,   0,   0,   0,   82,  26,  1,  0,   0,   0,   83, 84,  5,
+      116, 0,   0,   84,  28, 1,  0,   0,   0,   85,  89,  3,   21, 10,  0,   86,  88, 3,   23,
+      11,  0,   87,  86,  1,  0,  0,   0,   88,  91,  1,   0,   0,  0,   89,  87,  1,  0,   0,
+      0,   89,  90,  1,   0,  0,  0,   90,  30,  1,   0,   0,   0,  91,  89,  1,   0,  0,   0,
+      92,  98,  5,   61,  0,  0,  93,  94,  5,   62,  0,   0,   94, 98,  5,   61,  0,  0,   95,
+      96,  5,   60,  0,   0,  96, 98,  5,   61,  0,   0,   97,  92, 1,   0,   0,   0,  97,  93,
+      1,   0,   0,   0,   97, 95, 1,   0,   0,   0,   98,  32,  1,  0,   0,   0,   99, 100, 7,
+      2,   0,   0,   100, 34, 1,  0,   0,   0,   101, 102, 7,   3,  0,   0,   102, 36, 1,   0,
+      0,   0,   103, 104, 5,  91, 0,   0,   104, 38,  1,   0,   0,  0,   105, 106, 5,  93,  0,
+      0,   106, 40,  1,   0,  0,  0,   107, 108, 7,   4,   0,   0,  108, 109, 1,   0,  0,   0,
+      109, 110, 6,   20,  0,  0,  110, 42,  1,   0,   0,   0,   7,  0,   68,  73,  79, 81,  89,
+      97,  1,   6,   0,   0};
+    staticData->serializedATN = antlr4::atn::SerializedATNView(serializedATNSegment,
+                                                               sizeof(serializedATNSegment)
+                                                                 / sizeof(serializedATNSegment[0]));
+
+    antlr4::atn::ATNDeserializer deserializer;
+    staticData->atn = deserializer.deserialize(staticData->serializedATN);
+
+    const size_t count = staticData->atn->getNumberOfDecisions();
+    staticData->decisionToDFA.reserve(count);
+    for (size_t i = 0; i < count; i++)
+    {
+        staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
+    }
+    exprlexerLexerStaticData = staticData.release();
+}
+
+} // namespace
+
+ExprLexer::ExprLexer(CharStream* input):
+    Lexer(input)
+{
+    ExprLexer::initialize();
+    _interpreter = new atn::LexerATNSimulator(this,
+                                              *exprlexerLexerStaticData->atn,
+                                              exprlexerLexerStaticData->decisionToDFA,
+                                              exprlexerLexerStaticData->sharedContextCache);
+}
+
+ExprLexer::~ExprLexer()
+{
+    delete _interpreter;
+}
+
+std::string ExprLexer::getGrammarFileName() const
+{
+    return "Expr.g4";
+}
+
+const std::vector<std::string>& ExprLexer::getRuleNames() const
+{
+    return exprlexerLexerStaticData->ruleNames;
+}
+
+const std::vector<std::string>& ExprLexer::getChannelNames() const
+{
+    return exprlexerLexerStaticData->channelNames;
+}
+
+const std::vector<std::string>& ExprLexer::getModeNames() const
+{
+    return exprlexerLexerStaticData->modeNames;
+}
+
+const dfa::Vocabulary& ExprLexer::getVocabulary() const
+{
+    return exprlexerLexerStaticData->vocabulary;
+}
+
+antlr4::atn::SerializedATNView ExprLexer::getSerializedATN() const
+{
+    return exprlexerLexerStaticData->serializedATN;
+}
+
+const atn::ATN& ExprLexer::getATN() const
+{
+    return *exprlexerLexerStaticData->atn;
+}
+
+void ExprLexer::initialize()
+{
+#if ANTLR4_USE_THREAD_LOCAL_CACHE
+    exprlexerLexerInitialize();
+#else
+    ::antlr4::internal::call_once(exprlexerLexerOnceFlag, exprlexerLexerInitialize);
 #endif
 }

--- a/src/libs/antares/antlr-interface/ExprLexer.h
+++ b/src/libs/antares/antlr-interface/ExprLexer.h
@@ -3,49 +3,58 @@
 
 #pragma once
 
-
 #include "antlr4-runtime.h"
 
-
-
-
-class  ExprLexer : public antlr4::Lexer {
+class ExprLexer: public antlr4::Lexer
+{
 public:
-  enum {
-    T__0 = 1, T__1 = 2, T__2 = 3, T__3 = 4, T__4 = 5, T__5 = 6, T__6 = 7, 
-    T__7 = 8, T__8 = 9, NUMBER = 10, TIME = 11, IDENTIFIER = 12, COMPARISON = 13, 
-    ADDSUB = 14, MULDIV = 15, LBRACKET = 16, RBRACKET = 17, WS = 18
-  };
+    enum
+    {
+        T__0 = 1,
+        T__1 = 2,
+        T__2 = 3,
+        T__3 = 4,
+        T__4 = 5,
+        T__5 = 6,
+        T__6 = 7,
+        T__7 = 8,
+        T__8 = 9,
+        NUMBER = 10,
+        TIME = 11,
+        IDENTIFIER = 12,
+        COMPARISON = 13,
+        ADDSUB = 14,
+        MULDIV = 15,
+        LBRACKET = 16,
+        RBRACKET = 17,
+        WS = 18
+    };
 
-  explicit ExprLexer(antlr4::CharStream *input);
+    explicit ExprLexer(antlr4::CharStream* input);
 
-  ~ExprLexer() override;
+    ~ExprLexer() override;
 
+    std::string getGrammarFileName() const override;
 
-  std::string getGrammarFileName() const override;
+    const std::vector<std::string>& getRuleNames() const override;
 
-  const std::vector<std::string>& getRuleNames() const override;
+    const std::vector<std::string>& getChannelNames() const override;
 
-  const std::vector<std::string>& getChannelNames() const override;
+    const std::vector<std::string>& getModeNames() const override;
 
-  const std::vector<std::string>& getModeNames() const override;
+    const antlr4::dfa::Vocabulary& getVocabulary() const override;
 
-  const antlr4::dfa::Vocabulary& getVocabulary() const override;
+    antlr4::atn::SerializedATNView getSerializedATN() const override;
 
-  antlr4::atn::SerializedATNView getSerializedATN() const override;
+    const antlr4::atn::ATN& getATN() const override;
 
-  const antlr4::atn::ATN& getATN() const override;
-
-  // By default the static state used to implement the lexer is lazily initialized during the first
-  // call to the constructor. You can call this function if you wish to initialize the static state
-  // ahead of time.
-  static void initialize();
+    // By default the static state used to implement the lexer is lazily initialized during the
+    // first call to the constructor. You can call this function if you wish to initialize the
+    // static state ahead of time.
+    static void initialize();
 
 private:
+    // Individual action functions triggered by action() above.
 
-  // Individual action functions triggered by action() above.
-
-  // Individual semantic predicate functions triggered by sempred() above.
-
+    // Individual semantic predicate functions triggered by sempred() above.
 };
-

--- a/src/libs/antares/antlr-interface/ExprLexer.h
+++ b/src/libs/antares/antlr-interface/ExprLexer.h
@@ -3,58 +3,49 @@
 
 #pragma once
 
+
 #include "antlr4-runtime.h"
 
-class ExprLexer: public antlr4::Lexer
-{
+
+
+
+class  ExprLexer : public antlr4::Lexer {
 public:
-    enum
-    {
-        T__0 = 1,
-        T__1 = 2,
-        T__2 = 3,
-        T__3 = 4,
-        T__4 = 5,
-        T__5 = 6,
-        T__6 = 7,
-        T__7 = 8,
-        T__8 = 9,
-        NUMBER = 10,
-        TIME = 11,
-        IDENTIFIER = 12,
-        COMPARISON = 13,
-        ADDSUB = 14,
-        MULDIV = 15,
-        LBRACKET = 16,
-        RBRACKET = 17,
-        WS = 18
-    };
+  enum {
+    T__0 = 1, T__1 = 2, T__2 = 3, T__3 = 4, T__4 = 5, T__5 = 6, T__6 = 7, 
+    T__7 = 8, T__8 = 9, NUMBER = 10, TIME = 11, IDENTIFIER = 12, COMPARISON = 13, 
+    ADDSUB = 14, MULDIV = 15, LBRACKET = 16, RBRACKET = 17, WS = 18
+  };
 
-    explicit ExprLexer(antlr4::CharStream* input);
+  explicit ExprLexer(antlr4::CharStream *input);
 
-    ~ExprLexer() override;
+  ~ExprLexer() override;
 
-    std::string getGrammarFileName() const override;
 
-    const std::vector<std::string>& getRuleNames() const override;
+  std::string getGrammarFileName() const override;
 
-    const std::vector<std::string>& getChannelNames() const override;
+  const std::vector<std::string>& getRuleNames() const override;
 
-    const std::vector<std::string>& getModeNames() const override;
+  const std::vector<std::string>& getChannelNames() const override;
 
-    const antlr4::dfa::Vocabulary& getVocabulary() const override;
+  const std::vector<std::string>& getModeNames() const override;
 
-    antlr4::atn::SerializedATNView getSerializedATN() const override;
+  const antlr4::dfa::Vocabulary& getVocabulary() const override;
 
-    const antlr4::atn::ATN& getATN() const override;
+  antlr4::atn::SerializedATNView getSerializedATN() const override;
 
-    // By default the static state used to implement the lexer is lazily initialized during the
-    // first call to the constructor. You can call this function if you wish to initialize the
-    // static state ahead of time.
-    static void initialize();
+  const antlr4::atn::ATN& getATN() const override;
+
+  // By default the static state used to implement the lexer is lazily initialized during the first
+  // call to the constructor. You can call this function if you wish to initialize the static state
+  // ahead of time.
+  static void initialize();
 
 private:
-    // Individual action functions triggered by action() above.
 
-    // Individual semantic predicate functions triggered by sempred() above.
+  // Individual action functions triggered by action() above.
+
+  // Individual semantic predicate functions triggered by sempred() above.
+
 };
+

--- a/src/libs/antares/antlr-interface/ExprParser.cpp
+++ b/src/libs/antares/antlr-interface/ExprParser.cpp
@@ -1,1176 +1,884 @@
 
 // Generated from Expr.g4 by ANTLR 4.13.1
 
-#include "ExprParser.h"
 
 #include "ExprVisitor.h"
+
+#include "ExprParser.h"
+
 
 using namespace antlrcpp;
 
 using namespace antlr4;
 
-namespace
-{
+namespace {
 
-struct ExprParserStaticData final
-{
-    ExprParserStaticData(std::vector<std::string> ruleNames,
-                         std::vector<std::string> literalNames,
-                         std::vector<std::string> symbolicNames):
-        ruleNames(std::move(ruleNames)),
-        literalNames(std::move(literalNames)),
+struct ExprParserStaticData final {
+  ExprParserStaticData(std::vector<std::string> ruleNames,
+                        std::vector<std::string> literalNames,
+                        std::vector<std::string> symbolicNames)
+      : ruleNames(std::move(ruleNames)), literalNames(std::move(literalNames)),
         symbolicNames(std::move(symbolicNames)),
-        vocabulary(this->literalNames, this->symbolicNames)
-    {
-    }
+        vocabulary(this->literalNames, this->symbolicNames) {}
 
-    ExprParserStaticData(const ExprParserStaticData&) = delete;
-    ExprParserStaticData(ExprParserStaticData&&) = delete;
-    ExprParserStaticData& operator=(const ExprParserStaticData&) = delete;
-    ExprParserStaticData& operator=(ExprParserStaticData&&) = delete;
+  ExprParserStaticData(const ExprParserStaticData&) = delete;
+  ExprParserStaticData(ExprParserStaticData&&) = delete;
+  ExprParserStaticData& operator=(const ExprParserStaticData&) = delete;
+  ExprParserStaticData& operator=(ExprParserStaticData&&) = delete;
 
-    std::vector<antlr4::dfa::DFA> decisionToDFA;
-    antlr4::atn::PredictionContextCache sharedContextCache;
-    const std::vector<std::string> ruleNames;
-    const std::vector<std::string> literalNames;
-    const std::vector<std::string> symbolicNames;
-    const antlr4::dfa::Vocabulary vocabulary;
-    antlr4::atn::SerializedATNView serializedATN;
-    std::unique_ptr<antlr4::atn::ATN> atn;
+  std::vector<antlr4::dfa::DFA> decisionToDFA;
+  antlr4::atn::PredictionContextCache sharedContextCache;
+  const std::vector<std::string> ruleNames;
+  const std::vector<std::string> literalNames;
+  const std::vector<std::string> symbolicNames;
+  const antlr4::dfa::Vocabulary vocabulary;
+  antlr4::atn::SerializedATNView serializedATN;
+  std::unique_ptr<antlr4::atn::ATN> atn;
 };
 
 ::antlr4::internal::OnceFlag exprParserOnceFlag;
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
 static thread_local
 #endif
-  ExprParserStaticData* exprParserStaticData
-  = nullptr;
+ExprParserStaticData *exprParserStaticData = nullptr;
 
-void exprParserInitialize()
-{
+void exprParserInitialize() {
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
-    if (exprParserStaticData != nullptr)
-    {
-        return;
-    }
+  if (exprParserStaticData != nullptr) {
+    return;
+  }
 #else
-    assert(exprParserStaticData == nullptr);
+  assert(exprParserStaticData == nullptr);
 #endif
-    auto staticData = std::make_unique<ExprParserStaticData>(std::vector<std::string>{"fullexpr",
-                                                                                      "shift",
-                                                                                      "expr"},
-                                                             std::vector<std::string>{"",
-                                                                                      "'+'",
-                                                                                      "'-'",
-                                                                                      "'/'",
-                                                                                      "'*'",
-                                                                                      "'.'",
-                                                                                      "'('",
-                                                                                      "')'",
-                                                                                      "','",
-                                                                                      "'..'",
-                                                                                      "",
-                                                                                      "'t'",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "'['",
-                                                                                      "']'"},
-                                                             std::vector<std::string>{"",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "",
-                                                                                      "NUMBER",
-                                                                                      "TIME",
-                                                                                      "IDENTIFIER",
-                                                                                      "COMPARISON",
-                                                                                      "ADDSUB",
-                                                                                      "MULDIV",
-                                                                                      "LBRACKET",
-                                                                                      "RBRACKET",
-                                                                                      "WS"});
-    static const int32_t serializedATNSegment[] = {
-      4,  1,  18, 86, 2,  0,  7,  0,  2, 1,  7,  1,  2,  2,  7,  2,  1,  0,  1,  0,  1,  0,  1,  1,
-      1,  1,  1,  1,  3,  1,  13, 8,  1, 1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,
-      2,  1,  2,  1,  2,  1,  2,  1,  2, 1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,
-      2,  1,  2,  1,  2,  5,  2,  37, 8, 2,  10, 2,  12, 2,  40, 9,  2,  1,  2,  1,  2,  1,  2,  1,
-      2,  1,  2,  1,  2,  1,  2,  5,  2, 49, 8,  2,  10, 2,  12, 2,  52, 9,  2,  1,  2,  1,  2,  1,
-      2,  1,  2,  1,  2,  1,  2,  1,  2, 1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,
-      2,  1,  2,  3,  2,  70, 8,  2,  1, 2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,
-      1,  2,  5,  2,  81, 8,  2,  10, 2, 12, 2,  84, 9,  2,  1,  2,  0,  1,  4,  3,  0,  2,  4,  0,
-      2,  1,  0,  1,  2,  1,  0,  3,  4, 97, 0,  6,  1,  0,  0,  0,  2,  9,  1,  0,  0,  0,  4,  69,
-      1,  0,  0,  0,  6,  7,  3,  4,  2, 0,  7,  8,  5,  0,  0,  1,  8,  1,  1,  0,  0,  0,  9,  12,
-      5,  11, 0,  0,  10, 11, 7,  0,  0, 0,  11, 13, 3,  4,  2,  0,  12, 10, 1,  0,  0,  0,  12, 13,
-      1,  0,  0,  0,  13, 3,  1,  0,  0, 0,  14, 15, 6,  2,  -1, 0,  15, 16, 5,  2,  0,  0,  16, 70,
-      3,  4,  2,  13, 17, 70, 5,  12, 0, 0,  18, 19, 5,  12, 0,  0,  19, 20, 5,  5,  0,  0,  20, 70,
-      5,  12, 0,  0,  21, 70, 5,  10, 0, 0,  22, 23, 5,  6,  0,  0,  23, 24, 3,  4,  2,  0,  24, 25,
-      5,  7,  0,  0,  25, 70, 1,  0,  0, 0,  26, 27, 5,  12, 0,  0,  27, 28, 5,  6,  0,  0,  28, 29,
-      3,  4,  2,  0,  29, 30, 5,  7,  0, 0,  30, 70, 1,  0,  0,  0,  31, 32, 5,  12, 0,  0,  32, 33,
-      5,  16, 0,  0,  33, 38, 3,  2,  1, 0,  34, 35, 5,  8,  0,  0,  35, 37, 3,  2,  1,  0,  36, 34,
-      1,  0,  0,  0,  37, 40, 1,  0,  0, 0,  38, 36, 1,  0,  0,  0,  38, 39, 1,  0,  0,  0,  39, 41,
-      1,  0,  0,  0,  40, 38, 1,  0,  0, 0,  41, 42, 5,  17, 0,  0,  42, 70, 1,  0,  0,  0,  43, 44,
-      5,  12, 0,  0,  44, 45, 5,  16, 0, 0,  45, 50, 3,  4,  2,  0,  46, 47, 5,  8,  0,  0,  47, 49,
-      3,  4,  2,  0,  48, 46, 1,  0,  0, 0,  49, 52, 1,  0,  0,  0,  50, 48, 1,  0,  0,  0,  50, 51,
-      1,  0,  0,  0,  51, 53, 1,  0,  0, 0,  52, 50, 1,  0,  0,  0,  53, 54, 5,  17, 0,  0,  54, 70,
-      1,  0,  0,  0,  55, 56, 5,  12, 0, 0,  56, 57, 5,  16, 0,  0,  57, 58, 3,  2,  1,  0,  58, 59,
-      5,  9,  0,  0,  59, 60, 3,  2,  1, 0,  60, 61, 5,  17, 0,  0,  61, 70, 1,  0,  0,  0,  62, 63,
-      5,  12, 0,  0,  63, 64, 5,  16, 0, 0,  64, 65, 3,  4,  2,  0,  65, 66, 5,  9,  0,  0,  66, 67,
-      3,  4,  2,  0,  67, 68, 5,  17, 0, 0,  68, 70, 1,  0,  0,  0,  69, 14, 1,  0,  0,  0,  69, 17,
-      1,  0,  0,  0,  69, 18, 1,  0,  0, 0,  69, 21, 1,  0,  0,  0,  69, 22, 1,  0,  0,  0,  69, 26,
-      1,  0,  0,  0,  69, 31, 1,  0,  0, 0,  69, 43, 1,  0,  0,  0,  69, 55, 1,  0,  0,  0,  69, 62,
-      1,  0,  0,  0,  70, 82, 1,  0,  0, 0,  71, 72, 10, 12, 0,  0,  72, 73, 7,  1,  0,  0,  73, 81,
-      3,  4,  2,  13, 74, 75, 10, 11, 0, 0,  75, 76, 7,  0,  0,  0,  76, 81, 3,  4,  2,  12, 77, 78,
-      10, 10, 0,  0,  78, 79, 5,  13, 0, 0,  79, 81, 3,  4,  2,  11, 80, 71, 1,  0,  0,  0,  80, 74,
-      1,  0,  0,  0,  80, 77, 1,  0,  0, 0,  81, 84, 1,  0,  0,  0,  82, 80, 1,  0,  0,  0,  82, 83,
-      1,  0,  0,  0,  83, 5,  1,  0,  0, 0,  84, 82, 1,  0,  0,  0,  6,  12, 38, 50, 69, 80, 82};
-    staticData->serializedATN = antlr4::atn::SerializedATNView(serializedATNSegment,
-                                                               sizeof(serializedATNSegment)
-                                                                 / sizeof(serializedATNSegment[0]));
-
-    antlr4::atn::ATNDeserializer deserializer;
-    staticData->atn = deserializer.deserialize(staticData->serializedATN);
-
-    const size_t count = staticData->atn->getNumberOfDecisions();
-    staticData->decisionToDFA.reserve(count);
-    for (size_t i = 0; i < count; i++)
-    {
-        staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
+  auto staticData = std::make_unique<ExprParserStaticData>(
+    std::vector<std::string>{
+      "fullexpr", "shift", "expr"
+    },
+    std::vector<std::string>{
+      "", "'+'", "'-'", "'/'", "'*'", "'.'", "'('", "')'", "','", "'..'", 
+      "", "'t'", "", "", "", "", "'['", "']'"
+    },
+    std::vector<std::string>{
+      "", "", "", "", "", "", "", "", "", "", "NUMBER", "TIME", "IDENTIFIER", 
+      "COMPARISON", "ADDSUB", "MULDIV", "LBRACKET", "RBRACKET", "WS"
     }
-    exprParserStaticData = staticData.release();
+  );
+  static const int32_t serializedATNSegment[] = {
+  	4,1,18,86,2,0,7,0,2,1,7,1,2,2,7,2,1,0,1,0,1,0,1,1,1,1,1,1,3,1,13,8,1,
+  	1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,
+  	2,1,2,1,2,1,2,1,2,5,2,37,8,2,10,2,12,2,40,9,2,1,2,1,2,1,2,1,2,1,2,1,2,
+  	1,2,5,2,49,8,2,10,2,12,2,52,9,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,
+  	2,1,2,1,2,1,2,1,2,1,2,1,2,3,2,70,8,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,
+  	1,2,5,2,81,8,2,10,2,12,2,84,9,2,1,2,0,1,4,3,0,2,4,0,2,1,0,1,2,1,0,3,4,
+  	97,0,6,1,0,0,0,2,9,1,0,0,0,4,69,1,0,0,0,6,7,3,4,2,0,7,8,5,0,0,1,8,1,1,
+  	0,0,0,9,12,5,11,0,0,10,11,7,0,0,0,11,13,3,4,2,0,12,10,1,0,0,0,12,13,1,
+  	0,0,0,13,3,1,0,0,0,14,15,6,2,-1,0,15,16,5,2,0,0,16,70,3,4,2,13,17,70,
+  	5,12,0,0,18,19,5,12,0,0,19,20,5,5,0,0,20,70,5,12,0,0,21,70,5,10,0,0,22,
+  	23,5,6,0,0,23,24,3,4,2,0,24,25,5,7,0,0,25,70,1,0,0,0,26,27,5,12,0,0,27,
+  	28,5,6,0,0,28,29,3,4,2,0,29,30,5,7,0,0,30,70,1,0,0,0,31,32,5,12,0,0,32,
+  	33,5,16,0,0,33,38,3,2,1,0,34,35,5,8,0,0,35,37,3,2,1,0,36,34,1,0,0,0,37,
+  	40,1,0,0,0,38,36,1,0,0,0,38,39,1,0,0,0,39,41,1,0,0,0,40,38,1,0,0,0,41,
+  	42,5,17,0,0,42,70,1,0,0,0,43,44,5,12,0,0,44,45,5,16,0,0,45,50,3,4,2,0,
+  	46,47,5,8,0,0,47,49,3,4,2,0,48,46,1,0,0,0,49,52,1,0,0,0,50,48,1,0,0,0,
+  	50,51,1,0,0,0,51,53,1,0,0,0,52,50,1,0,0,0,53,54,5,17,0,0,54,70,1,0,0,
+  	0,55,56,5,12,0,0,56,57,5,16,0,0,57,58,3,2,1,0,58,59,5,9,0,0,59,60,3,2,
+  	1,0,60,61,5,17,0,0,61,70,1,0,0,0,62,63,5,12,0,0,63,64,5,16,0,0,64,65,
+  	3,4,2,0,65,66,5,9,0,0,66,67,3,4,2,0,67,68,5,17,0,0,68,70,1,0,0,0,69,14,
+  	1,0,0,0,69,17,1,0,0,0,69,18,1,0,0,0,69,21,1,0,0,0,69,22,1,0,0,0,69,26,
+  	1,0,0,0,69,31,1,0,0,0,69,43,1,0,0,0,69,55,1,0,0,0,69,62,1,0,0,0,70,82,
+  	1,0,0,0,71,72,10,12,0,0,72,73,7,1,0,0,73,81,3,4,2,13,74,75,10,11,0,0,
+  	75,76,7,0,0,0,76,81,3,4,2,12,77,78,10,10,0,0,78,79,5,13,0,0,79,81,3,4,
+  	2,11,80,71,1,0,0,0,80,74,1,0,0,0,80,77,1,0,0,0,81,84,1,0,0,0,82,80,1,
+  	0,0,0,82,83,1,0,0,0,83,5,1,0,0,0,84,82,1,0,0,0,6,12,38,50,69,80,82
+  };
+  staticData->serializedATN = antlr4::atn::SerializedATNView(serializedATNSegment, sizeof(serializedATNSegment) / sizeof(serializedATNSegment[0]));
+
+  antlr4::atn::ATNDeserializer deserializer;
+  staticData->atn = deserializer.deserialize(staticData->serializedATN);
+
+  const size_t count = staticData->atn->getNumberOfDecisions();
+  staticData->decisionToDFA.reserve(count);
+  for (size_t i = 0; i < count; i++) { 
+    staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
+  }
+  exprParserStaticData = staticData.release();
 }
 
-} // namespace
-
-ExprParser::ExprParser(TokenStream* input):
-    ExprParser(input, antlr4::atn::ParserATNSimulatorOptions())
-{
 }
 
-ExprParser::ExprParser(TokenStream* input, const antlr4::atn::ParserATNSimulatorOptions& options):
-    Parser(input)
-{
-    ExprParser::initialize();
-    _interpreter = new atn::ParserATNSimulator(this,
-                                               *exprParserStaticData->atn,
-                                               exprParserStaticData->decisionToDFA,
-                                               exprParserStaticData->sharedContextCache,
-                                               options);
+ExprParser::ExprParser(TokenStream *input) : ExprParser(input, antlr4::atn::ParserATNSimulatorOptions()) {}
+
+ExprParser::ExprParser(TokenStream *input, const antlr4::atn::ParserATNSimulatorOptions &options) : Parser(input) {
+  ExprParser::initialize();
+  _interpreter = new atn::ParserATNSimulator(this, *exprParserStaticData->atn, exprParserStaticData->decisionToDFA, exprParserStaticData->sharedContextCache, options);
 }
 
-ExprParser::~ExprParser()
-{
-    delete _interpreter;
+ExprParser::~ExprParser() {
+  delete _interpreter;
 }
 
-const atn::ATN& ExprParser::getATN() const
-{
-    return *exprParserStaticData->atn;
+const atn::ATN& ExprParser::getATN() const {
+  return *exprParserStaticData->atn;
 }
 
-std::string ExprParser::getGrammarFileName() const
-{
-    return "Expr.g4";
+std::string ExprParser::getGrammarFileName() const {
+  return "Expr.g4";
 }
 
-const std::vector<std::string>& ExprParser::getRuleNames() const
-{
-    return exprParserStaticData->ruleNames;
+const std::vector<std::string>& ExprParser::getRuleNames() const {
+  return exprParserStaticData->ruleNames;
 }
 
-const dfa::Vocabulary& ExprParser::getVocabulary() const
-{
-    return exprParserStaticData->vocabulary;
+const dfa::Vocabulary& ExprParser::getVocabulary() const {
+  return exprParserStaticData->vocabulary;
 }
 
-antlr4::atn::SerializedATNView ExprParser::getSerializedATN() const
-{
-    return exprParserStaticData->serializedATN;
+antlr4::atn::SerializedATNView ExprParser::getSerializedATN() const {
+  return exprParserStaticData->serializedATN;
 }
 
-//----------------- FullexprContext
-//------------------------------------------------------------------
 
-ExprParser::FullexprContext::FullexprContext(ParserRuleContext* parent, size_t invokingState):
-    ParserRuleContext(parent, invokingState)
-{
+//----------------- FullexprContext ------------------------------------------------------------------
+
+ExprParser::FullexprContext::FullexprContext(ParserRuleContext *parent, size_t invokingState)
+  : ParserRuleContext(parent, invokingState) {
 }
 
-ExprParser::ExprContext* ExprParser::FullexprContext::expr()
-{
-    return getRuleContext<ExprParser::ExprContext>(0);
+ExprParser::ExprContext* ExprParser::FullexprContext::expr() {
+  return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-tree::TerminalNode* ExprParser::FullexprContext::EOF()
-{
-    return getToken(ExprParser::EOF, 0);
+tree::TerminalNode* ExprParser::FullexprContext::EOF() {
+  return getToken(ExprParser::EOF, 0);
 }
 
-size_t ExprParser::FullexprContext::getRuleIndex() const
-{
-    return ExprParser::RuleFullexpr;
+
+size_t ExprParser::FullexprContext::getRuleIndex() const {
+  return ExprParser::RuleFullexpr;
 }
 
-std::any ExprParser::FullexprContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitFullexpr(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+
+std::any ExprParser::FullexprContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitFullexpr(this);
+  else
+    return visitor->visitChildren(this);
 }
 
-ExprParser::FullexprContext* ExprParser::fullexpr()
-{
-    FullexprContext* _localctx = _tracker.createInstance<FullexprContext>(_ctx, getState());
-    enterRule(_localctx, 0, ExprParser::RuleFullexpr);
+ExprParser::FullexprContext* ExprParser::fullexpr() {
+  FullexprContext *_localctx = _tracker.createInstance<FullexprContext>(_ctx, getState());
+  enterRule(_localctx, 0, ExprParser::RuleFullexpr);
 
 #if __cplusplus > 201703L
-    auto onExit = finally(
-      [=, this]
-      {
+  auto onExit = finally([=, this] {
 #else
-    auto onExit = finally(
-      [=]
-      {
+  auto onExit = finally([=] {
 #endif
-          exitRule();
-      });
-    try
-    {
-        enterOuterAlt(_localctx, 1);
-        setState(6);
-        expr(0);
-        setState(7);
-        match(ExprParser::EOF);
-    }
-    catch (RecognitionException& e)
-    {
-        _errHandler->reportError(this, e);
-        _localctx->exception = std::current_exception();
-        _errHandler->recover(this, _localctx->exception);
-    }
+    exitRule();
+  });
+  try {
+    enterOuterAlt(_localctx, 1);
+    setState(6);
+    expr(0);
+    setState(7);
+    match(ExprParser::EOF);
+   
+  }
+  catch (RecognitionException &e) {
+    _errHandler->reportError(this, e);
+    _localctx->exception = std::current_exception();
+    _errHandler->recover(this, _localctx->exception);
+  }
 
-    return _localctx;
+  return _localctx;
 }
 
 //----------------- ShiftContext ------------------------------------------------------------------
 
-ExprParser::ShiftContext::ShiftContext(ParserRuleContext* parent, size_t invokingState):
-    ParserRuleContext(parent, invokingState)
-{
+ExprParser::ShiftContext::ShiftContext(ParserRuleContext *parent, size_t invokingState)
+  : ParserRuleContext(parent, invokingState) {
 }
 
-tree::TerminalNode* ExprParser::ShiftContext::TIME()
-{
-    return getToken(ExprParser::TIME, 0);
+tree::TerminalNode* ExprParser::ShiftContext::TIME() {
+  return getToken(ExprParser::TIME, 0);
 }
 
-ExprParser::ExprContext* ExprParser::ShiftContext::expr()
-{
-    return getRuleContext<ExprParser::ExprContext>(0);
+ExprParser::ExprContext* ExprParser::ShiftContext::expr() {
+  return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-size_t ExprParser::ShiftContext::getRuleIndex() const
-{
-    return ExprParser::RuleShift;
+
+size_t ExprParser::ShiftContext::getRuleIndex() const {
+  return ExprParser::RuleShift;
 }
 
-std::any ExprParser::ShiftContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitShift(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+
+std::any ExprParser::ShiftContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitShift(this);
+  else
+    return visitor->visitChildren(this);
 }
 
-ExprParser::ShiftContext* ExprParser::shift()
-{
-    ShiftContext* _localctx = _tracker.createInstance<ShiftContext>(_ctx, getState());
-    enterRule(_localctx, 2, ExprParser::RuleShift);
-    size_t _la = 0;
+ExprParser::ShiftContext* ExprParser::shift() {
+  ShiftContext *_localctx = _tracker.createInstance<ShiftContext>(_ctx, getState());
+  enterRule(_localctx, 2, ExprParser::RuleShift);
+  size_t _la = 0;
 
 #if __cplusplus > 201703L
-    auto onExit = finally(
-      [=, this]
-      {
+  auto onExit = finally([=, this] {
 #else
-    auto onExit = finally(
-      [=]
-      {
+  auto onExit = finally([=] {
 #endif
-          exitRule();
-      });
-    try
-    {
-        enterOuterAlt(_localctx, 1);
-        setState(9);
-        match(ExprParser::TIME);
-        setState(12);
-        _errHandler->sync(this);
+    exitRule();
+  });
+  try {
+    enterOuterAlt(_localctx, 1);
+    setState(9);
+    match(ExprParser::TIME);
+    setState(12);
+    _errHandler->sync(this);
 
-        _la = _input->LA(1);
-        if (_la == ExprParser::T__0
+    _la = _input->LA(1);
+    if (_la == ExprParser::T__0
 
-            || _la == ExprParser::T__1)
-        {
-            setState(10);
-            antlrcpp::downCast<ShiftContext*>(_localctx)->op = _input->LT(1);
-            _la = _input->LA(1);
-            if (!(_la == ExprParser::T__0
+    || _la == ExprParser::T__1) {
+      setState(10);
+      antlrcpp::downCast<ShiftContext *>(_localctx)->op = _input->LT(1);
+      _la = _input->LA(1);
+      if (!(_la == ExprParser::T__0
 
-                  || _la == ExprParser::T__1))
-            {
-                antlrcpp::downCast<ShiftContext*>(_localctx)->op = _errHandler->recoverInline(this);
-            }
-            else
-            {
-                _errHandler->reportMatch(this);
-                consume();
-            }
-            setState(11);
-            expr(0);
-        }
+      || _la == ExprParser::T__1)) {
+        antlrcpp::downCast<ShiftContext *>(_localctx)->op = _errHandler->recoverInline(this);
+      }
+      else {
+        _errHandler->reportMatch(this);
+        consume();
+      }
+      setState(11);
+      expr(0);
     }
-    catch (RecognitionException& e)
-    {
-        _errHandler->reportError(this, e);
-        _localctx->exception = std::current_exception();
-        _errHandler->recover(this, _localctx->exception);
-    }
+   
+  }
+  catch (RecognitionException &e) {
+    _errHandler->reportError(this, e);
+    _localctx->exception = std::current_exception();
+    _errHandler->recover(this, _localctx->exception);
+  }
 
-    return _localctx;
+  return _localctx;
 }
 
 //----------------- ExprContext ------------------------------------------------------------------
 
-ExprParser::ExprContext::ExprContext(ParserRuleContext* parent, size_t invokingState):
-    ParserRuleContext(parent, invokingState)
-{
+ExprParser::ExprContext::ExprContext(ParserRuleContext *parent, size_t invokingState)
+  : ParserRuleContext(parent, invokingState) {
 }
 
-size_t ExprParser::ExprContext::getRuleIndex() const
-{
-    return ExprParser::RuleExpr;
+
+size_t ExprParser::ExprContext::getRuleIndex() const {
+  return ExprParser::RuleExpr;
 }
 
-void ExprParser::ExprContext::copyFrom(ExprContext* ctx)
-{
-    ParserRuleContext::copyFrom(ctx);
+void ExprParser::ExprContext::copyFrom(ExprContext *ctx) {
+  ParserRuleContext::copyFrom(ctx);
 }
 
-//----------------- IdentifierContext
-//------------------------------------------------------------------
+//----------------- IdentifierContext ------------------------------------------------------------------
 
-tree::TerminalNode* ExprParser::IdentifierContext::IDENTIFIER()
-{
-    return getToken(ExprParser::IDENTIFIER, 0);
+tree::TerminalNode* ExprParser::IdentifierContext::IDENTIFIER() {
+  return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-ExprParser::IdentifierContext::IdentifierContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
+ExprParser::IdentifierContext::IdentifierContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::IdentifierContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitIdentifier(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- NegationContext ------------------------------------------------------------------
+
+ExprParser::ExprContext* ExprParser::NegationContext::expr() {
+  return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-std::any ExprParser::IdentifierContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitIdentifier(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+ExprParser::NegationContext::NegationContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::NegationContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitNegation(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- ExpressionContext ------------------------------------------------------------------
+
+ExprParser::ExprContext* ExprParser::ExpressionContext::expr() {
+  return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-//----------------- NegationContext
-//------------------------------------------------------------------
+ExprParser::ExpressionContext::ExpressionContext(ExprContext *ctx) { copyFrom(ctx); }
 
-ExprParser::ExprContext* ExprParser::NegationContext::expr()
-{
-    return getRuleContext<ExprParser::ExprContext>(0);
+
+std::any ExprParser::ExpressionContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitExpression(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- ComparisonContext ------------------------------------------------------------------
+
+std::vector<ExprParser::ExprContext *> ExprParser::ComparisonContext::expr() {
+  return getRuleContexts<ExprParser::ExprContext>();
 }
 
-ExprParser::NegationContext::NegationContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
+ExprParser::ExprContext* ExprParser::ComparisonContext::expr(size_t i) {
+  return getRuleContext<ExprParser::ExprContext>(i);
 }
 
-std::any ExprParser::NegationContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitNegation(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+tree::TerminalNode* ExprParser::ComparisonContext::COMPARISON() {
+  return getToken(ExprParser::COMPARISON, 0);
 }
 
-//----------------- ExpressionContext
-//------------------------------------------------------------------
+ExprParser::ComparisonContext::ComparisonContext(ExprContext *ctx) { copyFrom(ctx); }
 
-ExprParser::ExprContext* ExprParser::ExpressionContext::expr()
-{
-    return getRuleContext<ExprParser::ExprContext>(0);
+
+std::any ExprParser::ComparisonContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitComparison(this);
+  else
+    return visitor->visitChildren(this);
 }
-
-ExprParser::ExpressionContext::ExpressionContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
-}
-
-std::any ExprParser::ExpressionContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitExpression(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
-}
-
-//----------------- ComparisonContext
-//------------------------------------------------------------------
-
-std::vector<ExprParser::ExprContext*> ExprParser::ComparisonContext::expr()
-{
-    return getRuleContexts<ExprParser::ExprContext>();
-}
-
-ExprParser::ExprContext* ExprParser::ComparisonContext::expr(size_t i)
-{
-    return getRuleContext<ExprParser::ExprContext>(i);
-}
-
-tree::TerminalNode* ExprParser::ComparisonContext::COMPARISON()
-{
-    return getToken(ExprParser::COMPARISON, 0);
-}
-
-ExprParser::ComparisonContext::ComparisonContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
-}
-
-std::any ExprParser::ComparisonContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitComparison(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
-}
-
 //----------------- AddsubContext ------------------------------------------------------------------
 
-std::vector<ExprParser::ExprContext*> ExprParser::AddsubContext::expr()
-{
-    return getRuleContexts<ExprParser::ExprContext>();
+std::vector<ExprParser::ExprContext *> ExprParser::AddsubContext::expr() {
+  return getRuleContexts<ExprParser::ExprContext>();
 }
 
-ExprParser::ExprContext* ExprParser::AddsubContext::expr(size_t i)
-{
-    return getRuleContext<ExprParser::ExprContext>(i);
+ExprParser::ExprContext* ExprParser::AddsubContext::expr(size_t i) {
+  return getRuleContext<ExprParser::ExprContext>(i);
 }
 
-ExprParser::AddsubContext::AddsubContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
+ExprParser::AddsubContext::AddsubContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::AddsubContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitAddsub(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- PortFieldContext ------------------------------------------------------------------
+
+std::vector<tree::TerminalNode *> ExprParser::PortFieldContext::IDENTIFIER() {
+  return getTokens(ExprParser::IDENTIFIER);
 }
 
-std::any ExprParser::AddsubContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitAddsub(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+tree::TerminalNode* ExprParser::PortFieldContext::IDENTIFIER(size_t i) {
+  return getToken(ExprParser::IDENTIFIER, i);
 }
 
-//----------------- PortFieldContext
-//------------------------------------------------------------------
+ExprParser::PortFieldContext::PortFieldContext(ExprContext *ctx) { copyFrom(ctx); }
 
-std::vector<tree::TerminalNode*> ExprParser::PortFieldContext::IDENTIFIER()
-{
-    return getTokens(ExprParser::IDENTIFIER);
+
+std::any ExprParser::PortFieldContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitPortField(this);
+  else
+    return visitor->visitChildren(this);
 }
-
-tree::TerminalNode* ExprParser::PortFieldContext::IDENTIFIER(size_t i)
-{
-    return getToken(ExprParser::IDENTIFIER, i);
-}
-
-ExprParser::PortFieldContext::PortFieldContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
-}
-
-std::any ExprParser::PortFieldContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitPortField(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
-}
-
 //----------------- MuldivContext ------------------------------------------------------------------
 
-std::vector<ExprParser::ExprContext*> ExprParser::MuldivContext::expr()
-{
-    return getRuleContexts<ExprParser::ExprContext>();
+std::vector<ExprParser::ExprContext *> ExprParser::MuldivContext::expr() {
+  return getRuleContexts<ExprParser::ExprContext>();
 }
 
-ExprParser::ExprContext* ExprParser::MuldivContext::expr(size_t i)
-{
-    return getRuleContext<ExprParser::ExprContext>(i);
+ExprParser::ExprContext* ExprParser::MuldivContext::expr(size_t i) {
+  return getRuleContext<ExprParser::ExprContext>(i);
 }
 
-ExprParser::MuldivContext::MuldivContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
-}
+ExprParser::MuldivContext::MuldivContext(ExprContext *ctx) { copyFrom(ctx); }
 
-std::any ExprParser::MuldivContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitMuldiv(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
-}
 
+std::any ExprParser::MuldivContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitMuldiv(this);
+  else
+    return visitor->visitChildren(this);
+}
 //----------------- NumberContext ------------------------------------------------------------------
 
-tree::TerminalNode* ExprParser::NumberContext::NUMBER()
-{
-    return getToken(ExprParser::NUMBER, 0);
+tree::TerminalNode* ExprParser::NumberContext::NUMBER() {
+  return getToken(ExprParser::NUMBER, 0);
 }
 
-ExprParser::NumberContext::NumberContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
+ExprParser::NumberContext::NumberContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::NumberContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitNumber(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- TimeIndexContext ------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::TimeIndexContext::IDENTIFIER() {
+  return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-std::any ExprParser::NumberContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitNumber(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+tree::TerminalNode* ExprParser::TimeIndexContext::LBRACKET() {
+  return getToken(ExprParser::LBRACKET, 0);
 }
 
-//----------------- TimeIndexContext
-//------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::TimeIndexContext::IDENTIFIER()
-{
-    return getToken(ExprParser::IDENTIFIER, 0);
+std::vector<ExprParser::ExprContext *> ExprParser::TimeIndexContext::expr() {
+  return getRuleContexts<ExprParser::ExprContext>();
 }
 
-tree::TerminalNode* ExprParser::TimeIndexContext::LBRACKET()
-{
-    return getToken(ExprParser::LBRACKET, 0);
+ExprParser::ExprContext* ExprParser::TimeIndexContext::expr(size_t i) {
+  return getRuleContext<ExprParser::ExprContext>(i);
 }
 
-std::vector<ExprParser::ExprContext*> ExprParser::TimeIndexContext::expr()
-{
-    return getRuleContexts<ExprParser::ExprContext>();
+tree::TerminalNode* ExprParser::TimeIndexContext::RBRACKET() {
+  return getToken(ExprParser::RBRACKET, 0);
 }
 
-ExprParser::ExprContext* ExprParser::TimeIndexContext::expr(size_t i)
-{
-    return getRuleContext<ExprParser::ExprContext>(i);
+ExprParser::TimeIndexContext::TimeIndexContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::TimeIndexContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitTimeIndex(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- TimeShiftContext ------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::TimeShiftContext::IDENTIFIER() {
+  return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-tree::TerminalNode* ExprParser::TimeIndexContext::RBRACKET()
-{
-    return getToken(ExprParser::RBRACKET, 0);
+tree::TerminalNode* ExprParser::TimeShiftContext::LBRACKET() {
+  return getToken(ExprParser::LBRACKET, 0);
 }
 
-ExprParser::TimeIndexContext::TimeIndexContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
+std::vector<ExprParser::ShiftContext *> ExprParser::TimeShiftContext::shift() {
+  return getRuleContexts<ExprParser::ShiftContext>();
 }
 
-std::any ExprParser::TimeIndexContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitTimeIndex(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+ExprParser::ShiftContext* ExprParser::TimeShiftContext::shift(size_t i) {
+  return getRuleContext<ExprParser::ShiftContext>(i);
 }
 
-//----------------- TimeShiftContext
-//------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::TimeShiftContext::IDENTIFIER()
-{
-    return getToken(ExprParser::IDENTIFIER, 0);
+tree::TerminalNode* ExprParser::TimeShiftContext::RBRACKET() {
+  return getToken(ExprParser::RBRACKET, 0);
 }
 
-tree::TerminalNode* ExprParser::TimeShiftContext::LBRACKET()
-{
-    return getToken(ExprParser::LBRACKET, 0);
+ExprParser::TimeShiftContext::TimeShiftContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::TimeShiftContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitTimeShift(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- FunctionContext ------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::FunctionContext::IDENTIFIER() {
+  return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-std::vector<ExprParser::ShiftContext*> ExprParser::TimeShiftContext::shift()
-{
-    return getRuleContexts<ExprParser::ShiftContext>();
+ExprParser::ExprContext* ExprParser::FunctionContext::expr() {
+  return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-ExprParser::ShiftContext* ExprParser::TimeShiftContext::shift(size_t i)
-{
-    return getRuleContext<ExprParser::ShiftContext>(i);
+ExprParser::FunctionContext::FunctionContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::FunctionContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitFunction(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- TimeShiftRangeContext ------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::TimeShiftRangeContext::IDENTIFIER() {
+  return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-tree::TerminalNode* ExprParser::TimeShiftContext::RBRACKET()
-{
-    return getToken(ExprParser::RBRACKET, 0);
+tree::TerminalNode* ExprParser::TimeShiftRangeContext::LBRACKET() {
+  return getToken(ExprParser::LBRACKET, 0);
 }
 
-ExprParser::TimeShiftContext::TimeShiftContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
+tree::TerminalNode* ExprParser::TimeShiftRangeContext::RBRACKET() {
+  return getToken(ExprParser::RBRACKET, 0);
 }
 
-std::any ExprParser::TimeShiftContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitTimeShift(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+std::vector<ExprParser::ShiftContext *> ExprParser::TimeShiftRangeContext::shift() {
+  return getRuleContexts<ExprParser::ShiftContext>();
 }
 
-//----------------- FunctionContext
-//------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::FunctionContext::IDENTIFIER()
-{
-    return getToken(ExprParser::IDENTIFIER, 0);
+ExprParser::ShiftContext* ExprParser::TimeShiftRangeContext::shift(size_t i) {
+  return getRuleContext<ExprParser::ShiftContext>(i);
 }
 
-ExprParser::ExprContext* ExprParser::FunctionContext::expr()
-{
-    return getRuleContext<ExprParser::ExprContext>(0);
+ExprParser::TimeShiftRangeContext::TimeShiftRangeContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::TimeShiftRangeContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitTimeShiftRange(this);
+  else
+    return visitor->visitChildren(this);
+}
+//----------------- TimeRangeContext ------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::TimeRangeContext::IDENTIFIER() {
+  return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-ExprParser::FunctionContext::FunctionContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
+tree::TerminalNode* ExprParser::TimeRangeContext::LBRACKET() {
+  return getToken(ExprParser::LBRACKET, 0);
 }
 
-std::any ExprParser::FunctionContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitFunction(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
+std::vector<ExprParser::ExprContext *> ExprParser::TimeRangeContext::expr() {
+  return getRuleContexts<ExprParser::ExprContext>();
 }
 
-//----------------- TimeShiftRangeContext
-//------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::TimeShiftRangeContext::IDENTIFIER()
-{
-    return getToken(ExprParser::IDENTIFIER, 0);
+ExprParser::ExprContext* ExprParser::TimeRangeContext::expr(size_t i) {
+  return getRuleContext<ExprParser::ExprContext>(i);
 }
 
-tree::TerminalNode* ExprParser::TimeShiftRangeContext::LBRACKET()
-{
-    return getToken(ExprParser::LBRACKET, 0);
+tree::TerminalNode* ExprParser::TimeRangeContext::RBRACKET() {
+  return getToken(ExprParser::RBRACKET, 0);
 }
 
-tree::TerminalNode* ExprParser::TimeShiftRangeContext::RBRACKET()
-{
-    return getToken(ExprParser::RBRACKET, 0);
+ExprParser::TimeRangeContext::TimeRangeContext(ExprContext *ctx) { copyFrom(ctx); }
+
+
+std::any ExprParser::TimeRangeContext::accept(tree::ParseTreeVisitor *visitor) {
+  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    return parserVisitor->visitTimeRange(this);
+  else
+    return visitor->visitChildren(this);
 }
 
-std::vector<ExprParser::ShiftContext*> ExprParser::TimeShiftRangeContext::shift()
-{
-    return getRuleContexts<ExprParser::ShiftContext>();
+ExprParser::ExprContext* ExprParser::expr() {
+   return expr(0);
 }
 
-ExprParser::ShiftContext* ExprParser::TimeShiftRangeContext::shift(size_t i)
-{
-    return getRuleContext<ExprParser::ShiftContext>(i);
-}
-
-ExprParser::TimeShiftRangeContext::TimeShiftRangeContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
-}
-
-std::any ExprParser::TimeShiftRangeContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitTimeShiftRange(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
-}
-
-//----------------- TimeRangeContext
-//------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::TimeRangeContext::IDENTIFIER()
-{
-    return getToken(ExprParser::IDENTIFIER, 0);
-}
-
-tree::TerminalNode* ExprParser::TimeRangeContext::LBRACKET()
-{
-    return getToken(ExprParser::LBRACKET, 0);
-}
-
-std::vector<ExprParser::ExprContext*> ExprParser::TimeRangeContext::expr()
-{
-    return getRuleContexts<ExprParser::ExprContext>();
-}
-
-ExprParser::ExprContext* ExprParser::TimeRangeContext::expr(size_t i)
-{
-    return getRuleContext<ExprParser::ExprContext>(i);
-}
-
-tree::TerminalNode* ExprParser::TimeRangeContext::RBRACKET()
-{
-    return getToken(ExprParser::RBRACKET, 0);
-}
-
-ExprParser::TimeRangeContext::TimeRangeContext(ExprContext* ctx)
-{
-    copyFrom(ctx);
-}
-
-std::any ExprParser::TimeRangeContext::accept(tree::ParseTreeVisitor* visitor)
-{
-    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    {
-        return parserVisitor->visitTimeRange(this);
-    }
-    else
-    {
-        return visitor->visitChildren(this);
-    }
-}
-
-ExprParser::ExprContext* ExprParser::expr()
-{
-    return expr(0);
-}
-
-ExprParser::ExprContext* ExprParser::expr(int precedence)
-{
-    ParserRuleContext* parentContext = _ctx;
-    size_t parentState = getState();
-    ExprParser::ExprContext* _localctx = _tracker.createInstance<ExprContext>(_ctx, parentState);
-    ExprParser::ExprContext* previousContext = _localctx;
-    (void)previousContext; // Silence compiler, in case the context is not used by generated code.
-    size_t startState = 4;
-    enterRecursionRule(_localctx, 4, ExprParser::RuleExpr, precedence);
+ExprParser::ExprContext* ExprParser::expr(int precedence) {
+  ParserRuleContext *parentContext = _ctx;
+  size_t parentState = getState();
+  ExprParser::ExprContext *_localctx = _tracker.createInstance<ExprContext>(_ctx, parentState);
+  ExprParser::ExprContext *previousContext = _localctx;
+  (void)previousContext; // Silence compiler, in case the context is not used by generated code.
+  size_t startState = 4;
+  enterRecursionRule(_localctx, 4, ExprParser::RuleExpr, precedence);
 
     size_t _la = 0;
 
 #if __cplusplus > 201703L
-    auto onExit = finally(
-      [=, this]
-      {
+  auto onExit = finally([=, this] {
 #else
-    auto onExit = finally(
-      [=]
-      {
+  auto onExit = finally([=] {
 #endif
-          unrollRecursionContexts(parentContext);
-      });
-    try
-    {
-        size_t alt;
-        enterOuterAlt(_localctx, 1);
-        setState(69);
+    unrollRecursionContexts(parentContext);
+  });
+  try {
+    size_t alt;
+    enterOuterAlt(_localctx, 1);
+    setState(69);
+    _errHandler->sync(this);
+    switch (getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 3, _ctx)) {
+    case 1: {
+      _localctx = _tracker.createInstance<NegationContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+
+      setState(15);
+      match(ExprParser::T__1);
+      setState(16);
+      expr(13);
+      break;
+    }
+
+    case 2: {
+      _localctx = _tracker.createInstance<IdentifierContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(17);
+      match(ExprParser::IDENTIFIER);
+      break;
+    }
+
+    case 3: {
+      _localctx = _tracker.createInstance<PortFieldContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(18);
+      match(ExprParser::IDENTIFIER);
+      setState(19);
+      match(ExprParser::T__4);
+      setState(20);
+      match(ExprParser::IDENTIFIER);
+      break;
+    }
+
+    case 4: {
+      _localctx = _tracker.createInstance<NumberContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(21);
+      match(ExprParser::NUMBER);
+      break;
+    }
+
+    case 5: {
+      _localctx = _tracker.createInstance<ExpressionContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(22);
+      match(ExprParser::T__5);
+      setState(23);
+      expr(0);
+      setState(24);
+      match(ExprParser::T__6);
+      break;
+    }
+
+    case 6: {
+      _localctx = _tracker.createInstance<FunctionContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(26);
+      match(ExprParser::IDENTIFIER);
+      setState(27);
+      match(ExprParser::T__5);
+      setState(28);
+      expr(0);
+      setState(29);
+      match(ExprParser::T__6);
+      break;
+    }
+
+    case 7: {
+      _localctx = _tracker.createInstance<TimeShiftContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(31);
+      match(ExprParser::IDENTIFIER);
+      setState(32);
+      match(ExprParser::LBRACKET);
+      setState(33);
+      shift();
+      setState(38);
+      _errHandler->sync(this);
+      _la = _input->LA(1);
+      while (_la == ExprParser::T__7) {
+        setState(34);
+        match(ExprParser::T__7);
+        setState(35);
+        shift();
+        setState(40);
         _errHandler->sync(this);
-        switch (getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 3, _ctx))
-        {
-        case 1:
-        {
-            _localctx = _tracker.createInstance<NegationContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
+        _la = _input->LA(1);
+      }
+      setState(41);
+      match(ExprParser::RBRACKET);
+      break;
+    }
 
-            setState(15);
-            match(ExprParser::T__1);
-            setState(16);
-            expr(13);
-            break;
+    case 8: {
+      _localctx = _tracker.createInstance<TimeIndexContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(43);
+      match(ExprParser::IDENTIFIER);
+      setState(44);
+      match(ExprParser::LBRACKET);
+      setState(45);
+      expr(0);
+      setState(50);
+      _errHandler->sync(this);
+      _la = _input->LA(1);
+      while (_la == ExprParser::T__7) {
+        setState(46);
+        match(ExprParser::T__7);
+        setState(47);
+        expr(0);
+        setState(52);
+        _errHandler->sync(this);
+        _la = _input->LA(1);
+      }
+      setState(53);
+      match(ExprParser::RBRACKET);
+      break;
+    }
+
+    case 9: {
+      _localctx = _tracker.createInstance<TimeShiftRangeContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(55);
+      match(ExprParser::IDENTIFIER);
+      setState(56);
+      match(ExprParser::LBRACKET);
+      setState(57);
+      antlrcpp::downCast<TimeShiftRangeContext *>(_localctx)->shift1 = shift();
+      setState(58);
+      match(ExprParser::T__8);
+      setState(59);
+      antlrcpp::downCast<TimeShiftRangeContext *>(_localctx)->shift2 = shift();
+      setState(60);
+      match(ExprParser::RBRACKET);
+      break;
+    }
+
+    case 10: {
+      _localctx = _tracker.createInstance<TimeRangeContext>(_localctx);
+      _ctx = _localctx;
+      previousContext = _localctx;
+      setState(62);
+      match(ExprParser::IDENTIFIER);
+      setState(63);
+      match(ExprParser::LBRACKET);
+      setState(64);
+      expr(0);
+      setState(65);
+      match(ExprParser::T__8);
+      setState(66);
+      expr(0);
+      setState(67);
+      match(ExprParser::RBRACKET);
+      break;
+    }
+
+    default:
+      break;
+    }
+    _ctx->stop = _input->LT(-1);
+    setState(82);
+    _errHandler->sync(this);
+    alt = getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 5, _ctx);
+    while (alt != 2 && alt != atn::ATN::INVALID_ALT_NUMBER) {
+      if (alt == 1) {
+        if (!_parseListeners.empty())
+          triggerExitRuleEvent();
+        previousContext = _localctx;
+        setState(80);
+        _errHandler->sync(this);
+        switch (getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 4, _ctx)) {
+        case 1: {
+          auto newContext = _tracker.createInstance<MuldivContext>(_tracker.createInstance<ExprContext>(parentContext, parentState));
+          _localctx = newContext;
+          pushNewRecursionContext(newContext, startState, RuleExpr);
+          setState(71);
+
+          if (!(precpred(_ctx, 12))) throw FailedPredicateException(this, "precpred(_ctx, 12)");
+          setState(72);
+          antlrcpp::downCast<MuldivContext *>(_localctx)->op = _input->LT(1);
+          _la = _input->LA(1);
+          if (!(_la == ExprParser::T__2
+
+          || _la == ExprParser::T__3)) {
+            antlrcpp::downCast<MuldivContext *>(_localctx)->op = _errHandler->recoverInline(this);
+          }
+          else {
+            _errHandler->reportMatch(this);
+            consume();
+          }
+          setState(73);
+          expr(13);
+          break;
         }
 
-        case 2:
-        {
-            _localctx = _tracker.createInstance<IdentifierContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(17);
-            match(ExprParser::IDENTIFIER);
-            break;
+        case 2: {
+          auto newContext = _tracker.createInstance<AddsubContext>(_tracker.createInstance<ExprContext>(parentContext, parentState));
+          _localctx = newContext;
+          pushNewRecursionContext(newContext, startState, RuleExpr);
+          setState(74);
+
+          if (!(precpred(_ctx, 11))) throw FailedPredicateException(this, "precpred(_ctx, 11)");
+          setState(75);
+          antlrcpp::downCast<AddsubContext *>(_localctx)->op = _input->LT(1);
+          _la = _input->LA(1);
+          if (!(_la == ExprParser::T__0
+
+          || _la == ExprParser::T__1)) {
+            antlrcpp::downCast<AddsubContext *>(_localctx)->op = _errHandler->recoverInline(this);
+          }
+          else {
+            _errHandler->reportMatch(this);
+            consume();
+          }
+          setState(76);
+          expr(12);
+          break;
         }
 
-        case 3:
-        {
-            _localctx = _tracker.createInstance<PortFieldContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(18);
-            match(ExprParser::IDENTIFIER);
-            setState(19);
-            match(ExprParser::T__4);
-            setState(20);
-            match(ExprParser::IDENTIFIER);
-            break;
-        }
+        case 3: {
+          auto newContext = _tracker.createInstance<ComparisonContext>(_tracker.createInstance<ExprContext>(parentContext, parentState));
+          _localctx = newContext;
+          pushNewRecursionContext(newContext, startState, RuleExpr);
+          setState(77);
 
-        case 4:
-        {
-            _localctx = _tracker.createInstance<NumberContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(21);
-            match(ExprParser::NUMBER);
-            break;
-        }
-
-        case 5:
-        {
-            _localctx = _tracker.createInstance<ExpressionContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(22);
-            match(ExprParser::T__5);
-            setState(23);
-            expr(0);
-            setState(24);
-            match(ExprParser::T__6);
-            break;
-        }
-
-        case 6:
-        {
-            _localctx = _tracker.createInstance<FunctionContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(26);
-            match(ExprParser::IDENTIFIER);
-            setState(27);
-            match(ExprParser::T__5);
-            setState(28);
-            expr(0);
-            setState(29);
-            match(ExprParser::T__6);
-            break;
-        }
-
-        case 7:
-        {
-            _localctx = _tracker.createInstance<TimeShiftContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(31);
-            match(ExprParser::IDENTIFIER);
-            setState(32);
-            match(ExprParser::LBRACKET);
-            setState(33);
-            shift();
-            setState(38);
-            _errHandler->sync(this);
-            _la = _input->LA(1);
-            while (_la == ExprParser::T__7)
-            {
-                setState(34);
-                match(ExprParser::T__7);
-                setState(35);
-                shift();
-                setState(40);
-                _errHandler->sync(this);
-                _la = _input->LA(1);
-            }
-            setState(41);
-            match(ExprParser::RBRACKET);
-            break;
-        }
-
-        case 8:
-        {
-            _localctx = _tracker.createInstance<TimeIndexContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(43);
-            match(ExprParser::IDENTIFIER);
-            setState(44);
-            match(ExprParser::LBRACKET);
-            setState(45);
-            expr(0);
-            setState(50);
-            _errHandler->sync(this);
-            _la = _input->LA(1);
-            while (_la == ExprParser::T__7)
-            {
-                setState(46);
-                match(ExprParser::T__7);
-                setState(47);
-                expr(0);
-                setState(52);
-                _errHandler->sync(this);
-                _la = _input->LA(1);
-            }
-            setState(53);
-            match(ExprParser::RBRACKET);
-            break;
-        }
-
-        case 9:
-        {
-            _localctx = _tracker.createInstance<TimeShiftRangeContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(55);
-            match(ExprParser::IDENTIFIER);
-            setState(56);
-            match(ExprParser::LBRACKET);
-            setState(57);
-            antlrcpp::downCast<TimeShiftRangeContext*>(_localctx)->shift1 = shift();
-            setState(58);
-            match(ExprParser::T__8);
-            setState(59);
-            antlrcpp::downCast<TimeShiftRangeContext*>(_localctx)->shift2 = shift();
-            setState(60);
-            match(ExprParser::RBRACKET);
-            break;
-        }
-
-        case 10:
-        {
-            _localctx = _tracker.createInstance<TimeRangeContext>(_localctx);
-            _ctx = _localctx;
-            previousContext = _localctx;
-            setState(62);
-            match(ExprParser::IDENTIFIER);
-            setState(63);
-            match(ExprParser::LBRACKET);
-            setState(64);
-            expr(0);
-            setState(65);
-            match(ExprParser::T__8);
-            setState(66);
-            expr(0);
-            setState(67);
-            match(ExprParser::RBRACKET);
-            break;
+          if (!(precpred(_ctx, 10))) throw FailedPredicateException(this, "precpred(_ctx, 10)");
+          setState(78);
+          match(ExprParser::COMPARISON);
+          setState(79);
+          expr(11);
+          break;
         }
 
         default:
-            break;
-        }
-        _ctx->stop = _input->LT(-1);
-        setState(82);
-        _errHandler->sync(this);
-        alt = getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 5, _ctx);
-        while (alt != 2 && alt != atn::ATN::INVALID_ALT_NUMBER)
-        {
-            if (alt == 1)
-            {
-                if (!_parseListeners.empty())
-                {
-                    triggerExitRuleEvent();
-                }
-                previousContext = _localctx;
-                setState(80);
-                _errHandler->sync(this);
-                switch (getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 4, _ctx))
-                {
-                case 1:
-                {
-                    auto newContext = _tracker.createInstance<MuldivContext>(
-                      _tracker.createInstance<ExprContext>(parentContext, parentState));
-                    _localctx = newContext;
-                    pushNewRecursionContext(newContext, startState, RuleExpr);
-                    setState(71);
-
-                    if (!(precpred(_ctx, 12)))
-                    {
-                        throw FailedPredicateException(this, "precpred(_ctx, 12)");
-                    }
-                    setState(72);
-                    antlrcpp::downCast<MuldivContext*>(_localctx)->op = _input->LT(1);
-                    _la = _input->LA(1);
-                    if (!(_la == ExprParser::T__2
-
-                          || _la == ExprParser::T__3))
-                    {
-                        antlrcpp::downCast<MuldivContext*>(_localctx)->op = _errHandler
-                                                                              ->recoverInline(this);
-                    }
-                    else
-                    {
-                        _errHandler->reportMatch(this);
-                        consume();
-                    }
-                    setState(73);
-                    expr(13);
-                    break;
-                }
-
-                case 2:
-                {
-                    auto newContext = _tracker.createInstance<AddsubContext>(
-                      _tracker.createInstance<ExprContext>(parentContext, parentState));
-                    _localctx = newContext;
-                    pushNewRecursionContext(newContext, startState, RuleExpr);
-                    setState(74);
-
-                    if (!(precpred(_ctx, 11)))
-                    {
-                        throw FailedPredicateException(this, "precpred(_ctx, 11)");
-                    }
-                    setState(75);
-                    antlrcpp::downCast<AddsubContext*>(_localctx)->op = _input->LT(1);
-                    _la = _input->LA(1);
-                    if (!(_la == ExprParser::T__0
-
-                          || _la == ExprParser::T__1))
-                    {
-                        antlrcpp::downCast<AddsubContext*>(_localctx)->op = _errHandler
-                                                                              ->recoverInline(this);
-                    }
-                    else
-                    {
-                        _errHandler->reportMatch(this);
-                        consume();
-                    }
-                    setState(76);
-                    expr(12);
-                    break;
-                }
-
-                case 3:
-                {
-                    auto newContext = _tracker.createInstance<ComparisonContext>(
-                      _tracker.createInstance<ExprContext>(parentContext, parentState));
-                    _localctx = newContext;
-                    pushNewRecursionContext(newContext, startState, RuleExpr);
-                    setState(77);
-
-                    if (!(precpred(_ctx, 10)))
-                    {
-                        throw FailedPredicateException(this, "precpred(_ctx, 10)");
-                    }
-                    setState(78);
-                    match(ExprParser::COMPARISON);
-                    setState(79);
-                    expr(11);
-                    break;
-                }
-
-                default:
-                    break;
-                }
-            }
-            setState(84);
-            _errHandler->sync(this);
-            alt = getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 5, _ctx);
-        }
+          break;
+        } 
+      }
+      setState(84);
+      _errHandler->sync(this);
+      alt = getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 5, _ctx);
     }
-    catch (RecognitionException& e)
-    {
-        _errHandler->reportError(this, e);
-        _localctx->exception = std::current_exception();
-        _errHandler->recover(this, _localctx->exception);
-    }
-    return _localctx;
+  }
+  catch (RecognitionException &e) {
+    _errHandler->reportError(this, e);
+    _localctx->exception = std::current_exception();
+    _errHandler->recover(this, _localctx->exception);
+  }
+  return _localctx;
 }
 
-bool ExprParser::sempred(RuleContext* context, size_t ruleIndex, size_t predicateIndex)
-{
-    switch (ruleIndex)
-    {
-    case 2:
-        return exprSempred(antlrcpp::downCast<ExprContext*>(context), predicateIndex);
+bool ExprParser::sempred(RuleContext *context, size_t ruleIndex, size_t predicateIndex) {
+  switch (ruleIndex) {
+    case 2: return exprSempred(antlrcpp::downCast<ExprContext *>(context), predicateIndex);
 
-    default:
-        break;
-    }
-    return true;
+  default:
+    break;
+  }
+  return true;
 }
 
-bool ExprParser::exprSempred(ExprContext* _localctx, size_t predicateIndex)
-{
-    switch (predicateIndex)
-    {
-    case 0:
-        return precpred(_ctx, 12);
-    case 1:
-        return precpred(_ctx, 11);
-    case 2:
-        return precpred(_ctx, 10);
+bool ExprParser::exprSempred(ExprContext *_localctx, size_t predicateIndex) {
+  switch (predicateIndex) {
+    case 0: return precpred(_ctx, 12);
+    case 1: return precpred(_ctx, 11);
+    case 2: return precpred(_ctx, 10);
 
-    default:
-        break;
-    }
-    return true;
+  default:
+    break;
+  }
+  return true;
 }
 
-void ExprParser::initialize()
-{
+void ExprParser::initialize() {
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
-    exprParserInitialize();
+  exprParserInitialize();
 #else
-    ::antlr4::internal::call_once(exprParserOnceFlag, exprParserInitialize);
+  ::antlr4::internal::call_once(exprParserOnceFlag, exprParserInitialize);
 #endif
 }

--- a/src/libs/antares/antlr-interface/ExprParser.cpp
+++ b/src/libs/antares/antlr-interface/ExprParser.cpp
@@ -1,884 +1,1176 @@
 
 // Generated from Expr.g4 by ANTLR 4.13.1
 
-
-#include "ExprVisitor.h"
-
 #include "ExprParser.h"
 
+#include "ExprVisitor.h"
 
 using namespace antlrcpp;
 
 using namespace antlr4;
 
-namespace {
+namespace
+{
 
-struct ExprParserStaticData final {
-  ExprParserStaticData(std::vector<std::string> ruleNames,
-                        std::vector<std::string> literalNames,
-                        std::vector<std::string> symbolicNames)
-      : ruleNames(std::move(ruleNames)), literalNames(std::move(literalNames)),
+struct ExprParserStaticData final
+{
+    ExprParserStaticData(std::vector<std::string> ruleNames,
+                         std::vector<std::string> literalNames,
+                         std::vector<std::string> symbolicNames):
+        ruleNames(std::move(ruleNames)),
+        literalNames(std::move(literalNames)),
         symbolicNames(std::move(symbolicNames)),
-        vocabulary(this->literalNames, this->symbolicNames) {}
+        vocabulary(this->literalNames, this->symbolicNames)
+    {
+    }
 
-  ExprParserStaticData(const ExprParserStaticData&) = delete;
-  ExprParserStaticData(ExprParserStaticData&&) = delete;
-  ExprParserStaticData& operator=(const ExprParserStaticData&) = delete;
-  ExprParserStaticData& operator=(ExprParserStaticData&&) = delete;
+    ExprParserStaticData(const ExprParserStaticData&) = delete;
+    ExprParserStaticData(ExprParserStaticData&&) = delete;
+    ExprParserStaticData& operator=(const ExprParserStaticData&) = delete;
+    ExprParserStaticData& operator=(ExprParserStaticData&&) = delete;
 
-  std::vector<antlr4::dfa::DFA> decisionToDFA;
-  antlr4::atn::PredictionContextCache sharedContextCache;
-  const std::vector<std::string> ruleNames;
-  const std::vector<std::string> literalNames;
-  const std::vector<std::string> symbolicNames;
-  const antlr4::dfa::Vocabulary vocabulary;
-  antlr4::atn::SerializedATNView serializedATN;
-  std::unique_ptr<antlr4::atn::ATN> atn;
+    std::vector<antlr4::dfa::DFA> decisionToDFA;
+    antlr4::atn::PredictionContextCache sharedContextCache;
+    const std::vector<std::string> ruleNames;
+    const std::vector<std::string> literalNames;
+    const std::vector<std::string> symbolicNames;
+    const antlr4::dfa::Vocabulary vocabulary;
+    antlr4::atn::SerializedATNView serializedATN;
+    std::unique_ptr<antlr4::atn::ATN> atn;
 };
 
 ::antlr4::internal::OnceFlag exprParserOnceFlag;
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
 static thread_local
 #endif
-ExprParserStaticData *exprParserStaticData = nullptr;
+  ExprParserStaticData* exprParserStaticData
+  = nullptr;
 
-void exprParserInitialize() {
+void exprParserInitialize()
+{
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
-  if (exprParserStaticData != nullptr) {
-    return;
-  }
-#else
-  assert(exprParserStaticData == nullptr);
-#endif
-  auto staticData = std::make_unique<ExprParserStaticData>(
-    std::vector<std::string>{
-      "fullexpr", "shift", "expr"
-    },
-    std::vector<std::string>{
-      "", "'+'", "'-'", "'/'", "'*'", "'.'", "'('", "')'", "','", "'..'", 
-      "", "'t'", "", "", "", "", "'['", "']'"
-    },
-    std::vector<std::string>{
-      "", "", "", "", "", "", "", "", "", "", "NUMBER", "TIME", "IDENTIFIER", 
-      "COMPARISON", "ADDSUB", "MULDIV", "LBRACKET", "RBRACKET", "WS"
+    if (exprParserStaticData != nullptr)
+    {
+        return;
     }
-  );
-  static const int32_t serializedATNSegment[] = {
-  	4,1,18,86,2,0,7,0,2,1,7,1,2,2,7,2,1,0,1,0,1,0,1,1,1,1,1,1,3,1,13,8,1,
-  	1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,
-  	2,1,2,1,2,1,2,1,2,5,2,37,8,2,10,2,12,2,40,9,2,1,2,1,2,1,2,1,2,1,2,1,2,
-  	1,2,5,2,49,8,2,10,2,12,2,52,9,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,
-  	2,1,2,1,2,1,2,1,2,1,2,1,2,3,2,70,8,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,
-  	1,2,5,2,81,8,2,10,2,12,2,84,9,2,1,2,0,1,4,3,0,2,4,0,2,1,0,1,2,1,0,3,4,
-  	97,0,6,1,0,0,0,2,9,1,0,0,0,4,69,1,0,0,0,6,7,3,4,2,0,7,8,5,0,0,1,8,1,1,
-  	0,0,0,9,12,5,11,0,0,10,11,7,0,0,0,11,13,3,4,2,0,12,10,1,0,0,0,12,13,1,
-  	0,0,0,13,3,1,0,0,0,14,15,6,2,-1,0,15,16,5,2,0,0,16,70,3,4,2,13,17,70,
-  	5,12,0,0,18,19,5,12,0,0,19,20,5,5,0,0,20,70,5,12,0,0,21,70,5,10,0,0,22,
-  	23,5,6,0,0,23,24,3,4,2,0,24,25,5,7,0,0,25,70,1,0,0,0,26,27,5,12,0,0,27,
-  	28,5,6,0,0,28,29,3,4,2,0,29,30,5,7,0,0,30,70,1,0,0,0,31,32,5,12,0,0,32,
-  	33,5,16,0,0,33,38,3,2,1,0,34,35,5,8,0,0,35,37,3,2,1,0,36,34,1,0,0,0,37,
-  	40,1,0,0,0,38,36,1,0,0,0,38,39,1,0,0,0,39,41,1,0,0,0,40,38,1,0,0,0,41,
-  	42,5,17,0,0,42,70,1,0,0,0,43,44,5,12,0,0,44,45,5,16,0,0,45,50,3,4,2,0,
-  	46,47,5,8,0,0,47,49,3,4,2,0,48,46,1,0,0,0,49,52,1,0,0,0,50,48,1,0,0,0,
-  	50,51,1,0,0,0,51,53,1,0,0,0,52,50,1,0,0,0,53,54,5,17,0,0,54,70,1,0,0,
-  	0,55,56,5,12,0,0,56,57,5,16,0,0,57,58,3,2,1,0,58,59,5,9,0,0,59,60,3,2,
-  	1,0,60,61,5,17,0,0,61,70,1,0,0,0,62,63,5,12,0,0,63,64,5,16,0,0,64,65,
-  	3,4,2,0,65,66,5,9,0,0,66,67,3,4,2,0,67,68,5,17,0,0,68,70,1,0,0,0,69,14,
-  	1,0,0,0,69,17,1,0,0,0,69,18,1,0,0,0,69,21,1,0,0,0,69,22,1,0,0,0,69,26,
-  	1,0,0,0,69,31,1,0,0,0,69,43,1,0,0,0,69,55,1,0,0,0,69,62,1,0,0,0,70,82,
-  	1,0,0,0,71,72,10,12,0,0,72,73,7,1,0,0,73,81,3,4,2,13,74,75,10,11,0,0,
-  	75,76,7,0,0,0,76,81,3,4,2,12,77,78,10,10,0,0,78,79,5,13,0,0,79,81,3,4,
-  	2,11,80,71,1,0,0,0,80,74,1,0,0,0,80,77,1,0,0,0,81,84,1,0,0,0,82,80,1,
-  	0,0,0,82,83,1,0,0,0,83,5,1,0,0,0,84,82,1,0,0,0,6,12,38,50,69,80,82
-  };
-  staticData->serializedATN = antlr4::atn::SerializedATNView(serializedATNSegment, sizeof(serializedATNSegment) / sizeof(serializedATNSegment[0]));
+#else
+    assert(exprParserStaticData == nullptr);
+#endif
+    auto staticData = std::make_unique<ExprParserStaticData>(std::vector<std::string>{"fullexpr",
+                                                                                      "shift",
+                                                                                      "expr"},
+                                                             std::vector<std::string>{"",
+                                                                                      "'+'",
+                                                                                      "'-'",
+                                                                                      "'/'",
+                                                                                      "'*'",
+                                                                                      "'.'",
+                                                                                      "'('",
+                                                                                      "')'",
+                                                                                      "','",
+                                                                                      "'..'",
+                                                                                      "",
+                                                                                      "'t'",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "'['",
+                                                                                      "']'"},
+                                                             std::vector<std::string>{"",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "",
+                                                                                      "NUMBER",
+                                                                                      "TIME",
+                                                                                      "IDENTIFIER",
+                                                                                      "COMPARISON",
+                                                                                      "ADDSUB",
+                                                                                      "MULDIV",
+                                                                                      "LBRACKET",
+                                                                                      "RBRACKET",
+                                                                                      "WS"});
+    static const int32_t serializedATNSegment[] = {
+      4,  1,  18, 86, 2,  0,  7,  0,  2, 1,  7,  1,  2,  2,  7,  2,  1,  0,  1,  0,  1,  0,  1,  1,
+      1,  1,  1,  1,  3,  1,  13, 8,  1, 1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,
+      2,  1,  2,  1,  2,  1,  2,  1,  2, 1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,
+      2,  1,  2,  1,  2,  5,  2,  37, 8, 2,  10, 2,  12, 2,  40, 9,  2,  1,  2,  1,  2,  1,  2,  1,
+      2,  1,  2,  1,  2,  1,  2,  5,  2, 49, 8,  2,  10, 2,  12, 2,  52, 9,  2,  1,  2,  1,  2,  1,
+      2,  1,  2,  1,  2,  1,  2,  1,  2, 1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,
+      2,  1,  2,  3,  2,  70, 8,  2,  1, 2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,  1,  2,
+      1,  2,  5,  2,  81, 8,  2,  10, 2, 12, 2,  84, 9,  2,  1,  2,  0,  1,  4,  3,  0,  2,  4,  0,
+      2,  1,  0,  1,  2,  1,  0,  3,  4, 97, 0,  6,  1,  0,  0,  0,  2,  9,  1,  0,  0,  0,  4,  69,
+      1,  0,  0,  0,  6,  7,  3,  4,  2, 0,  7,  8,  5,  0,  0,  1,  8,  1,  1,  0,  0,  0,  9,  12,
+      5,  11, 0,  0,  10, 11, 7,  0,  0, 0,  11, 13, 3,  4,  2,  0,  12, 10, 1,  0,  0,  0,  12, 13,
+      1,  0,  0,  0,  13, 3,  1,  0,  0, 0,  14, 15, 6,  2,  -1, 0,  15, 16, 5,  2,  0,  0,  16, 70,
+      3,  4,  2,  13, 17, 70, 5,  12, 0, 0,  18, 19, 5,  12, 0,  0,  19, 20, 5,  5,  0,  0,  20, 70,
+      5,  12, 0,  0,  21, 70, 5,  10, 0, 0,  22, 23, 5,  6,  0,  0,  23, 24, 3,  4,  2,  0,  24, 25,
+      5,  7,  0,  0,  25, 70, 1,  0,  0, 0,  26, 27, 5,  12, 0,  0,  27, 28, 5,  6,  0,  0,  28, 29,
+      3,  4,  2,  0,  29, 30, 5,  7,  0, 0,  30, 70, 1,  0,  0,  0,  31, 32, 5,  12, 0,  0,  32, 33,
+      5,  16, 0,  0,  33, 38, 3,  2,  1, 0,  34, 35, 5,  8,  0,  0,  35, 37, 3,  2,  1,  0,  36, 34,
+      1,  0,  0,  0,  37, 40, 1,  0,  0, 0,  38, 36, 1,  0,  0,  0,  38, 39, 1,  0,  0,  0,  39, 41,
+      1,  0,  0,  0,  40, 38, 1,  0,  0, 0,  41, 42, 5,  17, 0,  0,  42, 70, 1,  0,  0,  0,  43, 44,
+      5,  12, 0,  0,  44, 45, 5,  16, 0, 0,  45, 50, 3,  4,  2,  0,  46, 47, 5,  8,  0,  0,  47, 49,
+      3,  4,  2,  0,  48, 46, 1,  0,  0, 0,  49, 52, 1,  0,  0,  0,  50, 48, 1,  0,  0,  0,  50, 51,
+      1,  0,  0,  0,  51, 53, 1,  0,  0, 0,  52, 50, 1,  0,  0,  0,  53, 54, 5,  17, 0,  0,  54, 70,
+      1,  0,  0,  0,  55, 56, 5,  12, 0, 0,  56, 57, 5,  16, 0,  0,  57, 58, 3,  2,  1,  0,  58, 59,
+      5,  9,  0,  0,  59, 60, 3,  2,  1, 0,  60, 61, 5,  17, 0,  0,  61, 70, 1,  0,  0,  0,  62, 63,
+      5,  12, 0,  0,  63, 64, 5,  16, 0, 0,  64, 65, 3,  4,  2,  0,  65, 66, 5,  9,  0,  0,  66, 67,
+      3,  4,  2,  0,  67, 68, 5,  17, 0, 0,  68, 70, 1,  0,  0,  0,  69, 14, 1,  0,  0,  0,  69, 17,
+      1,  0,  0,  0,  69, 18, 1,  0,  0, 0,  69, 21, 1,  0,  0,  0,  69, 22, 1,  0,  0,  0,  69, 26,
+      1,  0,  0,  0,  69, 31, 1,  0,  0, 0,  69, 43, 1,  0,  0,  0,  69, 55, 1,  0,  0,  0,  69, 62,
+      1,  0,  0,  0,  70, 82, 1,  0,  0, 0,  71, 72, 10, 12, 0,  0,  72, 73, 7,  1,  0,  0,  73, 81,
+      3,  4,  2,  13, 74, 75, 10, 11, 0, 0,  75, 76, 7,  0,  0,  0,  76, 81, 3,  4,  2,  12, 77, 78,
+      10, 10, 0,  0,  78, 79, 5,  13, 0, 0,  79, 81, 3,  4,  2,  11, 80, 71, 1,  0,  0,  0,  80, 74,
+      1,  0,  0,  0,  80, 77, 1,  0,  0, 0,  81, 84, 1,  0,  0,  0,  82, 80, 1,  0,  0,  0,  82, 83,
+      1,  0,  0,  0,  83, 5,  1,  0,  0, 0,  84, 82, 1,  0,  0,  0,  6,  12, 38, 50, 69, 80, 82};
+    staticData->serializedATN = antlr4::atn::SerializedATNView(serializedATNSegment,
+                                                               sizeof(serializedATNSegment)
+                                                                 / sizeof(serializedATNSegment[0]));
 
-  antlr4::atn::ATNDeserializer deserializer;
-  staticData->atn = deserializer.deserialize(staticData->serializedATN);
+    antlr4::atn::ATNDeserializer deserializer;
+    staticData->atn = deserializer.deserialize(staticData->serializedATN);
 
-  const size_t count = staticData->atn->getNumberOfDecisions();
-  staticData->decisionToDFA.reserve(count);
-  for (size_t i = 0; i < count; i++) { 
-    staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
-  }
-  exprParserStaticData = staticData.release();
+    const size_t count = staticData->atn->getNumberOfDecisions();
+    staticData->decisionToDFA.reserve(count);
+    for (size_t i = 0; i < count; i++)
+    {
+        staticData->decisionToDFA.emplace_back(staticData->atn->getDecisionState(i), i);
+    }
+    exprParserStaticData = staticData.release();
 }
 
+} // namespace
+
+ExprParser::ExprParser(TokenStream* input):
+    ExprParser(input, antlr4::atn::ParserATNSimulatorOptions())
+{
 }
 
-ExprParser::ExprParser(TokenStream *input) : ExprParser(input, antlr4::atn::ParserATNSimulatorOptions()) {}
-
-ExprParser::ExprParser(TokenStream *input, const antlr4::atn::ParserATNSimulatorOptions &options) : Parser(input) {
-  ExprParser::initialize();
-  _interpreter = new atn::ParserATNSimulator(this, *exprParserStaticData->atn, exprParserStaticData->decisionToDFA, exprParserStaticData->sharedContextCache, options);
+ExprParser::ExprParser(TokenStream* input, const antlr4::atn::ParserATNSimulatorOptions& options):
+    Parser(input)
+{
+    ExprParser::initialize();
+    _interpreter = new atn::ParserATNSimulator(this,
+                                               *exprParserStaticData->atn,
+                                               exprParserStaticData->decisionToDFA,
+                                               exprParserStaticData->sharedContextCache,
+                                               options);
 }
 
-ExprParser::~ExprParser() {
-  delete _interpreter;
+ExprParser::~ExprParser()
+{
+    delete _interpreter;
 }
 
-const atn::ATN& ExprParser::getATN() const {
-  return *exprParserStaticData->atn;
+const atn::ATN& ExprParser::getATN() const
+{
+    return *exprParserStaticData->atn;
 }
 
-std::string ExprParser::getGrammarFileName() const {
-  return "Expr.g4";
+std::string ExprParser::getGrammarFileName() const
+{
+    return "Expr.g4";
 }
 
-const std::vector<std::string>& ExprParser::getRuleNames() const {
-  return exprParserStaticData->ruleNames;
+const std::vector<std::string>& ExprParser::getRuleNames() const
+{
+    return exprParserStaticData->ruleNames;
 }
 
-const dfa::Vocabulary& ExprParser::getVocabulary() const {
-  return exprParserStaticData->vocabulary;
+const dfa::Vocabulary& ExprParser::getVocabulary() const
+{
+    return exprParserStaticData->vocabulary;
 }
 
-antlr4::atn::SerializedATNView ExprParser::getSerializedATN() const {
-  return exprParserStaticData->serializedATN;
+antlr4::atn::SerializedATNView ExprParser::getSerializedATN() const
+{
+    return exprParserStaticData->serializedATN;
 }
 
+//----------------- FullexprContext
+//------------------------------------------------------------------
 
-//----------------- FullexprContext ------------------------------------------------------------------
-
-ExprParser::FullexprContext::FullexprContext(ParserRuleContext *parent, size_t invokingState)
-  : ParserRuleContext(parent, invokingState) {
+ExprParser::FullexprContext::FullexprContext(ParserRuleContext* parent, size_t invokingState):
+    ParserRuleContext(parent, invokingState)
+{
 }
 
-ExprParser::ExprContext* ExprParser::FullexprContext::expr() {
-  return getRuleContext<ExprParser::ExprContext>(0);
+ExprParser::ExprContext* ExprParser::FullexprContext::expr()
+{
+    return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-tree::TerminalNode* ExprParser::FullexprContext::EOF() {
-  return getToken(ExprParser::EOF, 0);
+tree::TerminalNode* ExprParser::FullexprContext::EOF()
+{
+    return getToken(ExprParser::EOF, 0);
 }
 
-
-size_t ExprParser::FullexprContext::getRuleIndex() const {
-  return ExprParser::RuleFullexpr;
+size_t ExprParser::FullexprContext::getRuleIndex() const
+{
+    return ExprParser::RuleFullexpr;
 }
 
-
-std::any ExprParser::FullexprContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitFullexpr(this);
-  else
-    return visitor->visitChildren(this);
+std::any ExprParser::FullexprContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitFullexpr(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-ExprParser::FullexprContext* ExprParser::fullexpr() {
-  FullexprContext *_localctx = _tracker.createInstance<FullexprContext>(_ctx, getState());
-  enterRule(_localctx, 0, ExprParser::RuleFullexpr);
+ExprParser::FullexprContext* ExprParser::fullexpr()
+{
+    FullexprContext* _localctx = _tracker.createInstance<FullexprContext>(_ctx, getState());
+    enterRule(_localctx, 0, ExprParser::RuleFullexpr);
 
 #if __cplusplus > 201703L
-  auto onExit = finally([=, this] {
+    auto onExit = finally(
+      [=, this]
+      {
 #else
-  auto onExit = finally([=] {
+    auto onExit = finally(
+      [=]
+      {
 #endif
-    exitRule();
-  });
-  try {
-    enterOuterAlt(_localctx, 1);
-    setState(6);
-    expr(0);
-    setState(7);
-    match(ExprParser::EOF);
-   
-  }
-  catch (RecognitionException &e) {
-    _errHandler->reportError(this, e);
-    _localctx->exception = std::current_exception();
-    _errHandler->recover(this, _localctx->exception);
-  }
+          exitRule();
+      });
+    try
+    {
+        enterOuterAlt(_localctx, 1);
+        setState(6);
+        expr(0);
+        setState(7);
+        match(ExprParser::EOF);
+    }
+    catch (RecognitionException& e)
+    {
+        _errHandler->reportError(this, e);
+        _localctx->exception = std::current_exception();
+        _errHandler->recover(this, _localctx->exception);
+    }
 
-  return _localctx;
+    return _localctx;
 }
 
 //----------------- ShiftContext ------------------------------------------------------------------
 
-ExprParser::ShiftContext::ShiftContext(ParserRuleContext *parent, size_t invokingState)
-  : ParserRuleContext(parent, invokingState) {
+ExprParser::ShiftContext::ShiftContext(ParserRuleContext* parent, size_t invokingState):
+    ParserRuleContext(parent, invokingState)
+{
 }
 
-tree::TerminalNode* ExprParser::ShiftContext::TIME() {
-  return getToken(ExprParser::TIME, 0);
+tree::TerminalNode* ExprParser::ShiftContext::TIME()
+{
+    return getToken(ExprParser::TIME, 0);
 }
 
-ExprParser::ExprContext* ExprParser::ShiftContext::expr() {
-  return getRuleContext<ExprParser::ExprContext>(0);
+ExprParser::ExprContext* ExprParser::ShiftContext::expr()
+{
+    return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-
-size_t ExprParser::ShiftContext::getRuleIndex() const {
-  return ExprParser::RuleShift;
+size_t ExprParser::ShiftContext::getRuleIndex() const
+{
+    return ExprParser::RuleShift;
 }
 
-
-std::any ExprParser::ShiftContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitShift(this);
-  else
-    return visitor->visitChildren(this);
+std::any ExprParser::ShiftContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitShift(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-ExprParser::ShiftContext* ExprParser::shift() {
-  ShiftContext *_localctx = _tracker.createInstance<ShiftContext>(_ctx, getState());
-  enterRule(_localctx, 2, ExprParser::RuleShift);
-  size_t _la = 0;
+ExprParser::ShiftContext* ExprParser::shift()
+{
+    ShiftContext* _localctx = _tracker.createInstance<ShiftContext>(_ctx, getState());
+    enterRule(_localctx, 2, ExprParser::RuleShift);
+    size_t _la = 0;
 
 #if __cplusplus > 201703L
-  auto onExit = finally([=, this] {
+    auto onExit = finally(
+      [=, this]
+      {
 #else
-  auto onExit = finally([=] {
+    auto onExit = finally(
+      [=]
+      {
 #endif
-    exitRule();
-  });
-  try {
-    enterOuterAlt(_localctx, 1);
-    setState(9);
-    match(ExprParser::TIME);
-    setState(12);
-    _errHandler->sync(this);
+          exitRule();
+      });
+    try
+    {
+        enterOuterAlt(_localctx, 1);
+        setState(9);
+        match(ExprParser::TIME);
+        setState(12);
+        _errHandler->sync(this);
 
-    _la = _input->LA(1);
-    if (_la == ExprParser::T__0
+        _la = _input->LA(1);
+        if (_la == ExprParser::T__0
 
-    || _la == ExprParser::T__1) {
-      setState(10);
-      antlrcpp::downCast<ShiftContext *>(_localctx)->op = _input->LT(1);
-      _la = _input->LA(1);
-      if (!(_la == ExprParser::T__0
+            || _la == ExprParser::T__1)
+        {
+            setState(10);
+            antlrcpp::downCast<ShiftContext*>(_localctx)->op = _input->LT(1);
+            _la = _input->LA(1);
+            if (!(_la == ExprParser::T__0
 
-      || _la == ExprParser::T__1)) {
-        antlrcpp::downCast<ShiftContext *>(_localctx)->op = _errHandler->recoverInline(this);
-      }
-      else {
-        _errHandler->reportMatch(this);
-        consume();
-      }
-      setState(11);
-      expr(0);
+                  || _la == ExprParser::T__1))
+            {
+                antlrcpp::downCast<ShiftContext*>(_localctx)->op = _errHandler->recoverInline(this);
+            }
+            else
+            {
+                _errHandler->reportMatch(this);
+                consume();
+            }
+            setState(11);
+            expr(0);
+        }
     }
-   
-  }
-  catch (RecognitionException &e) {
-    _errHandler->reportError(this, e);
-    _localctx->exception = std::current_exception();
-    _errHandler->recover(this, _localctx->exception);
-  }
+    catch (RecognitionException& e)
+    {
+        _errHandler->reportError(this, e);
+        _localctx->exception = std::current_exception();
+        _errHandler->recover(this, _localctx->exception);
+    }
 
-  return _localctx;
+    return _localctx;
 }
 
 //----------------- ExprContext ------------------------------------------------------------------
 
-ExprParser::ExprContext::ExprContext(ParserRuleContext *parent, size_t invokingState)
-  : ParserRuleContext(parent, invokingState) {
+ExprParser::ExprContext::ExprContext(ParserRuleContext* parent, size_t invokingState):
+    ParserRuleContext(parent, invokingState)
+{
 }
 
-
-size_t ExprParser::ExprContext::getRuleIndex() const {
-  return ExprParser::RuleExpr;
+size_t ExprParser::ExprContext::getRuleIndex() const
+{
+    return ExprParser::RuleExpr;
 }
 
-void ExprParser::ExprContext::copyFrom(ExprContext *ctx) {
-  ParserRuleContext::copyFrom(ctx);
+void ExprParser::ExprContext::copyFrom(ExprContext* ctx)
+{
+    ParserRuleContext::copyFrom(ctx);
 }
 
-//----------------- IdentifierContext ------------------------------------------------------------------
+//----------------- IdentifierContext
+//------------------------------------------------------------------
 
-tree::TerminalNode* ExprParser::IdentifierContext::IDENTIFIER() {
-  return getToken(ExprParser::IDENTIFIER, 0);
+tree::TerminalNode* ExprParser::IdentifierContext::IDENTIFIER()
+{
+    return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-ExprParser::IdentifierContext::IdentifierContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::IdentifierContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitIdentifier(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- NegationContext ------------------------------------------------------------------
-
-ExprParser::ExprContext* ExprParser::NegationContext::expr() {
-  return getRuleContext<ExprParser::ExprContext>(0);
+ExprParser::IdentifierContext::IdentifierContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
 }
 
-ExprParser::NegationContext::NegationContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::NegationContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitNegation(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- ExpressionContext ------------------------------------------------------------------
-
-ExprParser::ExprContext* ExprParser::ExpressionContext::expr() {
-  return getRuleContext<ExprParser::ExprContext>(0);
+std::any ExprParser::IdentifierContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitIdentifier(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-ExprParser::ExpressionContext::ExpressionContext(ExprContext *ctx) { copyFrom(ctx); }
+//----------------- NegationContext
+//------------------------------------------------------------------
 
-
-std::any ExprParser::ExpressionContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitExpression(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- ComparisonContext ------------------------------------------------------------------
-
-std::vector<ExprParser::ExprContext *> ExprParser::ComparisonContext::expr() {
-  return getRuleContexts<ExprParser::ExprContext>();
+ExprParser::ExprContext* ExprParser::NegationContext::expr()
+{
+    return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-ExprParser::ExprContext* ExprParser::ComparisonContext::expr(size_t i) {
-  return getRuleContext<ExprParser::ExprContext>(i);
+ExprParser::NegationContext::NegationContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
 }
 
-tree::TerminalNode* ExprParser::ComparisonContext::COMPARISON() {
-  return getToken(ExprParser::COMPARISON, 0);
+std::any ExprParser::NegationContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitNegation(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-ExprParser::ComparisonContext::ComparisonContext(ExprContext *ctx) { copyFrom(ctx); }
+//----------------- ExpressionContext
+//------------------------------------------------------------------
 
-
-std::any ExprParser::ComparisonContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitComparison(this);
-  else
-    return visitor->visitChildren(this);
+ExprParser::ExprContext* ExprParser::ExpressionContext::expr()
+{
+    return getRuleContext<ExprParser::ExprContext>(0);
 }
+
+ExprParser::ExpressionContext::ExpressionContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
+}
+
+std::any ExprParser::ExpressionContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitExpression(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
+}
+
+//----------------- ComparisonContext
+//------------------------------------------------------------------
+
+std::vector<ExprParser::ExprContext*> ExprParser::ComparisonContext::expr()
+{
+    return getRuleContexts<ExprParser::ExprContext>();
+}
+
+ExprParser::ExprContext* ExprParser::ComparisonContext::expr(size_t i)
+{
+    return getRuleContext<ExprParser::ExprContext>(i);
+}
+
+tree::TerminalNode* ExprParser::ComparisonContext::COMPARISON()
+{
+    return getToken(ExprParser::COMPARISON, 0);
+}
+
+ExprParser::ComparisonContext::ComparisonContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
+}
+
+std::any ExprParser::ComparisonContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitComparison(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
+}
+
 //----------------- AddsubContext ------------------------------------------------------------------
 
-std::vector<ExprParser::ExprContext *> ExprParser::AddsubContext::expr() {
-  return getRuleContexts<ExprParser::ExprContext>();
+std::vector<ExprParser::ExprContext*> ExprParser::AddsubContext::expr()
+{
+    return getRuleContexts<ExprParser::ExprContext>();
 }
 
-ExprParser::ExprContext* ExprParser::AddsubContext::expr(size_t i) {
-  return getRuleContext<ExprParser::ExprContext>(i);
+ExprParser::ExprContext* ExprParser::AddsubContext::expr(size_t i)
+{
+    return getRuleContext<ExprParser::ExprContext>(i);
 }
 
-ExprParser::AddsubContext::AddsubContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::AddsubContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitAddsub(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- PortFieldContext ------------------------------------------------------------------
-
-std::vector<tree::TerminalNode *> ExprParser::PortFieldContext::IDENTIFIER() {
-  return getTokens(ExprParser::IDENTIFIER);
+ExprParser::AddsubContext::AddsubContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
 }
 
-tree::TerminalNode* ExprParser::PortFieldContext::IDENTIFIER(size_t i) {
-  return getToken(ExprParser::IDENTIFIER, i);
+std::any ExprParser::AddsubContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitAddsub(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-ExprParser::PortFieldContext::PortFieldContext(ExprContext *ctx) { copyFrom(ctx); }
+//----------------- PortFieldContext
+//------------------------------------------------------------------
 
-
-std::any ExprParser::PortFieldContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitPortField(this);
-  else
-    return visitor->visitChildren(this);
+std::vector<tree::TerminalNode*> ExprParser::PortFieldContext::IDENTIFIER()
+{
+    return getTokens(ExprParser::IDENTIFIER);
 }
+
+tree::TerminalNode* ExprParser::PortFieldContext::IDENTIFIER(size_t i)
+{
+    return getToken(ExprParser::IDENTIFIER, i);
+}
+
+ExprParser::PortFieldContext::PortFieldContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
+}
+
+std::any ExprParser::PortFieldContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitPortField(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
+}
+
 //----------------- MuldivContext ------------------------------------------------------------------
 
-std::vector<ExprParser::ExprContext *> ExprParser::MuldivContext::expr() {
-  return getRuleContexts<ExprParser::ExprContext>();
+std::vector<ExprParser::ExprContext*> ExprParser::MuldivContext::expr()
+{
+    return getRuleContexts<ExprParser::ExprContext>();
 }
 
-ExprParser::ExprContext* ExprParser::MuldivContext::expr(size_t i) {
-  return getRuleContext<ExprParser::ExprContext>(i);
+ExprParser::ExprContext* ExprParser::MuldivContext::expr(size_t i)
+{
+    return getRuleContext<ExprParser::ExprContext>(i);
 }
 
-ExprParser::MuldivContext::MuldivContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::MuldivContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitMuldiv(this);
-  else
-    return visitor->visitChildren(this);
+ExprParser::MuldivContext::MuldivContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
 }
+
+std::any ExprParser::MuldivContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitMuldiv(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
+}
+
 //----------------- NumberContext ------------------------------------------------------------------
 
-tree::TerminalNode* ExprParser::NumberContext::NUMBER() {
-  return getToken(ExprParser::NUMBER, 0);
+tree::TerminalNode* ExprParser::NumberContext::NUMBER()
+{
+    return getToken(ExprParser::NUMBER, 0);
 }
 
-ExprParser::NumberContext::NumberContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::NumberContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitNumber(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- TimeIndexContext ------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::TimeIndexContext::IDENTIFIER() {
-  return getToken(ExprParser::IDENTIFIER, 0);
+ExprParser::NumberContext::NumberContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
 }
 
-tree::TerminalNode* ExprParser::TimeIndexContext::LBRACKET() {
-  return getToken(ExprParser::LBRACKET, 0);
+std::any ExprParser::NumberContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitNumber(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-std::vector<ExprParser::ExprContext *> ExprParser::TimeIndexContext::expr() {
-  return getRuleContexts<ExprParser::ExprContext>();
+//----------------- TimeIndexContext
+//------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::TimeIndexContext::IDENTIFIER()
+{
+    return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-ExprParser::ExprContext* ExprParser::TimeIndexContext::expr(size_t i) {
-  return getRuleContext<ExprParser::ExprContext>(i);
+tree::TerminalNode* ExprParser::TimeIndexContext::LBRACKET()
+{
+    return getToken(ExprParser::LBRACKET, 0);
 }
 
-tree::TerminalNode* ExprParser::TimeIndexContext::RBRACKET() {
-  return getToken(ExprParser::RBRACKET, 0);
+std::vector<ExprParser::ExprContext*> ExprParser::TimeIndexContext::expr()
+{
+    return getRuleContexts<ExprParser::ExprContext>();
 }
 
-ExprParser::TimeIndexContext::TimeIndexContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::TimeIndexContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitTimeIndex(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- TimeShiftContext ------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::TimeShiftContext::IDENTIFIER() {
-  return getToken(ExprParser::IDENTIFIER, 0);
+ExprParser::ExprContext* ExprParser::TimeIndexContext::expr(size_t i)
+{
+    return getRuleContext<ExprParser::ExprContext>(i);
 }
 
-tree::TerminalNode* ExprParser::TimeShiftContext::LBRACKET() {
-  return getToken(ExprParser::LBRACKET, 0);
+tree::TerminalNode* ExprParser::TimeIndexContext::RBRACKET()
+{
+    return getToken(ExprParser::RBRACKET, 0);
 }
 
-std::vector<ExprParser::ShiftContext *> ExprParser::TimeShiftContext::shift() {
-  return getRuleContexts<ExprParser::ShiftContext>();
+ExprParser::TimeIndexContext::TimeIndexContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
 }
 
-ExprParser::ShiftContext* ExprParser::TimeShiftContext::shift(size_t i) {
-  return getRuleContext<ExprParser::ShiftContext>(i);
+std::any ExprParser::TimeIndexContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitTimeIndex(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-tree::TerminalNode* ExprParser::TimeShiftContext::RBRACKET() {
-  return getToken(ExprParser::RBRACKET, 0);
+//----------------- TimeShiftContext
+//------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::TimeShiftContext::IDENTIFIER()
+{
+    return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-ExprParser::TimeShiftContext::TimeShiftContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::TimeShiftContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitTimeShift(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- FunctionContext ------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::FunctionContext::IDENTIFIER() {
-  return getToken(ExprParser::IDENTIFIER, 0);
+tree::TerminalNode* ExprParser::TimeShiftContext::LBRACKET()
+{
+    return getToken(ExprParser::LBRACKET, 0);
 }
 
-ExprParser::ExprContext* ExprParser::FunctionContext::expr() {
-  return getRuleContext<ExprParser::ExprContext>(0);
+std::vector<ExprParser::ShiftContext*> ExprParser::TimeShiftContext::shift()
+{
+    return getRuleContexts<ExprParser::ShiftContext>();
 }
 
-ExprParser::FunctionContext::FunctionContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::FunctionContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitFunction(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- TimeShiftRangeContext ------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::TimeShiftRangeContext::IDENTIFIER() {
-  return getToken(ExprParser::IDENTIFIER, 0);
+ExprParser::ShiftContext* ExprParser::TimeShiftContext::shift(size_t i)
+{
+    return getRuleContext<ExprParser::ShiftContext>(i);
 }
 
-tree::TerminalNode* ExprParser::TimeShiftRangeContext::LBRACKET() {
-  return getToken(ExprParser::LBRACKET, 0);
+tree::TerminalNode* ExprParser::TimeShiftContext::RBRACKET()
+{
+    return getToken(ExprParser::RBRACKET, 0);
 }
 
-tree::TerminalNode* ExprParser::TimeShiftRangeContext::RBRACKET() {
-  return getToken(ExprParser::RBRACKET, 0);
+ExprParser::TimeShiftContext::TimeShiftContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
 }
 
-std::vector<ExprParser::ShiftContext *> ExprParser::TimeShiftRangeContext::shift() {
-  return getRuleContexts<ExprParser::ShiftContext>();
+std::any ExprParser::TimeShiftContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitTimeShift(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-ExprParser::ShiftContext* ExprParser::TimeShiftRangeContext::shift(size_t i) {
-  return getRuleContext<ExprParser::ShiftContext>(i);
+//----------------- FunctionContext
+//------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::FunctionContext::IDENTIFIER()
+{
+    return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-ExprParser::TimeShiftRangeContext::TimeShiftRangeContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::TimeShiftRangeContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitTimeShiftRange(this);
-  else
-    return visitor->visitChildren(this);
-}
-//----------------- TimeRangeContext ------------------------------------------------------------------
-
-tree::TerminalNode* ExprParser::TimeRangeContext::IDENTIFIER() {
-  return getToken(ExprParser::IDENTIFIER, 0);
+ExprParser::ExprContext* ExprParser::FunctionContext::expr()
+{
+    return getRuleContext<ExprParser::ExprContext>(0);
 }
 
-tree::TerminalNode* ExprParser::TimeRangeContext::LBRACKET() {
-  return getToken(ExprParser::LBRACKET, 0);
+ExprParser::FunctionContext::FunctionContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
 }
 
-std::vector<ExprParser::ExprContext *> ExprParser::TimeRangeContext::expr() {
-  return getRuleContexts<ExprParser::ExprContext>();
+std::any ExprParser::FunctionContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitFunction(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
 }
 
-ExprParser::ExprContext* ExprParser::TimeRangeContext::expr(size_t i) {
-  return getRuleContext<ExprParser::ExprContext>(i);
+//----------------- TimeShiftRangeContext
+//------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::TimeShiftRangeContext::IDENTIFIER()
+{
+    return getToken(ExprParser::IDENTIFIER, 0);
 }
 
-tree::TerminalNode* ExprParser::TimeRangeContext::RBRACKET() {
-  return getToken(ExprParser::RBRACKET, 0);
+tree::TerminalNode* ExprParser::TimeShiftRangeContext::LBRACKET()
+{
+    return getToken(ExprParser::LBRACKET, 0);
 }
 
-ExprParser::TimeRangeContext::TimeRangeContext(ExprContext *ctx) { copyFrom(ctx); }
-
-
-std::any ExprParser::TimeRangeContext::accept(tree::ParseTreeVisitor *visitor) {
-  if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
-    return parserVisitor->visitTimeRange(this);
-  else
-    return visitor->visitChildren(this);
+tree::TerminalNode* ExprParser::TimeShiftRangeContext::RBRACKET()
+{
+    return getToken(ExprParser::RBRACKET, 0);
 }
 
-ExprParser::ExprContext* ExprParser::expr() {
-   return expr(0);
+std::vector<ExprParser::ShiftContext*> ExprParser::TimeShiftRangeContext::shift()
+{
+    return getRuleContexts<ExprParser::ShiftContext>();
 }
 
-ExprParser::ExprContext* ExprParser::expr(int precedence) {
-  ParserRuleContext *parentContext = _ctx;
-  size_t parentState = getState();
-  ExprParser::ExprContext *_localctx = _tracker.createInstance<ExprContext>(_ctx, parentState);
-  ExprParser::ExprContext *previousContext = _localctx;
-  (void)previousContext; // Silence compiler, in case the context is not used by generated code.
-  size_t startState = 4;
-  enterRecursionRule(_localctx, 4, ExprParser::RuleExpr, precedence);
+ExprParser::ShiftContext* ExprParser::TimeShiftRangeContext::shift(size_t i)
+{
+    return getRuleContext<ExprParser::ShiftContext>(i);
+}
+
+ExprParser::TimeShiftRangeContext::TimeShiftRangeContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
+}
+
+std::any ExprParser::TimeShiftRangeContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitTimeShiftRange(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
+}
+
+//----------------- TimeRangeContext
+//------------------------------------------------------------------
+
+tree::TerminalNode* ExprParser::TimeRangeContext::IDENTIFIER()
+{
+    return getToken(ExprParser::IDENTIFIER, 0);
+}
+
+tree::TerminalNode* ExprParser::TimeRangeContext::LBRACKET()
+{
+    return getToken(ExprParser::LBRACKET, 0);
+}
+
+std::vector<ExprParser::ExprContext*> ExprParser::TimeRangeContext::expr()
+{
+    return getRuleContexts<ExprParser::ExprContext>();
+}
+
+ExprParser::ExprContext* ExprParser::TimeRangeContext::expr(size_t i)
+{
+    return getRuleContext<ExprParser::ExprContext>(i);
+}
+
+tree::TerminalNode* ExprParser::TimeRangeContext::RBRACKET()
+{
+    return getToken(ExprParser::RBRACKET, 0);
+}
+
+ExprParser::TimeRangeContext::TimeRangeContext(ExprContext* ctx)
+{
+    copyFrom(ctx);
+}
+
+std::any ExprParser::TimeRangeContext::accept(tree::ParseTreeVisitor* visitor)
+{
+    if (auto parserVisitor = dynamic_cast<ExprVisitor*>(visitor))
+    {
+        return parserVisitor->visitTimeRange(this);
+    }
+    else
+    {
+        return visitor->visitChildren(this);
+    }
+}
+
+ExprParser::ExprContext* ExprParser::expr()
+{
+    return expr(0);
+}
+
+ExprParser::ExprContext* ExprParser::expr(int precedence)
+{
+    ParserRuleContext* parentContext = _ctx;
+    size_t parentState = getState();
+    ExprParser::ExprContext* _localctx = _tracker.createInstance<ExprContext>(_ctx, parentState);
+    ExprParser::ExprContext* previousContext = _localctx;
+    (void)previousContext; // Silence compiler, in case the context is not used by generated code.
+    size_t startState = 4;
+    enterRecursionRule(_localctx, 4, ExprParser::RuleExpr, precedence);
 
     size_t _la = 0;
 
 #if __cplusplus > 201703L
-  auto onExit = finally([=, this] {
+    auto onExit = finally(
+      [=, this]
+      {
 #else
-  auto onExit = finally([=] {
+    auto onExit = finally(
+      [=]
+      {
 #endif
-    unrollRecursionContexts(parentContext);
-  });
-  try {
-    size_t alt;
-    enterOuterAlt(_localctx, 1);
-    setState(69);
-    _errHandler->sync(this);
-    switch (getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 3, _ctx)) {
-    case 1: {
-      _localctx = _tracker.createInstance<NegationContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-
-      setState(15);
-      match(ExprParser::T__1);
-      setState(16);
-      expr(13);
-      break;
-    }
-
-    case 2: {
-      _localctx = _tracker.createInstance<IdentifierContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(17);
-      match(ExprParser::IDENTIFIER);
-      break;
-    }
-
-    case 3: {
-      _localctx = _tracker.createInstance<PortFieldContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(18);
-      match(ExprParser::IDENTIFIER);
-      setState(19);
-      match(ExprParser::T__4);
-      setState(20);
-      match(ExprParser::IDENTIFIER);
-      break;
-    }
-
-    case 4: {
-      _localctx = _tracker.createInstance<NumberContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(21);
-      match(ExprParser::NUMBER);
-      break;
-    }
-
-    case 5: {
-      _localctx = _tracker.createInstance<ExpressionContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(22);
-      match(ExprParser::T__5);
-      setState(23);
-      expr(0);
-      setState(24);
-      match(ExprParser::T__6);
-      break;
-    }
-
-    case 6: {
-      _localctx = _tracker.createInstance<FunctionContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(26);
-      match(ExprParser::IDENTIFIER);
-      setState(27);
-      match(ExprParser::T__5);
-      setState(28);
-      expr(0);
-      setState(29);
-      match(ExprParser::T__6);
-      break;
-    }
-
-    case 7: {
-      _localctx = _tracker.createInstance<TimeShiftContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(31);
-      match(ExprParser::IDENTIFIER);
-      setState(32);
-      match(ExprParser::LBRACKET);
-      setState(33);
-      shift();
-      setState(38);
-      _errHandler->sync(this);
-      _la = _input->LA(1);
-      while (_la == ExprParser::T__7) {
-        setState(34);
-        match(ExprParser::T__7);
-        setState(35);
-        shift();
-        setState(40);
+          unrollRecursionContexts(parentContext);
+      });
+    try
+    {
+        size_t alt;
+        enterOuterAlt(_localctx, 1);
+        setState(69);
         _errHandler->sync(this);
-        _la = _input->LA(1);
-      }
-      setState(41);
-      match(ExprParser::RBRACKET);
-      break;
-    }
+        switch (getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 3, _ctx))
+        {
+        case 1:
+        {
+            _localctx = _tracker.createInstance<NegationContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
 
-    case 8: {
-      _localctx = _tracker.createInstance<TimeIndexContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(43);
-      match(ExprParser::IDENTIFIER);
-      setState(44);
-      match(ExprParser::LBRACKET);
-      setState(45);
-      expr(0);
-      setState(50);
-      _errHandler->sync(this);
-      _la = _input->LA(1);
-      while (_la == ExprParser::T__7) {
-        setState(46);
-        match(ExprParser::T__7);
-        setState(47);
-        expr(0);
-        setState(52);
-        _errHandler->sync(this);
-        _la = _input->LA(1);
-      }
-      setState(53);
-      match(ExprParser::RBRACKET);
-      break;
-    }
-
-    case 9: {
-      _localctx = _tracker.createInstance<TimeShiftRangeContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(55);
-      match(ExprParser::IDENTIFIER);
-      setState(56);
-      match(ExprParser::LBRACKET);
-      setState(57);
-      antlrcpp::downCast<TimeShiftRangeContext *>(_localctx)->shift1 = shift();
-      setState(58);
-      match(ExprParser::T__8);
-      setState(59);
-      antlrcpp::downCast<TimeShiftRangeContext *>(_localctx)->shift2 = shift();
-      setState(60);
-      match(ExprParser::RBRACKET);
-      break;
-    }
-
-    case 10: {
-      _localctx = _tracker.createInstance<TimeRangeContext>(_localctx);
-      _ctx = _localctx;
-      previousContext = _localctx;
-      setState(62);
-      match(ExprParser::IDENTIFIER);
-      setState(63);
-      match(ExprParser::LBRACKET);
-      setState(64);
-      expr(0);
-      setState(65);
-      match(ExprParser::T__8);
-      setState(66);
-      expr(0);
-      setState(67);
-      match(ExprParser::RBRACKET);
-      break;
-    }
-
-    default:
-      break;
-    }
-    _ctx->stop = _input->LT(-1);
-    setState(82);
-    _errHandler->sync(this);
-    alt = getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 5, _ctx);
-    while (alt != 2 && alt != atn::ATN::INVALID_ALT_NUMBER) {
-      if (alt == 1) {
-        if (!_parseListeners.empty())
-          triggerExitRuleEvent();
-        previousContext = _localctx;
-        setState(80);
-        _errHandler->sync(this);
-        switch (getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 4, _ctx)) {
-        case 1: {
-          auto newContext = _tracker.createInstance<MuldivContext>(_tracker.createInstance<ExprContext>(parentContext, parentState));
-          _localctx = newContext;
-          pushNewRecursionContext(newContext, startState, RuleExpr);
-          setState(71);
-
-          if (!(precpred(_ctx, 12))) throw FailedPredicateException(this, "precpred(_ctx, 12)");
-          setState(72);
-          antlrcpp::downCast<MuldivContext *>(_localctx)->op = _input->LT(1);
-          _la = _input->LA(1);
-          if (!(_la == ExprParser::T__2
-
-          || _la == ExprParser::T__3)) {
-            antlrcpp::downCast<MuldivContext *>(_localctx)->op = _errHandler->recoverInline(this);
-          }
-          else {
-            _errHandler->reportMatch(this);
-            consume();
-          }
-          setState(73);
-          expr(13);
-          break;
+            setState(15);
+            match(ExprParser::T__1);
+            setState(16);
+            expr(13);
+            break;
         }
 
-        case 2: {
-          auto newContext = _tracker.createInstance<AddsubContext>(_tracker.createInstance<ExprContext>(parentContext, parentState));
-          _localctx = newContext;
-          pushNewRecursionContext(newContext, startState, RuleExpr);
-          setState(74);
-
-          if (!(precpred(_ctx, 11))) throw FailedPredicateException(this, "precpred(_ctx, 11)");
-          setState(75);
-          antlrcpp::downCast<AddsubContext *>(_localctx)->op = _input->LT(1);
-          _la = _input->LA(1);
-          if (!(_la == ExprParser::T__0
-
-          || _la == ExprParser::T__1)) {
-            antlrcpp::downCast<AddsubContext *>(_localctx)->op = _errHandler->recoverInline(this);
-          }
-          else {
-            _errHandler->reportMatch(this);
-            consume();
-          }
-          setState(76);
-          expr(12);
-          break;
+        case 2:
+        {
+            _localctx = _tracker.createInstance<IdentifierContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(17);
+            match(ExprParser::IDENTIFIER);
+            break;
         }
 
-        case 3: {
-          auto newContext = _tracker.createInstance<ComparisonContext>(_tracker.createInstance<ExprContext>(parentContext, parentState));
-          _localctx = newContext;
-          pushNewRecursionContext(newContext, startState, RuleExpr);
-          setState(77);
+        case 3:
+        {
+            _localctx = _tracker.createInstance<PortFieldContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(18);
+            match(ExprParser::IDENTIFIER);
+            setState(19);
+            match(ExprParser::T__4);
+            setState(20);
+            match(ExprParser::IDENTIFIER);
+            break;
+        }
 
-          if (!(precpred(_ctx, 10))) throw FailedPredicateException(this, "precpred(_ctx, 10)");
-          setState(78);
-          match(ExprParser::COMPARISON);
-          setState(79);
-          expr(11);
-          break;
+        case 4:
+        {
+            _localctx = _tracker.createInstance<NumberContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(21);
+            match(ExprParser::NUMBER);
+            break;
+        }
+
+        case 5:
+        {
+            _localctx = _tracker.createInstance<ExpressionContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(22);
+            match(ExprParser::T__5);
+            setState(23);
+            expr(0);
+            setState(24);
+            match(ExprParser::T__6);
+            break;
+        }
+
+        case 6:
+        {
+            _localctx = _tracker.createInstance<FunctionContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(26);
+            match(ExprParser::IDENTIFIER);
+            setState(27);
+            match(ExprParser::T__5);
+            setState(28);
+            expr(0);
+            setState(29);
+            match(ExprParser::T__6);
+            break;
+        }
+
+        case 7:
+        {
+            _localctx = _tracker.createInstance<TimeShiftContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(31);
+            match(ExprParser::IDENTIFIER);
+            setState(32);
+            match(ExprParser::LBRACKET);
+            setState(33);
+            shift();
+            setState(38);
+            _errHandler->sync(this);
+            _la = _input->LA(1);
+            while (_la == ExprParser::T__7)
+            {
+                setState(34);
+                match(ExprParser::T__7);
+                setState(35);
+                shift();
+                setState(40);
+                _errHandler->sync(this);
+                _la = _input->LA(1);
+            }
+            setState(41);
+            match(ExprParser::RBRACKET);
+            break;
+        }
+
+        case 8:
+        {
+            _localctx = _tracker.createInstance<TimeIndexContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(43);
+            match(ExprParser::IDENTIFIER);
+            setState(44);
+            match(ExprParser::LBRACKET);
+            setState(45);
+            expr(0);
+            setState(50);
+            _errHandler->sync(this);
+            _la = _input->LA(1);
+            while (_la == ExprParser::T__7)
+            {
+                setState(46);
+                match(ExprParser::T__7);
+                setState(47);
+                expr(0);
+                setState(52);
+                _errHandler->sync(this);
+                _la = _input->LA(1);
+            }
+            setState(53);
+            match(ExprParser::RBRACKET);
+            break;
+        }
+
+        case 9:
+        {
+            _localctx = _tracker.createInstance<TimeShiftRangeContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(55);
+            match(ExprParser::IDENTIFIER);
+            setState(56);
+            match(ExprParser::LBRACKET);
+            setState(57);
+            antlrcpp::downCast<TimeShiftRangeContext*>(_localctx)->shift1 = shift();
+            setState(58);
+            match(ExprParser::T__8);
+            setState(59);
+            antlrcpp::downCast<TimeShiftRangeContext*>(_localctx)->shift2 = shift();
+            setState(60);
+            match(ExprParser::RBRACKET);
+            break;
+        }
+
+        case 10:
+        {
+            _localctx = _tracker.createInstance<TimeRangeContext>(_localctx);
+            _ctx = _localctx;
+            previousContext = _localctx;
+            setState(62);
+            match(ExprParser::IDENTIFIER);
+            setState(63);
+            match(ExprParser::LBRACKET);
+            setState(64);
+            expr(0);
+            setState(65);
+            match(ExprParser::T__8);
+            setState(66);
+            expr(0);
+            setState(67);
+            match(ExprParser::RBRACKET);
+            break;
         }
 
         default:
-          break;
-        } 
-      }
-      setState(84);
-      _errHandler->sync(this);
-      alt = getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 5, _ctx);
+            break;
+        }
+        _ctx->stop = _input->LT(-1);
+        setState(82);
+        _errHandler->sync(this);
+        alt = getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 5, _ctx);
+        while (alt != 2 && alt != atn::ATN::INVALID_ALT_NUMBER)
+        {
+            if (alt == 1)
+            {
+                if (!_parseListeners.empty())
+                {
+                    triggerExitRuleEvent();
+                }
+                previousContext = _localctx;
+                setState(80);
+                _errHandler->sync(this);
+                switch (getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 4, _ctx))
+                {
+                case 1:
+                {
+                    auto newContext = _tracker.createInstance<MuldivContext>(
+                      _tracker.createInstance<ExprContext>(parentContext, parentState));
+                    _localctx = newContext;
+                    pushNewRecursionContext(newContext, startState, RuleExpr);
+                    setState(71);
+
+                    if (!(precpred(_ctx, 12)))
+                    {
+                        throw FailedPredicateException(this, "precpred(_ctx, 12)");
+                    }
+                    setState(72);
+                    antlrcpp::downCast<MuldivContext*>(_localctx)->op = _input->LT(1);
+                    _la = _input->LA(1);
+                    if (!(_la == ExprParser::T__2
+
+                          || _la == ExprParser::T__3))
+                    {
+                        antlrcpp::downCast<MuldivContext*>(_localctx)->op = _errHandler
+                                                                              ->recoverInline(this);
+                    }
+                    else
+                    {
+                        _errHandler->reportMatch(this);
+                        consume();
+                    }
+                    setState(73);
+                    expr(13);
+                    break;
+                }
+
+                case 2:
+                {
+                    auto newContext = _tracker.createInstance<AddsubContext>(
+                      _tracker.createInstance<ExprContext>(parentContext, parentState));
+                    _localctx = newContext;
+                    pushNewRecursionContext(newContext, startState, RuleExpr);
+                    setState(74);
+
+                    if (!(precpred(_ctx, 11)))
+                    {
+                        throw FailedPredicateException(this, "precpred(_ctx, 11)");
+                    }
+                    setState(75);
+                    antlrcpp::downCast<AddsubContext*>(_localctx)->op = _input->LT(1);
+                    _la = _input->LA(1);
+                    if (!(_la == ExprParser::T__0
+
+                          || _la == ExprParser::T__1))
+                    {
+                        antlrcpp::downCast<AddsubContext*>(_localctx)->op = _errHandler
+                                                                              ->recoverInline(this);
+                    }
+                    else
+                    {
+                        _errHandler->reportMatch(this);
+                        consume();
+                    }
+                    setState(76);
+                    expr(12);
+                    break;
+                }
+
+                case 3:
+                {
+                    auto newContext = _tracker.createInstance<ComparisonContext>(
+                      _tracker.createInstance<ExprContext>(parentContext, parentState));
+                    _localctx = newContext;
+                    pushNewRecursionContext(newContext, startState, RuleExpr);
+                    setState(77);
+
+                    if (!(precpred(_ctx, 10)))
+                    {
+                        throw FailedPredicateException(this, "precpred(_ctx, 10)");
+                    }
+                    setState(78);
+                    match(ExprParser::COMPARISON);
+                    setState(79);
+                    expr(11);
+                    break;
+                }
+
+                default:
+                    break;
+                }
+            }
+            setState(84);
+            _errHandler->sync(this);
+            alt = getInterpreter<atn::ParserATNSimulator>()->adaptivePredict(_input, 5, _ctx);
+        }
     }
-  }
-  catch (RecognitionException &e) {
-    _errHandler->reportError(this, e);
-    _localctx->exception = std::current_exception();
-    _errHandler->recover(this, _localctx->exception);
-  }
-  return _localctx;
+    catch (RecognitionException& e)
+    {
+        _errHandler->reportError(this, e);
+        _localctx->exception = std::current_exception();
+        _errHandler->recover(this, _localctx->exception);
+    }
+    return _localctx;
 }
 
-bool ExprParser::sempred(RuleContext *context, size_t ruleIndex, size_t predicateIndex) {
-  switch (ruleIndex) {
-    case 2: return exprSempred(antlrcpp::downCast<ExprContext *>(context), predicateIndex);
+bool ExprParser::sempred(RuleContext* context, size_t ruleIndex, size_t predicateIndex)
+{
+    switch (ruleIndex)
+    {
+    case 2:
+        return exprSempred(antlrcpp::downCast<ExprContext*>(context), predicateIndex);
 
-  default:
-    break;
-  }
-  return true;
+    default:
+        break;
+    }
+    return true;
 }
 
-bool ExprParser::exprSempred(ExprContext *_localctx, size_t predicateIndex) {
-  switch (predicateIndex) {
-    case 0: return precpred(_ctx, 12);
-    case 1: return precpred(_ctx, 11);
-    case 2: return precpred(_ctx, 10);
+bool ExprParser::exprSempred(ExprContext* _localctx, size_t predicateIndex)
+{
+    switch (predicateIndex)
+    {
+    case 0:
+        return precpred(_ctx, 12);
+    case 1:
+        return precpred(_ctx, 11);
+    case 2:
+        return precpred(_ctx, 10);
 
-  default:
-    break;
-  }
-  return true;
+    default:
+        break;
+    }
+    return true;
 }
 
-void ExprParser::initialize() {
+void ExprParser::initialize()
+{
 #if ANTLR4_USE_THREAD_LOCAL_CACHE
-  exprParserInitialize();
+    exprParserInitialize();
 #else
-  ::antlr4::internal::call_once(exprParserOnceFlag, exprParserInitialize);
+    ::antlr4::internal::call_once(exprParserOnceFlag, exprParserInitialize);
 #endif
 }

--- a/src/libs/antares/antlr-interface/ExprParser.h
+++ b/src/libs/antares/antlr-interface/ExprParser.h
@@ -3,242 +3,266 @@
 
 #pragma once
 
-
 #include "antlr4-runtime.h"
 
-
-
-
-class  ExprParser : public antlr4::Parser {
+class ExprParser: public antlr4::Parser
+{
 public:
-  enum {
-    T__0 = 1, T__1 = 2, T__2 = 3, T__3 = 4, T__4 = 5, T__5 = 6, T__6 = 7, 
-    T__7 = 8, T__8 = 9, NUMBER = 10, TIME = 11, IDENTIFIER = 12, COMPARISON = 13, 
-    ADDSUB = 14, MULDIV = 15, LBRACKET = 16, RBRACKET = 17, WS = 18
-  };
+    enum
+    {
+        T__0 = 1,
+        T__1 = 2,
+        T__2 = 3,
+        T__3 = 4,
+        T__4 = 5,
+        T__5 = 6,
+        T__6 = 7,
+        T__7 = 8,
+        T__8 = 9,
+        NUMBER = 10,
+        TIME = 11,
+        IDENTIFIER = 12,
+        COMPARISON = 13,
+        ADDSUB = 14,
+        MULDIV = 15,
+        LBRACKET = 16,
+        RBRACKET = 17,
+        WS = 18
+    };
+
+    enum
+    {
+        RuleFullexpr = 0,
+        RuleShift = 1,
+        RuleExpr = 2
+    };
+
+    explicit ExprParser(antlr4::TokenStream* input);
+
+    ExprParser(antlr4::TokenStream* input, const antlr4::atn::ParserATNSimulatorOptions& options);
+
+    ~ExprParser() override;
+
+    std::string getGrammarFileName() const override;
+
+    const antlr4::atn::ATN& getATN() const override;
+
+    const std::vector<std::string>& getRuleNames() const override;
+
+    const antlr4::dfa::Vocabulary& getVocabulary() const override;
+
+    antlr4::atn::SerializedATNView getSerializedATN() const override;
+
+    class FullexprContext;
+    class ShiftContext;
+    class ExprContext;
+
+    class FullexprContext: public antlr4::ParserRuleContext
+    {
+    public:
+        FullexprContext(antlr4::ParserRuleContext* parent, size_t invokingState);
+        virtual size_t getRuleIndex() const override;
+        ExprContext* expr();
+        antlr4::tree::TerminalNode* EOF();
+
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
+
+    FullexprContext* fullexpr();
+
+    class ShiftContext: public antlr4::ParserRuleContext
+    {
+    public:
+        antlr4::Token* op = nullptr;
+        ShiftContext(antlr4::ParserRuleContext* parent, size_t invokingState);
+        virtual size_t getRuleIndex() const override;
+        antlr4::tree::TerminalNode* TIME();
+        ExprContext* expr();
+
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
+
+    ShiftContext* shift();
 
-  enum {
-    RuleFullexpr = 0, RuleShift = 1, RuleExpr = 2
-  };
+    class ExprContext: public antlr4::ParserRuleContext
+    {
+    public:
+        ExprContext(antlr4::ParserRuleContext* parent, size_t invokingState);
 
-  explicit ExprParser(antlr4::TokenStream *input);
+        ExprContext() = default;
+        void copyFrom(ExprContext* context);
+        using antlr4::ParserRuleContext::copyFrom;
+
+        virtual size_t getRuleIndex() const override;
+    };
+
+    class IdentifierContext: public ExprContext
+    {
+    public:
+        IdentifierContext(ExprContext* ctx);
+
+        antlr4::tree::TerminalNode* IDENTIFIER();
+
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
+
+    class NegationContext: public ExprContext
+    {
+    public:
+        NegationContext(ExprContext* ctx);
 
-  ExprParser(antlr4::TokenStream *input, const antlr4::atn::ParserATNSimulatorOptions &options);
+        ExprContext* expr();
 
-  ~ExprParser() override;
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-  std::string getGrammarFileName() const override;
+    class ExpressionContext: public ExprContext
+    {
+    public:
+        ExpressionContext(ExprContext* ctx);
 
-  const antlr4::atn::ATN& getATN() const override;
+        ExprContext* expr();
 
-  const std::vector<std::string>& getRuleNames() const override;
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-  const antlr4::dfa::Vocabulary& getVocabulary() const override;
+    class ComparisonContext: public ExprContext
+    {
+    public:
+        ComparisonContext(ExprContext* ctx);
 
-  antlr4::atn::SerializedATNView getSerializedATN() const override;
+        std::vector<ExprContext*> expr();
+        ExprContext* expr(size_t i);
+        antlr4::tree::TerminalNode* COMPARISON();
+
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
+
+    class AddsubContext: public ExprContext
+    {
+    public:
+        AddsubContext(ExprContext* ctx);
+
+        antlr4::Token* op = nullptr;
+        std::vector<ExprContext*> expr();
+        ExprContext* expr(size_t i);
+
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
+
+    class PortFieldContext: public ExprContext
+    {
+    public:
+        PortFieldContext(ExprContext* ctx);
+
+        std::vector<antlr4::tree::TerminalNode*> IDENTIFIER();
+        antlr4::tree::TerminalNode* IDENTIFIER(size_t i);
 
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-  class FullexprContext;
-  class ShiftContext;
-  class ExprContext; 
+    class MuldivContext: public ExprContext
+    {
+    public:
+        MuldivContext(ExprContext* ctx);
 
-  class  FullexprContext : public antlr4::ParserRuleContext {
-  public:
-    FullexprContext(antlr4::ParserRuleContext *parent, size_t invokingState);
-    virtual size_t getRuleIndex() const override;
-    ExprContext *expr();
-    antlr4::tree::TerminalNode *EOF();
+        antlr4::Token* op = nullptr;
+        std::vector<ExprContext*> expr();
+        ExprContext* expr(size_t i);
 
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-   
-  };
+    class NumberContext: public ExprContext
+    {
+    public:
+        NumberContext(ExprContext* ctx);
 
-  FullexprContext* fullexpr();
+        antlr4::tree::TerminalNode* NUMBER();
 
-  class  ShiftContext : public antlr4::ParserRuleContext {
-  public:
-    antlr4::Token *op = nullptr;
-    ShiftContext(antlr4::ParserRuleContext *parent, size_t invokingState);
-    virtual size_t getRuleIndex() const override;
-    antlr4::tree::TerminalNode *TIME();
-    ExprContext *expr();
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
+    class TimeIndexContext: public ExprContext
+    {
+    public:
+        TimeIndexContext(ExprContext* ctx);
 
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-   
-  };
+        antlr4::tree::TerminalNode* IDENTIFIER();
+        antlr4::tree::TerminalNode* LBRACKET();
+        std::vector<ExprContext*> expr();
+        ExprContext* expr(size_t i);
+        antlr4::tree::TerminalNode* RBRACKET();
 
-  ShiftContext* shift();
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-  class  ExprContext : public antlr4::ParserRuleContext {
-  public:
-    ExprContext(antlr4::ParserRuleContext *parent, size_t invokingState);
-   
-    ExprContext() = default;
-    void copyFrom(ExprContext *context);
-    using antlr4::ParserRuleContext::copyFrom;
+    class TimeShiftContext: public ExprContext
+    {
+    public:
+        TimeShiftContext(ExprContext* ctx);
 
-    virtual size_t getRuleIndex() const override;
+        antlr4::tree::TerminalNode* IDENTIFIER();
+        antlr4::tree::TerminalNode* LBRACKET();
+        std::vector<ShiftContext*> shift();
+        ShiftContext* shift(size_t i);
+        antlr4::tree::TerminalNode* RBRACKET();
 
-   
-  };
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-  class  IdentifierContext : public ExprContext {
-  public:
-    IdentifierContext(ExprContext *ctx);
+    class FunctionContext: public ExprContext
+    {
+    public:
+        FunctionContext(ExprContext* ctx);
 
-    antlr4::tree::TerminalNode *IDENTIFIER();
+        antlr4::tree::TerminalNode* IDENTIFIER();
+        ExprContext* expr();
 
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-  class  NegationContext : public ExprContext {
-  public:
-    NegationContext(ExprContext *ctx);
+    class TimeShiftRangeContext: public ExprContext
+    {
+    public:
+        TimeShiftRangeContext(ExprContext* ctx);
 
-    ExprContext *expr();
+        ExprParser::ShiftContext* shift1 = nullptr;
+        ExprParser::ShiftContext* shift2 = nullptr;
+        antlr4::tree::TerminalNode* IDENTIFIER();
+        antlr4::tree::TerminalNode* LBRACKET();
+        antlr4::tree::TerminalNode* RBRACKET();
+        std::vector<ShiftContext*> shift();
+        ShiftContext* shift(size_t i);
 
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-  class  ExpressionContext : public ExprContext {
-  public:
-    ExpressionContext(ExprContext *ctx);
+    class TimeRangeContext: public ExprContext
+    {
+    public:
+        TimeRangeContext(ExprContext* ctx);
 
-    ExprContext *expr();
+        antlr4::tree::TerminalNode* IDENTIFIER();
+        antlr4::tree::TerminalNode* LBRACKET();
+        std::vector<ExprContext*> expr();
+        ExprContext* expr(size_t i);
+        antlr4::tree::TerminalNode* RBRACKET();
 
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
+        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
+    };
 
-  class  ComparisonContext : public ExprContext {
-  public:
-    ComparisonContext(ExprContext *ctx);
+    ExprContext* expr();
+    ExprContext* expr(int precedence);
 
-    std::vector<ExprContext *> expr();
-    ExprContext* expr(size_t i);
-    antlr4::tree::TerminalNode *COMPARISON();
+    bool sempred(antlr4::RuleContext* _localctx, size_t ruleIndex, size_t predicateIndex) override;
 
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
+    bool exprSempred(ExprContext* _localctx, size_t predicateIndex);
 
-  class  AddsubContext : public ExprContext {
-  public:
-    AddsubContext(ExprContext *ctx);
-
-    antlr4::Token *op = nullptr;
-    std::vector<ExprContext *> expr();
-    ExprContext* expr(size_t i);
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  class  PortFieldContext : public ExprContext {
-  public:
-    PortFieldContext(ExprContext *ctx);
-
-    std::vector<antlr4::tree::TerminalNode *> IDENTIFIER();
-    antlr4::tree::TerminalNode* IDENTIFIER(size_t i);
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  class  MuldivContext : public ExprContext {
-  public:
-    MuldivContext(ExprContext *ctx);
-
-    antlr4::Token *op = nullptr;
-    std::vector<ExprContext *> expr();
-    ExprContext* expr(size_t i);
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  class  NumberContext : public ExprContext {
-  public:
-    NumberContext(ExprContext *ctx);
-
-    antlr4::tree::TerminalNode *NUMBER();
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  class  TimeIndexContext : public ExprContext {
-  public:
-    TimeIndexContext(ExprContext *ctx);
-
-    antlr4::tree::TerminalNode *IDENTIFIER();
-    antlr4::tree::TerminalNode *LBRACKET();
-    std::vector<ExprContext *> expr();
-    ExprContext* expr(size_t i);
-    antlr4::tree::TerminalNode *RBRACKET();
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  class  TimeShiftContext : public ExprContext {
-  public:
-    TimeShiftContext(ExprContext *ctx);
-
-    antlr4::tree::TerminalNode *IDENTIFIER();
-    antlr4::tree::TerminalNode *LBRACKET();
-    std::vector<ShiftContext *> shift();
-    ShiftContext* shift(size_t i);
-    antlr4::tree::TerminalNode *RBRACKET();
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  class  FunctionContext : public ExprContext {
-  public:
-    FunctionContext(ExprContext *ctx);
-
-    antlr4::tree::TerminalNode *IDENTIFIER();
-    ExprContext *expr();
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  class  TimeShiftRangeContext : public ExprContext {
-  public:
-    TimeShiftRangeContext(ExprContext *ctx);
-
-    ExprParser::ShiftContext *shift1 = nullptr;
-    ExprParser::ShiftContext *shift2 = nullptr;
-    antlr4::tree::TerminalNode *IDENTIFIER();
-    antlr4::tree::TerminalNode *LBRACKET();
-    antlr4::tree::TerminalNode *RBRACKET();
-    std::vector<ShiftContext *> shift();
-    ShiftContext* shift(size_t i);
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  class  TimeRangeContext : public ExprContext {
-  public:
-    TimeRangeContext(ExprContext *ctx);
-
-    antlr4::tree::TerminalNode *IDENTIFIER();
-    antlr4::tree::TerminalNode *LBRACKET();
-    std::vector<ExprContext *> expr();
-    ExprContext* expr(size_t i);
-    antlr4::tree::TerminalNode *RBRACKET();
-
-    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
-  };
-
-  ExprContext* expr();
-  ExprContext* expr(int precedence);
-
-  bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
-
-  bool exprSempred(ExprContext *_localctx, size_t predicateIndex);
-
-  // By default the static state used to implement the parser is lazily initialized during the first
-  // call to the constructor. You can call this function if you wish to initialize the static state
-  // ahead of time.
-  static void initialize();
+    // By default the static state used to implement the parser is lazily initialized during the
+    // first call to the constructor. You can call this function if you wish to initialize the
+    // static state ahead of time.
+    static void initialize();
 
 private:
 };
-

--- a/src/libs/antares/antlr-interface/ExprParser.h
+++ b/src/libs/antares/antlr-interface/ExprParser.h
@@ -3,266 +3,242 @@
 
 #pragma once
 
+
 #include "antlr4-runtime.h"
 
-class ExprParser: public antlr4::Parser
-{
+
+
+
+class  ExprParser : public antlr4::Parser {
 public:
-    enum
-    {
-        T__0 = 1,
-        T__1 = 2,
-        T__2 = 3,
-        T__3 = 4,
-        T__4 = 5,
-        T__5 = 6,
-        T__6 = 7,
-        T__7 = 8,
-        T__8 = 9,
-        NUMBER = 10,
-        TIME = 11,
-        IDENTIFIER = 12,
-        COMPARISON = 13,
-        ADDSUB = 14,
-        MULDIV = 15,
-        LBRACKET = 16,
-        RBRACKET = 17,
-        WS = 18
-    };
+  enum {
+    T__0 = 1, T__1 = 2, T__2 = 3, T__3 = 4, T__4 = 5, T__5 = 6, T__6 = 7, 
+    T__7 = 8, T__8 = 9, NUMBER = 10, TIME = 11, IDENTIFIER = 12, COMPARISON = 13, 
+    ADDSUB = 14, MULDIV = 15, LBRACKET = 16, RBRACKET = 17, WS = 18
+  };
 
-    enum
-    {
-        RuleFullexpr = 0,
-        RuleShift = 1,
-        RuleExpr = 2
-    };
+  enum {
+    RuleFullexpr = 0, RuleShift = 1, RuleExpr = 2
+  };
 
-    explicit ExprParser(antlr4::TokenStream* input);
+  explicit ExprParser(antlr4::TokenStream *input);
 
-    ExprParser(antlr4::TokenStream* input, const antlr4::atn::ParserATNSimulatorOptions& options);
+  ExprParser(antlr4::TokenStream *input, const antlr4::atn::ParserATNSimulatorOptions &options);
 
-    ~ExprParser() override;
+  ~ExprParser() override;
 
-    std::string getGrammarFileName() const override;
+  std::string getGrammarFileName() const override;
 
-    const antlr4::atn::ATN& getATN() const override;
+  const antlr4::atn::ATN& getATN() const override;
 
-    const std::vector<std::string>& getRuleNames() const override;
+  const std::vector<std::string>& getRuleNames() const override;
 
-    const antlr4::dfa::Vocabulary& getVocabulary() const override;
+  const antlr4::dfa::Vocabulary& getVocabulary() const override;
 
-    antlr4::atn::SerializedATNView getSerializedATN() const override;
+  antlr4::atn::SerializedATNView getSerializedATN() const override;
 
-    class FullexprContext;
-    class ShiftContext;
-    class ExprContext;
 
-    class FullexprContext: public antlr4::ParserRuleContext
-    {
-    public:
-        FullexprContext(antlr4::ParserRuleContext* parent, size_t invokingState);
-        virtual size_t getRuleIndex() const override;
-        ExprContext* expr();
-        antlr4::tree::TerminalNode* EOF();
+  class FullexprContext;
+  class ShiftContext;
+  class ExprContext; 
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+  class  FullexprContext : public antlr4::ParserRuleContext {
+  public:
+    FullexprContext(antlr4::ParserRuleContext *parent, size_t invokingState);
+    virtual size_t getRuleIndex() const override;
+    ExprContext *expr();
+    antlr4::tree::TerminalNode *EOF();
 
-    FullexprContext* fullexpr();
 
-    class ShiftContext: public antlr4::ParserRuleContext
-    {
-    public:
-        antlr4::Token* op = nullptr;
-        ShiftContext(antlr4::ParserRuleContext* parent, size_t invokingState);
-        virtual size_t getRuleIndex() const override;
-        antlr4::tree::TerminalNode* TIME();
-        ExprContext* expr();
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+   
+  };
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+  FullexprContext* fullexpr();
 
-    ShiftContext* shift();
+  class  ShiftContext : public antlr4::ParserRuleContext {
+  public:
+    antlr4::Token *op = nullptr;
+    ShiftContext(antlr4::ParserRuleContext *parent, size_t invokingState);
+    virtual size_t getRuleIndex() const override;
+    antlr4::tree::TerminalNode *TIME();
+    ExprContext *expr();
 
-    class ExprContext: public antlr4::ParserRuleContext
-    {
-    public:
-        ExprContext(antlr4::ParserRuleContext* parent, size_t invokingState);
 
-        ExprContext() = default;
-        void copyFrom(ExprContext* context);
-        using antlr4::ParserRuleContext::copyFrom;
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+   
+  };
 
-        virtual size_t getRuleIndex() const override;
-    };
+  ShiftContext* shift();
 
-    class IdentifierContext: public ExprContext
-    {
-    public:
-        IdentifierContext(ExprContext* ctx);
+  class  ExprContext : public antlr4::ParserRuleContext {
+  public:
+    ExprContext(antlr4::ParserRuleContext *parent, size_t invokingState);
+   
+    ExprContext() = default;
+    void copyFrom(ExprContext *context);
+    using antlr4::ParserRuleContext::copyFrom;
 
-        antlr4::tree::TerminalNode* IDENTIFIER();
+    virtual size_t getRuleIndex() const override;
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+   
+  };
 
-    class NegationContext: public ExprContext
-    {
-    public:
-        NegationContext(ExprContext* ctx);
+  class  IdentifierContext : public ExprContext {
+  public:
+    IdentifierContext(ExprContext *ctx);
 
-        ExprContext* expr();
+    antlr4::tree::TerminalNode *IDENTIFIER();
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class ExpressionContext: public ExprContext
-    {
-    public:
-        ExpressionContext(ExprContext* ctx);
+  class  NegationContext : public ExprContext {
+  public:
+    NegationContext(ExprContext *ctx);
 
-        ExprContext* expr();
+    ExprContext *expr();
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class ComparisonContext: public ExprContext
-    {
-    public:
-        ComparisonContext(ExprContext* ctx);
+  class  ExpressionContext : public ExprContext {
+  public:
+    ExpressionContext(ExprContext *ctx);
 
-        std::vector<ExprContext*> expr();
-        ExprContext* expr(size_t i);
-        antlr4::tree::TerminalNode* COMPARISON();
+    ExprContext *expr();
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class AddsubContext: public ExprContext
-    {
-    public:
-        AddsubContext(ExprContext* ctx);
+  class  ComparisonContext : public ExprContext {
+  public:
+    ComparisonContext(ExprContext *ctx);
 
-        antlr4::Token* op = nullptr;
-        std::vector<ExprContext*> expr();
-        ExprContext* expr(size_t i);
+    std::vector<ExprContext *> expr();
+    ExprContext* expr(size_t i);
+    antlr4::tree::TerminalNode *COMPARISON();
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class PortFieldContext: public ExprContext
-    {
-    public:
-        PortFieldContext(ExprContext* ctx);
+  class  AddsubContext : public ExprContext {
+  public:
+    AddsubContext(ExprContext *ctx);
 
-        std::vector<antlr4::tree::TerminalNode*> IDENTIFIER();
-        antlr4::tree::TerminalNode* IDENTIFIER(size_t i);
+    antlr4::Token *op = nullptr;
+    std::vector<ExprContext *> expr();
+    ExprContext* expr(size_t i);
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class MuldivContext: public ExprContext
-    {
-    public:
-        MuldivContext(ExprContext* ctx);
+  class  PortFieldContext : public ExprContext {
+  public:
+    PortFieldContext(ExprContext *ctx);
 
-        antlr4::Token* op = nullptr;
-        std::vector<ExprContext*> expr();
-        ExprContext* expr(size_t i);
+    std::vector<antlr4::tree::TerminalNode *> IDENTIFIER();
+    antlr4::tree::TerminalNode* IDENTIFIER(size_t i);
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class NumberContext: public ExprContext
-    {
-    public:
-        NumberContext(ExprContext* ctx);
+  class  MuldivContext : public ExprContext {
+  public:
+    MuldivContext(ExprContext *ctx);
 
-        antlr4::tree::TerminalNode* NUMBER();
+    antlr4::Token *op = nullptr;
+    std::vector<ExprContext *> expr();
+    ExprContext* expr(size_t i);
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class TimeIndexContext: public ExprContext
-    {
-    public:
-        TimeIndexContext(ExprContext* ctx);
+  class  NumberContext : public ExprContext {
+  public:
+    NumberContext(ExprContext *ctx);
 
-        antlr4::tree::TerminalNode* IDENTIFIER();
-        antlr4::tree::TerminalNode* LBRACKET();
-        std::vector<ExprContext*> expr();
-        ExprContext* expr(size_t i);
-        antlr4::tree::TerminalNode* RBRACKET();
+    antlr4::tree::TerminalNode *NUMBER();
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class TimeShiftContext: public ExprContext
-    {
-    public:
-        TimeShiftContext(ExprContext* ctx);
+  class  TimeIndexContext : public ExprContext {
+  public:
+    TimeIndexContext(ExprContext *ctx);
 
-        antlr4::tree::TerminalNode* IDENTIFIER();
-        antlr4::tree::TerminalNode* LBRACKET();
-        std::vector<ShiftContext*> shift();
-        ShiftContext* shift(size_t i);
-        antlr4::tree::TerminalNode* RBRACKET();
+    antlr4::tree::TerminalNode *IDENTIFIER();
+    antlr4::tree::TerminalNode *LBRACKET();
+    std::vector<ExprContext *> expr();
+    ExprContext* expr(size_t i);
+    antlr4::tree::TerminalNode *RBRACKET();
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class FunctionContext: public ExprContext
-    {
-    public:
-        FunctionContext(ExprContext* ctx);
+  class  TimeShiftContext : public ExprContext {
+  public:
+    TimeShiftContext(ExprContext *ctx);
 
-        antlr4::tree::TerminalNode* IDENTIFIER();
-        ExprContext* expr();
+    antlr4::tree::TerminalNode *IDENTIFIER();
+    antlr4::tree::TerminalNode *LBRACKET();
+    std::vector<ShiftContext *> shift();
+    ShiftContext* shift(size_t i);
+    antlr4::tree::TerminalNode *RBRACKET();
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class TimeShiftRangeContext: public ExprContext
-    {
-    public:
-        TimeShiftRangeContext(ExprContext* ctx);
+  class  FunctionContext : public ExprContext {
+  public:
+    FunctionContext(ExprContext *ctx);
 
-        ExprParser::ShiftContext* shift1 = nullptr;
-        ExprParser::ShiftContext* shift2 = nullptr;
-        antlr4::tree::TerminalNode* IDENTIFIER();
-        antlr4::tree::TerminalNode* LBRACKET();
-        antlr4::tree::TerminalNode* RBRACKET();
-        std::vector<ShiftContext*> shift();
-        ShiftContext* shift(size_t i);
+    antlr4::tree::TerminalNode *IDENTIFIER();
+    ExprContext *expr();
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    class TimeRangeContext: public ExprContext
-    {
-    public:
-        TimeRangeContext(ExprContext* ctx);
+  class  TimeShiftRangeContext : public ExprContext {
+  public:
+    TimeShiftRangeContext(ExprContext *ctx);
 
-        antlr4::tree::TerminalNode* IDENTIFIER();
-        antlr4::tree::TerminalNode* LBRACKET();
-        std::vector<ExprContext*> expr();
-        ExprContext* expr(size_t i);
-        antlr4::tree::TerminalNode* RBRACKET();
+    ExprParser::ShiftContext *shift1 = nullptr;
+    ExprParser::ShiftContext *shift2 = nullptr;
+    antlr4::tree::TerminalNode *IDENTIFIER();
+    antlr4::tree::TerminalNode *LBRACKET();
+    antlr4::tree::TerminalNode *RBRACKET();
+    std::vector<ShiftContext *> shift();
+    ShiftContext* shift(size_t i);
 
-        virtual std::any accept(antlr4::tree::ParseTreeVisitor* visitor) override;
-    };
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    ExprContext* expr();
-    ExprContext* expr(int precedence);
+  class  TimeRangeContext : public ExprContext {
+  public:
+    TimeRangeContext(ExprContext *ctx);
 
-    bool sempred(antlr4::RuleContext* _localctx, size_t ruleIndex, size_t predicateIndex) override;
+    antlr4::tree::TerminalNode *IDENTIFIER();
+    antlr4::tree::TerminalNode *LBRACKET();
+    std::vector<ExprContext *> expr();
+    ExprContext* expr(size_t i);
+    antlr4::tree::TerminalNode *RBRACKET();
 
-    bool exprSempred(ExprContext* _localctx, size_t predicateIndex);
+    virtual std::any accept(antlr4::tree::ParseTreeVisitor *visitor) override;
+  };
 
-    // By default the static state used to implement the parser is lazily initialized during the
-    // first call to the constructor. You can call this function if you wish to initialize the
-    // static state ahead of time.
-    static void initialize();
+  ExprContext* expr();
+  ExprContext* expr(int precedence);
+
+  bool sempred(antlr4::RuleContext *_localctx, size_t ruleIndex, size_t predicateIndex) override;
+
+  bool exprSempred(ExprContext *_localctx, size_t predicateIndex);
+
+  // By default the static state used to implement the parser is lazily initialized during the first
+  // call to the constructor. You can call this function if you wish to initialize the static state
+  // ahead of time.
+  static void initialize();
 
 private:
 };
+

--- a/src/libs/antares/antlr-interface/ExprVisitor.cpp
+++ b/src/libs/antares/antlr-interface/ExprVisitor.cpp
@@ -1,4 +1,7 @@
 
 // Generated from Expr.g4 by ANTLR 4.13.1
 
+
 #include "ExprVisitor.h"
+
+

--- a/src/libs/antares/antlr-interface/ExprVisitor.cpp
+++ b/src/libs/antares/antlr-interface/ExprVisitor.cpp
@@ -1,7 +1,4 @@
 
 // Generated from Expr.g4 by ANTLR 4.13.1
 
-
 #include "ExprVisitor.h"
-
-

--- a/src/libs/antares/antlr-interface/ExprVisitor.h
+++ b/src/libs/antares/antlr-interface/ExprVisitor.h
@@ -3,46 +3,52 @@
 
 #pragma once
 
-#include "ExprParser.h"
+
 #include "antlr4-runtime.h"
+#include "ExprParser.h"
+
+
 
 /**
  * This class defines an abstract visitor for a parse tree
  * produced by ExprParser.
  */
-class ExprVisitor: public antlr4::tree::AbstractParseTreeVisitor
-{
+class  ExprVisitor : public antlr4::tree::AbstractParseTreeVisitor {
 public:
-    /**
-     * Visit parse trees produced by ExprParser.
-     */
-    virtual std::any visitFullexpr(ExprParser::FullexprContext* context) = 0;
 
-    virtual std::any visitShift(ExprParser::ShiftContext* context) = 0;
+  /**
+   * Visit parse trees produced by ExprParser.
+   */
+    virtual std::any visitFullexpr(ExprParser::FullexprContext *context) = 0;
 
-    virtual std::any visitIdentifier(ExprParser::IdentifierContext* context) = 0;
+    virtual std::any visitShift(ExprParser::ShiftContext *context) = 0;
 
-    virtual std::any visitNegation(ExprParser::NegationContext* context) = 0;
+    virtual std::any visitIdentifier(ExprParser::IdentifierContext *context) = 0;
 
-    virtual std::any visitExpression(ExprParser::ExpressionContext* context) = 0;
+    virtual std::any visitNegation(ExprParser::NegationContext *context) = 0;
 
-    virtual std::any visitComparison(ExprParser::ComparisonContext* context) = 0;
+    virtual std::any visitExpression(ExprParser::ExpressionContext *context) = 0;
 
-    virtual std::any visitAddsub(ExprParser::AddsubContext* context) = 0;
+    virtual std::any visitComparison(ExprParser::ComparisonContext *context) = 0;
 
-    virtual std::any visitPortField(ExprParser::PortFieldContext* context) = 0;
+    virtual std::any visitAddsub(ExprParser::AddsubContext *context) = 0;
 
-    virtual std::any visitMuldiv(ExprParser::MuldivContext* context) = 0;
+    virtual std::any visitPortField(ExprParser::PortFieldContext *context) = 0;
 
-    virtual std::any visitNumber(ExprParser::NumberContext* context) = 0;
+    virtual std::any visitMuldiv(ExprParser::MuldivContext *context) = 0;
 
-    virtual std::any visitTimeIndex(ExprParser::TimeIndexContext* context) = 0;
+    virtual std::any visitNumber(ExprParser::NumberContext *context) = 0;
 
-    virtual std::any visitTimeShift(ExprParser::TimeShiftContext* context) = 0;
+    virtual std::any visitTimeIndex(ExprParser::TimeIndexContext *context) = 0;
 
-    virtual std::any visitFunction(ExprParser::FunctionContext* context) = 0;
+    virtual std::any visitTimeShift(ExprParser::TimeShiftContext *context) = 0;
 
-    virtual std::any visitTimeShiftRange(ExprParser::TimeShiftRangeContext* context) = 0;
+    virtual std::any visitFunction(ExprParser::FunctionContext *context) = 0;
 
-    virtual std::any visitTimeRange(ExprParser::TimeRangeContext* context) = 0;
+    virtual std::any visitTimeShiftRange(ExprParser::TimeShiftRangeContext *context) = 0;
+
+    virtual std::any visitTimeRange(ExprParser::TimeRangeContext *context) = 0;
+
+
 };
+

--- a/src/libs/antares/antlr-interface/ExprVisitor.h
+++ b/src/libs/antares/antlr-interface/ExprVisitor.h
@@ -3,52 +3,46 @@
 
 #pragma once
 
-
-#include "antlr4-runtime.h"
 #include "ExprParser.h"
-
-
+#include "antlr4-runtime.h"
 
 /**
  * This class defines an abstract visitor for a parse tree
  * produced by ExprParser.
  */
-class  ExprVisitor : public antlr4::tree::AbstractParseTreeVisitor {
+class ExprVisitor: public antlr4::tree::AbstractParseTreeVisitor
+{
 public:
+    /**
+     * Visit parse trees produced by ExprParser.
+     */
+    virtual std::any visitFullexpr(ExprParser::FullexprContext* context) = 0;
 
-  /**
-   * Visit parse trees produced by ExprParser.
-   */
-    virtual std::any visitFullexpr(ExprParser::FullexprContext *context) = 0;
+    virtual std::any visitShift(ExprParser::ShiftContext* context) = 0;
 
-    virtual std::any visitShift(ExprParser::ShiftContext *context) = 0;
+    virtual std::any visitIdentifier(ExprParser::IdentifierContext* context) = 0;
 
-    virtual std::any visitIdentifier(ExprParser::IdentifierContext *context) = 0;
+    virtual std::any visitNegation(ExprParser::NegationContext* context) = 0;
 
-    virtual std::any visitNegation(ExprParser::NegationContext *context) = 0;
+    virtual std::any visitExpression(ExprParser::ExpressionContext* context) = 0;
 
-    virtual std::any visitExpression(ExprParser::ExpressionContext *context) = 0;
+    virtual std::any visitComparison(ExprParser::ComparisonContext* context) = 0;
 
-    virtual std::any visitComparison(ExprParser::ComparisonContext *context) = 0;
+    virtual std::any visitAddsub(ExprParser::AddsubContext* context) = 0;
 
-    virtual std::any visitAddsub(ExprParser::AddsubContext *context) = 0;
+    virtual std::any visitPortField(ExprParser::PortFieldContext* context) = 0;
 
-    virtual std::any visitPortField(ExprParser::PortFieldContext *context) = 0;
+    virtual std::any visitMuldiv(ExprParser::MuldivContext* context) = 0;
 
-    virtual std::any visitMuldiv(ExprParser::MuldivContext *context) = 0;
+    virtual std::any visitNumber(ExprParser::NumberContext* context) = 0;
 
-    virtual std::any visitNumber(ExprParser::NumberContext *context) = 0;
+    virtual std::any visitTimeIndex(ExprParser::TimeIndexContext* context) = 0;
 
-    virtual std::any visitTimeIndex(ExprParser::TimeIndexContext *context) = 0;
+    virtual std::any visitTimeShift(ExprParser::TimeShiftContext* context) = 0;
 
-    virtual std::any visitTimeShift(ExprParser::TimeShiftContext *context) = 0;
+    virtual std::any visitFunction(ExprParser::FunctionContext* context) = 0;
 
-    virtual std::any visitFunction(ExprParser::FunctionContext *context) = 0;
+    virtual std::any visitTimeShiftRange(ExprParser::TimeShiftRangeContext* context) = 0;
 
-    virtual std::any visitTimeShiftRange(ExprParser::TimeShiftRangeContext *context) = 0;
-
-    virtual std::any visitTimeRange(ExprParser::TimeRangeContext *context) = 0;
-
-
+    virtual std::any visitTimeRange(ExprParser::TimeRangeContext* context) = 0;
 };
-

--- a/src/libs/antares/args/args_to_utf8.cpp
+++ b/src/libs/antares/args/args_to_utf8.cpp
@@ -53,7 +53,14 @@ std::pair<int, char**> IntoUTF8ArgsTranslator::convert()
     for (int i = 0; i != argc_; ++i)
     {
         const uint len = (uint)wcslen(wargv[i]);
-        const uint newLen = WideCharToMultiByte(CP_UTF8, 0, wargv[i], len, nullptr, 0, nullptr, nullptr);
+        const uint newLen = WideCharToMultiByte(CP_UTF8,
+                                                0,
+                                                wargv[i],
+                                                len,
+                                                nullptr,
+                                                0,
+                                                nullptr,
+                                                nullptr);
         argv_[i] = (char*)malloc((newLen + 1) * sizeof(char));
         memset(argv_[i], 0, (newLen + 1) * sizeof(char));
         WideCharToMultiByte(CP_UTF8, 0, wargv[i], len, argv_[i], newLen, nullptr, nullptr);

--- a/src/libs/antares/args/args_to_utf8.cpp
+++ b/src/libs/antares/args/args_to_utf8.cpp
@@ -53,14 +53,7 @@ std::pair<int, char**> IntoUTF8ArgsTranslator::convert()
     for (int i = 0; i != argc_; ++i)
     {
         const uint len = (uint)wcslen(wargv[i]);
-        const uint newLen = WideCharToMultiByte(CP_UTF8,
-                                                0,
-                                                wargv[i],
-                                                len,
-                                                nullptr,
-                                                0,
-                                                nullptr,
-                                                nullptr);
+        const uint newLen = WideCharToMultiByte(CP_UTF8, 0, wargv[i], len, nullptr, 0, nullptr, nullptr);
         argv_[i] = (char*)malloc((newLen + 1) * sizeof(char));
         memset(argv_[i], 0, (newLen + 1) * sizeof(char));
         WideCharToMultiByte(CP_UTF8, 0, wargv[i], len, argv_[i], newLen, nullptr, nullptr);

--- a/src/libs/antares/array/include/antares/array/matrix.hxx
+++ b/src/libs/antares/array/include/antares/array/matrix.hxx
@@ -1044,8 +1044,6 @@ bool Matrix<T, ReadWriteT>::internalLoadCSVFile(const AnyString& filename,
                                                 uint options,
                                                 BufferType* buffer)
 {
-    using namespace Yuni;
-
     // Status
     bool result = false;
 
@@ -1057,7 +1055,7 @@ bool Matrix<T, ReadWriteT>::internalLoadCSVFile(const AnyString& filename,
 
     switch (loadFromFileToBuffer(*buffer, filename))
     {
-    case IO::errNone:
+    case Yuni::IO::errNone:
     {
         // Empty files
         if (buffer->empty())
@@ -1098,7 +1096,7 @@ bool Matrix<T, ReadWriteT>::internalLoadCSVFile(const AnyString& filename,
         }
         break;
     }
-    case IO::errNotFound:
+    case Yuni::IO::errNotFound:
     {
         if (not(options & optQuiet))
         {
@@ -1106,7 +1104,7 @@ bool Matrix<T, ReadWriteT>::internalLoadCSVFile(const AnyString& filename,
         }
         break;
     }
-    case IO::errMemoryLimit:
+    case Yuni::IO::errMemoryLimit:
     {
         if (not(options & optQuiet))
         {

--- a/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
+++ b/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
@@ -28,7 +28,6 @@ void checkOrtoolsUsage(Antares::Data::UnitCommitmentMode ucMode,
                        bool ortoolsUsed,
                        const std::string& solverName);
 
-
 void checkStudyVersion(const AnyString& optStudyFolder);
 
 void checkSimplexRangeHydroPricing(Antares::Data::SimplexOptimization optRange,

--- a/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
+++ b/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
@@ -28,6 +28,7 @@ void checkOrtoolsUsage(Antares::Data::UnitCommitmentMode ucMode,
                        bool ortoolsUsed,
                        const std::string& solverName);
 
+
 void checkStudyVersion(const AnyString& optStudyFolder);
 
 void checkSimplexRangeHydroPricing(Antares::Data::SimplexOptimization optRange,

--- a/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
@@ -130,14 +130,13 @@ public:
     explicit InvalidSolver(const std::string& solver, const std::string& availableSolverList);
 };
 
-class InvalidSolverSpecificParameters: public LoadingError
+class InvalidSolverSpecificParameters : public LoadingError
 {
 public:
-    explicit InvalidSolverSpecificParameters(const std::string& solver,
-                                             const std::string& specificParameters);
+    explicit InvalidSolverSpecificParameters(const std::string& solver, const std::string& specificParameters);
 };
 
-class InvalidStudy: public LoadingError
+class InvalidStudy : public LoadingError
 {
 public:
     explicit InvalidStudy(const Yuni::String& study);

--- a/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
@@ -130,13 +130,14 @@ public:
     explicit InvalidSolver(const std::string& solver, const std::string& availableSolverList);
 };
 
-class InvalidSolverSpecificParameters : public LoadingError
+class InvalidSolverSpecificParameters: public LoadingError
 {
 public:
-    explicit InvalidSolverSpecificParameters(const std::string& solver, const std::string& specificParameters);
+    explicit InvalidSolverSpecificParameters(const std::string& solver,
+                                             const std::string& specificParameters);
 };
 
-class InvalidStudy : public LoadingError
+class InvalidStudy: public LoadingError
 {
 public:
     explicit InvalidStudy(const Yuni::String& study);

--- a/src/libs/antares/file-tree-study-loader/include/antares/file-tree-study-loader/FileTreeStudyLoader.h
+++ b/src/libs/antares/file-tree-study-loader/include/antares/file-tree-study-loader/FileTreeStudyLoader.h
@@ -31,6 +31,7 @@ namespace Data
 {
 class Study;
 }
+
 /**
  * @class FileTreeStudyLoader
  * @brief A class to load studies from the file tree.

--- a/src/libs/antares/file-tree-study-loader/include/antares/file-tree-study-loader/FileTreeStudyLoader.h
+++ b/src/libs/antares/file-tree-study-loader/include/antares/file-tree-study-loader/FileTreeStudyLoader.h
@@ -31,7 +31,6 @@ namespace Data
 {
 class Study;
 }
-
 /**
  * @class FileTreeStudyLoader
  * @brief A class to load studies from the file tree.

--- a/src/libs/antares/inifile/include/antares/inifile/inifile.hxx
+++ b/src/libs/antares/inifile/include/antares/inifile/inifile.hxx
@@ -32,7 +32,8 @@ inline bool IniFile::empty() const
     return not firstSection;
 }
 
-inline IniFile::Section::Section(const AnyString& name): name(name)
+inline IniFile::Section::Section(const AnyString& name):
+    name(name)
 {
 }
 

--- a/src/libs/antares/inifile/include/antares/inifile/inifile.hxx
+++ b/src/libs/antares/inifile/include/antares/inifile/inifile.hxx
@@ -32,8 +32,7 @@ inline bool IniFile::empty() const
     return not firstSection;
 }
 
-inline IniFile::Section::Section(const AnyString& name):
-    name(name)
+inline IniFile::Section::Section(const AnyString& name): name(name)
 {
 }
 

--- a/src/libs/antares/inifile/inifile.cpp
+++ b/src/libs/antares/inifile/inifile.cpp
@@ -65,9 +65,8 @@ void IniFile::Section::saveToStream(std::ostream& stream_out, uint64_t& written)
     stream_out << '[' << name << "]\n";
     written += 4 /* []\n\n */ + name.size();
 
-    each([&stream_out, &written](const IniFile::Property& p) {
-        p.saveToStream(stream_out, written);
-    });
+    each([&stream_out, &written](const IniFile::Property& p)
+         { p.saveToStream(stream_out, written); });
 
     stream_out << '\n';
 }
@@ -249,7 +248,7 @@ bool IniFile::open(const fs::path& filename, bool warnings)
 
     if (std::ifstream file(filename); file.is_open())
     {
-        if (! readStream(file))
+        if (!readStream(file))
         {
             logs.error() << "Invalid INI file : " << filename;
             return false;
@@ -266,9 +265,8 @@ bool IniFile::open(const fs::path& filename, bool warnings)
 
 void IniFile::saveToStream(std::ostream& stream_out, uint64_t& written) const
 {
-    each([&stream_out, &written](const IniFile::Section& s) {
-        s.saveToStream(stream_out, written);
-    });
+    each([&stream_out, &written](const IniFile::Section& s)
+         { s.saveToStream(stream_out, written); });
 
     if (written != 0)
     {

--- a/src/libs/antares/inifile/inifile.cpp
+++ b/src/libs/antares/inifile/inifile.cpp
@@ -65,8 +65,9 @@ void IniFile::Section::saveToStream(std::ostream& stream_out, uint64_t& written)
     stream_out << '[' << name << "]\n";
     written += 4 /* []\n\n */ + name.size();
 
-    each([&stream_out, &written](const IniFile::Property& p)
-         { p.saveToStream(stream_out, written); });
+    each([&stream_out, &written](const IniFile::Property& p) {
+        p.saveToStream(stream_out, written);
+    });
 
     stream_out << '\n';
 }
@@ -248,7 +249,7 @@ bool IniFile::open(const fs::path& filename, bool warnings)
 
     if (std::ifstream file(filename); file.is_open())
     {
-        if (!readStream(file))
+        if (! readStream(file))
         {
             logs.error() << "Invalid INI file : " << filename;
             return false;
@@ -265,8 +266,9 @@ bool IniFile::open(const fs::path& filename, bool warnings)
 
 void IniFile::saveToStream(std::ostream& stream_out, uint64_t& written) const
 {
-    each([&stream_out, &written](const IniFile::Section& s)
-         { s.saveToStream(stream_out, written); });
+    each([&stream_out, &written](const IniFile::Section& s) {
+        s.saveToStream(stream_out, written);
+    });
 
     if (written != 0)
     {

--- a/src/libs/antares/io/file.cpp
+++ b/src/libs/antares/io/file.cpp
@@ -27,13 +27,13 @@
 
 #ifdef YUNI_OS_WINDOWS
 #include <io.h>
+
 #include <yuni/core/system/windows.hdr.h>
 #else
 #include <sys/types.h>
 #include <unistd.h>
 #endif
 #include <errno.h>
-
 #include <fstream>
 
 #include <antares/logs/logs.h>

--- a/src/libs/antares/io/file.cpp
+++ b/src/libs/antares/io/file.cpp
@@ -27,13 +27,13 @@
 
 #ifdef YUNI_OS_WINDOWS
 #include <io.h>
-
 #include <yuni/core/system/windows.hdr.h>
 #else
 #include <sys/types.h>
 #include <unistd.h>
 #endif
 #include <errno.h>
+
 #include <fstream>
 
 #include <antares/logs/logs.h>

--- a/src/libs/antares/io/include/antares/io/file.h
+++ b/src/libs/antares/io/include/antares/io/file.h
@@ -21,9 +21,9 @@
 #ifndef __LIBS_ANTARES_IO_FILE_H__
 #define __LIBS_ANTARES_IO_FILE_H__
 
-#include <yuni/core/string.h>
-
 #include <filesystem>
+
+#include <yuni/core/string.h>
 
 namespace Antares::IO
 {

--- a/src/libs/antares/io/include/antares/io/file.h
+++ b/src/libs/antares/io/include/antares/io/file.h
@@ -21,9 +21,9 @@
 #ifndef __LIBS_ANTARES_IO_FILE_H__
 #define __LIBS_ANTARES_IO_FILE_H__
 
-#include <filesystem>
-
 #include <yuni/core/string.h>
+
+#include <filesystem>
 
 namespace Antares::IO
 {

--- a/src/libs/antares/locale/locale.cpp
+++ b/src/libs/antares/locale/locale.cpp
@@ -37,7 +37,7 @@ void InitializeDefaultLocale()
     }
 
 #else
-    if (! std::setlocale(LC_ALL, "en_US.utf8"))
+    if (!std::setlocale(LC_ALL, "en_US.utf8"))
     {
         std::cerr << "impossible to set locale to en_US.utf8" << std::endl;
     }

--- a/src/libs/antares/locale/locale.cpp
+++ b/src/libs/antares/locale/locale.cpp
@@ -37,7 +37,7 @@ void InitializeDefaultLocale()
     }
 
 #else
-    if (!std::setlocale(LC_ALL, "en_US.utf8"))
+    if (! std::setlocale(LC_ALL, "en_US.utf8"))
     {
         std::cerr << "impossible to set locale to en_US.utf8" << std::endl;
     }

--- a/src/libs/antares/study-loader/include/antares/study-loader/IStudyLoader.h
+++ b/src/libs/antares/study-loader/include/antares/study-loader/IStudyLoader.h
@@ -29,6 +29,7 @@ namespace Data
 {
 class Study;
 }
+
 /**
  * @class IStudyLoader
  * @brief The IStudyLoader class is an interface for loading studies.

--- a/src/libs/antares/study-loader/include/antares/study-loader/IStudyLoader.h
+++ b/src/libs/antares/study-loader/include/antares/study-loader/IStudyLoader.h
@@ -29,7 +29,6 @@ namespace Data
 {
 class Study;
 }
-
 /**
  * @class IStudyLoader
  * @brief The IStudyLoader class is an interface for loading studies.

--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -51,20 +51,19 @@ Area::Area():
     internalInitialize();
 }
 
-Area::Area(const AnyString& name):
-    Area()
+Area::Area(const AnyString& name) : Area()
 {
     internalInitialize();
     this->name = name;
     this->id = Antares::transformNameIntoID(this->name);
 }
 
-Area::Area(const AnyString& name, const AnyString& id):
-    Area()
+Area::Area(const AnyString& name, const AnyString& id) : Area()
 {
     internalInitialize();
     this->name = name;
     this->id = Antares::transformNameIntoID(id);
+
 }
 
 Area::~Area()

--- a/src/libs/antares/study/area/area.cpp
+++ b/src/libs/antares/study/area/area.cpp
@@ -51,19 +51,20 @@ Area::Area():
     internalInitialize();
 }
 
-Area::Area(const AnyString& name) : Area()
+Area::Area(const AnyString& name):
+    Area()
 {
     internalInitialize();
     this->name = name;
     this->id = Antares::transformNameIntoID(this->name);
 }
 
-Area::Area(const AnyString& name, const AnyString& id) : Area()
+Area::Area(const AnyString& name, const AnyString& id):
+    Area()
 {
     internalInitialize();
     this->name = name;
     this->id = Antares::transformNameIntoID(id);
-
 }
 
 Area::~Area()

--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -21,9 +21,9 @@
 
 #include "antares/study/area/links.h"
 
-#include <array>
 #include <filesystem>
 #include <limits>
+#include <array>
 
 #include <antares/exception/LoadingError.hpp>
 #include <antares/logs/logs.h>
@@ -308,13 +308,9 @@ namespace // anonymous
 
 bool isPropertyUsedForLinkTSgeneration(const std::string& key)
 {
-    std::array<std::string, 7> listKeys = {"unitcount",
-                                           "nominalcapacity",
-                                           "law.planned",
-                                           "law.forced",
-                                           "volatility.planned",
-                                           "volatility.forced",
-                                           "force-no-generation"};
+    std::array<std::string, 7> listKeys
+        = {"unitcount", "nominalcapacity", "law.planned", "law.forced",
+           "volatility.planned", "volatility.forced", "force-no-generation"};
     return std::find(listKeys.begin(), listKeys.end(), key) != listKeys.end();
 }
 

--- a/src/libs/antares/study/area/links.cpp
+++ b/src/libs/antares/study/area/links.cpp
@@ -21,9 +21,9 @@
 
 #include "antares/study/area/links.h"
 
+#include <array>
 #include <filesystem>
 #include <limits>
-#include <array>
 
 #include <antares/exception/LoadingError.hpp>
 #include <antares/logs/logs.h>
@@ -308,9 +308,13 @@ namespace // anonymous
 
 bool isPropertyUsedForLinkTSgeneration(const std::string& key)
 {
-    std::array<std::string, 7> listKeys
-        = {"unitcount", "nominalcapacity", "law.planned", "law.forced",
-           "volatility.planned", "volatility.forced", "force-no-generation"};
+    std::array<std::string, 7> listKeys = {"unitcount",
+                                           "nominalcapacity",
+                                           "law.planned",
+                                           "law.forced",
+                                           "volatility.planned",
+                                           "volatility.forced",
+                                           "force-no-generation"};
     return std::find(listKeys.begin(), listKeys.end(), key) != listKeys.end();
 }
 

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -968,9 +968,8 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
             ret = hydroSeries->LoadMaxPower(area.id, buffer) && ret;
         }
 
-        hydroSeries->resizeTSinDeratedMode(study.parameters.derated,
-                                           studyVersion,
-                                           study.usedByTheSolver);
+        hydroSeries->resizeTSinDeratedMode(
+            study.parameters.derated, studyVersion, study.usedByTheSolver);
     }
 
     // Wind
@@ -1279,7 +1278,7 @@ Area* AreaList::findFromPosition(const int x, const int y) const
         {
             auto lastArea = i->second;
             if (lastArea->ui && std::abs(lastArea->ui->x - x) < nearestDistance
-                && std::abs(lastArea->ui->y - y) < nearestDistance)
+                             && std::abs(lastArea->ui->y - y) < nearestDistance)
             {
                 nearestItem = lastArea;
             }
@@ -1327,14 +1326,12 @@ void AreaListEnsureDataLoadPrepro(AreaList* l)
     /* Asserts */
     assert(l);
 
-    l->each(
-      [](Data::Area& area)
-      {
-          if (!area.load.prepro)
-          {
-              area.load.prepro = new Antares::Data::Load::Prepro();
-          }
-      });
+    l->each([](Data::Area& area) {
+        if (!area.load.prepro)
+        {
+            area.load.prepro = new Antares::Data::Load::Prepro();
+        }
+    });
 }
 
 void AreaListEnsureDataSolarPrepro(AreaList* l)

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -968,8 +968,9 @@ static bool AreaListLoadFromFolderSingleArea(Study& study,
             ret = hydroSeries->LoadMaxPower(area.id, buffer) && ret;
         }
 
-        hydroSeries->resizeTSinDeratedMode(
-            study.parameters.derated, studyVersion, study.usedByTheSolver);
+        hydroSeries->resizeTSinDeratedMode(study.parameters.derated,
+                                           studyVersion,
+                                           study.usedByTheSolver);
     }
 
     // Wind
@@ -1278,7 +1279,7 @@ Area* AreaList::findFromPosition(const int x, const int y) const
         {
             auto lastArea = i->second;
             if (lastArea->ui && std::abs(lastArea->ui->x - x) < nearestDistance
-                             && std::abs(lastArea->ui->y - y) < nearestDistance)
+                && std::abs(lastArea->ui->y - y) < nearestDistance)
             {
                 nearestItem = lastArea;
             }
@@ -1326,12 +1327,14 @@ void AreaListEnsureDataLoadPrepro(AreaList* l)
     /* Asserts */
     assert(l);
 
-    l->each([](Data::Area& area) {
-        if (!area.load.prepro)
-        {
-            area.load.prepro = new Antares::Data::Load::Prepro();
-        }
-    });
+    l->each(
+      [](Data::Area& area)
+      {
+          if (!area.load.prepro)
+          {
+              area.load.prepro = new Antares::Data::Load::Prepro();
+          }
+      });
 }
 
 void AreaListEnsureDataSolarPrepro(AreaList* l)

--- a/src/libs/antares/study/binding_constraint/BindingConstraintGroupRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintGroupRepository.cpp
@@ -60,9 +60,7 @@ bool BindingConstraintGroupRepository::buildFrom(const BindingConstraintsReposit
 
 bool BindingConstraintGroupRepository::timeSeriesWidthConsistentInGroups() const
 {
-    bool allConsistent = !std::ranges::any_of(
-      groups_,
-      [](const auto& group)
+    bool allConsistent = !std::ranges::any_of(groups_, [](const auto& group)
       {
           const auto& constraints = group->constraints();
           if (constraints.empty())
@@ -70,8 +68,7 @@ bool BindingConstraintGroupRepository::timeSeriesWidthConsistentInGroups() const
               return false;
           }
           auto width = (*constraints.begin())->RHSTimeSeries().width;
-          bool isConsistent = std::ranges::all_of(
-            constraints,
+          bool isConsistent = std::ranges::all_of(constraints,
             [&width](const std::shared_ptr<BindingConstraint>& bc)
             {
                 bool sameWidth = bc->RHSTimeSeries().width == width;
@@ -92,16 +89,15 @@ bool BindingConstraintGroupRepository::timeSeriesWidthConsistentInGroups() const
 
 void BindingConstraintGroupRepository::resizeAllTimeseriesNumbers(unsigned int nb_years)
 {
-    std::ranges::for_each(groups_,
-                          [&nb_years](auto& group) { group->timeseriesNumbers.reset(nb_years); });
+    std::ranges::for_each(groups_, [&nb_years](auto& group)
+        { group->timeseriesNumbers.reset(nb_years); });
 }
 
 BindingConstraintGroup* BindingConstraintGroupRepository::operator[](const std::string& name) const
 {
-    if (auto group = std::ranges::find_if(groups_,
-                                          [&name](auto& group_of_constraint)
-                                          { return group_of_constraint->name() == name; });
-        group != groups_.end())
+    if (auto group = std::ranges::find_if(groups_, [&name](auto& group_of_constraint)
+                { return group_of_constraint->name() == name; });
+            group != groups_.end())
     {
         return group->get();
     }

--- a/src/libs/antares/study/binding_constraint/BindingConstraintGroupRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintGroupRepository.cpp
@@ -60,7 +60,9 @@ bool BindingConstraintGroupRepository::buildFrom(const BindingConstraintsReposit
 
 bool BindingConstraintGroupRepository::timeSeriesWidthConsistentInGroups() const
 {
-    bool allConsistent = !std::ranges::any_of(groups_, [](const auto& group)
+    bool allConsistent = !std::ranges::any_of(
+      groups_,
+      [](const auto& group)
       {
           const auto& constraints = group->constraints();
           if (constraints.empty())
@@ -68,7 +70,8 @@ bool BindingConstraintGroupRepository::timeSeriesWidthConsistentInGroups() const
               return false;
           }
           auto width = (*constraints.begin())->RHSTimeSeries().width;
-          bool isConsistent = std::ranges::all_of(constraints,
+          bool isConsistent = std::ranges::all_of(
+            constraints,
             [&width](const std::shared_ptr<BindingConstraint>& bc)
             {
                 bool sameWidth = bc->RHSTimeSeries().width == width;
@@ -89,15 +92,16 @@ bool BindingConstraintGroupRepository::timeSeriesWidthConsistentInGroups() const
 
 void BindingConstraintGroupRepository::resizeAllTimeseriesNumbers(unsigned int nb_years)
 {
-    std::ranges::for_each(groups_, [&nb_years](auto& group)
-        { group->timeseriesNumbers.reset(nb_years); });
+    std::ranges::for_each(groups_,
+                          [&nb_years](auto& group) { group->timeseriesNumbers.reset(nb_years); });
 }
 
 BindingConstraintGroup* BindingConstraintGroupRepository::operator[](const std::string& name) const
 {
-    if (auto group = std::ranges::find_if(groups_, [&name](auto& group_of_constraint)
-                { return group_of_constraint->name() == name; });
-            group != groups_.end())
+    if (auto group = std::ranges::find_if(groups_,
+                                          [&name](auto& group_of_constraint)
+                                          { return group_of_constraint->name() == name; });
+        group != groups_.end())
     {
         return group->get();
     }

--- a/src/libs/antares/study/cleaner/cleaner-v20.cpp
+++ b/src/libs/antares/study/cleaner/cleaner-v20.cpp
@@ -391,7 +391,6 @@ bool listOfFilesAnDirectoriesToKeep(StudyCleaningInfos* infos)
     buffer.clear() << infos->folder << "/input/bindingconstraints/bindingconstraints.ini";
     if (ini.open(buffer))
     {
-
         ini.each(
           [&e](const IniFile::Section& section)
           {

--- a/src/libs/antares/study/cleaner/cleaner-v20.cpp
+++ b/src/libs/antares/study/cleaner/cleaner-v20.cpp
@@ -391,6 +391,7 @@ bool listOfFilesAnDirectoriesToKeep(StudyCleaningInfos* infos)
     buffer.clear() << infos->folder << "/input/bindingconstraints/bindingconstraints.ini";
     if (ini.open(buffer))
     {
+
         ini.each(
           [&e](const IniFile::Section& section)
           {

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -75,7 +75,8 @@ public:
     ** \param version Current study version
     ** \return True if the settings have been loaded, false if at least one error has occured
     */
-    bool loadFromFile(const AnyString& filename, const StudyVersion& version);
+    bool loadFromFile(const AnyString& filename,
+                      const StudyVersion& version);
 
     /*!
     ** \brief Prepare all settings for a simulation
@@ -500,7 +501,8 @@ public:
 
 private:
     //! Load data from an INI file
-    bool loadFromINI(const IniFile& ini, const StudyVersion& version);
+    bool loadFromINI(const IniFile& ini,
+                     const StudyVersion& version);
 
     void resetPlayedYears(uint nbOfYears);
 

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -75,8 +75,7 @@ public:
     ** \param version Current study version
     ** \return True if the settings have been loaded, false if at least one error has occured
     */
-    bool loadFromFile(const AnyString& filename,
-                      const StudyVersion& version);
+    bool loadFromFile(const AnyString& filename, const StudyVersion& version);
 
     /*!
     ** \brief Prepare all settings for a simulation
@@ -501,8 +500,7 @@ public:
 
 private:
     //! Load data from an INI file
-    bool loadFromINI(const IniFile& ini,
-                     const StudyVersion& version);
+    bool loadFromINI(const IniFile& ini, const StudyVersion& version);
 
     void resetPlayedYears(uint nbOfYears);
 

--- a/src/libs/antares/study/include/antares/study/parts/hydro/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/container.h
@@ -22,7 +22,6 @@
 #define __ANTARES_LIBS_STUDY_PARTS_HYDRO_CONTAINER_H__
 
 #include <optional>
-
 #include "../../fwd.h"
 #include "allocation.h"
 #include "prepro.h"
@@ -31,7 +30,7 @@
 namespace Antares::Data
 {
 
-//! The maximum number of days in a year
+    //! The maximum number of days in a year
 constexpr size_t dayYearCount = 366;
 
 struct DailyDemand
@@ -234,7 +233,9 @@ private:
 // As this function can be called a lot of times, we pass working variables and returned variables
 // as arguments, so that we don't have to create them locally (as in a classical function) each
 // time.
-double getWaterValue(const double& level, const Matrix<double>& waterValues, const uint day);
+double getWaterValue(const double& level,
+                   const Matrix<double>& waterValues,
+                   const uint day);
 
 // Interpolates a rate from the credit modulation table according to a level
 double getWeeklyModulation(const double& level /* format : in % of reservoir capacity */,

--- a/src/libs/antares/study/include/antares/study/parts/hydro/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/container.h
@@ -22,6 +22,7 @@
 #define __ANTARES_LIBS_STUDY_PARTS_HYDRO_CONTAINER_H__
 
 #include <optional>
+
 #include "../../fwd.h"
 #include "allocation.h"
 #include "prepro.h"
@@ -30,7 +31,7 @@
 namespace Antares::Data
 {
 
-    //! The maximum number of days in a year
+//! The maximum number of days in a year
 constexpr size_t dayYearCount = 366;
 
 struct DailyDemand
@@ -233,9 +234,7 @@ private:
 // As this function can be called a lot of times, we pass working variables and returned variables
 // as arguments, so that we don't have to create them locally (as in a classical function) each
 // time.
-double getWaterValue(const double& level,
-                   const Matrix<double>& waterValues,
-                   const uint day);
+double getWaterValue(const double& level, const Matrix<double>& waterValues, const uint day);
 
 // Interpolates a rate from the credit modulation table according to a level
 double getWeeklyModulation(const double& level /* format : in % of reservoir capacity */,

--- a/src/libs/antares/study/include/antares/study/scenario-builder/hydroLevelsData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/hydroLevelsData.h
@@ -21,9 +21,8 @@
 #ifndef __LIBS_STUDY_SCENARIO_BUILDER_DATA_HYDRO_LEVELS_H__
 #define __LIBS_STUDY_SCENARIO_BUILDER_DATA_HYDRO_LEVELS_H__
 
-#include <functional>
-
 #include "scBuilderDataInterface.h"
+#include <functional>
 
 namespace Antares
 {

--- a/src/libs/antares/study/include/antares/study/scenario-builder/hydroLevelsData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/hydroLevelsData.h
@@ -21,8 +21,9 @@
 #ifndef __LIBS_STUDY_SCENARIO_BUILDER_DATA_HYDRO_LEVELS_H__
 #define __LIBS_STUDY_SCENARIO_BUILDER_DATA_HYDRO_LEVELS_H__
 
-#include "scBuilderDataInterface.h"
 #include <functional>
+
+#include "scBuilderDataInterface.h"
 
 namespace Antares
 {

--- a/src/libs/antares/study/include/antares/study/sets.hxx
+++ b/src/libs/antares/study/include/antares/study/sets.hxx
@@ -288,8 +288,8 @@ bool Sets<T>::loadFromFile(const std::filesystem::path& filename)
                     continue;
                 }
 
-                logs.warning() << "sets: `" << filename << "`: Invalid property `"
-                               << p->key << '\'';
+                logs.warning() << "sets: `" << filename << "`: Invalid property `" << p->key
+                               << '\'';
             }
 
             // Add the new group

--- a/src/libs/antares/study/include/antares/study/sets.hxx
+++ b/src/libs/antares/study/include/antares/study/sets.hxx
@@ -288,8 +288,8 @@ bool Sets<T>::loadFromFile(const std::filesystem::path& filename)
                     continue;
                 }
 
-                logs.warning() << "sets: `" << filename << "`: Invalid property `" << p->key
-                               << '\'';
+                logs.warning() << "sets: `" << filename << "`: Invalid property `"
+                               << p->key << '\'';
             }
 
             // Add the new group

--- a/src/libs/antares/study/include/antares/study/sets.hxx
+++ b/src/libs/antares/study/include/antares/study/sets.hxx
@@ -176,8 +176,8 @@ bool Sets<T>::saveToFile(const StringT& filename) const
     using namespace Yuni;
     using namespace Antares;
 
-    IO::File::Stream file;
-    if (!file.open(filename, IO::OpenMode::write | IO::OpenMode::truncate))
+    Yuni::IO::File::Stream file;
+    if (!file.open(filename, Yuni::IO::OpenMode::write | Yuni::IO::OpenMode::truncate))
     {
         logs.error() << "I/O Error: " << filename << ": impossible to write the file";
         return false;

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1111,16 +1111,10 @@ static bool SGDIntLoadFamily_Legacy(Parameters& d,
 
     if (key == "initial-reservoir-levels") // ignored since 9.2
     {
-        if (version >= StudyVersion(9, 2))
-        {
-            logs.warning()
-              << "Option initial-reservoir-levels is deprecated, please remove it from the study";
-        }
+        if (version >= StudyVersion(9,2))
+            logs.warning() << "Option initial-reservoir-levels is deprecated, please remove it from the study";
         else if (value == "hot start")
-        {
-            logs.warning()
-              << "Hydro hot start not supported with this solver, please use a version < 9.2";
-        }
+            logs.warning() << "Hydro hot start not supported with this solver, please use a version < 9.2";
         return true;
     }
 
@@ -1133,7 +1127,8 @@ bool firstKeyLetterIsValid(const String& name)
     return (firstLetter >= 'a' && firstLetter <= 'z');
 }
 
-bool Parameters::loadFromINI(const IniFile& ini, const StudyVersion& version)
+bool Parameters::loadFromINI(const IniFile& ini,
+                             const StudyVersion& version)
 {
     // Reset inner data
     reset();
@@ -1299,9 +1294,7 @@ void Parameters::fixBadValues()
     }
 
     if (simulationDays.first == 0)
-    {
         simulationDays.first = 1;
-    }
     else
     {
         simulationDays.first = std::clamp(simulationDays.first, 1u, 365u);
@@ -1965,7 +1958,8 @@ void Parameters::saveToINI(IniFile& ini) const
     }
 }
 
-bool Parameters::loadFromFile(const AnyString& filename, const StudyVersion& version)
+bool Parameters::loadFromFile(const AnyString& filename,
+                              const StudyVersion& version)
 {
     // Loading the INI file
     IniFile ini;

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1111,10 +1111,16 @@ static bool SGDIntLoadFamily_Legacy(Parameters& d,
 
     if (key == "initial-reservoir-levels") // ignored since 9.2
     {
-        if (version >= StudyVersion(9,2))
-            logs.warning() << "Option initial-reservoir-levels is deprecated, please remove it from the study";
+        if (version >= StudyVersion(9, 2))
+        {
+            logs.warning()
+              << "Option initial-reservoir-levels is deprecated, please remove it from the study";
+        }
         else if (value == "hot start")
-            logs.warning() << "Hydro hot start not supported with this solver, please use a version < 9.2";
+        {
+            logs.warning()
+              << "Hydro hot start not supported with this solver, please use a version < 9.2";
+        }
         return true;
     }
 
@@ -1127,8 +1133,7 @@ bool firstKeyLetterIsValid(const String& name)
     return (firstLetter >= 'a' && firstLetter <= 'z');
 }
 
-bool Parameters::loadFromINI(const IniFile& ini,
-                             const StudyVersion& version)
+bool Parameters::loadFromINI(const IniFile& ini, const StudyVersion& version)
 {
     // Reset inner data
     reset();
@@ -1294,7 +1299,9 @@ void Parameters::fixBadValues()
     }
 
     if (simulationDays.first == 0)
+    {
         simulationDays.first = 1;
+    }
     else
     {
         simulationDays.first = std::clamp(simulationDays.first, 1u, 365u);
@@ -1958,8 +1965,7 @@ void Parameters::saveToINI(IniFile& ini) const
     }
 }
 
-bool Parameters::loadFromFile(const AnyString& filename,
-                              const StudyVersion& version)
+bool Parameters::loadFromFile(const AnyString& filename, const StudyVersion& version)
 {
     // Loading the INI file
     IniFile ini;

--- a/src/libs/antares/study/parts/common/cluster_list.cpp
+++ b/src/libs/antares/study/parts/common/cluster_list.cpp
@@ -263,8 +263,9 @@ bool ClusterList<ClusterT>::saveDataSeriesToFolder(const AnyString& folder) cons
 template<class ClusterT>
 bool ClusterList<ClusterT>::loadDataSeriesFromFolder(Study& s, const AnyString& folder)
 {
-    return std::ranges::all_of(allClusters_, [&s, &folder](auto c)
-        { return c->loadDataSeriesFromFolder(s, folder); });
+    return std::ranges::all_of(allClusters_,
+                               [&s, &folder](auto c)
+                               { return c->loadDataSeriesFromFolder(s, folder); });
 }
 
 template<class ClusterT>

--- a/src/libs/antares/study/parts/common/cluster_list.cpp
+++ b/src/libs/antares/study/parts/common/cluster_list.cpp
@@ -263,9 +263,8 @@ bool ClusterList<ClusterT>::saveDataSeriesToFolder(const AnyString& folder) cons
 template<class ClusterT>
 bool ClusterList<ClusterT>::loadDataSeriesFromFolder(Study& s, const AnyString& folder)
 {
-    return std::ranges::all_of(allClusters_,
-                               [&s, &folder](auto c)
-                               { return c->loadDataSeriesFromFolder(s, folder); });
+    return std::ranges::all_of(allClusters_, [&s, &folder](auto c)
+        { return c->loadDataSeriesFromFolder(s, folder); });
 }
 
 template<class ClusterT>

--- a/src/libs/antares/study/parts/hydro/allocation.cpp
+++ b/src/libs/antares/study/parts/hydro/allocation.cpp
@@ -164,8 +164,7 @@ void HydroAllocation::clear()
 #endif
 }
 
-bool HydroAllocation::loadFromFile(const AreaName& referencearea,
-                                   const fs::path& filename)
+bool HydroAllocation::loadFromFile(const AreaName& referencearea, const fs::path& filename)
 {
     clear();
 
@@ -177,21 +176,24 @@ bool HydroAllocation::loadFromFile(const AreaName& referencearea,
     }
 
     if (ini.empty())
-        return true;
-
-    ini.each([this](const IniFile::Section& section)
     {
-        for (auto* p = section.firstProperty; p; p = p->next)
-        {
-            double coeff = p->value.to<double>();
-            if (!Utils::isZero(coeff))
-            {
-                AreaName areaname = p->key;
-                areaname.toLower();
-                pValues[areaname] = coeff;
-            }
-        }
-    });
+        return true;
+    }
+
+    ini.each(
+      [this](const IniFile::Section& section)
+      {
+          for (auto* p = section.firstProperty; p; p = p->next)
+          {
+              double coeff = p->value.to<double>();
+              if (!Utils::isZero(coeff))
+              {
+                  AreaName areaname = p->key;
+                  areaname.toLower();
+                  pValues[areaname] = coeff;
+              }
+          }
+      });
     return true;
 }
 

--- a/src/libs/antares/study/parts/hydro/allocation.cpp
+++ b/src/libs/antares/study/parts/hydro/allocation.cpp
@@ -164,7 +164,8 @@ void HydroAllocation::clear()
 #endif
 }
 
-bool HydroAllocation::loadFromFile(const AreaName& referencearea, const fs::path& filename)
+bool HydroAllocation::loadFromFile(const AreaName& referencearea,
+                                   const fs::path& filename)
 {
     clear();
 
@@ -176,24 +177,21 @@ bool HydroAllocation::loadFromFile(const AreaName& referencearea, const fs::path
     }
 
     if (ini.empty())
-    {
         return true;
-    }
 
-    ini.each(
-      [this](const IniFile::Section& section)
-      {
-          for (auto* p = section.firstProperty; p; p = p->next)
-          {
-              double coeff = p->value.to<double>();
-              if (!Utils::isZero(coeff))
-              {
-                  AreaName areaname = p->key;
-                  areaname.toLower();
-                  pValues[areaname] = coeff;
-              }
-          }
-      });
+    ini.each([this](const IniFile::Section& section)
+    {
+        for (auto* p = section.firstProperty; p; p = p->next)
+        {
+            double coeff = p->value.to<double>();
+            if (!Utils::isZero(coeff))
+            {
+                AreaName areaname = p->key;
+                areaname.toLower();
+                pValues[areaname] = coeff;
+            }
+        }
+    });
     return true;
 }
 

--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -32,7 +32,7 @@ using namespace Yuni;
 
 namespace Antares::Data
 {
-PartHydro::PartHydro() :
+PartHydro::PartHydro():
     interDailyBreakdown(0.),
     intraDailyModulation(2.),
     intermonthlyBreakdown(0),
@@ -113,7 +113,9 @@ static bool loadProperties(Study& study,
                            T PartHydro::*ptr)
 {
     if (!property)
+    {
         return false;
+    }
 
     bool ret = true;
 
@@ -242,52 +244,74 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
 
     if (IniFile::Section* section = ini.find("inter-daily-breakdown"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::interDailyBreakdown) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::interDailyBreakdown)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("intra-daily-modulation"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::intraDailyModulation) && ret;
+        ret = loadProperties(study,
+                             section->firstProperty,
+                             buffer,
+                             &PartHydro::intraDailyModulation)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("reservoir"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::reservoirManagement) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::reservoirManagement)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("reservoir capacity"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::reservoirCapacity) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::reservoirCapacity)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("follow load"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::followLoadModulations) && ret;
+        ret = loadProperties(study,
+                             section->firstProperty,
+                             buffer,
+                             &PartHydro::followLoadModulations)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("use water"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::useWaterValue) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::useWaterValue)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("hard bounds"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::hardBoundsOnRuleCurves) && ret;
+        ret = loadProperties(study,
+                             section->firstProperty,
+                             buffer,
+                             &PartHydro::hardBoundsOnRuleCurves)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("use heuristic"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::useHeuristicTarget) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::useHeuristicTarget)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("power to level"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::powerToLevel) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::powerToLevel)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("initialize reservoir date"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::initializeReservoirLevelDate) && ret;
+        ret = loadProperties(study,
+                             section->firstProperty,
+                             buffer,
+                             &PartHydro::initializeReservoirLevelDate)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("use leeway"))
@@ -297,17 +321,20 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
 
     if (IniFile::Section* section = ini.find("leeway low"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::leewayLowerBound) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::leewayLowerBound)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("leeway up"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::leewayUpperBound) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::leewayUpperBound)
+              && ret;
     }
 
     if (IniFile::Section* section = ini.find("pumping efficiency"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::pumpingEfficiency) && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::pumpingEfficiency)
+              && ret;
     }
 
     return ret;
@@ -317,10 +344,12 @@ bool PartHydro::checkReservoirLevels(const Study& study)
 {
     bool ret = true;
 
-    for (const auto& [areaName, area] : study.areas)
+    for (const auto& [areaName, area]: study.areas)
     {
         if (!study.usedByTheSolver)
+        {
             return true;
+        }
 
         auto& col = area->hydro.inflowPattern[0];
         bool errorInflow = false;
@@ -340,8 +369,8 @@ bool PartHydro::checkReservoirLevels(const Study& study)
         for (unsigned int day = 0; day < DAYS_PER_YEAR; day++)
         {
             if (!errorLevels
-                    && (colMin[day] < 0 || colAvg[day] < 0 || colMin[day] > colMax[day]
-                        || colAvg[day] > 100 || colMax[day] > 100))
+                && (colMin[day] < 0 || colAvg[day] < 0 || colMin[day] > colMax[day]
+                    || colAvg[day] > 100 || colMax[day] > 100))
             {
                 logs.error() << areaName << ": invalid reservoir level value";
                 errorLevels = true;
@@ -352,7 +381,7 @@ bool PartHydro::checkReservoirLevels(const Study& study)
         for (int i = 0; i < 101; i++)
         {
             if ((area->hydro.creditModulation[i][0] < 0)
-                    || (area->hydro.creditModulation[i][1] < 0))
+                || (area->hydro.creditModulation[i][1] < 0))
             {
                 logs.error() << areaName << ": invalid credit modulation value";
                 ret = false;
@@ -372,75 +401,73 @@ bool PartHydro::checkProperties(Study& study)
     // the study, because they are too small (< 1e-6). We cannot have reservoir management = yes and
     // capacity = 0 because of further division by capacity. reservoir management = no and capacity
     // = 0 is possible (no use of capacity further)
-    study.areas.each([&ret](Data::Area& area)
-    {
-        if (area.hydro.reservoirCapacity < 1e-3 && area.hydro.reservoirManagement)
-        {
-            logs.error() << area.name
-                         << ": reservoir capacity not defined. Impossible to manage.";
-            ret = false;
-        }
+    study.areas.each(
+      [&ret](Data::Area& area)
+      {
+          if (area.hydro.reservoirCapacity < 1e-3 && area.hydro.reservoirManagement)
+          {
+              logs.error() << area.name
+                           << ": reservoir capacity not defined. Impossible to manage.";
+              ret = false;
+          }
 
-        if (!area.hydro.useHeuristicTarget && !area.hydro.useWaterValue)
-        {
-            logs.error() << area.name
-                         << " : use water value = no conflicts with use heuristic target = no";
-            ret = false;
-        }
+          if (!area.hydro.useHeuristicTarget && !area.hydro.useWaterValue)
+          {
+              logs.error() << area.name
+                           << " : use water value = no conflicts with use heuristic target = no";
+              ret = false;
+          }
 
-        if (area.hydro.intraDailyModulation < 1.)
-        {
-            logs.error()
-              << area.id << ": Invalid intra-daily modulation. It must be >= 1.0, Got "
-              << area.hydro.intraDailyModulation << " (truncated to 1)";
-            area.hydro.intraDailyModulation = 1.;
-        }
+          if (area.hydro.intraDailyModulation < 1.)
+          {
+              logs.error() << area.id << ": Invalid intra-daily modulation. It must be >= 1.0, Got "
+                           << area.hydro.intraDailyModulation << " (truncated to 1)";
+              area.hydro.intraDailyModulation = 1.;
+          }
 
-        if (area.hydro.reservoirCapacity < 0)
-        {
-            logs.error() << area.id << ": Invalid reservoir capacity.";
-            area.hydro.reservoirCapacity = 0.;
-        }
+          if (area.hydro.reservoirCapacity < 0)
+          {
+              logs.error() << area.id << ": Invalid reservoir capacity.";
+              area.hydro.reservoirCapacity = 0.;
+          }
 
-        if (area.hydro.intermonthlyBreakdown < 0)
-        {
-            logs.error() << area.id << ": Invalid intermonthly breakdown";
-            area.hydro.intermonthlyBreakdown = 0.;
-        }
+          if (area.hydro.intermonthlyBreakdown < 0)
+          {
+              logs.error() << area.id << ": Invalid intermonthly breakdown";
+              area.hydro.intermonthlyBreakdown = 0.;
+          }
 
-        if (area.hydro.initializeReservoirLevelDate < 0)
-        {
-            logs.error() << area.id << ": Invalid initialize reservoir date";
-            area.hydro.initializeReservoirLevelDate = 0;
-        }
+          if (area.hydro.initializeReservoirLevelDate < 0)
+          {
+              logs.error() << area.id << ": Invalid initialize reservoir date";
+              area.hydro.initializeReservoirLevelDate = 0;
+          }
 
-        if (area.hydro.leewayLowerBound < 0.)
-        {
-            logs.error()
-              << area.id << ": Invalid leeway lower bound. It must be >= 0.0, Got "
-              << area.hydro.leewayLowerBound;
-            area.hydro.leewayLowerBound = 0.;
-        }
+          if (area.hydro.leewayLowerBound < 0.)
+          {
+              logs.error() << area.id << ": Invalid leeway lower bound. It must be >= 0.0, Got "
+                           << area.hydro.leewayLowerBound;
+              area.hydro.leewayLowerBound = 0.;
+          }
 
-        if (area.hydro.leewayUpperBound < 0.)
-        {
-            logs.error()
-              << area.id << ": Invalid leeway upper bound. It must be >= 0.0, Got "
-              << area.hydro.leewayUpperBound;
-            area.hydro.leewayUpperBound = 0.;
-        }
+          if (area.hydro.leewayUpperBound < 0.)
+          {
+              logs.error() << area.id << ": Invalid leeway upper bound. It must be >= 0.0, Got "
+                           << area.hydro.leewayUpperBound;
+              area.hydro.leewayUpperBound = 0.;
+          }
 
-        if (area.hydro.leewayLowerBound > area.hydro.leewayUpperBound)
-        {
+          if (area.hydro.leewayLowerBound > area.hydro.leewayUpperBound)
+          {
               logs.error() << area.id << ": Leeway lower bound greater than leeway upper bound.";
-        }
+          }
 
-        if (area.hydro.pumpingEfficiency < 0)
-        {
-            logs.error() << area.id << ": Invalid pumping efficiency";
-            area.hydro.pumpingEfficiency = 0.;
-        }
-    });
+          if (area.hydro.pumpingEfficiency < 0)
+          {
+              logs.error() << area.id << ": Invalid pumping efficiency";
+              area.hydro.pumpingEfficiency = 0.;
+          }
+      });
 
     return ret;
 }
@@ -465,40 +492,40 @@ bool PartHydro::SaveToFolder(const AreaList& areas, const AnyString& folder)
 
     struct AllSections
     {
-	IniFile::Section* s;
-	IniFile::Section* smod;
-	IniFile::Section* sIMB;
-	IniFile::Section* sreservoir;
-	IniFile::Section* sreservoirCapacity;
-	IniFile::Section* sFollowLoad;
-	IniFile::Section* sUseWater;
-	IniFile::Section* sHardBounds;
-	IniFile::Section* sInitializeReservoirDate;
-	IniFile::Section* sUseHeuristic;
-	IniFile::Section* sUseLeeway;
-	IniFile::Section* sPowerToLevel;
-	IniFile::Section* sLeewayLow;
-	IniFile::Section* sLeewayUp;
-	IniFile::Section* spumpingEfficiency;
+        IniFile::Section* s;
+        IniFile::Section* smod;
+        IniFile::Section* sIMB;
+        IniFile::Section* sreservoir;
+        IniFile::Section* sreservoirCapacity;
+        IniFile::Section* sFollowLoad;
+        IniFile::Section* sUseWater;
+        IniFile::Section* sHardBounds;
+        IniFile::Section* sInitializeReservoirDate;
+        IniFile::Section* sUseHeuristic;
+        IniFile::Section* sUseLeeway;
+        IniFile::Section* sPowerToLevel;
+        IniFile::Section* sLeewayLow;
+        IniFile::Section* sLeewayUp;
+        IniFile::Section* spumpingEfficiency;
 
-      AllSections(IniFile& ini) :
-	s(ini.addSection("inter-daily-breakdown")),
-	smod(ini.addSection("intra-daily-modulation")),
-	sIMB(ini.addSection("inter-monthly-breakdown")),
-	sreservoir(ini.addSection("reservoir")),
-	sreservoirCapacity(ini.addSection("reservoir capacity")),
-	sFollowLoad(ini.addSection("follow load")),
-	sUseWater(ini.addSection("use water")),
-	sHardBounds(ini.addSection("hard bounds")),
-	sInitializeReservoirDate(ini.addSection("initialize reservoir date")),
-	sUseHeuristic(ini.addSection("use heuristic")),
-	sUseLeeway(ini.addSection("use leeway")),
-	sPowerToLevel(ini.addSection("power to level")),
-	sLeewayLow(ini.addSection("leeway low")),
-	sLeewayUp(ini.addSection("leeway up")),
-	spumpingEfficiency(ini.addSection("pumping efficiency"))
+        AllSections(IniFile& ini):
+            s(ini.addSection("inter-daily-breakdown")),
+            smod(ini.addSection("intra-daily-modulation")),
+            sIMB(ini.addSection("inter-monthly-breakdown")),
+            sreservoir(ini.addSection("reservoir")),
+            sreservoirCapacity(ini.addSection("reservoir capacity")),
+            sFollowLoad(ini.addSection("follow load")),
+            sUseWater(ini.addSection("use water")),
+            sHardBounds(ini.addSection("hard bounds")),
+            sInitializeReservoirDate(ini.addSection("initialize reservoir date")),
+            sUseHeuristic(ini.addSection("use heuristic")),
+            sUseLeeway(ini.addSection("use leeway")),
+            sPowerToLevel(ini.addSection("power to level")),
+            sLeewayLow(ini.addSection("leeway low")),
+            sLeewayUp(ini.addSection("leeway up")),
+            spumpingEfficiency(ini.addSection("pumping efficiency"))
         {
-	}
+        }
     };
 
     // Init
@@ -515,7 +542,8 @@ bool PartHydro::SaveToFolder(const AreaList& areas, const AnyString& folder)
           allSections.s->add(area.id, area.hydro.interDailyBreakdown);
           allSections.smod->add(area.id, area.hydro.intraDailyModulation);
           allSections.sIMB->add(area.id, area.hydro.intermonthlyBreakdown);
-          allSections.sInitializeReservoirDate->add(area.id, area.hydro.initializeReservoirLevelDate);
+          allSections.sInitializeReservoirDate->add(area.id,
+                                                    area.hydro.initializeReservoirLevelDate);
           allSections.sLeewayLow->add(area.id, area.hydro.leewayLowerBound);
           allSections.sLeewayUp->add(area.id, area.hydro.leewayUpperBound);
           allSections.spumpingEfficiency->add(area.id, area.hydro.pumpingEfficiency);
@@ -740,8 +768,8 @@ bool PartHydro::CheckDailyMaxEnergy(const AnyString& areaName)
 }
 
 double getWaterValue(const double& level /* format : in % of reservoir capacity */,
-                   const Matrix<double>& waterValues,
-                   const uint day)
+                     const Matrix<double>& waterValues,
+                     const uint day)
 {
     assert((level >= 0. && level <= 100.) && "getWaterValue function : invalid level");
     double levelUp = ceil(level);
@@ -752,7 +780,7 @@ double getWaterValue(const double& level /* format : in % of reservoir capacity 
         return waterValues[(int)(levelUp)][day];
     }
     return waterValues[(int)(levelUp)][day] * (level - levelDown)
-            + waterValues[(int)(levelDown)][day] * (levelUp - level);
+           + waterValues[(int)(levelDown)][day] * (levelUp - level);
 }
 
 double getWeeklyModulation(const double& level /* format : in % of reservoir capacity */,

--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -32,7 +32,7 @@ using namespace Yuni;
 
 namespace Antares::Data
 {
-PartHydro::PartHydro():
+PartHydro::PartHydro() :
     interDailyBreakdown(0.),
     intraDailyModulation(2.),
     intermonthlyBreakdown(0),
@@ -113,9 +113,7 @@ static bool loadProperties(Study& study,
                            T PartHydro::*ptr)
 {
     if (!property)
-    {
         return false;
-    }
 
     bool ret = true;
 
@@ -244,74 +242,52 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
 
     if (IniFile::Section* section = ini.find("inter-daily-breakdown"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::interDailyBreakdown)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::interDailyBreakdown) && ret;
     }
 
     if (IniFile::Section* section = ini.find("intra-daily-modulation"))
     {
-        ret = loadProperties(study,
-                             section->firstProperty,
-                             buffer,
-                             &PartHydro::intraDailyModulation)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::intraDailyModulation) && ret;
     }
 
     if (IniFile::Section* section = ini.find("reservoir"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::reservoirManagement)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::reservoirManagement) && ret;
     }
 
     if (IniFile::Section* section = ini.find("reservoir capacity"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::reservoirCapacity)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::reservoirCapacity) && ret;
     }
 
     if (IniFile::Section* section = ini.find("follow load"))
     {
-        ret = loadProperties(study,
-                             section->firstProperty,
-                             buffer,
-                             &PartHydro::followLoadModulations)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::followLoadModulations) && ret;
     }
 
     if (IniFile::Section* section = ini.find("use water"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::useWaterValue)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::useWaterValue) && ret;
     }
 
     if (IniFile::Section* section = ini.find("hard bounds"))
     {
-        ret = loadProperties(study,
-                             section->firstProperty,
-                             buffer,
-                             &PartHydro::hardBoundsOnRuleCurves)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::hardBoundsOnRuleCurves) && ret;
     }
 
     if (IniFile::Section* section = ini.find("use heuristic"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::useHeuristicTarget)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::useHeuristicTarget) && ret;
     }
 
     if (IniFile::Section* section = ini.find("power to level"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::powerToLevel)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::powerToLevel) && ret;
     }
 
     if (IniFile::Section* section = ini.find("initialize reservoir date"))
     {
-        ret = loadProperties(study,
-                             section->firstProperty,
-                             buffer,
-                             &PartHydro::initializeReservoirLevelDate)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::initializeReservoirLevelDate) && ret;
     }
 
     if (IniFile::Section* section = ini.find("use leeway"))
@@ -321,20 +297,17 @@ bool PartHydro::LoadFromFolder(Study& study, const AnyString& folder)
 
     if (IniFile::Section* section = ini.find("leeway low"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::leewayLowerBound)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::leewayLowerBound) && ret;
     }
 
     if (IniFile::Section* section = ini.find("leeway up"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::leewayUpperBound)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::leewayUpperBound) && ret;
     }
 
     if (IniFile::Section* section = ini.find("pumping efficiency"))
     {
-        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::pumpingEfficiency)
-              && ret;
+        ret = loadProperties(study, section->firstProperty, buffer, &PartHydro::pumpingEfficiency) && ret;
     }
 
     return ret;
@@ -344,12 +317,10 @@ bool PartHydro::checkReservoirLevels(const Study& study)
 {
     bool ret = true;
 
-    for (const auto& [areaName, area]: study.areas)
+    for (const auto& [areaName, area] : study.areas)
     {
         if (!study.usedByTheSolver)
-        {
             return true;
-        }
 
         auto& col = area->hydro.inflowPattern[0];
         bool errorInflow = false;
@@ -369,8 +340,8 @@ bool PartHydro::checkReservoirLevels(const Study& study)
         for (unsigned int day = 0; day < DAYS_PER_YEAR; day++)
         {
             if (!errorLevels
-                && (colMin[day] < 0 || colAvg[day] < 0 || colMin[day] > colMax[day]
-                    || colAvg[day] > 100 || colMax[day] > 100))
+                    && (colMin[day] < 0 || colAvg[day] < 0 || colMin[day] > colMax[day]
+                        || colAvg[day] > 100 || colMax[day] > 100))
             {
                 logs.error() << areaName << ": invalid reservoir level value";
                 errorLevels = true;
@@ -381,7 +352,7 @@ bool PartHydro::checkReservoirLevels(const Study& study)
         for (int i = 0; i < 101; i++)
         {
             if ((area->hydro.creditModulation[i][0] < 0)
-                || (area->hydro.creditModulation[i][1] < 0))
+                    || (area->hydro.creditModulation[i][1] < 0))
             {
                 logs.error() << areaName << ": invalid credit modulation value";
                 ret = false;
@@ -401,73 +372,75 @@ bool PartHydro::checkProperties(Study& study)
     // the study, because they are too small (< 1e-6). We cannot have reservoir management = yes and
     // capacity = 0 because of further division by capacity. reservoir management = no and capacity
     // = 0 is possible (no use of capacity further)
-    study.areas.each(
-      [&ret](Data::Area& area)
-      {
-          if (area.hydro.reservoirCapacity < 1e-3 && area.hydro.reservoirManagement)
-          {
-              logs.error() << area.name
-                           << ": reservoir capacity not defined. Impossible to manage.";
-              ret = false;
-          }
+    study.areas.each([&ret](Data::Area& area)
+    {
+        if (area.hydro.reservoirCapacity < 1e-3 && area.hydro.reservoirManagement)
+        {
+            logs.error() << area.name
+                         << ": reservoir capacity not defined. Impossible to manage.";
+            ret = false;
+        }
 
-          if (!area.hydro.useHeuristicTarget && !area.hydro.useWaterValue)
-          {
-              logs.error() << area.name
-                           << " : use water value = no conflicts with use heuristic target = no";
-              ret = false;
-          }
+        if (!area.hydro.useHeuristicTarget && !area.hydro.useWaterValue)
+        {
+            logs.error() << area.name
+                         << " : use water value = no conflicts with use heuristic target = no";
+            ret = false;
+        }
 
-          if (area.hydro.intraDailyModulation < 1.)
-          {
-              logs.error() << area.id << ": Invalid intra-daily modulation. It must be >= 1.0, Got "
-                           << area.hydro.intraDailyModulation << " (truncated to 1)";
-              area.hydro.intraDailyModulation = 1.;
-          }
+        if (area.hydro.intraDailyModulation < 1.)
+        {
+            logs.error()
+              << area.id << ": Invalid intra-daily modulation. It must be >= 1.0, Got "
+              << area.hydro.intraDailyModulation << " (truncated to 1)";
+            area.hydro.intraDailyModulation = 1.;
+        }
 
-          if (area.hydro.reservoirCapacity < 0)
-          {
-              logs.error() << area.id << ": Invalid reservoir capacity.";
-              area.hydro.reservoirCapacity = 0.;
-          }
+        if (area.hydro.reservoirCapacity < 0)
+        {
+            logs.error() << area.id << ": Invalid reservoir capacity.";
+            area.hydro.reservoirCapacity = 0.;
+        }
 
-          if (area.hydro.intermonthlyBreakdown < 0)
-          {
-              logs.error() << area.id << ": Invalid intermonthly breakdown";
-              area.hydro.intermonthlyBreakdown = 0.;
-          }
+        if (area.hydro.intermonthlyBreakdown < 0)
+        {
+            logs.error() << area.id << ": Invalid intermonthly breakdown";
+            area.hydro.intermonthlyBreakdown = 0.;
+        }
 
-          if (area.hydro.initializeReservoirLevelDate < 0)
-          {
-              logs.error() << area.id << ": Invalid initialize reservoir date";
-              area.hydro.initializeReservoirLevelDate = 0;
-          }
+        if (area.hydro.initializeReservoirLevelDate < 0)
+        {
+            logs.error() << area.id << ": Invalid initialize reservoir date";
+            area.hydro.initializeReservoirLevelDate = 0;
+        }
 
-          if (area.hydro.leewayLowerBound < 0.)
-          {
-              logs.error() << area.id << ": Invalid leeway lower bound. It must be >= 0.0, Got "
-                           << area.hydro.leewayLowerBound;
-              area.hydro.leewayLowerBound = 0.;
-          }
+        if (area.hydro.leewayLowerBound < 0.)
+        {
+            logs.error()
+              << area.id << ": Invalid leeway lower bound. It must be >= 0.0, Got "
+              << area.hydro.leewayLowerBound;
+            area.hydro.leewayLowerBound = 0.;
+        }
 
-          if (area.hydro.leewayUpperBound < 0.)
-          {
-              logs.error() << area.id << ": Invalid leeway upper bound. It must be >= 0.0, Got "
-                           << area.hydro.leewayUpperBound;
-              area.hydro.leewayUpperBound = 0.;
-          }
+        if (area.hydro.leewayUpperBound < 0.)
+        {
+            logs.error()
+              << area.id << ": Invalid leeway upper bound. It must be >= 0.0, Got "
+              << area.hydro.leewayUpperBound;
+            area.hydro.leewayUpperBound = 0.;
+        }
 
-          if (area.hydro.leewayLowerBound > area.hydro.leewayUpperBound)
-          {
+        if (area.hydro.leewayLowerBound > area.hydro.leewayUpperBound)
+        {
               logs.error() << area.id << ": Leeway lower bound greater than leeway upper bound.";
-          }
+        }
 
-          if (area.hydro.pumpingEfficiency < 0)
-          {
-              logs.error() << area.id << ": Invalid pumping efficiency";
-              area.hydro.pumpingEfficiency = 0.;
-          }
-      });
+        if (area.hydro.pumpingEfficiency < 0)
+        {
+            logs.error() << area.id << ": Invalid pumping efficiency";
+            area.hydro.pumpingEfficiency = 0.;
+        }
+    });
 
     return ret;
 }
@@ -492,40 +465,40 @@ bool PartHydro::SaveToFolder(const AreaList& areas, const AnyString& folder)
 
     struct AllSections
     {
-        IniFile::Section* s;
-        IniFile::Section* smod;
-        IniFile::Section* sIMB;
-        IniFile::Section* sreservoir;
-        IniFile::Section* sreservoirCapacity;
-        IniFile::Section* sFollowLoad;
-        IniFile::Section* sUseWater;
-        IniFile::Section* sHardBounds;
-        IniFile::Section* sInitializeReservoirDate;
-        IniFile::Section* sUseHeuristic;
-        IniFile::Section* sUseLeeway;
-        IniFile::Section* sPowerToLevel;
-        IniFile::Section* sLeewayLow;
-        IniFile::Section* sLeewayUp;
-        IniFile::Section* spumpingEfficiency;
+	IniFile::Section* s;
+	IniFile::Section* smod;
+	IniFile::Section* sIMB;
+	IniFile::Section* sreservoir;
+	IniFile::Section* sreservoirCapacity;
+	IniFile::Section* sFollowLoad;
+	IniFile::Section* sUseWater;
+	IniFile::Section* sHardBounds;
+	IniFile::Section* sInitializeReservoirDate;
+	IniFile::Section* sUseHeuristic;
+	IniFile::Section* sUseLeeway;
+	IniFile::Section* sPowerToLevel;
+	IniFile::Section* sLeewayLow;
+	IniFile::Section* sLeewayUp;
+	IniFile::Section* spumpingEfficiency;
 
-        AllSections(IniFile& ini):
-            s(ini.addSection("inter-daily-breakdown")),
-            smod(ini.addSection("intra-daily-modulation")),
-            sIMB(ini.addSection("inter-monthly-breakdown")),
-            sreservoir(ini.addSection("reservoir")),
-            sreservoirCapacity(ini.addSection("reservoir capacity")),
-            sFollowLoad(ini.addSection("follow load")),
-            sUseWater(ini.addSection("use water")),
-            sHardBounds(ini.addSection("hard bounds")),
-            sInitializeReservoirDate(ini.addSection("initialize reservoir date")),
-            sUseHeuristic(ini.addSection("use heuristic")),
-            sUseLeeway(ini.addSection("use leeway")),
-            sPowerToLevel(ini.addSection("power to level")),
-            sLeewayLow(ini.addSection("leeway low")),
-            sLeewayUp(ini.addSection("leeway up")),
-            spumpingEfficiency(ini.addSection("pumping efficiency"))
+      AllSections(IniFile& ini) :
+	s(ini.addSection("inter-daily-breakdown")),
+	smod(ini.addSection("intra-daily-modulation")),
+	sIMB(ini.addSection("inter-monthly-breakdown")),
+	sreservoir(ini.addSection("reservoir")),
+	sreservoirCapacity(ini.addSection("reservoir capacity")),
+	sFollowLoad(ini.addSection("follow load")),
+	sUseWater(ini.addSection("use water")),
+	sHardBounds(ini.addSection("hard bounds")),
+	sInitializeReservoirDate(ini.addSection("initialize reservoir date")),
+	sUseHeuristic(ini.addSection("use heuristic")),
+	sUseLeeway(ini.addSection("use leeway")),
+	sPowerToLevel(ini.addSection("power to level")),
+	sLeewayLow(ini.addSection("leeway low")),
+	sLeewayUp(ini.addSection("leeway up")),
+	spumpingEfficiency(ini.addSection("pumping efficiency"))
         {
-        }
+	}
     };
 
     // Init
@@ -542,8 +515,7 @@ bool PartHydro::SaveToFolder(const AreaList& areas, const AnyString& folder)
           allSections.s->add(area.id, area.hydro.interDailyBreakdown);
           allSections.smod->add(area.id, area.hydro.intraDailyModulation);
           allSections.sIMB->add(area.id, area.hydro.intermonthlyBreakdown);
-          allSections.sInitializeReservoirDate->add(area.id,
-                                                    area.hydro.initializeReservoirLevelDate);
+          allSections.sInitializeReservoirDate->add(area.id, area.hydro.initializeReservoirLevelDate);
           allSections.sLeewayLow->add(area.id, area.hydro.leewayLowerBound);
           allSections.sLeewayUp->add(area.id, area.hydro.leewayUpperBound);
           allSections.spumpingEfficiency->add(area.id, area.hydro.pumpingEfficiency);
@@ -768,8 +740,8 @@ bool PartHydro::CheckDailyMaxEnergy(const AnyString& areaName)
 }
 
 double getWaterValue(const double& level /* format : in % of reservoir capacity */,
-                     const Matrix<double>& waterValues,
-                     const uint day)
+                   const Matrix<double>& waterValues,
+                   const uint day)
 {
     assert((level >= 0. && level <= 100.) && "getWaterValue function : invalid level");
     double levelUp = ceil(level);
@@ -780,7 +752,7 @@ double getWaterValue(const double& level /* format : in % of reservoir capacity 
         return waterValues[(int)(levelUp)][day];
     }
     return waterValues[(int)(levelUp)][day] * (level - levelDown)
-           + waterValues[(int)(levelDown)][day] * (levelUp - level);
+            + waterValues[(int)(levelDown)][day] * (levelUp - level);
 }
 
 double getWeeklyModulation(const double& level /* format : in % of reservoir capacity */,

--- a/src/libs/antares/study/parts/hydro/finalLevelValidator.cpp
+++ b/src/libs/antares/study/parts/hydro/finalLevelValidator.cpp
@@ -37,7 +37,7 @@ FinalLevelValidator::FinalLevelValidator(PartHydro& hydro,
                                          double finalLevel,
                                          const unsigned int year,
                                          const unsigned int lastSimulationDay,
-                                         const unsigned int firstMonthOfSimulation) :
+                                         const unsigned int firstMonthOfSimulation):
     year_(year),
     lastSimulationDay_(lastSimulationDay),
     firstMonthOfSimulation_(firstMonthOfSimulation),
@@ -52,36 +52,46 @@ FinalLevelValidator::FinalLevelValidator(PartHydro& hydro,
 bool FinalLevelValidator::check()
 {
     if (skippingFinalLevelUse())
+    {
         return true;
-    if (! checkForInfeasibility())
+    }
+    if (!checkForInfeasibility())
+    {
         return false;
+    }
     finalLevelFineForUse_ = true;
     return true;
 }
 
 bool FinalLevelValidator::skippingFinalLevelUse()
 {
-    if(! wasSetInScenarioBuilder())
+    if (!wasSetInScenarioBuilder())
+    {
         return true;
-    if (! compatibleWithReservoirProperties())
+    }
+    if (!compatibleWithReservoirProperties())
+    {
         return true;
+    }
     return false;
 }
 
 bool FinalLevelValidator::wasSetInScenarioBuilder()
 {
-    return ! isnan(finalLevel_);
+    return !isnan(finalLevel_);
 }
 
 bool FinalLevelValidator::compatibleWithReservoirProperties()
 {
     if (hydro_.reservoirManagement && !hydro_.useWaterValue)
+    {
         return true;
+    }
 
-    logs.warning() << "Final reservoir level not applicable! Year:" << year_ + 1
-                << ", Area:" << areaName_
-                << ". Check: Reservoir management = Yes, Use water values = No and proper initial "
-                   "reservoir level is provided ";
+    logs.warning()
+      << "Final reservoir level not applicable! Year:" << year_ + 1 << ", Area:" << areaName_
+      << ". Check: Reservoir management = Yes, Use water values = No and proper initial "
+         "reservoir level is provided ";
     return false;
 }
 
@@ -98,10 +108,12 @@ bool FinalLevelValidator::hydroAllocationStartMatchesSimulation() const
 {
     unsigned initReservoirLvlMonth = hydro_.initializeReservoirLevelDate; // month [0-11]
     if (lastSimulationDay_ == DAYS_PER_YEAR && initReservoirLvlMonth == firstMonthOfSimulation_)
+    {
         return true;
+    }
 
-    logs.error() << "Year " << year_ + 1 << ", area '" << areaName_ << "' : "
-                 << "Hydro allocation must start on the 1st simulation month and "
+    logs.error() << "Year " << year_ + 1 << ", area '" << areaName_
+                 << "' : " << "Hydro allocation must start on the 1st simulation month and "
                  << "simulation last a whole year";
     return false;
 }
@@ -115,8 +127,8 @@ bool FinalLevelValidator::isFinalLevelReachable() const
     {
         logs.error() << "Year: " << year_ + 1 << ". Area: " << areaName_
                      << ". Incompatible total inflows: " << totalYearInflows
-                     << " with initial: " << initialLevel_
-                     << " and final: " << finalLevel_ << " reservoir levels.";
+                     << " with initial: " << initialLevel_ << " and final: " << finalLevel_
+                     << " reservoir levels.";
         return false;
     }
     return true;
@@ -125,17 +137,19 @@ bool FinalLevelValidator::isFinalLevelReachable() const
 double FinalLevelValidator::calculateTotalInflows() const
 {
     // calculate yearly inflows
-    auto const& srcinflows = hydro_.series->storage.getColumn(year_);
+    const auto& srcinflows = hydro_.series->storage.getColumn(year_);
 
     double totalYearInflows = 0.0;
     for (unsigned int day = 0; day < DAYS_PER_YEAR; ++day)
+    {
         totalYearInflows += srcinflows[day];
+    }
     return totalYearInflows;
 }
 
 bool FinalLevelValidator::isBetweenRuleCurves() const
 {
-    double lowLevelLastDay  = hydro_.reservoirLevel[Data::PartHydro::minimum][DAYS_PER_YEAR - 1];
+    double lowLevelLastDay = hydro_.reservoirLevel[Data::PartHydro::minimum][DAYS_PER_YEAR - 1];
     double highLevelLastDay = hydro_.reservoirLevel[Data::PartHydro::maximum][DAYS_PER_YEAR - 1];
 
     if (finalLevel_ < lowLevelLastDay || finalLevel_ > highLevelLastDay)

--- a/src/libs/antares/study/parts/hydro/finalLevelValidator.cpp
+++ b/src/libs/antares/study/parts/hydro/finalLevelValidator.cpp
@@ -37,7 +37,7 @@ FinalLevelValidator::FinalLevelValidator(PartHydro& hydro,
                                          double finalLevel,
                                          const unsigned int year,
                                          const unsigned int lastSimulationDay,
-                                         const unsigned int firstMonthOfSimulation):
+                                         const unsigned int firstMonthOfSimulation) :
     year_(year),
     lastSimulationDay_(lastSimulationDay),
     firstMonthOfSimulation_(firstMonthOfSimulation),
@@ -52,46 +52,36 @@ FinalLevelValidator::FinalLevelValidator(PartHydro& hydro,
 bool FinalLevelValidator::check()
 {
     if (skippingFinalLevelUse())
-    {
         return true;
-    }
-    if (!checkForInfeasibility())
-    {
+    if (! checkForInfeasibility())
         return false;
-    }
     finalLevelFineForUse_ = true;
     return true;
 }
 
 bool FinalLevelValidator::skippingFinalLevelUse()
 {
-    if (!wasSetInScenarioBuilder())
-    {
+    if(! wasSetInScenarioBuilder())
         return true;
-    }
-    if (!compatibleWithReservoirProperties())
-    {
+    if (! compatibleWithReservoirProperties())
         return true;
-    }
     return false;
 }
 
 bool FinalLevelValidator::wasSetInScenarioBuilder()
 {
-    return !isnan(finalLevel_);
+    return ! isnan(finalLevel_);
 }
 
 bool FinalLevelValidator::compatibleWithReservoirProperties()
 {
     if (hydro_.reservoirManagement && !hydro_.useWaterValue)
-    {
         return true;
-    }
 
-    logs.warning()
-      << "Final reservoir level not applicable! Year:" << year_ + 1 << ", Area:" << areaName_
-      << ". Check: Reservoir management = Yes, Use water values = No and proper initial "
-         "reservoir level is provided ";
+    logs.warning() << "Final reservoir level not applicable! Year:" << year_ + 1
+                << ", Area:" << areaName_
+                << ". Check: Reservoir management = Yes, Use water values = No and proper initial "
+                   "reservoir level is provided ";
     return false;
 }
 
@@ -108,12 +98,10 @@ bool FinalLevelValidator::hydroAllocationStartMatchesSimulation() const
 {
     unsigned initReservoirLvlMonth = hydro_.initializeReservoirLevelDate; // month [0-11]
     if (lastSimulationDay_ == DAYS_PER_YEAR && initReservoirLvlMonth == firstMonthOfSimulation_)
-    {
         return true;
-    }
 
-    logs.error() << "Year " << year_ + 1 << ", area '" << areaName_
-                 << "' : " << "Hydro allocation must start on the 1st simulation month and "
+    logs.error() << "Year " << year_ + 1 << ", area '" << areaName_ << "' : "
+                 << "Hydro allocation must start on the 1st simulation month and "
                  << "simulation last a whole year";
     return false;
 }
@@ -127,8 +115,8 @@ bool FinalLevelValidator::isFinalLevelReachable() const
     {
         logs.error() << "Year: " << year_ + 1 << ". Area: " << areaName_
                      << ". Incompatible total inflows: " << totalYearInflows
-                     << " with initial: " << initialLevel_ << " and final: " << finalLevel_
-                     << " reservoir levels.";
+                     << " with initial: " << initialLevel_
+                     << " and final: " << finalLevel_ << " reservoir levels.";
         return false;
     }
     return true;
@@ -137,19 +125,17 @@ bool FinalLevelValidator::isFinalLevelReachable() const
 double FinalLevelValidator::calculateTotalInflows() const
 {
     // calculate yearly inflows
-    const auto& srcinflows = hydro_.series->storage.getColumn(year_);
+    auto const& srcinflows = hydro_.series->storage.getColumn(year_);
 
     double totalYearInflows = 0.0;
     for (unsigned int day = 0; day < DAYS_PER_YEAR; ++day)
-    {
         totalYearInflows += srcinflows[day];
-    }
     return totalYearInflows;
 }
 
 bool FinalLevelValidator::isBetweenRuleCurves() const
 {
-    double lowLevelLastDay = hydro_.reservoirLevel[Data::PartHydro::minimum][DAYS_PER_YEAR - 1];
+    double lowLevelLastDay  = hydro_.reservoirLevel[Data::PartHydro::minimum][DAYS_PER_YEAR - 1];
     double highLevelLastDay = hydro_.reservoirLevel[Data::PartHydro::maximum][DAYS_PER_YEAR - 1];
 
     if (finalLevel_ < lowLevelLastDay || finalLevel_ > highLevelLastDay)

--- a/src/libs/antares/study/parts/hydro/prepro.cpp
+++ b/src/libs/antares/study/parts/hydro/prepro.cpp
@@ -151,6 +151,7 @@ bool PreproHydro::loadFromFolder(Study& s, const AreaName& areaID, const std::st
     {
         mtrxOption = Matrix<>::optFixedSize | Matrix<>::optImmediate,
     };
+
     constexpr int maxNbOfLineToLoad = 12;
 
     data.resize(hydroPreproMax, 12, true);
@@ -160,7 +161,8 @@ bool PreproHydro::loadFromFolder(Study& s, const AreaName& areaID, const std::st
     bool ret = PreproHydroLoadSettings(this, buffer);
 
     buffer.clear() << folder << SEP << areaID << SEP << "energy.txt";
-    ret = data.loadFromCSVFile(buffer, hydroPreproMax, maxNbOfLineToLoad, mtrxOption, &s.dataBuffer) && ret;
+    ret = data.loadFromCSVFile(buffer, hydroPreproMax, maxNbOfLineToLoad, mtrxOption, &s.dataBuffer)
+          && ret;
 
     return ret;
 }
@@ -203,8 +205,8 @@ bool PreproHydro::validate(const std::string& areaID)
         {
             ret = false;
             logs.error() << "Hydro: Prepro: `" << areaID
-                         << "`: minimum energy: At least one value is negative (line: "
-                         << (i + 1) << ')';
+                         << "`: minimum energy: At least one value is negative (line: " << (i + 1)
+                         << ')';
             continue;
         }
         if (colMin[i] > colMax[i])

--- a/src/libs/antares/study/parts/hydro/prepro.cpp
+++ b/src/libs/antares/study/parts/hydro/prepro.cpp
@@ -151,7 +151,6 @@ bool PreproHydro::loadFromFolder(Study& s, const AreaName& areaID, const std::st
     {
         mtrxOption = Matrix<>::optFixedSize | Matrix<>::optImmediate,
     };
-
     constexpr int maxNbOfLineToLoad = 12;
 
     data.resize(hydroPreproMax, 12, true);
@@ -161,8 +160,7 @@ bool PreproHydro::loadFromFolder(Study& s, const AreaName& areaID, const std::st
     bool ret = PreproHydroLoadSettings(this, buffer);
 
     buffer.clear() << folder << SEP << areaID << SEP << "energy.txt";
-    ret = data.loadFromCSVFile(buffer, hydroPreproMax, maxNbOfLineToLoad, mtrxOption, &s.dataBuffer)
-          && ret;
+    ret = data.loadFromCSVFile(buffer, hydroPreproMax, maxNbOfLineToLoad, mtrxOption, &s.dataBuffer) && ret;
 
     return ret;
 }
@@ -205,8 +203,8 @@ bool PreproHydro::validate(const std::string& areaID)
         {
             ret = false;
             logs.error() << "Hydro: Prepro: `" << areaID
-                         << "`: minimum energy: At least one value is negative (line: " << (i + 1)
-                         << ')';
+                         << "`: minimum energy: At least one value is negative (line: "
+                         << (i + 1) << ')';
             continue;
         }
         if (colMin[i] > colMax[i])

--- a/src/libs/antares/study/parts/hydro/series.cpp
+++ b/src/libs/antares/study/parts/hydro/series.cpp
@@ -54,7 +54,7 @@ static void ConvertDailyTSintoHourlyTS(const Matrix<double>::ColumnType& dailyCo
 {
     uint hour = 0;
     uint day = 0;
-    
+
     while (hour < HOURS_PER_YEAR && day < DAYS_PER_YEAR)
     {
         for (uint i = 0; i < HOURS_PER_DAY; ++i)

--- a/src/libs/antares/study/parts/hydro/series.cpp
+++ b/src/libs/antares/study/parts/hydro/series.cpp
@@ -54,7 +54,7 @@ static void ConvertDailyTSintoHourlyTS(const Matrix<double>::ColumnType& dailyCo
 {
     uint hour = 0;
     uint day = 0;
-
+    
     while (hour < HOURS_PER_YEAR && day < DAYS_PER_YEAR)
     {
         for (uint i = 0; i < HOURS_PER_DAY; ++i)

--- a/src/libs/antares/study/parts/renewable/cluster_list.cpp
+++ b/src/libs/antares/study/parts/renewable/cluster_list.cpp
@@ -223,7 +223,7 @@ bool RenewableClusterList::loadFromFolder(const AnyString& folder, Area* area)
 bool RenewableClusterList::validateClusters() const
 {
     bool ret = true;
-    for (const auto& cluster: allClusters_)
+    for (const auto& cluster : allClusters_)
     {
         ret = cluster->integrityCheck() && ret;
     }

--- a/src/libs/antares/study/parts/renewable/cluster_list.cpp
+++ b/src/libs/antares/study/parts/renewable/cluster_list.cpp
@@ -223,7 +223,7 @@ bool RenewableClusterList::loadFromFolder(const AnyString& folder, Area* area)
 bool RenewableClusterList::validateClusters() const
 {
     bool ret = true;
-    for (const auto& cluster : allClusters_)
+    for (const auto& cluster: allClusters_)
     {
         ret = cluster->integrityCheck() && ret;
     }

--- a/src/libs/antares/study/parts/short-term-storage/container.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/container.cpp
@@ -37,8 +37,7 @@ namespace Antares::Data::ShortTermStorage
 {
 bool STStorageInput::validate() const
 {
-    return std::ranges::all_of(storagesByIndex, [](auto& cluster)
-        { return cluster.validate(); });
+    return std::ranges::all_of(storagesByIndex, [](auto& cluster) { return cluster.validate(); });
 }
 
 bool STStorageInput::createSTStorageClustersFromIniFile(const fs::path& path)
@@ -68,8 +67,9 @@ bool STStorageInput::createSTStorageClustersFromIniFile(const fs::path& path)
         storagesByIndex.push_back(cluster);
     }
 
-    std::ranges::sort(storagesByIndex, [](const auto& a, const auto& b)
-        { return a.properties.name < b.properties.name; });
+    std::ranges::sort(storagesByIndex,
+                      [](const auto& a, const auto& b)
+                      { return a.properties.name < b.properties.name; });
 
     return true;
 }
@@ -100,8 +100,8 @@ bool STStorageInput::saveToFolder(const std::string& folder) const
     IniFile ini;
 
     logs.debug() << "saving file " << pathIni;
-    std::ranges::for_each(storagesByIndex, [&ini](auto& storage)
-        { return storage.saveProperties(ini); });
+    std::ranges::for_each(storagesByIndex,
+                          [&ini](auto& storage) { return storage.saveProperties(ini); });
 
     return ini.save(pathIni);
 }
@@ -109,20 +109,20 @@ bool STStorageInput::saveToFolder(const std::string& folder) const
 bool STStorageInput::saveDataSeriesToFolder(const std::string& folder) const
 {
     Yuni::IO::Directory::Create(folder);
-    return std::ranges::all_of(storagesByIndex, [&folder](auto& storage)
-            { return storage.saveSeries(folder + SEP + storage.id); });
+    return std::ranges::all_of(storagesByIndex,
+                               [&folder](auto& storage)
+                               { return storage.saveSeries(folder + SEP + storage.id); });
 }
 
 std::size_t STStorageInput::count() const
 {
-    return std::ranges::count_if(storagesByIndex, [](const STStorageCluster& st)
-        { return st.properties.enabled; });
+    return std::ranges::count_if(storagesByIndex,
+                                 [](const STStorageCluster& st) { return st.properties.enabled; });
 }
 
 uint STStorageInput::removeDisabledClusters()
 {
-    return std::erase_if(storagesByIndex, [](const auto& c)
-        { return !c.enabled(); });
+    return std::erase_if(storagesByIndex, [](const auto& c) { return !c.enabled(); });
 }
 
 } // namespace Antares::Data::ShortTermStorage

--- a/src/libs/antares/study/parts/short-term-storage/container.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/container.cpp
@@ -37,7 +37,8 @@ namespace Antares::Data::ShortTermStorage
 {
 bool STStorageInput::validate() const
 {
-    return std::ranges::all_of(storagesByIndex, [](auto& cluster) { return cluster.validate(); });
+    return std::ranges::all_of(storagesByIndex, [](auto& cluster)
+        { return cluster.validate(); });
 }
 
 bool STStorageInput::createSTStorageClustersFromIniFile(const fs::path& path)
@@ -67,9 +68,8 @@ bool STStorageInput::createSTStorageClustersFromIniFile(const fs::path& path)
         storagesByIndex.push_back(cluster);
     }
 
-    std::ranges::sort(storagesByIndex,
-                      [](const auto& a, const auto& b)
-                      { return a.properties.name < b.properties.name; });
+    std::ranges::sort(storagesByIndex, [](const auto& a, const auto& b)
+        { return a.properties.name < b.properties.name; });
 
     return true;
 }
@@ -100,8 +100,8 @@ bool STStorageInput::saveToFolder(const std::string& folder) const
     IniFile ini;
 
     logs.debug() << "saving file " << pathIni;
-    std::ranges::for_each(storagesByIndex,
-                          [&ini](auto& storage) { return storage.saveProperties(ini); });
+    std::ranges::for_each(storagesByIndex, [&ini](auto& storage)
+        { return storage.saveProperties(ini); });
 
     return ini.save(pathIni);
 }
@@ -109,20 +109,20 @@ bool STStorageInput::saveToFolder(const std::string& folder) const
 bool STStorageInput::saveDataSeriesToFolder(const std::string& folder) const
 {
     Yuni::IO::Directory::Create(folder);
-    return std::ranges::all_of(storagesByIndex,
-                               [&folder](auto& storage)
-                               { return storage.saveSeries(folder + SEP + storage.id); });
+    return std::ranges::all_of(storagesByIndex, [&folder](auto& storage)
+            { return storage.saveSeries(folder + SEP + storage.id); });
 }
 
 std::size_t STStorageInput::count() const
 {
-    return std::ranges::count_if(storagesByIndex,
-                                 [](const STStorageCluster& st) { return st.properties.enabled; });
+    return std::ranges::count_if(storagesByIndex, [](const STStorageCluster& st)
+        { return st.properties.enabled; });
 }
 
 uint STStorageInput::removeDisabledClusters()
 {
-    return std::erase_if(storagesByIndex, [](const auto& c) { return !c.enabled(); });
+    return std::erase_if(storagesByIndex, [](const auto& c)
+        { return !c.enabled(); });
 }
 
 } // namespace Antares::Data::ShortTermStorage

--- a/src/libs/antares/study/parts/thermal/cluster_list.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_list.cpp
@@ -162,7 +162,8 @@ bool ThermalClusterList::loadFromFolder(Study& study, const AnyString& folder, A
         ret = cluster->modulation.loadFromCSVFile(modulationFile,
                                                   thermalModulationMax,
                                                   HOURS_PER_YEAR,
-                                                  options) && ret;
+                                                  options)
+              && ret;
 
         // Check the data integrity of the cluster
         addToCompleteList(cluster);
@@ -174,12 +175,11 @@ bool ThermalClusterList::loadFromFolder(Study& study, const AnyString& folder, A
     return ret;
 }
 
-
 bool ThermalClusterList::validateClusters(const Parameters& parameters) const
 {
     bool ret = true;
 
-    for (const auto& cluster : allClusters_)
+    for (const auto& cluster: allClusters_)
     {
         cluster->minUpTime = std::clamp(cluster->minUpTime, 1u, 168u);
         cluster->minDownTime = std::clamp(cluster->minDownTime, 1u, 168u);
@@ -206,7 +206,6 @@ bool ThermalClusterList::validateClusters(const Parameters& parameters) const
         cluster->nominalCapacityWithSpinning = cluster->nominalCapacity;
 
         ret = cluster->integrityCheck() && ret;
-
     }
 
     return ret;
@@ -377,7 +376,7 @@ void ThermalClusterList::reverseCalculationOfSpinning()
 
 void ThermalClusterList::enableMustrunForEveryone()
 {
-    for (const auto& c : allClusters_)
+    for (const auto& c: allClusters_)
     {
         c->mustrun = true;
     }
@@ -541,7 +540,6 @@ bool ThermalClusterList::saveToFolder(const AnyString& folder) const
         {
             ret = false;
         }
-
     }
 
     // Write the ini file
@@ -598,27 +596,32 @@ bool ThermalClusterList::loadPreproFromFolder(Study& study, const AnyString& fol
     return std::ranges::all_of(allClusters_ | std::views::filter(hasPrepro), loadPrepro);
 }
 
-bool ThermalClusterList::validatePrepro(const Study& study) {
+bool ThermalClusterList::validatePrepro(const Study& study)
+{
     auto hasPrepro = [](auto c) { return (bool)c->prepro; };
 
-    const bool globalThermalTSgeneration =
-        study.parameters.timeSeriesToGenerate & timeSeriesThermal;
+    const bool globalThermalTSgeneration = study.parameters.timeSeriesToGenerate
+                                           & timeSeriesThermal;
 
     if (!study.usedByTheSolver)
+    {
         return true;
+    }
 
-    return std::ranges::all_of(
-        allClusters_ | std::views::filter(hasPrepro),
-        [&globalThermalTSgeneration](auto& c) {
-            if (globalThermalTSgeneration && !c->prepro->validate()) {
-                return false;
-            }
+    return std::ranges::all_of(allClusters_ | std::views::filter(hasPrepro),
+                               [&globalThermalTSgeneration](auto& c)
+                               {
+                                   if (globalThermalTSgeneration && !c->prepro->validate())
+                                   {
+                                       return false;
+                                   }
 
-            if (c->doWeGenerateTS(globalThermalTSgeneration)) {
-                return c->prepro->normalizeAndCheckNPO();
-            }
-            return true;
-        });
+                                   if (c->doWeGenerateTS(globalThermalTSgeneration))
+                                   {
+                                       return c->prepro->normalizeAndCheckNPO();
+                                   }
+                                   return true;
+                               });
 }
 
 bool ThermalClusterList::loadEconomicCosts(Study& study, const AnyString& folder)

--- a/src/libs/antares/study/parts/thermal/cluster_list.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster_list.cpp
@@ -162,8 +162,7 @@ bool ThermalClusterList::loadFromFolder(Study& study, const AnyString& folder, A
         ret = cluster->modulation.loadFromCSVFile(modulationFile,
                                                   thermalModulationMax,
                                                   HOURS_PER_YEAR,
-                                                  options)
-              && ret;
+                                                  options) && ret;
 
         // Check the data integrity of the cluster
         addToCompleteList(cluster);
@@ -175,11 +174,12 @@ bool ThermalClusterList::loadFromFolder(Study& study, const AnyString& folder, A
     return ret;
 }
 
+
 bool ThermalClusterList::validateClusters(const Parameters& parameters) const
 {
     bool ret = true;
 
-    for (const auto& cluster: allClusters_)
+    for (const auto& cluster : allClusters_)
     {
         cluster->minUpTime = std::clamp(cluster->minUpTime, 1u, 168u);
         cluster->minDownTime = std::clamp(cluster->minDownTime, 1u, 168u);
@@ -206,6 +206,7 @@ bool ThermalClusterList::validateClusters(const Parameters& parameters) const
         cluster->nominalCapacityWithSpinning = cluster->nominalCapacity;
 
         ret = cluster->integrityCheck() && ret;
+
     }
 
     return ret;
@@ -376,7 +377,7 @@ void ThermalClusterList::reverseCalculationOfSpinning()
 
 void ThermalClusterList::enableMustrunForEveryone()
 {
-    for (const auto& c: allClusters_)
+    for (const auto& c : allClusters_)
     {
         c->mustrun = true;
     }
@@ -540,6 +541,7 @@ bool ThermalClusterList::saveToFolder(const AnyString& folder) const
         {
             ret = false;
         }
+
     }
 
     // Write the ini file
@@ -596,32 +598,27 @@ bool ThermalClusterList::loadPreproFromFolder(Study& study, const AnyString& fol
     return std::ranges::all_of(allClusters_ | std::views::filter(hasPrepro), loadPrepro);
 }
 
-bool ThermalClusterList::validatePrepro(const Study& study)
-{
+bool ThermalClusterList::validatePrepro(const Study& study) {
     auto hasPrepro = [](auto c) { return (bool)c->prepro; };
 
-    const bool globalThermalTSgeneration = study.parameters.timeSeriesToGenerate
-                                           & timeSeriesThermal;
+    const bool globalThermalTSgeneration =
+        study.parameters.timeSeriesToGenerate & timeSeriesThermal;
 
     if (!study.usedByTheSolver)
-    {
         return true;
-    }
 
-    return std::ranges::all_of(allClusters_ | std::views::filter(hasPrepro),
-                               [&globalThermalTSgeneration](auto& c)
-                               {
-                                   if (globalThermalTSgeneration && !c->prepro->validate())
-                                   {
-                                       return false;
-                                   }
+    return std::ranges::all_of(
+        allClusters_ | std::views::filter(hasPrepro),
+        [&globalThermalTSgeneration](auto& c) {
+            if (globalThermalTSgeneration && !c->prepro->validate()) {
+                return false;
+            }
 
-                                   if (c->doWeGenerateTS(globalThermalTSgeneration))
-                                   {
-                                       return c->prepro->normalizeAndCheckNPO();
-                                   }
-                                   return true;
-                               });
+            if (c->doWeGenerateTS(globalThermalTSgeneration)) {
+                return c->prepro->normalizeAndCheckNPO();
+            }
+            return true;
+        });
 }
 
 bool ThermalClusterList::loadEconomicCosts(Study& study, const AnyString& folder)

--- a/src/libs/antares/study/runtime/runtime.cpp
+++ b/src/libs/antares/study/runtime/runtime.cpp
@@ -214,7 +214,8 @@ void StudyRuntimeInfos::initializeRangeLimits(const Study& study, StudyRangeLimi
     }
     else
     {
-        simulationDaysPerMonth[ca.month] = study.calendar.months[ca.month].days - ca.dayMonth;
+        simulationDaysPerMonth[ca.month] = study.calendar.months[ca.month].days
+                                                 - ca.dayMonth;
         simulationDaysPerMonth[cb.month] = cb.dayMonth + 1;
         for (uint i = ca.month + 1; i < cb.month; ++i)
         {
@@ -441,8 +442,7 @@ void StudyRangeLimits::checkIntegrity() const
 
 void StudyRuntimeInfos::disableAllFilters(Study& study)
 {
-    study.areas.each(
-      [](Data::Area& area)
+    study.areas.each([](Data::Area& area)
       {
           area.filterSynthesis = filterAll;
           area.filterYearByYear = filterAll;

--- a/src/libs/antares/study/runtime/runtime.cpp
+++ b/src/libs/antares/study/runtime/runtime.cpp
@@ -214,8 +214,7 @@ void StudyRuntimeInfos::initializeRangeLimits(const Study& study, StudyRangeLimi
     }
     else
     {
-        simulationDaysPerMonth[ca.month] = study.calendar.months[ca.month].days
-                                                 - ca.dayMonth;
+        simulationDaysPerMonth[ca.month] = study.calendar.months[ca.month].days - ca.dayMonth;
         simulationDaysPerMonth[cb.month] = cb.dayMonth + 1;
         for (uint i = ca.month + 1; i < cb.month; ++i)
         {
@@ -442,7 +441,8 @@ void StudyRangeLimits::checkIntegrity() const
 
 void StudyRuntimeInfos::disableAllFilters(Study& study)
 {
-    study.areas.each([](Data::Area& area)
+    study.areas.each(
+      [](Data::Area& area)
       {
           area.filterSynthesis = filterAll;
           area.filterYearByYear = filterAll;

--- a/src/libs/antares/study/scenario-builder/BindingConstraintsTSNumbersData.cpp
+++ b/src/libs/antares/study/scenario-builder/BindingConstraintsTSNumbersData.cpp
@@ -81,11 +81,11 @@ bool BindingConstraintsTSNumberData::reset(const Study& study)
 {
     const uint nbYears = study.parameters.nbYears;
     std::ranges::for_each(study.bindingConstraintsGroups,
-                  [this, &nbYears](const auto& group)
-                  {
-                      auto& ts_numbers = rules_[group->name()];
-                      ts_numbers.reset(1, nbYears);
-                  });
+                          [this, &nbYears](const auto& group)
+                          {
+                              auto& ts_numbers = rules_[group->name()];
+                              ts_numbers.reset(1, nbYears);
+                          });
     return true;
 }
 

--- a/src/libs/antares/study/scenario-builder/BindingConstraintsTSNumbersData.cpp
+++ b/src/libs/antares/study/scenario-builder/BindingConstraintsTSNumbersData.cpp
@@ -81,11 +81,11 @@ bool BindingConstraintsTSNumberData::reset(const Study& study)
 {
     const uint nbYears = study.parameters.nbYears;
     std::ranges::for_each(study.bindingConstraintsGroups,
-                          [this, &nbYears](const auto& group)
-                          {
-                              auto& ts_numbers = rules_[group->name()];
-                              ts_numbers.reset(1, nbYears);
-                          });
+                  [this, &nbYears](const auto& group)
+                  {
+                      auto& ts_numbers = rules_[group->name()];
+                      ts_numbers.reset(1, nbYears);
+                  });
     return true;
 }
 

--- a/src/libs/antares/study/scenario-builder/hydroLevelsData.cpp
+++ b/src/libs/antares/study/scenario-builder/hydroLevelsData.cpp
@@ -29,9 +29,9 @@
 namespace Antares::Data::ScenarioBuilder
 {
 hydroLevelsData::hydroLevelsData(const std::string& iniFilePrefix,
-                                 std::function<void(Study&, MatrixType&)> applyToTarget):
-    addToPrefix_(iniFilePrefix),
-    applyToTarget_(applyToTarget)
+                                 std::function<void(Study&, MatrixType&)> applyToTarget) :
+        addToPrefix_(iniFilePrefix),
+        applyToTarget_(applyToTarget)
 {
 }
 

--- a/src/libs/antares/study/scenario-builder/hydroLevelsData.cpp
+++ b/src/libs/antares/study/scenario-builder/hydroLevelsData.cpp
@@ -29,9 +29,9 @@
 namespace Antares::Data::ScenarioBuilder
 {
 hydroLevelsData::hydroLevelsData(const std::string& iniFilePrefix,
-                                 std::function<void(Study&, MatrixType&)> applyToTarget) :
-        addToPrefix_(iniFilePrefix),
-        applyToTarget_(applyToTarget)
+                                 std::function<void(Study&, MatrixType&)> applyToTarget):
+    addToPrefix_(iniFilePrefix),
+    applyToTarget_(applyToTarget)
 {
 }
 

--- a/src/libs/antares/study/scenario-builder/rules.cpp
+++ b/src/libs/antares/study/scenario-builder/rules.cpp
@@ -288,9 +288,7 @@ bool Rules::readFinalHydroLevels(const AreaName::Vector& splitKey, String value,
 
     const Data::Area* area = getArea(areaname, updaterMode);
     if (!area)
-    {
         return false;
-    }
 
     double finalLevel = fromStringToHydroLevel(value, 1.);
     hydroFinalLevels.setTSnumber(area->index, year, finalLevel);
@@ -452,7 +450,8 @@ bool Rules::apply()
 
 void Rules::sendWarningsForDisabledClusters()
 {
-    for (auto it = disabledClustersOnRuleActive.begin(); it != disabledClustersOnRuleActive.end();
+    for (auto it = disabledClustersOnRuleActive.begin();
+         it != disabledClustersOnRuleActive.end();
          it++)
     {
         std::vector<uint>& scenariiForCurrentCluster = it->second;

--- a/src/libs/antares/study/scenario-builder/rules.cpp
+++ b/src/libs/antares/study/scenario-builder/rules.cpp
@@ -288,7 +288,9 @@ bool Rules::readFinalHydroLevels(const AreaName::Vector& splitKey, String value,
 
     const Data::Area* area = getArea(areaname, updaterMode);
     if (!area)
+    {
         return false;
+    }
 
     double finalLevel = fromStringToHydroLevel(value, 1.);
     hydroFinalLevels.setTSnumber(area->index, year, finalLevel);
@@ -450,8 +452,7 @@ bool Rules::apply()
 
 void Rules::sendWarningsForDisabledClusters()
 {
-    for (auto it = disabledClustersOnRuleActive.begin();
-         it != disabledClustersOnRuleActive.end();
+    for (auto it = disabledClustersOnRuleActive.begin(); it != disabledClustersOnRuleActive.end();
          it++)
     {
         std::vector<uint>& scenariiForCurrentCluster = it->second;

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -856,8 +856,7 @@ void Study::areaDelete(Area::Vector& arealist)
                             << area.name;
 
                 // Updating all hydro allocation
-                areas.each([&area](Data::Area& areait)
-                           { areait.hydro.allocation.remove(area.id); });
+                areas.each([&area](Data::Area& areait) { areait.hydro.allocation.remove(area.id); });
 
                 // Remove all binding constraints attached to the area
                 bindingConstraints.remove(*i);
@@ -957,7 +956,7 @@ bool Study::areaRename(Area* area, AreaName newName)
 
     // Updating all hydro allocation
     areas.each([&oldid, &newid](Data::Area& areait)
-               { areait.hydro.allocation.rename(oldid, newid); });
+        { areait.hydro.allocation.rename(oldid, newid); });
 
     ScenarioBuilderUpdater updaterSB(*this);
     bool ret = true;
@@ -1110,14 +1109,13 @@ void Study::destroyAllWindTSGeneratorData()
 
 void Study::destroyAllThermalTSGeneratorData()
 {
-    areas.each(
-      [](const Data::Area& area)
-      {
-          for (const auto& cluster: area.thermal.list.each_enabled_and_not_mustrun())
-          {
-              FreeAndNil(cluster->prepro);
-          }
-      });
+    areas.each([](const Data::Area& area)
+    {
+        for (const auto& cluster: area.thermal.list.each_enabled_and_not_mustrun())
+        {
+            FreeAndNil(cluster->prepro);
+        }
+    });
 }
 
 void Study::ensureDataAreLoadedForAllBindingConstraints()
@@ -1360,6 +1358,7 @@ bool Study::checkForFilenameLimits(bool output, const String& chfolder) const
         areas.each(
           [&output, &linkname, &areaname](const Area& area)
           {
+
               if (areaname.size() < area.id.size())
               {
                   areaname = area.id;

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -856,7 +856,8 @@ void Study::areaDelete(Area::Vector& arealist)
                             << area.name;
 
                 // Updating all hydro allocation
-                areas.each([&area](Data::Area& areait) { areait.hydro.allocation.remove(area.id); });
+                areas.each([&area](Data::Area& areait)
+                           { areait.hydro.allocation.remove(area.id); });
 
                 // Remove all binding constraints attached to the area
                 bindingConstraints.remove(*i);
@@ -956,7 +957,7 @@ bool Study::areaRename(Area* area, AreaName newName)
 
     // Updating all hydro allocation
     areas.each([&oldid, &newid](Data::Area& areait)
-        { areait.hydro.allocation.rename(oldid, newid); });
+               { areait.hydro.allocation.rename(oldid, newid); });
 
     ScenarioBuilderUpdater updaterSB(*this);
     bool ret = true;
@@ -1109,13 +1110,14 @@ void Study::destroyAllWindTSGeneratorData()
 
 void Study::destroyAllThermalTSGeneratorData()
 {
-    areas.each([](const Data::Area& area)
-    {
-        for (const auto& cluster: area.thermal.list.each_enabled_and_not_mustrun())
-        {
-            FreeAndNil(cluster->prepro);
-        }
-    });
+    areas.each(
+      [](const Data::Area& area)
+      {
+          for (const auto& cluster: area.thermal.list.each_enabled_and_not_mustrun())
+          {
+              FreeAndNil(cluster->prepro);
+          }
+      });
 }
 
 void Study::ensureDataAreLoadedForAllBindingConstraints()
@@ -1358,7 +1360,6 @@ bool Study::checkForFilenameLimits(bool output, const String& chfolder) const
         areas.each(
           [&output, &linkname, &areaname](const Area& area)
           {
-
               if (areaname.size() < area.id.size())
               {
                   areaname = area.id;

--- a/src/libs/antares/study/study.importprepro.cpp
+++ b/src/libs/antares/study/study.importprepro.cpp
@@ -50,7 +50,7 @@ bool Study::importTimeseriesIntoInput()
         if (parameters.haveToImport(timeSeriesLoad))
         {
             logs.info() << "Importing load timeseries...";
-            for (const auto& [areaName, area] : areas)
+            for (const auto& [areaName, area]: areas)
             {
                 logs.info() << "Importing load timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "load" << SEP << "series";
@@ -63,7 +63,7 @@ bool Study::importTimeseriesIntoInput()
         if (parameters.haveToImport(timeSeriesSolar))
         {
             logs.info() << "Importing solar timeseries...";
-            for (const auto& [areaName, area] : areas)
+            for (const auto& [areaName, area]: areas)
             {
                 logs.info() << "Importing solar timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "solar" << SEP << "series";
@@ -76,7 +76,7 @@ bool Study::importTimeseriesIntoInput()
         if (parameters.haveToImport(timeSeriesHydro))
         {
             logs.info() << "Importing hydro timeseries...";
-            for (const auto& [areaName, area] : areas)
+            for (const auto& [areaName, area]: areas)
             {
                 logs.info() << "Importing hydro timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "hydro" << SEP << "series";
@@ -89,7 +89,7 @@ bool Study::importTimeseriesIntoInput()
         if (parameters.haveToImport(timeSeriesWind))
         {
             logs.info() << "Importing wind timeseries...";
-            for (const auto& [areaName, area] : areas)
+            for (const auto& [areaName, area]: areas)
             {
                 logs.info() << "Importing wind timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "wind" << SEP << "series";
@@ -104,7 +104,7 @@ bool Study::importTimeseriesIntoInput()
             logs.info() << "Importing thermal timeseries...";
             String msg;
 
-            for (const auto& [areaName, area] : areas)
+            for (const auto& [areaName, area]: areas)
             {
                 msg.clear() << "Importing thermal timeseries : " << areaName;
 

--- a/src/libs/antares/study/study.importprepro.cpp
+++ b/src/libs/antares/study/study.importprepro.cpp
@@ -50,7 +50,7 @@ bool Study::importTimeseriesIntoInput()
         if (parameters.haveToImport(timeSeriesLoad))
         {
             logs.info() << "Importing load timeseries...";
-            for (const auto& [areaName, area]: areas)
+            for (const auto& [areaName, area] : areas)
             {
                 logs.info() << "Importing load timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "load" << SEP << "series";
@@ -63,7 +63,7 @@ bool Study::importTimeseriesIntoInput()
         if (parameters.haveToImport(timeSeriesSolar))
         {
             logs.info() << "Importing solar timeseries...";
-            for (const auto& [areaName, area]: areas)
+            for (const auto& [areaName, area] : areas)
             {
                 logs.info() << "Importing solar timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "solar" << SEP << "series";
@@ -76,7 +76,7 @@ bool Study::importTimeseriesIntoInput()
         if (parameters.haveToImport(timeSeriesHydro))
         {
             logs.info() << "Importing hydro timeseries...";
-            for (const auto& [areaName, area]: areas)
+            for (const auto& [areaName, area] : areas)
             {
                 logs.info() << "Importing hydro timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "hydro" << SEP << "series";
@@ -89,7 +89,7 @@ bool Study::importTimeseriesIntoInput()
         if (parameters.haveToImport(timeSeriesWind))
         {
             logs.info() << "Importing wind timeseries...";
-            for (const auto& [areaName, area]: areas)
+            for (const auto& [areaName, area] : areas)
             {
                 logs.info() << "Importing wind timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "wind" << SEP << "series";
@@ -104,7 +104,7 @@ bool Study::importTimeseriesIntoInput()
             logs.info() << "Importing thermal timeseries...";
             String msg;
 
-            for (const auto& [areaName, area]: areas)
+            for (const auto& [areaName, area] : areas)
             {
                 msg.clear() << "Importing thermal timeseries : " << areaName;
 

--- a/src/libs/antares/study/xcast/xcast.cpp
+++ b/src/libs/antares/study/xcast/xcast.cpp
@@ -207,7 +207,8 @@ bool XCast::loadFromFolder(const AnyString& folder)
               // For each property
               if (section.name == "general")
               {
-                  for (const IniFile::Property* p = section.firstProperty; p != nullptr; p = p->next)
+                  for (const IniFile::Property* p = section.firstProperty; p != nullptr;
+                       p = p->next)
                   {
                       CString<30, false> key = p->key;
                       key.toLower();

--- a/src/libs/antares/study/xcast/xcast.cpp
+++ b/src/libs/antares/study/xcast/xcast.cpp
@@ -207,8 +207,7 @@ bool XCast::loadFromFolder(const AnyString& folder)
               // For each property
               if (section.name == "general")
               {
-                  for (const IniFile::Property* p = section.firstProperty; p != nullptr;
-                       p = p->next)
+                  for (const IniFile::Property* p = section.firstProperty; p != nullptr; p = p->next)
                   {
                       CString<30, false> key = p->key;
                       key.toLower();

--- a/src/libs/antares/utils/utils.cpp
+++ b/src/libs/antares/utils/utils.cpp
@@ -117,7 +117,7 @@ std::vector<std::pair<std::string, std::string>> splitStringIntoPairs(const std:
         {
             logs.warning() << "Error while parsing: " << token;
             logs.warning() << "Correct format is: \"object1" << delimiter2 << "object2"
-                           << delimiter1 << "object3" << delimiter2 << "object4\"";
+                << delimiter1 << "object3" << delimiter2 << "object4\"";
         }
     }
 

--- a/src/libs/antares/utils/utils.cpp
+++ b/src/libs/antares/utils/utils.cpp
@@ -117,7 +117,7 @@ std::vector<std::pair<std::string, std::string>> splitStringIntoPairs(const std:
         {
             logs.warning() << "Error while parsing: " << token;
             logs.warning() << "Correct format is: \"object1" << delimiter2 << "object2"
-                << delimiter1 << "object3" << delimiter2 << "object4\"";
+                           << delimiter1 << "object3" << delimiter2 << "object4\"";
         }
     }
 

--- a/src/libs/antares/writer/in_memory_writer.cpp
+++ b/src/libs/antares/writer/in_memory_writer.cpp
@@ -24,9 +24,9 @@
 
 #include <antares/benchmarking/DurationCollector.h>
 #include <antares/benchmarking/timer.h>
+#include <antares/io/file.h>
 #include <antares/logs/logs.h>
 #include <antares/writer/in_memory_writer.h>
-#include <antares/io/file.h>
 
 namespace fs = std::filesystem;
 

--- a/src/libs/antares/writer/in_memory_writer.cpp
+++ b/src/libs/antares/writer/in_memory_writer.cpp
@@ -24,9 +24,9 @@
 
 #include <antares/benchmarking/DurationCollector.h>
 #include <antares/benchmarking/timer.h>
-#include <antares/io/file.h>
 #include <antares/logs/logs.h>
 #include <antares/writer/in_memory_writer.h>
+#include <antares/io/file.h>
 
 namespace fs = std::filesystem;
 

--- a/src/libs/antares/writer/zip_writer.cpp
+++ b/src/libs/antares/writer/zip_writer.cpp
@@ -51,7 +51,6 @@ static void logErrorAndThrow [[noreturn]] (const std::string& errorMessage)
     throw std::runtime_error(errorMessage);
 }
 
-
 // Class ZipWriteJob
 template<class ContentT>
 ZipWriteJob<ContentT>::ZipWriteJob(ZipWriter& writer,

--- a/src/libs/antares/writer/zip_writer.cpp
+++ b/src/libs/antares/writer/zip_writer.cpp
@@ -51,6 +51,7 @@ static void logErrorAndThrow [[noreturn]] (const std::string& errorMessage)
     throw std::runtime_error(errorMessage);
 }
 
+
 // Class ZipWriteJob
 template<class ContentT>
 ZipWriteJob<ContentT>::ZipWriteJob(ZipWriter& writer,

--- a/src/libs/fswalker/fswalker.cpp
+++ b/src/libs/fswalker/fswalker.cpp
@@ -320,7 +320,7 @@ void WalkerThread::walk(const String& path)
 
     do
     {
-        assert(pContext.top());
+        assert(pContext.top() );
         auto& context = *(pContext.top());
 
         if (pShouldStop)

--- a/src/libs/fswalker/fswalker.cpp
+++ b/src/libs/fswalker/fswalker.cpp
@@ -320,7 +320,7 @@ void WalkerThread::walk(const String& path)
 
     do
     {
-        assert(pContext.top() );
+        assert(pContext.top());
         auto& context = *(pContext.top());
 
         if (pShouldStop)

--- a/src/solver/application/ScenarioBuilderOwner.cpp
+++ b/src/solver/application/ScenarioBuilderOwner.cpp
@@ -31,7 +31,8 @@ Antares::Solver::ScenarioBuilderOwner::ScenarioBuilderOwner(Data::Study& study):
 {
 }
 
-void Antares::Solver::ScenarioBuilderOwner::callScenarioBuilder()  {
+void Antares::Solver::ScenarioBuilderOwner::callScenarioBuilder()
+{
     TSGenerator::ResizeGeneratedTimeSeries(study_.areas, study_.parameters);
 
     // Sampled time-series Numbers
@@ -54,4 +55,3 @@ void Antares::Solver::ScenarioBuilderOwner::callScenarioBuilder()  {
         ApplyCustomScenario(study_);
     }
 }
-

--- a/src/solver/application/ScenarioBuilderOwner.cpp
+++ b/src/solver/application/ScenarioBuilderOwner.cpp
@@ -31,8 +31,7 @@ Antares::Solver::ScenarioBuilderOwner::ScenarioBuilderOwner(Data::Study& study):
 {
 }
 
-void Antares::Solver::ScenarioBuilderOwner::callScenarioBuilder()
-{
+void Antares::Solver::ScenarioBuilderOwner::callScenarioBuilder()  {
     TSGenerator::ResizeGeneratedTimeSeries(study_.areas, study_.parameters);
 
     // Sampled time-series Numbers
@@ -55,3 +54,4 @@ void Antares::Solver::ScenarioBuilderOwner::callScenarioBuilder()
         ApplyCustomScenario(study_);
     }
 }
+

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -338,10 +338,14 @@ void Application::prepare(int argc, char* argv[])
     // don't de-allocate these.
 
     if (!parseCommandLine(options)) // --help
+    {
         return;
+    }
 
     if (!handleOptions(options)) // --version, --list-solvers
-       return;
+    {
+        return;
+    }
 
     // Perform some checks
     checkAndCorrectSettingsAndOptions(pSettings, options);

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -338,14 +338,10 @@ void Application::prepare(int argc, char* argv[])
     // don't de-allocate these.
 
     if (!parseCommandLine(options)) // --help
-    {
         return;
-    }
 
     if (!handleOptions(options)) // --version, --list-solvers
-    {
-        return;
-    }
+       return;
 
     // Perform some checks
     checkAndCorrectSettingsAndOptions(pSettings, options);

--- a/src/solver/constraints-builder/cbuilder.cpp
+++ b/src/solver/constraints-builder/cbuilder.cpp
@@ -364,8 +364,7 @@ bool CBuilder::saveCBuilderToFile(const String& filename) const
 
     if (filename == "")
     {
-        fs::path path = fs::path(pStudy.folder.c_str()) / "settings"
-                                     / "constraintbuilder.ini";
+        fs::path path = fs::path(pStudy.folder.c_str()) / "settings" / "constraintbuilder.ini";
 
         return ini.save(path.string());
     }
@@ -399,12 +398,12 @@ bool CBuilder::completeCBuilderFromFile(const std::string& filename)
         CString<50, false> key;
         CString<50, false> value;
 
-        for (section = ini.firstSection; section ; section = section->next)
+        for (section = ini.firstSection; section; section = section->next)
         {
             if (section->name == ".general")
             {
                 IniFile::Property* p = section->firstProperty;
-                for (; p ; p = p->next)
+                for (; p; p = p->next)
                 {
                     key = p->key;
                     key.toLower();

--- a/src/solver/constraints-builder/cbuilder.cpp
+++ b/src/solver/constraints-builder/cbuilder.cpp
@@ -364,7 +364,8 @@ bool CBuilder::saveCBuilderToFile(const String& filename) const
 
     if (filename == "")
     {
-        fs::path path = fs::path(pStudy.folder.c_str()) / "settings" / "constraintbuilder.ini";
+        fs::path path = fs::path(pStudy.folder.c_str()) / "settings"
+                                     / "constraintbuilder.ini";
 
         return ini.save(path.string());
     }
@@ -398,12 +399,12 @@ bool CBuilder::completeCBuilderFromFile(const std::string& filename)
         CString<50, false> key;
         CString<50, false> value;
 
-        for (section = ini.firstSection; section; section = section->next)
+        for (section = ini.firstSection; section ; section = section->next)
         {
             if (section->name == ".general")
             {
                 IniFile::Property* p = section->firstProperty;
-                for (; p; p = p->next)
+                for (; p ; p = p->next)
                 {
                     key = p->key;
                     key.toLower();

--- a/src/solver/hydro/include/antares/solver/hydro/management/HydroInputsChecker.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/HydroInputsChecker.h
@@ -24,7 +24,6 @@
 #include "antares/solver/hydro/management/MinGenerationScaling.h"
 #include "antares/solver/hydro/management/PrepareInflows.h"
 #include "antares/study/study.h"
-
 namespace Antares
 {
 

--- a/src/solver/hydro/include/antares/solver/hydro/management/HydroInputsChecker.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/HydroInputsChecker.h
@@ -24,6 +24,7 @@
 #include "antares/solver/hydro/management/MinGenerationScaling.h"
 #include "antares/solver/hydro/management/PrepareInflows.h"
 #include "antares/study/study.h"
+
 namespace Antares
 {
 

--- a/src/solver/hydro/include/antares/solver/hydro/management/management.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/management.h
@@ -80,20 +80,16 @@ public:
 
 private:
     //! Prepare the net demand for each area
-    void prepareNetDemand(
-      uint year,
-      Data::SimulationMode mode,
-      const Antares::Data::Area::ScratchMap& scratchmap,
-      HydroSpecificMap& hydro_specific_map);
+    void prepareNetDemand(uint year,
+                          Data::SimulationMode mode,
+                          const Antares::Data::Area::ScratchMap& scratchmap,
+                          HydroSpecificMap& hydro_specific_map);
     //! Prepare the effective demand for each area
-    void prepareEffectiveDemand(
-      uint year,
-      HydroSpecificMap& hydro_specific_map);
+    void prepareEffectiveDemand(uint year, HydroSpecificMap& hydro_specific_map);
     //! Monthly Optimal generations
-    void prepareMonthlyOptimalGenerations(
-      double* random_reservoir_level,
-      uint y,
-      HydroSpecificMap& hydro_specific_map);
+    void prepareMonthlyOptimalGenerations(double* random_reservoir_level,
+                                          uint y,
+                                          HydroSpecificMap& hydro_specific_map);
 
     //! Monthly target generations
     // note: inflows may have two different types, if in swap mode or not
@@ -103,10 +99,9 @@ private:
       Antares::Data::AreaDependantHydroManagementData& data,
       Antares::Data::TimeDependantHydroManagementData& hydro_specific);
 
-    void prepareDailyOptimalGenerations(
-      uint y,
-      Antares::Data::Area::ScratchMap& scratchmap,
-      HydroSpecificMap& hydro_specific_map);
+    void prepareDailyOptimalGenerations(uint y,
+                                        Antares::Data::Area::ScratchMap& scratchmap,
+                                        HydroSpecificMap& hydro_specific_map);
 
     void prepareDailyOptimalGenerations(
       Data::Area& area,

--- a/src/solver/hydro/include/antares/solver/hydro/management/management.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/management.h
@@ -80,16 +80,20 @@ public:
 
 private:
     //! Prepare the net demand for each area
-    void prepareNetDemand(uint year,
-                          Data::SimulationMode mode,
-                          const Antares::Data::Area::ScratchMap& scratchmap,
-                          HydroSpecificMap& hydro_specific_map);
+    void prepareNetDemand(
+      uint year,
+      Data::SimulationMode mode,
+      const Antares::Data::Area::ScratchMap& scratchmap,
+      HydroSpecificMap& hydro_specific_map);
     //! Prepare the effective demand for each area
-    void prepareEffectiveDemand(uint year, HydroSpecificMap& hydro_specific_map);
+    void prepareEffectiveDemand(
+      uint year,
+      HydroSpecificMap& hydro_specific_map);
     //! Monthly Optimal generations
-    void prepareMonthlyOptimalGenerations(double* random_reservoir_level,
-                                          uint y,
-                                          HydroSpecificMap& hydro_specific_map);
+    void prepareMonthlyOptimalGenerations(
+      double* random_reservoir_level,
+      uint y,
+      HydroSpecificMap& hydro_specific_map);
 
     //! Monthly target generations
     // note: inflows may have two different types, if in swap mode or not
@@ -99,9 +103,10 @@ private:
       Antares::Data::AreaDependantHydroManagementData& data,
       Antares::Data::TimeDependantHydroManagementData& hydro_specific);
 
-    void prepareDailyOptimalGenerations(uint y,
-                                        Antares::Data::Area::ScratchMap& scratchmap,
-                                        HydroSpecificMap& hydro_specific_map);
+    void prepareDailyOptimalGenerations(
+      uint y,
+      Antares::Data::Area::ScratchMap& scratchmap,
+      HydroSpecificMap& hydro_specific_map);
 
     void prepareDailyOptimalGenerations(
       Data::Area& area,

--- a/src/solver/hydro/management/HydroInputsChecker.cpp
+++ b/src/solver/hydro/management/HydroInputsChecker.cpp
@@ -53,15 +53,11 @@ void HydroInputsChecker::Execute(uint year)
 
     if (!checksOnGenerationPowerBounds(year))
     {
-        throw FatalError("hydro inputs checks: invalid minimum generation");
+	throw FatalError("hydro inputs checks: invalid minimum generation");
     }
     if (parameters_.useCustomScenario)
     {
-        CheckFinalReservoirLevelsConfiguration(areas_,
-                                               parameters_,
-                                               scenarioInitialHydroLevels_,
-                                               scenarioFinalHydroLevels_,
-                                               year);
+        CheckFinalReservoirLevelsConfiguration(areas_, parameters_, scenarioInitialHydroLevels_, scenarioFinalHydroLevels_, year);
     }
 }
 

--- a/src/solver/hydro/management/HydroInputsChecker.cpp
+++ b/src/solver/hydro/management/HydroInputsChecker.cpp
@@ -53,11 +53,15 @@ void HydroInputsChecker::Execute(uint year)
 
     if (!checksOnGenerationPowerBounds(year))
     {
-	throw FatalError("hydro inputs checks: invalid minimum generation");
+        throw FatalError("hydro inputs checks: invalid minimum generation");
     }
     if (parameters_.useCustomScenario)
     {
-        CheckFinalReservoirLevelsConfiguration(areas_, parameters_, scenarioInitialHydroLevels_, scenarioFinalHydroLevels_, year);
+        CheckFinalReservoirLevelsConfiguration(areas_,
+                                               parameters_,
+                                               scenarioInitialHydroLevels_,
+                                               scenarioFinalHydroLevels_,
+                                               year);
     }
 }
 

--- a/src/solver/hydro/management/PrepareInflows.cpp
+++ b/src/solver/hydro/management/PrepareInflows.cpp
@@ -10,12 +10,10 @@ PrepareInflows::PrepareInflows(Data::AreaList& areas, const Date::Calendar& cale
 {
 }
 
-void PrepareInflows::Run(uint year)
-{
+void PrepareInflows::Run(uint year){
     LoadInflows(year);
     ChangeInflowsToAccommodateFinalLevels(year);
 }
-
 void PrepareInflows::LoadInflows(uint year)
 {
     areas_.each(
@@ -68,27 +66,21 @@ void PrepareInflows::LoadInflows(uint year)
 
 void PrepareInflows::ChangeInflowsToAccommodateFinalLevels(uint year)
 {
-    areas_.each(
-      [this, &year](Data::Area& area)
-      {
-          auto& data = area.hydro.managementData[year];
+    areas_.each([this, &year](Data::Area& area) 
+    {
+        auto& data = area.hydro.managementData[year];
 
-          if (!area.hydro.deltaBetweenFinalAndInitialLevels[year].has_value())
-          {
-              return;
-          }
+        if (!area.hydro.deltaBetweenFinalAndInitialLevels[year].has_value())
+            return;
 
-          // Must be done before prepareMonthlyTargetGenerations
-          double delta = area.hydro.deltaBetweenFinalAndInitialLevels[year].value();
-          if (delta < 0)
-          {
-              data.inflows[0] -= delta;
-          }
-          else if (delta > 0)
-          {
-              data.inflows[11] -= delta;
-          }
-      });
+        // Must be done before prepareMonthlyTargetGenerations
+        double delta = area.hydro.deltaBetweenFinalAndInitialLevels[year].value();
+        if (delta < 0)
+            data.inflows[0] -= delta;
+        else if (delta > 0)
+            data.inflows[11] -= delta;
+    });
 }
+
 
 } // namespace Antares

--- a/src/solver/hydro/management/PrepareInflows.cpp
+++ b/src/solver/hydro/management/PrepareInflows.cpp
@@ -10,10 +10,12 @@ PrepareInflows::PrepareInflows(Data::AreaList& areas, const Date::Calendar& cale
 {
 }
 
-void PrepareInflows::Run(uint year){
+void PrepareInflows::Run(uint year)
+{
     LoadInflows(year);
     ChangeInflowsToAccommodateFinalLevels(year);
 }
+
 void PrepareInflows::LoadInflows(uint year)
 {
     areas_.each(
@@ -66,21 +68,27 @@ void PrepareInflows::LoadInflows(uint year)
 
 void PrepareInflows::ChangeInflowsToAccommodateFinalLevels(uint year)
 {
-    areas_.each([this, &year](Data::Area& area) 
-    {
-        auto& data = area.hydro.managementData[year];
+    areas_.each(
+      [this, &year](Data::Area& area)
+      {
+          auto& data = area.hydro.managementData[year];
 
-        if (!area.hydro.deltaBetweenFinalAndInitialLevels[year].has_value())
-            return;
+          if (!area.hydro.deltaBetweenFinalAndInitialLevels[year].has_value())
+          {
+              return;
+          }
 
-        // Must be done before prepareMonthlyTargetGenerations
-        double delta = area.hydro.deltaBetweenFinalAndInitialLevels[year].value();
-        if (delta < 0)
-            data.inflows[0] -= delta;
-        else if (delta > 0)
-            data.inflows[11] -= delta;
-    });
+          // Must be done before prepareMonthlyTargetGenerations
+          double delta = area.hydro.deltaBetweenFinalAndInitialLevels[year].value();
+          if (delta < 0)
+          {
+              data.inflows[0] -= delta;
+          }
+          else if (delta > 0)
+          {
+              data.inflows[11] -= delta;
+          }
+      });
 }
-
 
 } // namespace Antares

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -557,10 +557,9 @@ inline void HydroManagement::prepareDailyOptimalGenerations(
     }
 }
 
-void HydroManagement::prepareDailyOptimalGenerations(
-  uint y,
-  Antares::Data::Area::ScratchMap& scratchmap,
-  HydroSpecificMap& hydro_specific_map)
+void HydroManagement::prepareDailyOptimalGenerations(uint y,
+                                                     Antares::Data::Area::ScratchMap& scratchmap,
+                                                     HydroSpecificMap& hydro_specific_map)
 {
     areas_.each(
       [this, &scratchmap, &y, &hydro_specific_map](Data::Area& area)

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -557,9 +557,10 @@ inline void HydroManagement::prepareDailyOptimalGenerations(
     }
 }
 
-void HydroManagement::prepareDailyOptimalGenerations(uint y,
-                                                     Antares::Data::Area::ScratchMap& scratchmap,
-                                                     HydroSpecificMap& hydro_specific_map)
+void HydroManagement::prepareDailyOptimalGenerations(
+  uint y,
+  Antares::Data::Area::ScratchMap& scratchmap,
+  HydroSpecificMap& hydro_specific_map)
 {
     areas_.each(
       [this, &scratchmap, &y, &hydro_specific_map](Data::Area& area)

--- a/src/solver/hydro/management/hydro-final-reservoir-level-functions.cpp
+++ b/src/solver/hydro/management/hydro-final-reservoir-level-functions.cpp
@@ -40,30 +40,34 @@ void CheckFinalReservoirLevelsConfiguration(Data::AreaList& areas,
                                             uint year)
 {
     if (!parameters.yearsFilter.at(year))
-        return;
-
-    areas.each([&areas, &parameters, &scenarioInitialHydroLevels, &scenarioFinalHydroLevels, year](Data::Area &area)
     {
-         double initialLevel = scenarioInitialHydroLevels.entry[area.index][year];
-         double finalLevel = scenarioFinalHydroLevels.entry[area.index][year];
+        return;
+    }
 
-         Data::FinalLevelValidator validator(area.hydro,
-                                             area.index,
-                                             area.name,
-                                             initialLevel,
-                                             finalLevel,
-                                             year,
-                                             parameters.simulationDays.end,
-                                             parameters.firstMonthInYear);
-         if (!validator.check())
-         {
-             throw FatalError("hydro final level : infeasibility");
-         }
-         if (validator.finalLevelFineForUse())
-         {
-             area.hydro.deltaBetweenFinalAndInitialLevels[year] = finalLevel - initialLevel;
-         }
-     });
+    areas.each(
+      [&areas, &parameters, &scenarioInitialHydroLevels, &scenarioFinalHydroLevels, year](
+        Data::Area& area)
+      {
+          double initialLevel = scenarioInitialHydroLevels.entry[area.index][year];
+          double finalLevel = scenarioFinalHydroLevels.entry[area.index][year];
+
+          Data::FinalLevelValidator validator(area.hydro,
+                                              area.index,
+                                              area.name,
+                                              initialLevel,
+                                              finalLevel,
+                                              year,
+                                              parameters.simulationDays.end,
+                                              parameters.firstMonthInYear);
+          if (!validator.check())
+          {
+              throw FatalError("hydro final level : infeasibility");
+          }
+          if (validator.finalLevelFineForUse())
+          {
+              area.hydro.deltaBetweenFinalAndInitialLevels[year] = finalLevel - initialLevel;
+          }
+      });
 } // End function CheckFinalReservoirLevelsConfiguration
 
 } // namespace Antares::Solver

--- a/src/solver/hydro/management/hydro-final-reservoir-level-functions.cpp
+++ b/src/solver/hydro/management/hydro-final-reservoir-level-functions.cpp
@@ -40,34 +40,30 @@ void CheckFinalReservoirLevelsConfiguration(Data::AreaList& areas,
                                             uint year)
 {
     if (!parameters.yearsFilter.at(year))
-    {
         return;
-    }
 
-    areas.each(
-      [&areas, &parameters, &scenarioInitialHydroLevels, &scenarioFinalHydroLevels, year](
-        Data::Area& area)
-      {
-          double initialLevel = scenarioInitialHydroLevels.entry[area.index][year];
-          double finalLevel = scenarioFinalHydroLevels.entry[area.index][year];
+    areas.each([&areas, &parameters, &scenarioInitialHydroLevels, &scenarioFinalHydroLevels, year](Data::Area &area)
+    {
+         double initialLevel = scenarioInitialHydroLevels.entry[area.index][year];
+         double finalLevel = scenarioFinalHydroLevels.entry[area.index][year];
 
-          Data::FinalLevelValidator validator(area.hydro,
-                                              area.index,
-                                              area.name,
-                                              initialLevel,
-                                              finalLevel,
-                                              year,
-                                              parameters.simulationDays.end,
-                                              parameters.firstMonthInYear);
-          if (!validator.check())
-          {
-              throw FatalError("hydro final level : infeasibility");
-          }
-          if (validator.finalLevelFineForUse())
-          {
-              area.hydro.deltaBetweenFinalAndInitialLevels[year] = finalLevel - initialLevel;
-          }
-      });
+         Data::FinalLevelValidator validator(area.hydro,
+                                             area.index,
+                                             area.name,
+                                             initialLevel,
+                                             finalLevel,
+                                             year,
+                                             parameters.simulationDays.end,
+                                             parameters.firstMonthInYear);
+         if (!validator.check())
+         {
+             throw FatalError("hydro final level : infeasibility");
+         }
+         if (validator.finalLevelFineForUse())
+         {
+             area.hydro.deltaBetweenFinalAndInitialLevels[year] = finalLevel - initialLevel;
+         }
+     });
 } // End function CheckFinalReservoirLevelsConfiguration
 
 } // namespace Antares::Solver

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -140,11 +140,10 @@ HydroManagement::HydroManagement(const Data::AreaList& areas,
     }
 }
 
-void HydroManagement::prepareNetDemand(
-  uint year,
-  Data::SimulationMode mode,
-  const Antares::Data::Area::ScratchMap& scratchmap,
-  HydroSpecificMap& hydro_specific_map)
+void HydroManagement::prepareNetDemand(uint year,
+                                       Data::SimulationMode mode,
+                                       const Antares::Data::Area::ScratchMap& scratchmap,
+                                       HydroSpecificMap& hydro_specific_map)
 {
     areas_.each(
       [this, &year, &scratchmap, &mode, &hydro_specific_map](Data::Area& area)
@@ -197,9 +196,7 @@ void HydroManagement::prepareNetDemand(
       });
 }
 
-void HydroManagement::prepareEffectiveDemand(
-  uint year,
-  HydroSpecificMap& hydro_specific_map)
+void HydroManagement::prepareEffectiveDemand(uint year, HydroSpecificMap& hydro_specific_map)
 {
     areas_.each(
       [this, &year, &hydro_specific_map](Data::Area& area)
@@ -216,7 +213,8 @@ void HydroManagement::prepareEffectiveDemand(
               double effectiveDemand = 0;
               // area.hydro.allocation is indexed by area index
               area.hydro.allocation.eachNonNull(
-                [this, &effectiveDemand, &day, &hydro_specific_map](unsigned areaIndex, double value)
+                [this, &effectiveDemand, &day, &hydro_specific_map](unsigned areaIndex,
+                                                                    double value)
                 {
                     const auto* area = areas_.byIndex[areaIndex];
                     effectiveDemand += hydro_specific_map[area].daily[day].DLN * value;

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -140,10 +140,11 @@ HydroManagement::HydroManagement(const Data::AreaList& areas,
     }
 }
 
-void HydroManagement::prepareNetDemand(uint year,
-                                       Data::SimulationMode mode,
-                                       const Antares::Data::Area::ScratchMap& scratchmap,
-                                       HydroSpecificMap& hydro_specific_map)
+void HydroManagement::prepareNetDemand(
+  uint year,
+  Data::SimulationMode mode,
+  const Antares::Data::Area::ScratchMap& scratchmap,
+  HydroSpecificMap& hydro_specific_map)
 {
     areas_.each(
       [this, &year, &scratchmap, &mode, &hydro_specific_map](Data::Area& area)
@@ -196,7 +197,9 @@ void HydroManagement::prepareNetDemand(uint year,
       });
 }
 
-void HydroManagement::prepareEffectiveDemand(uint year, HydroSpecificMap& hydro_specific_map)
+void HydroManagement::prepareEffectiveDemand(
+  uint year,
+  HydroSpecificMap& hydro_specific_map)
 {
     areas_.each(
       [this, &year, &hydro_specific_map](Data::Area& area)
@@ -213,8 +216,7 @@ void HydroManagement::prepareEffectiveDemand(uint year, HydroSpecificMap& hydro_
               double effectiveDemand = 0;
               // area.hydro.allocation is indexed by area index
               area.hydro.allocation.eachNonNull(
-                [this, &effectiveDemand, &day, &hydro_specific_map](unsigned areaIndex,
-                                                                    double value)
+                [this, &effectiveDemand, &day, &hydro_specific_map](unsigned areaIndex, double value)
                 {
                     const auto* area = areas_.byIndex[areaIndex];
                     effectiveDemand += hydro_specific_map[area].daily[day].DLN * value;

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -151,10 +151,9 @@ double HydroManagement::prepareMonthlyTargetGenerations(
     return total;
 }
 
-void HydroManagement::prepareMonthlyOptimalGenerations(
-  double* random_reservoir_level,
-  uint y,
-  HydroSpecificMap& hydro_specific_map)
+void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_level,
+                                                       uint y,
+                                                       HydroSpecificMap& hydro_specific_map)
 {
     uint indexArea = 0;
     areas_.each(
@@ -291,9 +290,8 @@ void HydroManagement::prepareMonthlyOptimalGenerations(
               writeSolutionCost("Solution cost (noised) : ", solutionCostNoised);
               buffer << "\n\n";
 
-              buffer << '\t' << "\tInflows" << '\t' << "\tTarget Gen."
-                     << "\tTurbined"
-                     << "\tLevels" << '\t' << "\tLvl min" << '\t' << "\tLvl max\n";
+              buffer << '\t' << "\tInflows" << '\t' << "\tTarget Gen." << "\tTurbined" << "\tLevels"
+                     << '\t' << "\tLvl min" << '\t' << "\tLvl max\n";
               for (uint month = 0; month != 12; ++month)
               {
                   uint realmonth = (initReservoirLvlMonth + month) % 12;

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -151,9 +151,10 @@ double HydroManagement::prepareMonthlyTargetGenerations(
     return total;
 }
 
-void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_level,
-                                                       uint y,
-                                                       HydroSpecificMap& hydro_specific_map)
+void HydroManagement::prepareMonthlyOptimalGenerations(
+  double* random_reservoir_level,
+  uint y,
+  HydroSpecificMap& hydro_specific_map)
 {
     uint indexArea = 0;
     areas_.each(
@@ -290,8 +291,9 @@ void HydroManagement::prepareMonthlyOptimalGenerations(double* random_reservoir_
               writeSolutionCost("Solution cost (noised) : ", solutionCostNoised);
               buffer << "\n\n";
 
-              buffer << '\t' << "\tInflows" << '\t' << "\tTarget Gen." << "\tTurbined" << "\tLevels"
-                     << '\t' << "\tLvl min" << '\t' << "\tLvl max\n";
+              buffer << '\t' << "\tInflows" << '\t' << "\tTarget Gen."
+                     << "\tTurbined"
+                     << "\tLevels" << '\t' << "\tLvl min" << '\t' << "\tLvl max\n";
               for (uint month = 0; month != 12; ++month)
               {
                   uint realmonth = (initReservoirLvlMonth + month) % 12;

--- a/src/solver/misc/include/antares/solver/misc/options.h
+++ b/src/solver/misc/include/antares/solver/misc/options.h
@@ -27,8 +27,8 @@
 #include <yuni/core/getopt.h>
 #include <yuni/core/string.h>
 
-#include <antares/study/study.h>
 #include <antares/optimization-options/options.h>
+#include <antares/study/study.h>
 
 /*!
 ** \brief Command line settings for launching the simulation

--- a/src/solver/misc/include/antares/solver/misc/options.h
+++ b/src/solver/misc/include/antares/solver/misc/options.h
@@ -27,8 +27,8 @@
 #include <yuni/core/getopt.h>
 #include <yuni/core/string.h>
 
-#include <antares/optimization-options/options.h>
 #include <antares/study/study.h>
+#include <antares/optimization-options/options.h>
 
 /*!
 ** \brief Command line settings for launching the simulation

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -22,8 +22,8 @@
 #include "antares/solver/misc/options.h"
 
 #include <algorithm>
-#include <fstream>
 #include <cassert>
+#include <fstream>
 #include <limits>
 #include <string.h>
 

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -22,8 +22,8 @@
 #include "antares/solver/misc/options.h"
 
 #include <algorithm>
-#include <cassert>
 #include <fstream>
+#include <cassert>
 #include <limits>
 #include <string.h>
 

--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
@@ -22,8 +22,8 @@
 #include "antares/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.h"
 
 #include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/ISimulationObserver.h"
 #include "antares/solver/simulation/adequacy_patch_runtime_data.h"
+#include "antares/solver/simulation/ISimulationObserver.h"
 #include "antares/study/fwd.h"
 
 using namespace Antares::Data::AdequacyPatch;
@@ -47,11 +47,7 @@ void AdequacyPatchOptimization::solve()
 {
     Simulation::NullSimulationObserver nullSimulationObserver;
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = true;
-    OPT_OptimisationHebdomadaire(options_,
-                                 problemeHebdo_,
-                                 adqPatchParams_,
-                                 writer_,
-                                 nullSimulationObserver);
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_, nullSimulationObserver);
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = false;
 
     for (uint32_t pays = 0; pays < problemeHebdo_->NombreDePays; ++pays)
@@ -68,11 +64,7 @@ void AdequacyPatchOptimization::solve()
         }
     }
 
-    OPT_OptimisationHebdomadaire(options_,
-                                 problemeHebdo_,
-                                 adqPatchParams_,
-                                 writer_,
-                                 nullSimulationObserver);
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_, nullSimulationObserver);
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
+++ b/src/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.cpp
@@ -22,8 +22,8 @@
 #include "antares/solver/optimisation/adequacy_patch_local_matching/adequacy_patch_weekly_optimization.h"
 
 #include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/adequacy_patch_runtime_data.h"
 #include "antares/solver/simulation/ISimulationObserver.h"
+#include "antares/solver/simulation/adequacy_patch_runtime_data.h"
 #include "antares/study/fwd.h"
 
 using namespace Antares::Data::AdequacyPatch;
@@ -47,7 +47,11 @@ void AdequacyPatchOptimization::solve()
 {
     Simulation::NullSimulationObserver nullSimulationObserver;
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = true;
-    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_, nullSimulationObserver);
+    OPT_OptimisationHebdomadaire(options_,
+                                 problemeHebdo_,
+                                 adqPatchParams_,
+                                 writer_,
+                                 nullSimulationObserver);
     problemeHebdo_->adequacyPatchRuntimeData->AdequacyFirstStep = false;
 
     for (uint32_t pays = 0; pays < problemeHebdo_->NombreDePays; ++pays)
@@ -64,7 +68,11 @@ void AdequacyPatchOptimization::solve()
         }
     }
 
-    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_, nullSimulationObserver);
+    OPT_OptimisationHebdomadaire(options_,
+                                 problemeHebdo_,
+                                 adqPatchParams_,
+                                 writer_,
+                                 nullSimulationObserver);
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/base_weekly_optimization.cpp
+++ b/src/solver/optimisation/base_weekly_optimization.cpp
@@ -35,7 +35,8 @@ WeeklyOptimization::WeeklyOptimization(const OptimizationOptions& options,
                                        AdqPatchParams& adqPatchParams,
                                        uint thread_number,
                                        IResultWriter& writer,
-                                       Simulation::ISimulationObserver& simulationObserver):
+                                       Simulation::ISimulationObserver& simulationObserver
+                                       ) :
     options_(options),
     problemeHebdo_(problemesHebdo),
     adqPatchParams_(adqPatchParams),
@@ -45,14 +46,14 @@ WeeklyOptimization::WeeklyOptimization(const OptimizationOptions& options,
 {
 }
 
-std::unique_ptr<WeeklyOptimization> WeeklyOptimization::create(
-  const Antares::Data::Study& study,
-  const OptimizationOptions& options,
-  AdqPatchParams& adqPatchParams,
-  PROBLEME_HEBDO* problemeHebdo,
-  uint thread_number,
-  IResultWriter& writer,
-  Simulation::ISimulationObserver& simulationObserver)
+std::unique_ptr<WeeklyOptimization> WeeklyOptimization::create(const Antares::Data::Study& study,
+                                                               const OptimizationOptions& options,
+                                                               AdqPatchParams& adqPatchParams,
+                                                               PROBLEME_HEBDO* problemeHebdo,
+                                                               uint thread_number,
+    IResultWriter& writer,
+    Simulation::ISimulationObserver& simulationObserver
+  )
 {
     if (adqPatchParams.enabled && adqPatchParams.localMatching.enabled)
     {

--- a/src/solver/optimisation/base_weekly_optimization.cpp
+++ b/src/solver/optimisation/base_weekly_optimization.cpp
@@ -35,8 +35,7 @@ WeeklyOptimization::WeeklyOptimization(const OptimizationOptions& options,
                                        AdqPatchParams& adqPatchParams,
                                        uint thread_number,
                                        IResultWriter& writer,
-                                       Simulation::ISimulationObserver& simulationObserver
-                                       ) :
+                                       Simulation::ISimulationObserver& simulationObserver):
     options_(options),
     problemeHebdo_(problemesHebdo),
     adqPatchParams_(adqPatchParams),
@@ -46,14 +45,14 @@ WeeklyOptimization::WeeklyOptimization(const OptimizationOptions& options,
 {
 }
 
-std::unique_ptr<WeeklyOptimization> WeeklyOptimization::create(const Antares::Data::Study& study,
-                                                               const OptimizationOptions& options,
-                                                               AdqPatchParams& adqPatchParams,
-                                                               PROBLEME_HEBDO* problemeHebdo,
-                                                               uint thread_number,
-    IResultWriter& writer,
-    Simulation::ISimulationObserver& simulationObserver
-  )
+std::unique_ptr<WeeklyOptimization> WeeklyOptimization::create(
+  const Antares::Data::Study& study,
+  const OptimizationOptions& options,
+  AdqPatchParams& adqPatchParams,
+  PROBLEME_HEBDO* problemeHebdo,
+  uint thread_number,
+  IResultWriter& writer,
+  Simulation::ISimulationObserver& simulationObserver)
 {
     if (adqPatchParams.enabled && adqPatchParams.localMatching.enabled)
     {

--- a/src/solver/optimisation/include/antares/solver/optimisation/base_weekly_optimization.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/base_weekly_optimization.h
@@ -41,9 +41,8 @@ public:
       Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams,
       PROBLEME_HEBDO* problemesHebdo,
       uint numSpace,
-                                                      IResultWriter& writer,
-                                                      Simulation::ISimulationObserver& simulationObserver
-                                                      );
+      IResultWriter& writer,
+      Simulation::ISimulationObserver& simulationObserver);
 
 protected:
     explicit WeeklyOptimization(const OptimizationOptions& options,
@@ -51,8 +50,7 @@ protected:
                                 Antares::Data::AdequacyPatch::AdqPatchParams&,
                                 uint numSpace,
                                 IResultWriter& writer,
-                                Simulation::ISimulationObserver& simulationObserver
-                                );
+                                Simulation::ISimulationObserver& simulationObserver);
     Antares::Solver::Optimization::OptimizationOptions options_;
     PROBLEME_HEBDO* const problemeHebdo_ = nullptr;
     Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams_;

--- a/src/solver/optimisation/include/antares/solver/optimisation/base_weekly_optimization.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/base_weekly_optimization.h
@@ -41,8 +41,9 @@ public:
       Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams,
       PROBLEME_HEBDO* problemesHebdo,
       uint numSpace,
-      IResultWriter& writer,
-      Simulation::ISimulationObserver& simulationObserver);
+                                                      IResultWriter& writer,
+                                                      Simulation::ISimulationObserver& simulationObserver
+                                                      );
 
 protected:
     explicit WeeklyOptimization(const OptimizationOptions& options,
@@ -50,7 +51,8 @@ protected:
                                 Antares::Data::AdequacyPatch::AdqPatchParams&,
                                 uint numSpace,
                                 IResultWriter& writer,
-                                Simulation::ISimulationObserver& simulationObserver);
+                                Simulation::ISimulationObserver& simulationObserver
+                                );
     Antares::Solver::Optimization::OptimizationOptions options_;
     PROBLEME_HEBDO* const problemeHebdo_ = nullptr;
     Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams_;

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
@@ -70,7 +70,8 @@ bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options,
                                       PROBLEME_HEBDO* problemeHebdo,
                                       const AdqPatchParams& adqPatchParams,
                                       Solver::IResultWriter& writer,
-                                      Solver::Simulation::ISimulationObserver& simulationObserver);
+                                      Solver::Simulation::ISimulationObserver& simulationObserver
+                                      );
 void OPT_VerifierPresenceReserveJmoins1(PROBLEME_HEBDO*);
 bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO*);
 
@@ -91,7 +92,8 @@ bool OPT_OptimisationLineaire(const OptimizationOptions& options,
                               PROBLEME_HEBDO* problemeHebdo,
                               const AdqPatchParams& adqPatchParams,
                               Solver::IResultWriter& writer,
-                              Solver::Simulation::ISimulationObserver& simulationObserver);
+                              Solver::Simulation::ISimulationObserver& simulationObserver
+                              );
 void OPT_RestaurerLesDonnees(PROBLEME_HEBDO*);
 /*------------------------------*/
 

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
@@ -70,8 +70,7 @@ bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options,
                                       PROBLEME_HEBDO* problemeHebdo,
                                       const AdqPatchParams& adqPatchParams,
                                       Solver::IResultWriter& writer,
-                                      Solver::Simulation::ISimulationObserver& simulationObserver
-                                      );
+                                      Solver::Simulation::ISimulationObserver& simulationObserver);
 void OPT_VerifierPresenceReserveJmoins1(PROBLEME_HEBDO*);
 bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO*);
 
@@ -92,8 +91,7 @@ bool OPT_OptimisationLineaire(const OptimizationOptions& options,
                               PROBLEME_HEBDO* problemeHebdo,
                               const AdqPatchParams& adqPatchParams,
                               Solver::IResultWriter& writer,
-                              Solver::Simulation::ISimulationObserver& simulationObserver
-                              );
+                              Solver::Simulation::ISimulationObserver& simulationObserver);
 void OPT_RestaurerLesDonnees(PROBLEME_HEBDO*);
 /*------------------------------*/
 

--- a/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
@@ -21,8 +21,9 @@
 
 #pragma once
 
-#include "antares/solver/simulation/ISimulationObserver.h"
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
+#include "antares/solver/simulation/ISimulationObserver.h"
+
 
 #include "base_weekly_optimization.h"
 
@@ -35,8 +36,9 @@ public:
                                        PROBLEME_HEBDO* problemeHebdo,
                                        Antares::Data::AdequacyPatch::AdqPatchParams&,
                                        uint numSpace,
-                                       IResultWriter& writer,
-                                       Simulation::ISimulationObserver& simulationObserver);
+                                     IResultWriter& writer,
+                                     Simulation::ISimulationObserver& simulationObserver
+                                       );
     ~DefaultWeeklyOptimization() override = default;
     void solve() override;
 };

--- a/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
@@ -21,9 +21,8 @@
 
 #pragma once
 
-#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 #include "antares/solver/simulation/ISimulationObserver.h"
-
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 #include "base_weekly_optimization.h"
 
@@ -36,9 +35,8 @@ public:
                                        PROBLEME_HEBDO* problemeHebdo,
                                        Antares::Data::AdequacyPatch::AdqPatchParams&,
                                        uint numSpace,
-                                     IResultWriter& writer,
-                                     Simulation::ISimulationObserver& simulationObserver
-                                       );
+                                       IResultWriter& writer,
+                                       Simulation::ISimulationObserver& simulationObserver);
     ~DefaultWeeklyOptimization() override = default;
     void solve() override;
 };

--- a/src/solver/optimisation/opt_construction_variables_optimisees_quadratique.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_quadratique.cpp
@@ -31,7 +31,7 @@
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeQuadratique(PROBLEME_HEBDO* problemeHebdo)
 {
     const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
-    assert(ProblemeAResoudre);
+    assert(ProblemeAResoudre );
 
     int nombreDeVariables = 0;
     auto variableManager = VariableManagerFromProblemHebdo(problemeHebdo);

--- a/src/solver/optimisation/opt_construction_variables_optimisees_quadratique.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_quadratique.cpp
@@ -31,7 +31,7 @@
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeQuadratique(PROBLEME_HEBDO* problemeHebdo)
 {
     const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
-    assert(ProblemeAResoudre );
+    assert(ProblemeAResoudre);
 
     int nombreDeVariables = 0;
     auto variableManager = VariableManagerFromProblemHebdo(problemeHebdo);

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -45,8 +45,11 @@ void OPT_OptimisationHebdomadaire(const OptimizationOptions& options,
 {
     if (pProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE)
     {
-        if (!OPT_PilotageOptimisationLineaire(
-              options, pProblemeHebdo, adqPatchParams, writer, simulationObserver))
+        if (!OPT_PilotageOptimisationLineaire(options,
+                                              pProblemeHebdo,
+                                              adqPatchParams,
+                                              writer,
+                                              simulationObserver))
         {
             logs.error() << "Linear optimization failed";
             throw UnfeasibleProblemError("Linear optimization failed");

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -45,11 +45,8 @@ void OPT_OptimisationHebdomadaire(const OptimizationOptions& options,
 {
     if (pProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE)
     {
-        if (!OPT_PilotageOptimisationLineaire(options,
-                                              pProblemeHebdo,
-                                              adqPatchParams,
-                                              writer,
-                                              simulationObserver))
+        if (!OPT_PilotageOptimisationLineaire(
+              options, pProblemeHebdo, adqPatchParams, writer, simulationObserver))
         {
             logs.error() << "Linear optimization failed";
             throw UnfeasibleProblemError("Linear optimization failed");

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -77,5 +77,9 @@ bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options,
         OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage(problemeHebdo);
     }
 
-    return OPT_OptimisationLineaire(options, problemeHebdo, adqPatchParams, writer, simulationObserver);
+    return OPT_OptimisationLineaire(options,
+                                    problemeHebdo,
+                                    adqPatchParams,
+                                    writer,
+                                    simulationObserver);
 }

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -77,9 +77,5 @@ bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options,
         OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage(problemeHebdo);
     }
 
-    return OPT_OptimisationLineaire(options,
-                                    problemeHebdo,
-                                    adqPatchParams,
-                                    writer,
-                                    simulationObserver);
+    return OPT_OptimisationLineaire(options, problemeHebdo, adqPatchParams, writer, simulationObserver);
 }

--- a/src/solver/optimisation/weekly_optimization.cpp
+++ b/src/solver/optimisation/weekly_optimization.cpp
@@ -17,7 +17,7 @@
  *
  * You should have received a copy of the Mozilla Public Licence 2.0
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
-*/
+ */
 
 #include "antares/solver/optimisation/weekly_optimization.h"
 
@@ -25,19 +25,29 @@
 
 namespace Antares::Solver::Optimization
 {
-DefaultWeeklyOptimization::DefaultWeeklyOptimization(const OptimizationOptions& options,
-                                                     PROBLEME_HEBDO* problemeHebdo,
-                                                     AdqPatchParams& adqPatchParams,
-                                                     uint thread_number,
-                                                     IResultWriter& writer,
-                                                     Simulation::ISimulationObserver& simulationObserver) :
- WeeklyOptimization(options, problemeHebdo, adqPatchParams, thread_number, writer, simulationObserver)
+DefaultWeeklyOptimization::DefaultWeeklyOptimization(
+  const OptimizationOptions& options,
+  PROBLEME_HEBDO* problemeHebdo,
+  AdqPatchParams& adqPatchParams,
+  uint thread_number,
+  IResultWriter& writer,
+  Simulation::ISimulationObserver& simulationObserver):
+    WeeklyOptimization(options,
+                       problemeHebdo,
+                       adqPatchParams,
+                       thread_number,
+                       writer,
+                       simulationObserver)
 {
 }
 
 void DefaultWeeklyOptimization::solve()
 {
-    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_, simulationObserver_.get());
+    OPT_OptimisationHebdomadaire(options_,
+                                 problemeHebdo_,
+                                 adqPatchParams_,
+                                 writer_,
+                                 simulationObserver_.get());
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/optimisation/weekly_optimization.cpp
+++ b/src/solver/optimisation/weekly_optimization.cpp
@@ -17,7 +17,7 @@
  *
  * You should have received a copy of the Mozilla Public Licence 2.0
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
- */
+*/
 
 #include "antares/solver/optimisation/weekly_optimization.h"
 
@@ -25,29 +25,19 @@
 
 namespace Antares::Solver::Optimization
 {
-DefaultWeeklyOptimization::DefaultWeeklyOptimization(
-  const OptimizationOptions& options,
-  PROBLEME_HEBDO* problemeHebdo,
-  AdqPatchParams& adqPatchParams,
-  uint thread_number,
-  IResultWriter& writer,
-  Simulation::ISimulationObserver& simulationObserver):
-    WeeklyOptimization(options,
-                       problemeHebdo,
-                       adqPatchParams,
-                       thread_number,
-                       writer,
-                       simulationObserver)
+DefaultWeeklyOptimization::DefaultWeeklyOptimization(const OptimizationOptions& options,
+                                                     PROBLEME_HEBDO* problemeHebdo,
+                                                     AdqPatchParams& adqPatchParams,
+                                                     uint thread_number,
+                                                     IResultWriter& writer,
+                                                     Simulation::ISimulationObserver& simulationObserver) :
+ WeeklyOptimization(options, problemeHebdo, adqPatchParams, thread_number, writer, simulationObserver)
 {
 }
 
 void DefaultWeeklyOptimization::solve()
 {
-    OPT_OptimisationHebdomadaire(options_,
-                                 problemeHebdo_,
-                                 adqPatchParams_,
-                                 writer_,
-                                 simulationObserver_.get());
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, adqPatchParams_, writer_, simulationObserver_.get());
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -31,8 +31,10 @@ namespace Antares::Solver::Simulation
 {
 Adequacy::Adequacy(Data::Study& study,
                    IResultWriter& resultWriter,
-                   Simulation::ISimulationObserver& simulationObserver) :
- study(study), resultWriter(resultWriter), simulationObserver_(simulationObserver)
+                   Simulation::ISimulationObserver& simulationObserver):
+    study(study),
+    resultWriter(resultWriter),
+    simulationObserver_(simulationObserver)
 {
 }
 
@@ -68,7 +70,10 @@ bool Adequacy::simulationBegin()
         pProblemesHebdo.resize(pNbMaxPerformedYearsInParallel);
         for (uint numSpace = 0; numSpace < pNbMaxPerformedYearsInParallel; numSpace++)
         {
-            SIM_InitialisationProblemeHebdo(study, pProblemesHebdo[numSpace], nbHoursInAWeek, numSpace);
+            SIM_InitialisationProblemeHebdo(study,
+                                            pProblemesHebdo[numSpace],
+                                            nbHoursInAWeek,
+                                            numSpace);
         }
     }
 
@@ -405,8 +410,8 @@ void Adequacy::prepareClustersInMustRunMode(Data::Area::ScratchMap& scratchmap, 
 {
     for (uint i = 0; i < study.areas.size(); ++i)
     {
-        auto &area = *study.areas[i];
-        auto &scratchpad = scratchmap.at(&area);
+        auto& area = *study.areas[i];
+        auto& scratchpad = scratchmap.at(&area);
 
         std::ranges::fill(scratchpad.mustrunSum, 0);
         std::ranges::fill(scratchpad.originalMustrunSum, 0);
@@ -414,9 +419,9 @@ void Adequacy::prepareClustersInMustRunMode(Data::Area::ScratchMap& scratchmap, 
         auto& mrs = scratchpad.mustrunSum;
         auto& adq = scratchpad.originalMustrunSum;
 
-        for (const auto &cluster: area.thermal.list.each_mustrun_and_enabled())
+        for (const auto& cluster: area.thermal.list.each_mustrun_and_enabled())
         {
-            const auto &availableProduction = cluster->series.getColumn(year);
+            const auto& availableProduction = cluster->series.getColumn(year);
             for (uint h = 0; h != cluster->series.timeSeries.height; ++h)
             {
                 mrs[h] += availableProduction[h];
@@ -426,7 +431,8 @@ void Adequacy::prepareClustersInMustRunMode(Data::Area::ScratchMap& scratchmap, 
             {
                 for (uint h = 0; h != cluster->series.timeSeries.height; ++h)
                 {
-                    adq[h] += 2 * availableProduction[h]; // Why do we add the available production twice ?
+                    adq[h] += 2 * availableProduction[h]; // Why do we add the available production
+                                                          // twice ?
                 }
             }
         }

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -31,10 +31,8 @@ namespace Antares::Solver::Simulation
 {
 Adequacy::Adequacy(Data::Study& study,
                    IResultWriter& resultWriter,
-                   Simulation::ISimulationObserver& simulationObserver):
-    study(study),
-    resultWriter(resultWriter),
-    simulationObserver_(simulationObserver)
+                   Simulation::ISimulationObserver& simulationObserver) :
+ study(study), resultWriter(resultWriter), simulationObserver_(simulationObserver)
 {
 }
 
@@ -70,10 +68,7 @@ bool Adequacy::simulationBegin()
         pProblemesHebdo.resize(pNbMaxPerformedYearsInParallel);
         for (uint numSpace = 0; numSpace < pNbMaxPerformedYearsInParallel; numSpace++)
         {
-            SIM_InitialisationProblemeHebdo(study,
-                                            pProblemesHebdo[numSpace],
-                                            nbHoursInAWeek,
-                                            numSpace);
+            SIM_InitialisationProblemeHebdo(study, pProblemesHebdo[numSpace], nbHoursInAWeek, numSpace);
         }
     }
 
@@ -410,8 +405,8 @@ void Adequacy::prepareClustersInMustRunMode(Data::Area::ScratchMap& scratchmap, 
 {
     for (uint i = 0; i < study.areas.size(); ++i)
     {
-        auto& area = *study.areas[i];
-        auto& scratchpad = scratchmap.at(&area);
+        auto &area = *study.areas[i];
+        auto &scratchpad = scratchmap.at(&area);
 
         std::ranges::fill(scratchpad.mustrunSum, 0);
         std::ranges::fill(scratchpad.originalMustrunSum, 0);
@@ -419,9 +414,9 @@ void Adequacy::prepareClustersInMustRunMode(Data::Area::ScratchMap& scratchmap, 
         auto& mrs = scratchpad.mustrunSum;
         auto& adq = scratchpad.originalMustrunSum;
 
-        for (const auto& cluster: area.thermal.list.each_mustrun_and_enabled())
+        for (const auto &cluster: area.thermal.list.each_mustrun_and_enabled())
         {
-            const auto& availableProduction = cluster->series.getColumn(year);
+            const auto &availableProduction = cluster->series.getColumn(year);
             for (uint h = 0; h != cluster->series.timeSeries.height; ++h)
             {
                 mrs[h] += availableProduction[h];
@@ -431,8 +426,7 @@ void Adequacy::prepareClustersInMustRunMode(Data::Area::ScratchMap& scratchmap, 
             {
                 for (uint h = 0; h != cluster->series.timeSeries.height; ++h)
                 {
-                    adq[h] += 2 * availableProduction[h]; // Why do we add the available production
-                                                          // twice ?
+                    adq[h] += 2 * availableProduction[h]; // Why do we add the available production twice ?
                 }
             }
         }

--- a/src/solver/simulation/adequacy_mode.cpp
+++ b/src/solver/simulation/adequacy_mode.cpp
@@ -1,23 +1,23 @@
 /*
-* Copyright 2007-2024, RTE (https://www.rte-france.com)
-* See AUTHORS.txt
-* SPDX-License-Identifier: MPL-2.0
-* This file is part of Antares-Simulator,
-* Adequacy and Performance assessment for interconnected energy networks.
-*
-* Antares_Simulator is free software: you can redistribute it and/or modify
-* it under the terms of the Mozilla Public Licence 2.0 as published by
-* the Mozilla Foundation, either version 2 of the License, or
-* (at your option) any later version.
-*
-* Antares_Simulator is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* Mozilla Public Licence 2.0 for more details.
-*
-* You should have received a copy of the Mozilla Public Licence 2.0
-* along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
-*/
+ * Copyright 2007-2024, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
 
 #include "antares/solver/simulation/adequacy_mode.h"
 
@@ -27,24 +27,24 @@
 namespace Antares::Solver
 {
 void runSimulationInAdequacyMode(Antares::Data::Study& study,
-                                const Settings& settings,
+                                 const Settings& settings,
                                  Benchmarking::DurationCollector& durationCollector,
-                                IResultWriter& resultWriter,
-                                Benchmarking::OptimizationInfo& info,
-                                Simulation::ISimulationObserver& simulationObserver)
+                                 IResultWriter& resultWriter,
+                                 Benchmarking::OptimizationInfo& info,
+                                 Simulation::ISimulationObserver& simulationObserver)
 {
-   // Type of the simulation
-   typedef Solver::Simulation::ISimulation<Solver::Simulation::Adequacy> SimulationType;
-   SimulationType simulation(study, settings, durationCollector, resultWriter, simulationObserver);
-   simulation.checkWriter();
-   simulation.run();
+    // Type of the simulation
+    typedef Solver::Simulation::ISimulation<Solver::Simulation::Adequacy> SimulationType;
+    SimulationType simulation(study, settings, durationCollector, resultWriter, simulationObserver);
+    simulation.checkWriter();
+    simulation.run();
 
-   if (!(settings.noOutput || settings.tsGeneratorsOnly))
-   {
+    if (!(settings.noOutput || settings.tsGeneratorsOnly))
+    {
         durationCollector("synthesis_export")
           << [&simulation] { simulation.writeResults(/*synthesis:*/ true); };
 
-       info = simulation.getOptimizationInfo();
-   }
+        info = simulation.getOptimizationInfo();
+    }
 }
 } // namespace Antares::Solver

--- a/src/solver/simulation/adequacy_mode.cpp
+++ b/src/solver/simulation/adequacy_mode.cpp
@@ -1,23 +1,23 @@
 /*
- * Copyright 2007-2024, RTE (https://www.rte-france.com)
- * See AUTHORS.txt
- * SPDX-License-Identifier: MPL-2.0
- * This file is part of Antares-Simulator,
- * Adequacy and Performance assessment for interconnected energy networks.
- *
- * Antares_Simulator is free software: you can redistribute it and/or modify
- * it under the terms of the Mozilla Public Licence 2.0 as published by
- * the Mozilla Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * Antares_Simulator is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * Mozilla Public Licence 2.0 for more details.
- *
- * You should have received a copy of the Mozilla Public Licence 2.0
- * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
- */
+* Copyright 2007-2024, RTE (https://www.rte-france.com)
+* See AUTHORS.txt
+* SPDX-License-Identifier: MPL-2.0
+* This file is part of Antares-Simulator,
+* Adequacy and Performance assessment for interconnected energy networks.
+*
+* Antares_Simulator is free software: you can redistribute it and/or modify
+* it under the terms of the Mozilla Public Licence 2.0 as published by
+* the Mozilla Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Antares_Simulator is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* Mozilla Public Licence 2.0 for more details.
+*
+* You should have received a copy of the Mozilla Public Licence 2.0
+* along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+*/
 
 #include "antares/solver/simulation/adequacy_mode.h"
 
@@ -27,24 +27,24 @@
 namespace Antares::Solver
 {
 void runSimulationInAdequacyMode(Antares::Data::Study& study,
-                                 const Settings& settings,
+                                const Settings& settings,
                                  Benchmarking::DurationCollector& durationCollector,
-                                 IResultWriter& resultWriter,
-                                 Benchmarking::OptimizationInfo& info,
-                                 Simulation::ISimulationObserver& simulationObserver)
+                                IResultWriter& resultWriter,
+                                Benchmarking::OptimizationInfo& info,
+                                Simulation::ISimulationObserver& simulationObserver)
 {
-    // Type of the simulation
-    typedef Solver::Simulation::ISimulation<Solver::Simulation::Adequacy> SimulationType;
-    SimulationType simulation(study, settings, durationCollector, resultWriter, simulationObserver);
-    simulation.checkWriter();
-    simulation.run();
+   // Type of the simulation
+   typedef Solver::Simulation::ISimulation<Solver::Simulation::Adequacy> SimulationType;
+   SimulationType simulation(study, settings, durationCollector, resultWriter, simulationObserver);
+   simulation.checkWriter();
+   simulation.run();
 
-    if (!(settings.noOutput || settings.tsGeneratorsOnly))
-    {
+   if (!(settings.noOutput || settings.tsGeneratorsOnly))
+   {
         durationCollector("synthesis_export")
           << [&simulation] { simulation.writeResults(/*synthesis:*/ true); };
 
-        info = simulation.getOptimizationInfo();
-    }
+       info = simulation.getOptimizationInfo();
+   }
 }
 } // namespace Antares::Solver

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -338,21 +338,23 @@ void PrepareRandomNumbers(Data::Study& study,
       });
 }
 
-
 void SetInitialHydroLevel(Data::Study& study,
                           PROBLEME_HEBDO& problem,
                           const HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
 {
     uint firstDaySimu = study.parameters.simulationDays.first;
-    study.areas.each([&problem, &firstDaySimu, &hydroVentilationResults](const Data::Area& area)
-    {
-        if (area.hydro.reservoirManagement)
-        {
-            double capacity = area.hydro.reservoirCapacity;
-            problem.previousSimulationFinalLevel[area.index] =
-                hydroVentilationResults[area.index].NiveauxReservoirsDebutJours[firstDaySimu] * capacity;
-        }
-    });
+    study.areas.each(
+      [&problem, &firstDaySimu, &hydroVentilationResults](const Data::Area& area)
+      {
+          if (area.hydro.reservoirManagement)
+          {
+              double capacity = area.hydro.reservoirCapacity;
+              problem.previousSimulationFinalLevel[area.index] = hydroVentilationResults[area.index]
+                                                                   .NiveauxReservoirsDebutJours
+                                                                     [firstDaySimu]
+                                                                 * capacity;
+          }
+      });
 }
 
 void BuildThermalPartOfWeeklyProblem(Data::Study& study,

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -338,23 +338,21 @@ void PrepareRandomNumbers(Data::Study& study,
       });
 }
 
+
 void SetInitialHydroLevel(Data::Study& study,
                           PROBLEME_HEBDO& problem,
                           const HYDRO_VENTILATION_RESULTS& hydroVentilationResults)
 {
     uint firstDaySimu = study.parameters.simulationDays.first;
-    study.areas.each(
-      [&problem, &firstDaySimu, &hydroVentilationResults](const Data::Area& area)
-      {
-          if (area.hydro.reservoirManagement)
-          {
-              double capacity = area.hydro.reservoirCapacity;
-              problem.previousSimulationFinalLevel[area.index] = hydroVentilationResults[area.index]
-                                                                   .NiveauxReservoirsDebutJours
-                                                                     [firstDaySimu]
-                                                                 * capacity;
-          }
-      });
+    study.areas.each([&problem, &firstDaySimu, &hydroVentilationResults](const Data::Area& area)
+    {
+        if (area.hydro.reservoirManagement)
+        {
+            double capacity = area.hydro.reservoirCapacity;
+            problem.previousSimulationFinalLevel[area.index] =
+                hydroVentilationResults[area.index].NiveauxReservoirsDebutJours[firstDaySimu] * capacity;
+        }
+    });
 }
 
 void BuildThermalPartOfWeeklyProblem(Data::Study& study,

--- a/src/solver/simulation/common-hydro-levels.cpp
+++ b/src/solver/simulation/common-hydro-levels.cpp
@@ -33,7 +33,7 @@ void computingHydroLevels(const Data::AreaList& areas,
                           bool remixWasRun,
                           bool computeAnyway)
 {
-    for (const auto& [_, area] : areas)
+    for (const auto& [_, area]: areas)
     {
         if (!area->hydro.reservoirManagement)
         {
@@ -50,7 +50,7 @@ void computingHydroLevels(const Data::AreaList& areas,
         double reservoirCapacity = area->hydro.reservoirCapacity;
 
         std::vector<double>& inflows = problem.CaracteristiquesHydrauliques[index]
-            .ApportNaturelHoraire;
+                                         .ApportNaturelHoraire;
 
         RESULTATS_HORAIRES& weeklyResults = problem.ResultatsHoraires[index];
 
@@ -65,7 +65,7 @@ void computingHydroLevels(const Data::AreaList& areas,
         std::vector<double>& ovf = weeklyResults.debordementsHoraires;
 
         computeTimeStepLevel
-            computeLvlObj(nivInit, inflows, ovf, turb, pumpingRatio, pump, reservoirCapacity);
+          computeLvlObj(nivInit, inflows, ovf, turb, pumpingRatio, pump, reservoirCapacity);
 
         for (uint h = 0; h < nbHoursInAWeek - 1; h++)
         {
@@ -94,7 +94,7 @@ void interpolateWaterValue(const Data::AreaList& areas,
         daysOfWeek[d] = weekFirstDay + d;
     }
 
-    for (const auto& [_, area] : areas)
+    for (const auto& [_, area]: areas)
     {
         uint index = area->index;
 
@@ -118,22 +118,22 @@ void interpolateWaterValue(const Data::AreaList& areas,
         std::vector<double>& niv = weeklyResults.niveauxHoraires;
 
         waterVal[0] = Data::getWaterValue(problem.previousSimulationFinalLevel[index] * 100
-                / reservoirCapacity,
-                area->hydro.waterValues,
-                weekFirstDay);
+                                            / reservoirCapacity,
+                                          area->hydro.waterValues,
+                                          weekFirstDay);
 
         for (uint h = 1; h < nbHoursInAWeek; h++)
         {
             waterVal[h] = Data::getWaterValue(niv[h - 1],
-                    area->hydro.waterValues,
-                    daysOfWeek[h / 24]);
+                                              area->hydro.waterValues,
+                                              daysOfWeek[h / 24]);
         }
     }
 }
 
 void updatingWeeklyFinalHydroLevel(const Data::AreaList& areas, PROBLEME_HEBDO& problem)
 {
-    for (const auto& [_, area] : areas)
+    for (const auto& [_, area]: areas)
     {
         if (!area->hydro.reservoirManagement)
         {
@@ -149,7 +149,7 @@ void updatingWeeklyFinalHydroLevel(const Data::AreaList& areas, PROBLEME_HEBDO& 
         std::vector<double>& niv = weeklyResults.niveauxHoraires;
 
         problem.previousSimulationFinalLevel[index] = niv[nbHoursInAWeek - 1] * reservoirCapacity
-            / 100;
+                                                      / 100;
     }
 }
 

--- a/src/solver/simulation/common-hydro-levels.cpp
+++ b/src/solver/simulation/common-hydro-levels.cpp
@@ -33,7 +33,7 @@ void computingHydroLevels(const Data::AreaList& areas,
                           bool remixWasRun,
                           bool computeAnyway)
 {
-    for (const auto& [_, area]: areas)
+    for (const auto& [_, area] : areas)
     {
         if (!area->hydro.reservoirManagement)
         {
@@ -50,7 +50,7 @@ void computingHydroLevels(const Data::AreaList& areas,
         double reservoirCapacity = area->hydro.reservoirCapacity;
 
         std::vector<double>& inflows = problem.CaracteristiquesHydrauliques[index]
-                                         .ApportNaturelHoraire;
+            .ApportNaturelHoraire;
 
         RESULTATS_HORAIRES& weeklyResults = problem.ResultatsHoraires[index];
 
@@ -65,7 +65,7 @@ void computingHydroLevels(const Data::AreaList& areas,
         std::vector<double>& ovf = weeklyResults.debordementsHoraires;
 
         computeTimeStepLevel
-          computeLvlObj(nivInit, inflows, ovf, turb, pumpingRatio, pump, reservoirCapacity);
+            computeLvlObj(nivInit, inflows, ovf, turb, pumpingRatio, pump, reservoirCapacity);
 
         for (uint h = 0; h < nbHoursInAWeek - 1; h++)
         {
@@ -94,7 +94,7 @@ void interpolateWaterValue(const Data::AreaList& areas,
         daysOfWeek[d] = weekFirstDay + d;
     }
 
-    for (const auto& [_, area]: areas)
+    for (const auto& [_, area] : areas)
     {
         uint index = area->index;
 
@@ -118,22 +118,22 @@ void interpolateWaterValue(const Data::AreaList& areas,
         std::vector<double>& niv = weeklyResults.niveauxHoraires;
 
         waterVal[0] = Data::getWaterValue(problem.previousSimulationFinalLevel[index] * 100
-                                            / reservoirCapacity,
-                                          area->hydro.waterValues,
-                                          weekFirstDay);
+                / reservoirCapacity,
+                area->hydro.waterValues,
+                weekFirstDay);
 
         for (uint h = 1; h < nbHoursInAWeek; h++)
         {
             waterVal[h] = Data::getWaterValue(niv[h - 1],
-                                              area->hydro.waterValues,
-                                              daysOfWeek[h / 24]);
+                    area->hydro.waterValues,
+                    daysOfWeek[h / 24]);
         }
     }
 }
 
 void updatingWeeklyFinalHydroLevel(const Data::AreaList& areas, PROBLEME_HEBDO& problem)
 {
-    for (const auto& [_, area]: areas)
+    for (const auto& [_, area] : areas)
     {
         if (!area->hydro.reservoirManagement)
         {
@@ -149,7 +149,7 @@ void updatingWeeklyFinalHydroLevel(const Data::AreaList& areas, PROBLEME_HEBDO& 
         std::vector<double>& niv = weeklyResults.niveauxHoraires;
 
         problem.previousSimulationFinalLevel[index] = niv[nbHoursInAWeek - 1] * reservoirCapacity
-                                                      / 100;
+            / 100;
     }
 }
 

--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -51,7 +51,8 @@ static bool Remix(const Data::AreaList& areas,
     bool status = true;
 
     areas.each(
-      [&HE, &DE, &remix, &G, &status, &problem, &numSpace, &hourInYear](const Data::Area& area)
+      [&HE, &DE, &remix, &G, &status, &problem, &numSpace, &hourInYear]
+      (const Data::Area& area)
       {
           auto index = area.index;
 

--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -51,8 +51,7 @@ static bool Remix(const Data::AreaList& areas,
     bool status = true;
 
     areas.each(
-      [&HE, &DE, &remix, &G, &status, &problem, &numSpace, &hourInYear]
-      (const Data::Area& area)
+      [&HE, &DE, &remix, &G, &status, &problem, &numSpace, &hourInYear](const Data::Area& area)
       {
           auto index = area.index;
 

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -35,7 +35,7 @@ namespace Antares::Solver::Simulation
 {
 Economy::Economy(Data::Study& study,
                  IResultWriter& resultWriter,
-                 Simulation::ISimulationObserver& simulationObserver) :
+                 Simulation::ISimulationObserver& simulationObserver):
     study(study),
     preproOnly(false),
     resultWriter(resultWriter),
@@ -76,7 +76,10 @@ bool Economy::simulationBegin()
 
         for (uint numSpace = 0; numSpace < pNbMaxPerformedYearsInParallel; numSpace++)
         {
-            SIM_InitialisationProblemeHebdo(study, pProblemesHebdo[numSpace], nbHoursInAWeek, numSpace);
+            SIM_InitialisationProblemeHebdo(study,
+                                            pProblemesHebdo[numSpace],
+                                            nbHoursInAWeek,
+                                            numSpace);
 
             auto options = createOptimizationOptions(study);
             weeklyOptProblems_[numSpace] = Antares::Solver::Optimization::WeeklyOptimization::

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -35,7 +35,7 @@ namespace Antares::Solver::Simulation
 {
 Economy::Economy(Data::Study& study,
                  IResultWriter& resultWriter,
-                 Simulation::ISimulationObserver& simulationObserver):
+                 Simulation::ISimulationObserver& simulationObserver) :
     study(study),
     preproOnly(false),
     resultWriter(resultWriter),
@@ -76,10 +76,7 @@ bool Economy::simulationBegin()
 
         for (uint numSpace = 0; numSpace < pNbMaxPerformedYearsInParallel; numSpace++)
         {
-            SIM_InitialisationProblemeHebdo(study,
-                                            pProblemesHebdo[numSpace],
-                                            nbHoursInAWeek,
-                                            numSpace);
+            SIM_InitialisationProblemeHebdo(study, pProblemesHebdo[numSpace], nbHoursInAWeek, numSpace);
 
             auto options = createOptimizationOptions(study);
             weeklyOptProblems_[numSpace] = Antares::Solver::Optimization::WeeklyOptimization::

--- a/src/solver/simulation/economy_mode.cpp
+++ b/src/solver/simulation/economy_mode.cpp
@@ -1,23 +1,23 @@
 /*
- * Copyright 2007-2024, RTE (https://www.rte-france.com)
- * See AUTHORS.txt
- * SPDX-License-Identifier: MPL-2.0
- * This file is part of Antares-Simulator,
- * Adequacy and Performance assessment for interconnected energy networks.
- *
- * Antares_Simulator is free software: you can redistribute it and/or modify
- * it under the terms of the Mozilla Public Licence 2.0 as published by
- * the Mozilla Foundation, either version 2 of the License, or
- * (at your option) any later version.
- *
- * Antares_Simulator is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * Mozilla Public Licence 2.0 for more details.
- *
- * You should have received a copy of the Mozilla Public Licence 2.0
- * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
- */
+* Copyright 2007-2024, RTE (https://www.rte-france.com)
+* See AUTHORS.txt
+* SPDX-License-Identifier: MPL-2.0
+* This file is part of Antares-Simulator,
+* Adequacy and Performance assessment for interconnected energy networks.
+*
+* Antares_Simulator is free software: you can redistribute it and/or modify
+* it under the terms of the Mozilla Public Licence 2.0 as published by
+* the Mozilla Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Antares_Simulator is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* Mozilla Public Licence 2.0 for more details.
+*
+* You should have received a copy of the Mozilla Public Licence 2.0
+* along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+*/
 
 #include "antares/solver/simulation/economy_mode.h"
 
@@ -27,24 +27,25 @@
 namespace Antares::Solver
 {
 void runSimulationInEconomicMode(Antares::Data::Study& study,
-                                 const Settings& settings,
+                                const Settings& settings,
                                  Benchmarking::DurationCollector& durationCollector,
-                                 IResultWriter& resultWriter,
-                                 Benchmarking::OptimizationInfo& info,
-                                 Simulation::ISimulationObserver& simulationObserver)
+                                IResultWriter& resultWriter,
+                                Benchmarking::OptimizationInfo& info,
+                                Simulation::ISimulationObserver& simulationObserver
+)
 {
-    // Type of the simulation
-    typedef Solver::Simulation::ISimulation<Solver::Simulation::Economy> SimulationType;
-    SimulationType simulation(study, settings, durationCollector, resultWriter, simulationObserver);
-    simulation.checkWriter();
-    simulation.run();
+   // Type of the simulation
+   typedef Solver::Simulation::ISimulation<Solver::Simulation::Economy> SimulationType;
+   SimulationType simulation(study, settings, durationCollector, resultWriter, simulationObserver);
+   simulation.checkWriter();
+   simulation.run();
 
-    if (!(settings.noOutput || settings.tsGeneratorsOnly))
-    {
+   if (!(settings.noOutput || settings.tsGeneratorsOnly))
+   {
         durationCollector("synthesis_export")
           << [&simulation] { simulation.writeResults(/*synthesis:*/ true); };
 
-        info = simulation.getOptimizationInfo();
-    }
+       info = simulation.getOptimizationInfo();
+   }
 }
 } // namespace Antares::Solver

--- a/src/solver/simulation/economy_mode.cpp
+++ b/src/solver/simulation/economy_mode.cpp
@@ -1,23 +1,23 @@
 /*
-* Copyright 2007-2024, RTE (https://www.rte-france.com)
-* See AUTHORS.txt
-* SPDX-License-Identifier: MPL-2.0
-* This file is part of Antares-Simulator,
-* Adequacy and Performance assessment for interconnected energy networks.
-*
-* Antares_Simulator is free software: you can redistribute it and/or modify
-* it under the terms of the Mozilla Public Licence 2.0 as published by
-* the Mozilla Foundation, either version 2 of the License, or
-* (at your option) any later version.
-*
-* Antares_Simulator is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* Mozilla Public Licence 2.0 for more details.
-*
-* You should have received a copy of the Mozilla Public Licence 2.0
-* along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
-*/
+ * Copyright 2007-2024, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
 
 #include "antares/solver/simulation/economy_mode.h"
 
@@ -27,25 +27,24 @@
 namespace Antares::Solver
 {
 void runSimulationInEconomicMode(Antares::Data::Study& study,
-                                const Settings& settings,
+                                 const Settings& settings,
                                  Benchmarking::DurationCollector& durationCollector,
-                                IResultWriter& resultWriter,
-                                Benchmarking::OptimizationInfo& info,
-                                Simulation::ISimulationObserver& simulationObserver
-)
+                                 IResultWriter& resultWriter,
+                                 Benchmarking::OptimizationInfo& info,
+                                 Simulation::ISimulationObserver& simulationObserver)
 {
-   // Type of the simulation
-   typedef Solver::Simulation::ISimulation<Solver::Simulation::Economy> SimulationType;
-   SimulationType simulation(study, settings, durationCollector, resultWriter, simulationObserver);
-   simulation.checkWriter();
-   simulation.run();
+    // Type of the simulation
+    typedef Solver::Simulation::ISimulation<Solver::Simulation::Economy> SimulationType;
+    SimulationType simulation(study, settings, durationCollector, resultWriter, simulationObserver);
+    simulation.checkWriter();
+    simulation.run();
 
-   if (!(settings.noOutput || settings.tsGeneratorsOnly))
-   {
+    if (!(settings.noOutput || settings.tsGeneratorsOnly))
+    {
         durationCollector("synthesis_export")
           << [&simulation] { simulation.writeResults(/*synthesis:*/ true); };
 
-       info = simulation.getOptimizationInfo();
-   }
+        info = simulation.getOptimizationInfo();
+    }
 }
 } // namespace Antares::Solver

--- a/src/solver/simulation/include/antares/solver/simulation/ISimulationObserver.h
+++ b/src/solver/simulation/include/antares/solver/simulation/ISimulationObserver.h
@@ -53,13 +53,14 @@ public:
  * @brief The NullSimulationObserver class is a null object for the ISimulationObserver interface.
  * @details It overrides the notifyHebdoProblem method with an empty implementation.
  */
-class NullSimulationObserver : public ISimulationObserver
+class NullSimulationObserver: public ISimulationObserver
 {
 public:
     ~NullSimulationObserver() override = default;
+
     void notifyHebdoProblem(const PROBLEME_HEBDO&, int, std::string_view) override
     {
-        //null object pattern
+        // null object pattern
     }
 };
 } // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/include/antares/solver/simulation/ISimulationObserver.h
+++ b/src/solver/simulation/include/antares/solver/simulation/ISimulationObserver.h
@@ -53,14 +53,13 @@ public:
  * @brief The NullSimulationObserver class is a null object for the ISimulationObserver interface.
  * @details It overrides the notifyHebdoProblem method with an empty implementation.
  */
-class NullSimulationObserver: public ISimulationObserver
+class NullSimulationObserver : public ISimulationObserver
 {
 public:
     ~NullSimulationObserver() override = default;
-
     void notifyHebdoProblem(const PROBLEME_HEBDO&, int, std::string_view) override
     {
-        // null object pattern
+        //null object pattern
     }
 };
 } // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/include/antares/solver/simulation/adequacy.h
+++ b/src/solver/simulation/include/antares/solver/simulation/adequacy.h
@@ -48,8 +48,7 @@ public:
     **
     ** \param study The current study
     */
-    Adequacy(Data::Study& study,
-             IResultWriter& resultWriter,
+    Adequacy(Data::Study& study, IResultWriter& resultWriter,
              Simulation::ISimulationObserver& simulationObserver);
     //! Destructor
     ~Adequacy() = default;

--- a/src/solver/simulation/include/antares/solver/simulation/adequacy.h
+++ b/src/solver/simulation/include/antares/solver/simulation/adequacy.h
@@ -48,7 +48,8 @@ public:
     **
     ** \param study The current study
     */
-    Adequacy(Data::Study& study, IResultWriter& resultWriter,
+    Adequacy(Data::Study& study,
+             IResultWriter& resultWriter,
              Simulation::ISimulationObserver& simulationObserver);
     //! Destructor
     ~Adequacy() = default;

--- a/src/solver/simulation/include/antares/solver/simulation/economy_mode.h
+++ b/src/solver/simulation/include/antares/solver/simulation/economy_mode.h
@@ -34,5 +34,6 @@ void runSimulationInEconomicMode(Antares::Data::Study& study,
                                  Benchmarking::DurationCollector& durationCollector,
                                  IResultWriter& resultWriter,
                                  Benchmarking::OptimizationInfo& info,
-                                 Simulation::ISimulationObserver& simulationObserver);
+                                 Simulation::ISimulationObserver& simulationObserver
+);
 }

--- a/src/solver/simulation/include/antares/solver/simulation/economy_mode.h
+++ b/src/solver/simulation/include/antares/solver/simulation/economy_mode.h
@@ -34,6 +34,5 @@ void runSimulationInEconomicMode(Antares::Data::Study& study,
                                  Benchmarking::DurationCollector& durationCollector,
                                  IResultWriter& resultWriter,
                                  Benchmarking::OptimizationInfo& info,
-                                 Simulation::ISimulationObserver& simulationObserver
-);
+                                 Simulation::ISimulationObserver& simulationObserver);
 }

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -31,13 +31,15 @@
 #include <antares/exception/InitializationError.hpp>
 #include <antares/logs/logs.h>
 #include "antares/concurrency/concurrency.h"
+#include "antares/solver/variable/constants.h"
+#include "antares/solver/variable/print.h"
 #include "antares/solver/hydro/management/HydroInputsChecker.h"
 #include "antares/solver/hydro/management/management.h"
 #include "antares/solver/simulation/opt_time_writer.h"
 #include "antares/solver/simulation/timeseries-numbers.h"
 #include "antares/solver/ts-generator/generator.h"
-#include "antares/solver/variable/constants.h"
-#include "antares/solver/variable/print.h"
+
+
 
 namespace Antares::Solver::Simulation
 {
@@ -74,7 +76,10 @@ public:
         pDurationCollector(durationCollector),
         pResultWriter(resultWriter),
         simulationObserver_(simulationObserver),
-        hydroManagement(study.areas, study.parameters, study.calendar, resultWriter)
+        hydroManagement(study.areas,
+                        study.parameters,
+                        study.calendar,
+                        resultWriter)
     {
         scratchmap = study.areas.buildScratchMap(numSpace);
     }
@@ -159,8 +164,11 @@ public:
             simulation_->prepareClustersInMustRunMode(scratchmap, y);
 
             // 4 - Hydraulic ventilation
-            pDurationCollector("hydro_ventilation") << [this, &randomReservoirLevel]
-            { hydroManagement.makeVentilation(randomReservoirLevel, y, scratchmap); };
+            pDurationCollector("hydro_ventilation") << [this, &randomReservoirLevel] {
+                hydroManagement.makeVentilation(randomReservoirLevel,
+                                                y,
+                                                scratchmap);
+            };
 
             // Updating the state
             state.year = y;
@@ -715,15 +723,15 @@ void ISimulation<ImplementationType>::computeRandomNumbers(
                                                         max[firstDayOfMonth],
                                                         randomHydroGenerator);
 
-              // Possibly update the intial level from scenario builder
-              if (study.parameters.useCustomScenario)
-              {
-                  double levelFromScenarioBuilder = study.scenarioInitialHydroLevels[areaIndex][y];
-                  if (levelFromScenarioBuilder >= 0.)
-                  {
-                      randomLevel = levelFromScenarioBuilder;
-                  }
-              }
+            // Possibly update the intial level from scenario builder
+            if (study.parameters.useCustomScenario)
+            {
+                double levelFromScenarioBuilder = study.scenarioInitialHydroLevels[areaIndex][y];
+                if (levelFromScenarioBuilder >= 0.)
+                {
+                    randomLevel = levelFromScenarioBuilder;
+                }
+            }
 
               // Current area's hydro starting (or initial) level computation
               // (no matter if the year is performed or not, we always draw a random initial
@@ -747,12 +755,7 @@ void ISimulation<ImplementationType>::computeRandomNumbers(
         bool SpilledEnergySeedIsDefault = (currentSpilledEnergySeed == defaultSpilledEnergySeed);
         areaIndex = 0;
         study.areas.each(
-          [&isPerformed,
-           &areaIndex,
-           &randomUnsupplied,
-           &randomSpilled,
-           &randomForYears,
-           &indexYear,
+          [&isPerformed, &areaIndex, &randomUnsupplied, &randomSpilled, &randomForYears, &indexYear,
            &SpilledEnergySeedIsDefault](Data::Area& area)
           {
               (void)area; // Avoiding warnings at compilation (unused variable) on linux

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -31,15 +31,13 @@
 #include <antares/exception/InitializationError.hpp>
 #include <antares/logs/logs.h>
 #include "antares/concurrency/concurrency.h"
-#include "antares/solver/variable/constants.h"
-#include "antares/solver/variable/print.h"
 #include "antares/solver/hydro/management/HydroInputsChecker.h"
 #include "antares/solver/hydro/management/management.h"
 #include "antares/solver/simulation/opt_time_writer.h"
 #include "antares/solver/simulation/timeseries-numbers.h"
 #include "antares/solver/ts-generator/generator.h"
-
-
+#include "antares/solver/variable/constants.h"
+#include "antares/solver/variable/print.h"
 
 namespace Antares::Solver::Simulation
 {
@@ -76,10 +74,7 @@ public:
         pDurationCollector(durationCollector),
         pResultWriter(resultWriter),
         simulationObserver_(simulationObserver),
-        hydroManagement(study.areas,
-                        study.parameters,
-                        study.calendar,
-                        resultWriter)
+        hydroManagement(study.areas, study.parameters, study.calendar, resultWriter)
     {
         scratchmap = study.areas.buildScratchMap(numSpace);
     }
@@ -164,11 +159,8 @@ public:
             simulation_->prepareClustersInMustRunMode(scratchmap, y);
 
             // 4 - Hydraulic ventilation
-            pDurationCollector("hydro_ventilation") << [this, &randomReservoirLevel] {
-                hydroManagement.makeVentilation(randomReservoirLevel,
-                                                y,
-                                                scratchmap);
-            };
+            pDurationCollector("hydro_ventilation") << [this, &randomReservoirLevel]
+            { hydroManagement.makeVentilation(randomReservoirLevel, y, scratchmap); };
 
             // Updating the state
             state.year = y;
@@ -723,15 +715,15 @@ void ISimulation<ImplementationType>::computeRandomNumbers(
                                                         max[firstDayOfMonth],
                                                         randomHydroGenerator);
 
-            // Possibly update the intial level from scenario builder
-            if (study.parameters.useCustomScenario)
-            {
-                double levelFromScenarioBuilder = study.scenarioInitialHydroLevels[areaIndex][y];
-                if (levelFromScenarioBuilder >= 0.)
-                {
-                    randomLevel = levelFromScenarioBuilder;
-                }
-            }
+              // Possibly update the intial level from scenario builder
+              if (study.parameters.useCustomScenario)
+              {
+                  double levelFromScenarioBuilder = study.scenarioInitialHydroLevels[areaIndex][y];
+                  if (levelFromScenarioBuilder >= 0.)
+                  {
+                      randomLevel = levelFromScenarioBuilder;
+                  }
+              }
 
               // Current area's hydro starting (or initial) level computation
               // (no matter if the year is performed or not, we always draw a random initial
@@ -755,7 +747,12 @@ void ISimulation<ImplementationType>::computeRandomNumbers(
         bool SpilledEnergySeedIsDefault = (currentSpilledEnergySeed == defaultSpilledEnergySeed);
         areaIndex = 0;
         study.areas.each(
-          [&isPerformed, &areaIndex, &randomUnsupplied, &randomSpilled, &randomForYears, &indexYear,
+          [&isPerformed,
+           &areaIndex,
+           &randomUnsupplied,
+           &randomSpilled,
+           &randomForYears,
+           &indexYear,
            &SpilledEnergySeedIsDefault](Data::Area& area)
           {
               (void)area; // Avoiding warnings at compilation (unused variable) on linux

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -513,11 +513,11 @@ void SIM_RenseignementProblemeHebdo(const Study& study,
 
             if (area.hydro.useWaterValue)
             {
-                problem.CaracteristiquesHydrauliques[k].WeeklyWaterValueStateRegular
-                  = getWaterValue(problem.previousSimulationFinalLevel[k] * 100
-                                    / area.hydro.reservoirCapacity,
-                                  area.hydro.waterValues,
-                                  weekFirstDay);
+                problem.CaracteristiquesHydrauliques[k].WeeklyWaterValueStateRegular =
+                    getWaterValue(
+                        problem.previousSimulationFinalLevel[k] * 100 / area.hydro.reservoirCapacity,
+                        area.hydro.waterValues,
+                        weekFirstDay);
             }
 
             if (problem.CaracteristiquesHydrauliques[k].PresenceDHydrauliqueModulable > 0)

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -513,11 +513,11 @@ void SIM_RenseignementProblemeHebdo(const Study& study,
 
             if (area.hydro.useWaterValue)
             {
-                problem.CaracteristiquesHydrauliques[k].WeeklyWaterValueStateRegular =
-                    getWaterValue(
-                        problem.previousSimulationFinalLevel[k] * 100 / area.hydro.reservoirCapacity,
-                        area.hydro.waterValues,
-                        weekFirstDay);
+                problem.CaracteristiquesHydrauliques[k].WeeklyWaterValueStateRegular
+                  = getWaterValue(problem.previousSimulationFinalLevel[k] * 100
+                                    / area.hydro.reservoirCapacity,
+                                  area.hydro.waterValues,
+                                  weekFirstDay);
             }
 
             if (problem.CaracteristiquesHydrauliques[k].PresenceDHydrauliqueModulable > 0)

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -329,8 +329,7 @@ bool checkInterModalConsistencyForArea(const Area& area,
     {
         logs.error()
           << "Inter-modal correlation: time-series numbers of inter-modal modes in area '"
-          << area.name << "'"
-          << " are not identical";
+          << area.name << "'" << " are not identical";
 
         return false;
     }

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -329,7 +329,8 @@ bool checkInterModalConsistencyForArea(const Area& area,
     {
         logs.error()
           << "Inter-modal correlation: time-series numbers of inter-modal modes in area '"
-          << area.name << "'" << " are not identical";
+          << area.name << "'"
+          << " are not identical";
 
         return false;
     }

--- a/src/solver/ts-generator/availability.cpp
+++ b/src/solver/ts-generator/availability.cpp
@@ -23,12 +23,12 @@
 #include <sstream>
 #include <string>
 
+#include <antares/io/file.h> // For Antares::IO::fileSetContent
 #include <antares/logs/logs.h>
 #include <antares/solver/ts-generator/generator.h>
 #include <antares/solver/ts-generator/law.h>
 #include <antares/study/study.h>
 #include <antares/writer/i_writer.h>
-#include <antares/io/file.h> // For Antares::IO::fileSetContent
 #include "antares/study/simulation.h"
 
 #define SEP Yuni::IO::Separator
@@ -101,14 +101,18 @@ private:
                                const T& duration) const;
 };
 
-GeneratorTempData::GeneratorTempData(Data::Study& study, unsigned nbOfSeriesToGen, MersenneTwister& rndGenerator):
+GeneratorTempData::GeneratorTempData(Data::Study& study,
+                                     unsigned nbOfSeriesToGen,
+                                     MersenneTwister& rndGenerator):
     derated(study.parameters.derated),
     nbOfSeriesToGen_(nbOfSeriesToGen),
     rndgenerator(rndGenerator)
 {
 }
 
-GeneratorTempData::GeneratorTempData(bool derated, unsigned int nbOfSeriesToGen, MersenneTwister& rndGenerator):
+GeneratorTempData::GeneratorTempData(bool derated,
+                                     unsigned int nbOfSeriesToGen,
+                                     MersenneTwister& rndGenerator):
     derated(derated),
     nbOfSeriesToGen_(nbOfSeriesToGen),
     rndgenerator(rndGenerator)
@@ -623,14 +627,13 @@ void writeResultsToDisk(const Data::Study& study,
     writer.addEntryFromBuffer(savePath, buffer);
 }
 
-void writeResultsToDisk(const Matrix<>& series,
-                        const std::filesystem::path savePath)
+void writeResultsToDisk(const Matrix<>& series, const std::filesystem::path savePath)
 {
     std::string buffer;
     series.saveToBuffer(buffer, 0);
 
     std::filesystem::path parentDir = savePath.parent_path();
-    if (! std::filesystem::exists(parentDir))
+    if (!std::filesystem::exists(parentDir))
     {
         std::filesystem::create_directories(parentDir);
     }
@@ -680,21 +683,27 @@ bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
                                        generalParams.random);
     for (auto& link: links)
     {
-        if (! link.hasValidData)
+        if (!link.hasValidData)
         {
-            logs.error() << "Missing data for link " << link.namesPair.first << "/" << link.namesPair.second;
+            logs.error() << "Missing data for link " << link.namesPair.first << "/"
+                         << link.namesPair.second;
             return false;
         }
 
         if (link.forceNoGeneration)
+        {
             continue; // Skipping the link
+        }
 
         Data::TimeSeriesNumbers fakeTSnumbers; // gp : to quickly get rid of
         Data::TimeSeries ts(fakeTSnumbers);
         ts.resize(generalParams.nbLinkTStoGenerate, HOURS_PER_YEAR);
 
         // DIRECT
-        AvailabilityTSGeneratorData tsConfigDataDirect(link, ts, link.modulationCapacityDirect, link.namesPair.second);
+        AvailabilityTSGeneratorData tsConfigDataDirect(link,
+                                                       ts,
+                                                       link.modulationCapacityDirect,
+                                                       link.namesPair.second);
 
         generator.generateTS(tsConfigDataDirect);
 
@@ -703,12 +712,15 @@ bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
         writeResultsToDisk(ts.timeSeries, filePath);
 
         // INDIRECT
-        AvailabilityTSGeneratorData tsConfigDataIndirect(link, ts, link.modulationCapacityIndirect, link.namesPair.second);
+        AvailabilityTSGeneratorData tsConfigDataIndirect(link,
+                                                         ts,
+                                                         link.modulationCapacityIndirect,
+                                                         link.namesPair.second);
 
         generator.generateTS(tsConfigDataIndirect);
 
         filePath = savePath + SEP + link.namesPair.first + SEP + link.namesPair.second
-                               + "_indirect.txt";
+                   + "_indirect.txt";
         writeResultsToDisk(ts.timeSeries, filePath);
     }
 

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -70,7 +70,6 @@ struct LinkTSgenerationParams
     bool hasValidData = true;
 };
 
-
 class AvailabilityTSGeneratorData
 {
 public:
@@ -120,7 +119,6 @@ bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
 
 std::vector<Data::ThermalCluster*> getAllClustersToGen(const Data::AreaList& areas,
                                                        bool globalThermalTSgeneration);
-
 
 /*!
 ** \brief Destroy all TS Generators

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -70,6 +70,7 @@ struct LinkTSgenerationParams
     bool hasValidData = true;
 };
 
+
 class AvailabilityTSGeneratorData
 {
 public:
@@ -119,6 +120,7 @@ bool generateLinkTimeSeries(std::vector<LinkTSgenerationParams>& links,
 
 std::vector<Data::ThermalCluster*> getAllClustersToGen(const Data::AreaList& areas,
                                                        bool globalThermalTSgeneration);
+
 
 /*!
 ** \brief Destroy all TS Generators

--- a/src/solver/ts-generator/xcast/xcast.cpp
+++ b/src/solver/ts-generator/xcast/xcast.cpp
@@ -593,7 +593,8 @@ bool XCast::runWithPredicate(PredicateT& predicate, Progression::Task& progressi
 
     if (study.parameters.derated)
     {
-        study.areas.each([&predicate](Data::Area& area) { predicate.matrix(area).averageTimeseries(); });
+        study.areas.each([&predicate](Data::Area& area)
+                         { predicate.matrix(area).averageTimeseries(); });
     }
 
     if (study.parameters.timeSeriesToArchive & timeSeriesType)

--- a/src/solver/ts-generator/xcast/xcast.cpp
+++ b/src/solver/ts-generator/xcast/xcast.cpp
@@ -593,8 +593,7 @@ bool XCast::runWithPredicate(PredicateT& predicate, Progression::Task& progressi
 
     if (study.parameters.derated)
     {
-        study.areas.each([&predicate](Data::Area& area)
-                         { predicate.matrix(area).averageTimeseries(); });
+        study.areas.each([&predicate](Data::Area& area) { predicate.matrix(area).averageTimeseries(); });
     }
 
     if (study.parameters.timeSeriesToArchive & timeSeriesType)

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -56,10 +56,9 @@ static void checkSetSolverSpecificParameters(bool status,
     }
 }
 
-static void TuneSolverSpecificOptions(
-  MPSolver* solver,
-  const std::string& solverName,
-  const std::string& solverParameters)
+static void TuneSolverSpecificOptions(MPSolver* solver,
+                                      const std::string& solverName,
+                                      const std::string& solverParameters)
 {
     if (!solver)
     {
@@ -134,7 +133,6 @@ MPSolver* ProblemSimplexeNommeConverter::Convert()
 
     return solver;
 }
-
 
 void ProblemSimplexeNommeConverter::CopyMatrix(const MPSolver* solver) const
 {

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -56,9 +56,10 @@ static void checkSetSolverSpecificParameters(bool status,
     }
 }
 
-static void TuneSolverSpecificOptions(MPSolver* solver,
-                                      const std::string& solverName,
-                                      const std::string& solverParameters)
+static void TuneSolverSpecificOptions(
+  MPSolver* solver,
+  const std::string& solverName,
+  const std::string& solverParameters)
 {
     if (!solver)
     {
@@ -133,6 +134,7 @@ MPSolver* ProblemSimplexeNommeConverter::Convert()
 
     return solver;
 }
+
 
 void ProblemSimplexeNommeConverter::CopyMatrix(const MPSolver* solver) const
 {

--- a/src/solver/variable/include/antares/solver/variable/economy/all.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/all.h
@@ -248,8 +248,8 @@ typedef Variable::Join<
   Variable::Areas<VariablesPerArea>,
   // Variables for each set of areas
   Variable::Join<Variable::SetsOfAreas<VariablesPerSetOfAreas>,
-  // Variables for each binding constraint
-  Variable::BindingConstraints<VariablesPerBindingConstraints>>>
+                 // Variables for each binding constraint
+                 Variable::BindingConstraints<VariablesPerBindingConstraints>>>
   ItemList;
 
 /*!

--- a/src/solver/variable/include/antares/solver/variable/economy/all.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/all.h
@@ -248,8 +248,8 @@ typedef Variable::Join<
   Variable::Areas<VariablesPerArea>,
   // Variables for each set of areas
   Variable::Join<Variable::SetsOfAreas<VariablesPerSetOfAreas>,
-                 // Variables for each binding constraint
-                 Variable::BindingConstraints<VariablesPerBindingConstraints>>>
+  // Variables for each binding constraint
+  Variable::BindingConstraints<VariablesPerBindingConstraints>>>
   ItemList;
 
 /*!

--- a/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -147,7 +147,6 @@ public:
         NextType::simulationEnd();
     }
 
-
     void initializeFromStudy(Data::Study& study)
     {
         pNbYearsParallel = study.maxNbYearsInParallel;
@@ -257,8 +256,8 @@ public:
                 for (int dayInTheWeek = 0; dayInTheWeek < 7; dayInTheWeek++)
                 {
                     pValuesForTheCurrentYear[numSpace].day[dayInTheYear]
-                        -= state.problemeHebdo
-                        ->ResultatsContraintesCouplantes[associatedBC_][dayInTheWeek];
+                      -= state.problemeHebdo
+                           ->ResultatsContraintesCouplantes[associatedBC_][dayInTheWeek];
 
                     dayInTheYear++;
                 }
@@ -270,7 +269,7 @@ public:
             {
                 uint weekInTheYear = state.weekInTheYear;
                 double weeklyValue = -state.problemeHebdo
-                    ->ResultatsContraintesCouplantes[associatedBC_][0];
+                                        ->ResultatsContraintesCouplantes[associatedBC_][0];
 
                 pValuesForTheCurrentYear[numSpace].week[weekInTheYear] = weeklyValue;
 

--- a/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -147,6 +147,7 @@ public:
         NextType::simulationEnd();
     }
 
+
     void initializeFromStudy(Data::Study& study)
     {
         pNbYearsParallel = study.maxNbYearsInParallel;
@@ -256,8 +257,8 @@ public:
                 for (int dayInTheWeek = 0; dayInTheWeek < 7; dayInTheWeek++)
                 {
                     pValuesForTheCurrentYear[numSpace].day[dayInTheYear]
-                      -= state.problemeHebdo
-                           ->ResultatsContraintesCouplantes[associatedBC_][dayInTheWeek];
+                        -= state.problemeHebdo
+                        ->ResultatsContraintesCouplantes[associatedBC_][dayInTheWeek];
 
                     dayInTheYear++;
                 }
@@ -269,7 +270,7 @@ public:
             {
                 uint weekInTheYear = state.weekInTheYear;
                 double weeklyValue = -state.problemeHebdo
-                                        ->ResultatsContraintesCouplantes[associatedBC_][0];
+                    ->ResultatsContraintesCouplantes[associatedBC_][0];
 
                 pValuesForTheCurrentYear[numSpace].week[weekInTheYear] = weeklyValue;
 

--- a/src/solver/variable/include/antares/solver/variable/storage/minmax.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/minmax.h
@@ -84,14 +84,19 @@ protected:
             {
             case Category::hourly:
                 InternalExportIndices<maxHoursInAYear, VCardT>(report,
-                                                               Memory::RawPointer(minmax.hourly.data()),
+                                                               Memory::RawPointer(
+                                                                 minmax.hourly.data()),
                                                                fileLevel);
                 break;
             case Category::daily:
-                InternalExportIndices<maxDaysInAYear, VCardT>(report, minmax.daily.data(), fileLevel);
+                InternalExportIndices<maxDaysInAYear, VCardT>(report,
+                                                              minmax.daily.data(),
+                                                              fileLevel);
                 break;
             case Category::weekly:
-                InternalExportIndices<maxWeeksInAYear, VCardT>(report, minmax.weekly.data(), fileLevel);
+                InternalExportIndices<maxWeeksInAYear, VCardT>(report,
+                                                               minmax.weekly.data(),
+                                                               fileLevel);
                 break;
             case Category::monthly:
                 InternalExportIndices<maxMonths, VCardT>(report, minmax.monthly.data(), fileLevel);
@@ -107,7 +112,8 @@ protected:
             {
             case Category::hourly:
                 InternalExportValues<maxHoursInAYear, VCardT>(report,
-                                                              Memory::RawPointer(minmax.hourly.data()));
+                                                              Memory::RawPointer(
+                                                                minmax.hourly.data()));
                 break;
             case Category::daily:
                 InternalExportValues<maxDaysInAYear, VCardT>(report, minmax.daily.data());

--- a/src/solver/variable/include/antares/solver/variable/storage/minmax.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/minmax.h
@@ -84,19 +84,14 @@ protected:
             {
             case Category::hourly:
                 InternalExportIndices<maxHoursInAYear, VCardT>(report,
-                                                               Memory::RawPointer(
-                                                                 minmax.hourly.data()),
+                                                               Memory::RawPointer(minmax.hourly.data()),
                                                                fileLevel);
                 break;
             case Category::daily:
-                InternalExportIndices<maxDaysInAYear, VCardT>(report,
-                                                              minmax.daily.data(),
-                                                              fileLevel);
+                InternalExportIndices<maxDaysInAYear, VCardT>(report, minmax.daily.data(), fileLevel);
                 break;
             case Category::weekly:
-                InternalExportIndices<maxWeeksInAYear, VCardT>(report,
-                                                               minmax.weekly.data(),
-                                                               fileLevel);
+                InternalExportIndices<maxWeeksInAYear, VCardT>(report, minmax.weekly.data(), fileLevel);
                 break;
             case Category::monthly:
                 InternalExportIndices<maxMonths, VCardT>(report, minmax.monthly.data(), fileLevel);
@@ -112,8 +107,7 @@ protected:
             {
             case Category::hourly:
                 InternalExportValues<maxHoursInAYear, VCardT>(report,
-                                                              Memory::RawPointer(
-                                                                minmax.hourly.data()));
+                                                              Memory::RawPointer(minmax.hourly.data()));
                 break;
             case Category::daily:
                 InternalExportValues<maxDaysInAYear, VCardT>(report, minmax.daily.data());

--- a/src/solver/variable/storage/minmax-data.cpp
+++ b/src/solver/variable/storage/minmax-data.cpp
@@ -29,10 +29,10 @@ constexpr double eps = 1.e-7;
 
 static void initArray(bool opInferior, std::vector<MinMaxData::Data>& array)
 {
-    for (auto& data : array)
+    for (auto& data: array)
     {
         data.value = opInferior ? DBL_MAX : -DBL_MAX; // +inf or -inf
-        data.indice = (uint32_t)(-1); // invalid indice
+        data.indice = (uint32_t)(-1);                 // invalid indice
     }
 }
 

--- a/src/solver/variable/storage/minmax-data.cpp
+++ b/src/solver/variable/storage/minmax-data.cpp
@@ -29,10 +29,10 @@ constexpr double eps = 1.e-7;
 
 static void initArray(bool opInferior, std::vector<MinMaxData::Data>& array)
 {
-    for (auto& data: array)
+    for (auto& data : array)
     {
         data.value = opInferior ? DBL_MAX : -DBL_MAX; // +inf or -inf
-        data.indice = (uint32_t)(-1);                 // invalid indice
+        data.indice = (uint32_t)(-1); // invalid indice
     }
 }
 

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -82,7 +82,7 @@ HydroMaxPowerStudy::HydroMaxPowerStudy()
     area = addAreaToStudy("Area");
     area->thermal.unsuppliedEnergyCost = 1;
 
-    setNumberMCyears(1);
+	setNumberMCyears(1);
 
     TimeSeriesConfigurer loadTSconfig(area->load.series.timeSeries);
     loadTSconfig.setColumnCount(1).fillColumnWith(0, loadInArea);

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -82,7 +82,7 @@ HydroMaxPowerStudy::HydroMaxPowerStudy()
     area = addAreaToStudy("Area");
     area->thermal.unsuppliedEnergyCost = 1;
 
-	setNumberMCyears(1);
+    setNumberMCyears(1);
 
     TimeSeriesConfigurer loadTSconfig(area->load.series.timeSeries);
     loadTSconfig.setColumnCount(1).fillColumnWith(0, loadInArea);

--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -20,8 +20,9 @@
  */
 #define WIN32_LEAN_AND_MEAN
 
-#include "antares/application/ScenarioBuilderOwner.h"
 #include "in-memory-study.h"
+
+#include "antares/application/ScenarioBuilderOwner.h"
 
 void initializeStudy(Study* study)
 {
@@ -223,7 +224,8 @@ void StudyBuilder::setNumberMCyears(unsigned int nbYears)
 {
     study->parameters.resetPlaylist(nbYears);
     study->areas.resizeAllTimeseriesNumbers(nbYears);
-    study->areas.each([&](Data::Area& area) { area.hydro.deltaBetweenFinalAndInitialLevels.resize(nbYears); });
+    study->areas.each([&](Data::Area& area)
+                      { area.hydro.deltaBetweenFinalAndInitialLevels.resize(nbYears); });
 }
 
 void StudyBuilder::playOnlyYear(unsigned int year)

--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -20,9 +20,8 @@
  */
 #define WIN32_LEAN_AND_MEAN
 
-#include "in-memory-study.h"
-
 #include "antares/application/ScenarioBuilderOwner.h"
+#include "in-memory-study.h"
 
 void initializeStudy(Study* study)
 {
@@ -224,8 +223,7 @@ void StudyBuilder::setNumberMCyears(unsigned int nbYears)
 {
     study->parameters.resetPlaylist(nbYears);
     study->areas.resizeAllTimeseriesNumbers(nbYears);
-    study->areas.each([&](Data::Area& area)
-                      { area.hydro.deltaBetweenFinalAndInitialLevels.resize(nbYears); });
+    study->areas.each([&](Data::Area& area) { area.hydro.deltaBetweenFinalAndInitialLevels.resize(nbYears); });
 }
 
 void StudyBuilder::playOnlyYear(unsigned int year)

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -164,14 +164,17 @@ public:
     {
         return rules_->load;
     }
+
     BindingConstraintsTSNumberData& bcGroup()
     {
         return rules_->binding_constraints;
     }
+
     hydroTSNumberData& hydro()
     {
         return rules_->hydro;
     }
+
 private:
     Rules::Ptr rules_;
 };

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -164,17 +164,14 @@ public:
     {
         return rules_->load;
     }
-
     BindingConstraintsTSNumberData& bcGroup()
     {
         return rules_->binding_constraints;
     }
-
     hydroTSNumberData& hydro()
     {
         return rules_->hydro;
     }
-
 private:
     Rules::Ptr rules_;
 };

--- a/src/tests/src/libs/antares/antlr4-interface/test_antlr_interface.cpp
+++ b/src/tests/src/libs/antares/antlr4-interface/test_antlr_interface.cpp
@@ -19,15 +19,17 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE antlr_interface tests
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
-#include "antlr4-runtime.h"
 #include <iostream>
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "ExprLexer.h"
 #include "ExprParser.h"
+#include "antlr4-runtime.h"
 
 using namespace antlr4;
+
 BOOST_AUTO_TEST_CASE(test_antlr_interface)
 {
     const std::string my_input = "y = b + a*x";

--- a/src/tests/src/libs/antares/antlr4-interface/test_antlr_interface.cpp
+++ b/src/tests/src/libs/antares/antlr4-interface/test_antlr_interface.cpp
@@ -19,17 +19,15 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE antlr_interface tests
-#include <iostream>
-
-#include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include "antlr4-runtime.h"
+#include <iostream>
 
 #include "ExprLexer.h"
 #include "ExprParser.h"
-#include "antlr4-runtime.h"
 
 using namespace antlr4;
-
 BOOST_AUTO_TEST_CASE(test_antlr_interface)
 {
     const std::string my_input = "y = b + a*x";

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
@@ -355,12 +355,10 @@ BOOST_FIXTURE_TEST_CASE(on_area1_and_on_year_17__hydro_level_0_123_is_chosen__re
     AreaName::Vector splitKey = {"hl", "area 1", yearNumber};
     my_rule.readLine(splitKey, level);
 
-    BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_1->index),
-                      level.to<double>());
+	BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_1->index), level.to<double>());
 
-    BOOST_CHECK(my_rule.apply());
-    BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_1->index][yearNumber.to<uint>()],
-                      level.to<double>());
+	BOOST_CHECK(my_rule.apply());
+	BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_1->index][yearNumber.to<uint>()], level.to<double>());
 }
 
 BOOST_FIXTURE_TEST_CASE(
@@ -372,11 +370,10 @@ BOOST_FIXTURE_TEST_CASE(
     AreaName::Vector splitKey = {"hl", "area 2", yearNumber};
     BOOST_CHECK(my_rule.readLine(splitKey, level));
 
-    BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_2->index),
-                      1.);
+	BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_2->index), 1.);
 
-    BOOST_CHECK(my_rule.apply());
-    BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_2->index][yearNumber.to<uint>()], 1.);
+	BOOST_CHECK(my_rule.apply());
+	BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_2->index][yearNumber.to<uint>()], 1.);
 }
 
 BOOST_FIXTURE_TEST_CASE(
@@ -388,11 +385,10 @@ BOOST_FIXTURE_TEST_CASE(
     AreaName::Vector splitKey = {"hl", "area 3", yearNumber};
     BOOST_CHECK(my_rule.readLine(splitKey, level));
 
-    BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_3->index),
-                      0.);
+	BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_3->index), 0.);
 
-    BOOST_CHECK(my_rule.apply());
-    BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_3->index][yearNumber.to<uint>()], 0.);
+	BOOST_CHECK(my_rule.apply());
+	BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_3->index][yearNumber.to<uint>()], 0.);
 }
 
 // ========================
@@ -400,47 +396,47 @@ BOOST_FIXTURE_TEST_CASE(
 // ========================
 BOOST_FIXTURE_TEST_CASE(on_area1_and_on_year_8__hydro_level_0_342_is_chosen__reading_OK, Fixture)
 {
-    AreaName yearNumber = "8";
-    String level = "0.342";
-    AreaName::Vector splitKey = {"hfl", "area 1", yearNumber};
-    my_rule.readLine(splitKey, level, false);
+        AreaName yearNumber = "8";
+        String level = "0.342";
+        AreaName::Vector splitKey = {"hfl", "area 1", yearNumber};
+        my_rule.readLine(splitKey, level, false);
 
-    BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_1->index),
-                      level.to<double>());
+        BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_1->index),
+                          level.to<double>());
 
-    BOOST_CHECK(my_rule.apply());
-    BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_1->index][yearNumber.to<uint>()],
-                      level.to<double>());
+        BOOST_CHECK(my_rule.apply());
+        BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_1->index][yearNumber.to<uint>()],
+                          level.to<double>());
 }
 
-BOOST_FIXTURE_TEST_CASE(
-  on_area2_and_on_year_1__hydro_level_2_4_is_chosen_level_lowered_to_1__reading_OK,
-  Fixture)
+BOOST_FIXTURE_TEST_CASE(on_area2_and_on_year_1__hydro_level_2_4_is_chosen_level_lowered_to_1__reading_OK, Fixture)
 {
-    AreaName yearNumber = "1";
-    String level = "2.4";
-    AreaName::Vector splitKey = {"hfl", "area 2", yearNumber};
-    BOOST_CHECK(my_rule.readLine(splitKey, level, false));
+        AreaName yearNumber = "1";
+        String level = "2.4";
+        AreaName::Vector splitKey = {"hfl", "area 2", yearNumber};
+        BOOST_CHECK(my_rule.readLine(splitKey, level, false));
 
-    BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_2->index), 1.);
+        BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_2->index),
+                          1.);
 
-    BOOST_CHECK(my_rule.apply());
-    BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_2->index][yearNumber.to<uint>()], 1.);
+        BOOST_CHECK(my_rule.apply());
+        BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_2->index][yearNumber.to<uint>()],
+                          1.);
 }
 
-BOOST_FIXTURE_TEST_CASE(
-  on_area3_and_on_year_3__hydro_level_neg_5_2_is_chosen__level_raised_to_0__reading_OK,
-  Fixture)
+BOOST_FIXTURE_TEST_CASE(on_area3_and_on_year_3__hydro_level_neg_5_2_is_chosen__level_raised_to_0__reading_OK, Fixture)
 {
-    AreaName yearNumber = "3";
-    String level = "-5.2";
-    AreaName::Vector splitKey = {"hfl", "area 3", yearNumber};
-    BOOST_CHECK(my_rule.readLine(splitKey, level, false));
+        AreaName yearNumber = "3";
+        String level = "-5.2";
+        AreaName::Vector splitKey = {"hfl", "area 3", yearNumber};
+        BOOST_CHECK(my_rule.readLine(splitKey, level, false));
 
-    BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_3->index), 0.);
+        BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_3->index),
+                          0.);
 
-    BOOST_CHECK(my_rule.apply());
-    BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_3->index][yearNumber.to<uint>()], 0.);
+        BOOST_CHECK(my_rule.apply());
+        BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_3->index][yearNumber.to<uint>()],
+                          0.);
 }
 
 // ======================

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
@@ -355,10 +355,12 @@ BOOST_FIXTURE_TEST_CASE(on_area1_and_on_year_17__hydro_level_0_123_is_chosen__re
     AreaName::Vector splitKey = {"hl", "area 1", yearNumber};
     my_rule.readLine(splitKey, level);
 
-	BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_1->index), level.to<double>());
+    BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_1->index),
+                      level.to<double>());
 
-	BOOST_CHECK(my_rule.apply());
-	BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_1->index][yearNumber.to<uint>()], level.to<double>());
+    BOOST_CHECK(my_rule.apply());
+    BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_1->index][yearNumber.to<uint>()],
+                      level.to<double>());
 }
 
 BOOST_FIXTURE_TEST_CASE(
@@ -370,10 +372,11 @@ BOOST_FIXTURE_TEST_CASE(
     AreaName::Vector splitKey = {"hl", "area 2", yearNumber};
     BOOST_CHECK(my_rule.readLine(splitKey, level));
 
-	BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_2->index), 1.);
+    BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_2->index),
+                      1.);
 
-	BOOST_CHECK(my_rule.apply());
-	BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_2->index][yearNumber.to<uint>()], 1.);
+    BOOST_CHECK(my_rule.apply());
+    BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_2->index][yearNumber.to<uint>()], 1.);
 }
 
 BOOST_FIXTURE_TEST_CASE(
@@ -385,10 +388,11 @@ BOOST_FIXTURE_TEST_CASE(
     AreaName::Vector splitKey = {"hl", "area 3", yearNumber};
     BOOST_CHECK(my_rule.readLine(splitKey, level));
 
-	BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_3->index), 0.);
+    BOOST_CHECK_EQUAL(my_rule.hydroInitialLevels.get_value(yearNumber.to<uint>(), area_3->index),
+                      0.);
 
-	BOOST_CHECK(my_rule.apply());
-	BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_3->index][yearNumber.to<uint>()], 0.);
+    BOOST_CHECK(my_rule.apply());
+    BOOST_CHECK_EQUAL(study->scenarioInitialHydroLevels[area_3->index][yearNumber.to<uint>()], 0.);
 }
 
 // ========================
@@ -396,47 +400,47 @@ BOOST_FIXTURE_TEST_CASE(
 // ========================
 BOOST_FIXTURE_TEST_CASE(on_area1_and_on_year_8__hydro_level_0_342_is_chosen__reading_OK, Fixture)
 {
-        AreaName yearNumber = "8";
-        String level = "0.342";
-        AreaName::Vector splitKey = {"hfl", "area 1", yearNumber};
-        my_rule.readLine(splitKey, level, false);
+    AreaName yearNumber = "8";
+    String level = "0.342";
+    AreaName::Vector splitKey = {"hfl", "area 1", yearNumber};
+    my_rule.readLine(splitKey, level, false);
 
-        BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_1->index),
-                          level.to<double>());
+    BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_1->index),
+                      level.to<double>());
 
-        BOOST_CHECK(my_rule.apply());
-        BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_1->index][yearNumber.to<uint>()],
-                          level.to<double>());
+    BOOST_CHECK(my_rule.apply());
+    BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_1->index][yearNumber.to<uint>()],
+                      level.to<double>());
 }
 
-BOOST_FIXTURE_TEST_CASE(on_area2_and_on_year_1__hydro_level_2_4_is_chosen_level_lowered_to_1__reading_OK, Fixture)
+BOOST_FIXTURE_TEST_CASE(
+  on_area2_and_on_year_1__hydro_level_2_4_is_chosen_level_lowered_to_1__reading_OK,
+  Fixture)
 {
-        AreaName yearNumber = "1";
-        String level = "2.4";
-        AreaName::Vector splitKey = {"hfl", "area 2", yearNumber};
-        BOOST_CHECK(my_rule.readLine(splitKey, level, false));
+    AreaName yearNumber = "1";
+    String level = "2.4";
+    AreaName::Vector splitKey = {"hfl", "area 2", yearNumber};
+    BOOST_CHECK(my_rule.readLine(splitKey, level, false));
 
-        BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_2->index),
-                          1.);
+    BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_2->index), 1.);
 
-        BOOST_CHECK(my_rule.apply());
-        BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_2->index][yearNumber.to<uint>()],
-                          1.);
+    BOOST_CHECK(my_rule.apply());
+    BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_2->index][yearNumber.to<uint>()], 1.);
 }
 
-BOOST_FIXTURE_TEST_CASE(on_area3_and_on_year_3__hydro_level_neg_5_2_is_chosen__level_raised_to_0__reading_OK, Fixture)
+BOOST_FIXTURE_TEST_CASE(
+  on_area3_and_on_year_3__hydro_level_neg_5_2_is_chosen__level_raised_to_0__reading_OK,
+  Fixture)
 {
-        AreaName yearNumber = "3";
-        String level = "-5.2";
-        AreaName::Vector splitKey = {"hfl", "area 3", yearNumber};
-        BOOST_CHECK(my_rule.readLine(splitKey, level, false));
+    AreaName yearNumber = "3";
+    String level = "-5.2";
+    AreaName::Vector splitKey = {"hfl", "area 3", yearNumber};
+    BOOST_CHECK(my_rule.readLine(splitKey, level, false));
 
-        BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_3->index),
-                          0.);
+    BOOST_CHECK_EQUAL(my_rule.hydroFinalLevels.get_value(yearNumber.to<uint>(), area_3->index), 0.);
 
-        BOOST_CHECK(my_rule.apply());
-        BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_3->index][yearNumber.to<uint>()],
-                          0.);
+    BOOST_CHECK(my_rule.apply());
+    BOOST_CHECK_EQUAL(study->scenarioFinalHydroLevels[area_3->index][yearNumber.to<uint>()], 0.);
 }
 
 // ======================

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -436,9 +436,7 @@ BOOST_FIXTURE_TEST_CASE(
 // ========================
 // Tests on Hydro final levels
 // ========================
-BOOST_FIXTURE_TEST_CASE(
-  HYDRO_FINAL_LEVEL__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical,
-  saveFixture)
+BOOST_FIXTURE_TEST_CASE(HYDRO_FINAL_LEVEL__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
 {
     my_rule->hydroFinalLevels.setTSnumber(area_1->index, 4, 8);
     my_rule->hydroFinalLevels.setTSnumber(area_2->index, 11, 3);

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -436,7 +436,9 @@ BOOST_FIXTURE_TEST_CASE(
 // ========================
 // Tests on Hydro final levels
 // ========================
-BOOST_FIXTURE_TEST_CASE(HYDRO_FINAL_LEVEL__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical, saveFixture)
+BOOST_FIXTURE_TEST_CASE(
+  HYDRO_FINAL_LEVEL__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical,
+  saveFixture)
 {
     my_rule->hydroFinalLevels.setTSnumber(area_1->index, 4, 8);
     my_rule->hydroFinalLevels.setTSnumber(area_2->index, 11, 3);

--- a/src/tests/src/libs/antares/test_utils.cpp
+++ b/src/tests/src/libs/antares/test_utils.cpp
@@ -19,14 +19,14 @@
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
 #define BOOST_TEST_MODULE test utils
+#include <filesystem>
 #include <string>
 
 #include <boost/test/unit_test.hpp>
 
-#include <antares/utils/utils.h>
-
 #include <yuni/io/file.h>
-#include <filesystem>
+
+#include <antares/utils/utils.h>
 
 namespace fs = std::filesystem;
 
@@ -99,7 +99,8 @@ BOOST_AUTO_TEST_CASE(yuni_normalize_vs_std_lexically_normal)
     {
         Yuni::String yuniNorm;
         Yuni::IO::Normalize(yuniNorm, path.string());
-        BOOST_CHECK_MESSAGE(path.lexically_normal().string() == yuniNorm, std::string("Check failed for ") + path.string());
+        BOOST_CHECK_MESSAGE(path.lexically_normal().string() == yuniNorm,
+                            std::string("Check failed for ") + path.string());
     };
     helper(fs::path("a/./b/.."));
     helper(fs::path("a/.///b/../"));

--- a/src/tests/src/libs/antares/test_utils.cpp
+++ b/src/tests/src/libs/antares/test_utils.cpp
@@ -19,14 +19,14 @@
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
 #define BOOST_TEST_MODULE test utils
-#include <filesystem>
 #include <string>
 
 #include <boost/test/unit_test.hpp>
 
-#include <yuni/io/file.h>
-
 #include <antares/utils/utils.h>
+
+#include <yuni/io/file.h>
+#include <filesystem>
 
 namespace fs = std::filesystem;
 
@@ -99,8 +99,7 @@ BOOST_AUTO_TEST_CASE(yuni_normalize_vs_std_lexically_normal)
     {
         Yuni::String yuniNorm;
         Yuni::IO::Normalize(yuniNorm, path.string());
-        BOOST_CHECK_MESSAGE(path.lexically_normal().string() == yuniNorm,
-                            std::string("Check failed for ") + path.string());
+        BOOST_CHECK_MESSAGE(path.lexically_normal().string() == yuniNorm, std::string("Check failed for ") + path.string());
     };
     helper(fs::path("a/./b/.."));
     helper(fs::path("a/.///b/../"));

--- a/src/tests/src/libs/antares/yaml-parser/test_yaml_parser.cpp
+++ b/src/tests/src/libs/antares/yaml-parser/test_yaml_parser.cpp
@@ -19,19 +19,22 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE yamlcpp tests
-#include <boost/test/unit_test.hpp>
-#include <boost/test/data/test_case.hpp>
-#include "yaml-cpp/yaml.h"
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "yaml-cpp/yaml.h"
 
 // our data types
 struct Vec3
 {
     float x, y, z;
 };
+
 struct Power
 {
     std::string name;
@@ -44,6 +47,7 @@ struct Monster
     Vec3 position;
     std::vector<Power> powers;
 };
+
 namespace YAML
 {
 template<>
@@ -71,6 +75,7 @@ struct convert<Vec3>
         return true;
     }
 };
+
 template<>
 struct convert<Power>
 {
@@ -89,6 +94,7 @@ struct convert<Power>
         return true;
     }
 };
+
 template<>
 struct convert<Monster>
 {
@@ -108,7 +114,7 @@ struct convert<Monster>
         rhs.name = node["name"].as<std::string>();
         rhs.position = node["position"].as<Vec3>();
         const YAML::Node& powers = node["powers"];
-        for (const auto power : powers)
+        for (const auto power: powers)
         {
             rhs.powers.push_back(power.as<Power>());
         }

--- a/src/tests/src/libs/antares/yaml-parser/test_yaml_parser.cpp
+++ b/src/tests/src/libs/antares/yaml-parser/test_yaml_parser.cpp
@@ -19,22 +19,19 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #define BOOST_TEST_MODULE yamlcpp tests
-#include <fstream>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include "yaml-cpp/yaml.h"
 #include <iostream>
+#include <fstream>
 #include <string>
 #include <vector>
-
-#include <boost/test/data/test_case.hpp>
-#include <boost/test/unit_test.hpp>
-
-#include "yaml-cpp/yaml.h"
 
 // our data types
 struct Vec3
 {
     float x, y, z;
 };
-
 struct Power
 {
     std::string name;
@@ -47,7 +44,6 @@ struct Monster
     Vec3 position;
     std::vector<Power> powers;
 };
-
 namespace YAML
 {
 template<>
@@ -75,7 +71,6 @@ struct convert<Vec3>
         return true;
     }
 };
-
 template<>
 struct convert<Power>
 {
@@ -94,7 +89,6 @@ struct convert<Power>
         return true;
     }
 };
-
 template<>
 struct convert<Monster>
 {
@@ -114,7 +108,7 @@ struct convert<Monster>
         rhs.name = node["name"].as<std::string>();
         rhs.position = node["position"].as<Vec3>();
         const YAML::Node& powers = node["powers"];
-        for (const auto power: powers)
+        for (const auto power : powers)
         {
             rhs.powers.push_back(power.as<Power>());
         }

--- a/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
+++ b/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
@@ -21,11 +21,10 @@
 #define WIN32_LEAN_AND_MEAN
 #define BOOST_TEST_MODULE unfeasible_problem_analyzer
 
-#include <ortools/linear_solver/linear_solver.h>
-
 #include <boost/test/data/dataset.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
+#include <ortools/linear_solver/linear_solver.h>
 
 #include "antares/solver/infeasible-problem-analysis/constraint-slack-analysis.h"
 #include "antares/solver/infeasible-problem-analysis/unfeasible-pb-analyzer.h"

--- a/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
+++ b/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
@@ -21,10 +21,11 @@
 #define WIN32_LEAN_AND_MEAN
 #define BOOST_TEST_MODULE unfeasible_problem_analyzer
 
+#include <ortools/linear_solver/linear_solver.h>
+
 #include <boost/test/data/dataset.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
-#include <ortools/linear_solver/linear_solver.h>
 
 #include "antares/solver/infeasible-problem-analysis/constraint-slack-analysis.h"
 #include "antares/solver/infeasible-problem-analysis/unfeasible-pb-analyzer.h"

--- a/src/tests/src/solver/simulation/test-hydro-final-reservoir-level-functions.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-final-reservoir-level-functions.cpp
@@ -14,16 +14,16 @@
 using namespace Antares::Solver;
 using namespace Antares::Data;
 
-
 struct Fixture
 {
     Fixture(const Fixture& f) = delete;
     Fixture(const Fixture&& f) = delete;
     Fixture& operator=(const Fixture& f) = delete;
     Fixture& operator=(const Fixture&& f) = delete;
+
     Fixture()
     {
-        // Simulation last day must be 365 so that final level checks succeeds 
+        // Simulation last day must be 365 so that final level checks succeeds
         study->parameters.simulationDays.end = 365;
         study->parameters.firstMonthInYear = january;
         uint nbYears = study->parameters.nbYears = 2;
@@ -56,7 +56,6 @@ struct Fixture
         // Resize vector final levels delta with initial levels
         area_1->hydro.deltaBetweenFinalAndInitialLevels.resize(nbYears);
         area_2->hydro.deltaBetweenFinalAndInitialLevels.resize(nbYears);
-
 
         // Scenario builder for initial and final reservoir levels
         // -------------------------------------------------------
@@ -97,7 +96,7 @@ struct Fixture
         // ... Area 2 : Inflows time series
         area_2->hydro.series->storage.resize(nbInflowTS, 365);
         area_2->hydro.series->storage.timeSeries.fill(300.);
-        area_2->hydro.series->storage[0][0] = 300. + 1.; //DAYS_PER_YEAR
+        area_2->hydro.series->storage[0][0] = 300. + 1.; // DAYS_PER_YEAR
         area_2->hydro.series->storage[0][DAYS_PER_YEAR - 1] = 300. + 2.;
     }
 
@@ -179,7 +178,8 @@ BOOST_AUTO_TEST_CASE(final_level_not_set_by_user____check_succeeds_but_final_lev
     BOOST_CHECK_EQUAL(validator.finalLevelFineForUse(), false);
 }
 
-BOOST_AUTO_TEST_CASE(initial_level_month_and_simulation_first_month_different___check_fails_and_final_level_not_usable)
+BOOST_AUTO_TEST_CASE(
+  initial_level_month_and_simulation_first_month_different___check_fails_and_final_level_not_usable)
 {
     uint year = 0;
     area_1->hydro.initializeReservoirLevelDate = 3; // initialize reservoir level != January
@@ -234,7 +234,8 @@ BOOST_AUTO_TEST_CASE(final_level_out_of_rule_curves___check_fails_and_final_leve
     BOOST_CHECK_EQUAL(validator.finalLevelFineForUse(), false);
 }
 
-BOOST_AUTO_TEST_CASE(final_level_unreachable_because_of_too_few_inflows___check_fails_and_final_level_not_usable)
+BOOST_AUTO_TEST_CASE(
+  final_level_unreachable_because_of_too_few_inflows___check_fails_and_final_level_not_usable)
 {
     area_1->hydro.reservoirCapacity = 185000;
     uint year = 0;
@@ -258,7 +259,7 @@ BOOST_AUTO_TEST_CASE(final_level_unreachable_because_of_too_few_inflows___check_
 
 BOOST_AUTO_TEST_CASE(check_all_areas_final_levels_when_config_is_ok___all_checks_succeed)
 {
-    for (uint year : {0, 1})
+    for (uint year: {0, 1})
     {
         CheckFinalReservoirLevelsConfiguration(study->areas,
                                                study->parameters,

--- a/src/tests/src/solver/simulation/test-hydro-final-reservoir-level-functions.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-final-reservoir-level-functions.cpp
@@ -14,16 +14,16 @@
 using namespace Antares::Solver;
 using namespace Antares::Data;
 
+
 struct Fixture
 {
     Fixture(const Fixture& f) = delete;
     Fixture(const Fixture&& f) = delete;
     Fixture& operator=(const Fixture& f) = delete;
     Fixture& operator=(const Fixture&& f) = delete;
-
     Fixture()
     {
-        // Simulation last day must be 365 so that final level checks succeeds
+        // Simulation last day must be 365 so that final level checks succeeds 
         study->parameters.simulationDays.end = 365;
         study->parameters.firstMonthInYear = january;
         uint nbYears = study->parameters.nbYears = 2;
@@ -56,6 +56,7 @@ struct Fixture
         // Resize vector final levels delta with initial levels
         area_1->hydro.deltaBetweenFinalAndInitialLevels.resize(nbYears);
         area_2->hydro.deltaBetweenFinalAndInitialLevels.resize(nbYears);
+
 
         // Scenario builder for initial and final reservoir levels
         // -------------------------------------------------------
@@ -96,7 +97,7 @@ struct Fixture
         // ... Area 2 : Inflows time series
         area_2->hydro.series->storage.resize(nbInflowTS, 365);
         area_2->hydro.series->storage.timeSeries.fill(300.);
-        area_2->hydro.series->storage[0][0] = 300. + 1.; // DAYS_PER_YEAR
+        area_2->hydro.series->storage[0][0] = 300. + 1.; //DAYS_PER_YEAR
         area_2->hydro.series->storage[0][DAYS_PER_YEAR - 1] = 300. + 2.;
     }
 
@@ -178,8 +179,7 @@ BOOST_AUTO_TEST_CASE(final_level_not_set_by_user____check_succeeds_but_final_lev
     BOOST_CHECK_EQUAL(validator.finalLevelFineForUse(), false);
 }
 
-BOOST_AUTO_TEST_CASE(
-  initial_level_month_and_simulation_first_month_different___check_fails_and_final_level_not_usable)
+BOOST_AUTO_TEST_CASE(initial_level_month_and_simulation_first_month_different___check_fails_and_final_level_not_usable)
 {
     uint year = 0;
     area_1->hydro.initializeReservoirLevelDate = 3; // initialize reservoir level != January
@@ -234,8 +234,7 @@ BOOST_AUTO_TEST_CASE(final_level_out_of_rule_curves___check_fails_and_final_leve
     BOOST_CHECK_EQUAL(validator.finalLevelFineForUse(), false);
 }
 
-BOOST_AUTO_TEST_CASE(
-  final_level_unreachable_because_of_too_few_inflows___check_fails_and_final_level_not_usable)
+BOOST_AUTO_TEST_CASE(final_level_unreachable_because_of_too_few_inflows___check_fails_and_final_level_not_usable)
 {
     area_1->hydro.reservoirCapacity = 185000;
     uint year = 0;
@@ -259,7 +258,7 @@ BOOST_AUTO_TEST_CASE(
 
 BOOST_AUTO_TEST_CASE(check_all_areas_final_levels_when_config_is_ok___all_checks_succeed)
 {
-    for (uint year: {0, 1})
+    for (uint year : {0, 1})
     {
         CheckFinalReservoirLevelsConfiguration(study->areas,
                                                study->parameters,

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -133,13 +133,13 @@ LinkPairs extractLinkNamesFromStudy(fs::path studyDir)
 {
     LinkPairs to_return;
     fs::path linksDir = studyDir / "input" / "links";
-    for (auto const& item : fs::directory_iterator{linksDir})
+    for (const auto& item: fs::directory_iterator{linksDir})
     {
         if (item.is_directory())
         {
             std::string sourceAreaName = item.path().filename().generic_string();
             auto targetAreas = extractTargetAreas(item);
-            for (auto& targetAreaName : targetAreas)
+            for (auto& targetAreaName: targetAreas)
             {
                 auto linkPair = std::make_pair(sourceAreaName, targetAreaName);
                 to_return.push_back(linkPair);
@@ -152,25 +152,26 @@ LinkPairs extractLinkNamesFromStudy(fs::path studyDir)
 bool pairs_match(const LinkPair& p1, const LinkPair& p2)
 {
     return (p1.first == p2.first && p1.second == p2.second)
-            || (p1.first == p2.second && p1.second == p2.first);
+           || (p1.first == p2.second && p1.second == p2.first);
 }
 
 const LinkPair* getMatchingPairInCollection(const LinkPair& pair, const LinkPairs& collection)
 {
-    for(const auto& p : collection)
+    for (const auto& p: collection)
     {
         if (pairs_match(pair, p))
+        {
             return &p;
+        }
     }
     return nullptr;
 }
 
-LinkPairs extractLinkNamesFromCmdLine(const LinkPairs& allLinks,
-                                  const std::string linksFromCmdLine)
+LinkPairs extractLinkNamesFromCmdLine(const LinkPairs& allLinks, const std::string linksFromCmdLine)
 {
     LinkPairs to_return;
     LinkPairs pairsFromCmdLine = splitStringIntoPairs(linksFromCmdLine, ';', '.');
-    for (auto& p : pairsFromCmdLine)
+    for (auto& p: pairsFromCmdLine)
     {
         if (const auto* found_pair = getMatchingPairInCollection(p, allLinks); found_pair)
         {
@@ -198,9 +199,11 @@ bool readLinkGeneralProperty(StudyParamsForLinkTS& params,
     }
     if (key == "seed-tsgen-links")
     {
-        unsigned int seed {0};
-        if (! value.to<unsigned int>(seed))
+        unsigned int seed{0};
+        if (!value.to<unsigned int>(seed))
+        {
             return false;
+        }
         params.random.reset(seed);
         return true;
     }
@@ -218,14 +221,16 @@ StudyParamsForLinkTS readGeneralParamsForLinksTS(fs::path studyDir)
         // Skipping sections useless in the current context
         Yuni::String sectionName = section->name;
         if (sectionName != "general" && sectionName != "seeds - Mersenne Twister")
+        {
             continue;
+        }
 
         for (const IniFile::Property* p = section->firstProperty; p; p = p->next)
         {
-            if (! readLinkGeneralProperty(to_return, p->key, p->value))
+            if (!readLinkGeneralProperty(to_return, p->key, p->value))
             {
-                logs.warning() << ini.filename() << ": reading value of '"
-                               << p->key << "' went wrong";
+                logs.warning() << ini.filename() << ": reading value of '" << p->key
+                               << "' went wrong";
             }
         }
     }
@@ -236,7 +241,7 @@ std::vector<LinkTSgenerationParams> CreateLinkList(const LinkPairs& linksFromCmd
 {
     std::vector<LinkTSgenerationParams> to_return;
     to_return.reserve(linksFromCmdLine.size());
-    for (const auto& link_pair : linksFromCmdLine)
+    for (const auto& link_pair: linksFromCmdLine)
     {
         LinkTSgenerationParams params;
         params.namesPair = link_pair;
@@ -248,10 +253,12 @@ std::vector<LinkTSgenerationParams> CreateLinkList(const LinkPairs& linksFromCmd
 LinkTSgenerationParams* findLinkInList(const LinkPair& link_to_find,
                                        std::vector<LinkTSgenerationParams>& linkList)
 {
-    for(auto& link : linkList)
+    for (auto& link: linkList)
     {
         if (link.namesPair == link_to_find)
+        {
             return &link;
+        }
     }
     return nullptr;
 }
@@ -297,16 +304,15 @@ bool readLinkIniProperty(LinkTSgenerationParams* link,
     return true;
 }
 
-void readLinkIniProperties(LinkTSgenerationParams* link,
-                           IniFile::Section* section)
+void readLinkIniProperties(LinkTSgenerationParams* link, IniFile::Section* section)
 {
     for (const IniFile::Property* p = section->firstProperty; p; p = p->next)
     {
-        if (! readLinkIniProperty(link, p->key, p->value))
+        if (!readLinkIniProperty(link, p->key, p->value))
         {
             std::string linkName = link->namesPair.first + "." + link->namesPair.second;
-            logs.warning() << "Link '" << linkName << "' : reading value of '"
-                           << p->key << "' went wrong";
+            logs.warning() << "Link '" << linkName << "' : reading value of '" << p->key
+                           << "' went wrong";
             link->hasValidData = false;
         }
     }
@@ -331,7 +337,7 @@ void readSourceAreaIniFile(fs::path pathToIni,
 
 void readIniProperties(std::vector<LinkTSgenerationParams>& linkList, fs::path toLinksDir)
 {
-    for(auto& link : linkList)
+    for (auto& link: linkList)
     {
         std::string sourceAreaName = link.namesPair.first;
         fs::path pathToIni = toLinksDir / sourceAreaName / "properties.ini";
@@ -339,8 +345,7 @@ void readIniProperties(std::vector<LinkTSgenerationParams>& linkList, fs::path t
     }
 }
 
-bool readLinkPreproTimeSeries(LinkTSgenerationParams& link,
-                              fs::path sourceAreaDir)
+bool readLinkPreproTimeSeries(LinkTSgenerationParams& link, fs::path sourceAreaDir)
 {
     bool to_return = true;
     const auto preproId = link.namesPair.first + "/" + link.namesPair.second;
@@ -353,21 +358,19 @@ bool readLinkPreproTimeSeries(LinkTSgenerationParams& link,
     if (fs::exists(preproFile))
     {
         to_return = link.prepro->data.loadFromCSVFile(
-                                              preproFile.string(),
-                                              Data::PreproAvailability::preproAvailabilityMax,
-                                              DAYS_PER_YEAR)
-                    && link.prepro->validate()
-                    && to_return;
+                      preproFile.string(),
+                      Data::PreproAvailability::preproAvailabilityMax,
+                      DAYS_PER_YEAR)
+                    && link.prepro->validate() && to_return;
     }
 
     auto modulationFileDirect = preproFileRoot;
     modulationFileDirect += "_mod_direct.txt";
     if (fs::exists(modulationFileDirect))
     {
-        to_return = link.modulationCapacityDirect.loadFromCSVFile(
-                                                modulationFileDirect.string(),
-                                                1,
-                                                HOURS_PER_YEAR)
+        to_return = link.modulationCapacityDirect.loadFromCSVFile(modulationFileDirect.string(),
+                                                                  1,
+                                                                  HOURS_PER_YEAR)
                     && to_return;
     }
 
@@ -375,10 +378,9 @@ bool readLinkPreproTimeSeries(LinkTSgenerationParams& link,
     modulationFileIndirect += "_mod_indirect.txt";
     if (fs::exists(modulationFileIndirect))
     {
-        to_return = link.modulationCapacityIndirect.loadFromCSVFile(
-                                                modulationFileIndirect.string(),
-                                                1,
-                                                HOURS_PER_YEAR)
+        to_return = link.modulationCapacityIndirect.loadFromCSVFile(modulationFileIndirect.string(),
+                                                                    1,
+                                                                    HOURS_PER_YEAR)
                     && to_return;
     }
     // Makes possible a skip of TS generation when time comes
@@ -386,17 +388,16 @@ bool readLinkPreproTimeSeries(LinkTSgenerationParams& link,
     return to_return;
 }
 
-void readPreproTimeSeries(std::vector<LinkTSgenerationParams>& linkList,
-                          fs::path toLinksDir)
+void readPreproTimeSeries(std::vector<LinkTSgenerationParams>& linkList, fs::path toLinksDir)
 {
-    for(auto& link : linkList)
+    for (auto& link: linkList)
     {
         std::string sourceAreaName = link.namesPair.first;
         fs::path sourceAreaDir = toLinksDir / sourceAreaName;
-        if (! readLinkPreproTimeSeries(link, sourceAreaDir))
+        if (!readLinkPreproTimeSeries(link, sourceAreaDir))
         {
-            logs.warning() << "Could not load all prepro data for link '"
-                         << link.namesPair.first << "." << link.namesPair.second << "'";
+            logs.warning() << "Could not load all prepro data for link '" << link.namesPair.first
+                           << "." << link.namesPair.second << "'";
         }
     }
 }
@@ -416,6 +417,7 @@ std::string DateAndTime()
     Yuni::DateTime::TimestampToString(to_return, "%Y%m%d-%H%M", now);
     return to_return.to<std::string>();
 }
+
 // ============================================================================
 
 int main(int argc, char* argv[])
@@ -500,10 +502,11 @@ int main(int argc, char* argv[])
 
     // ============ LINKS : Getting data for generating LINKS time-series =====
     auto allLinksPairs = extractLinkNamesFromStudy(settings.studyFolder);
-    auto linksFromCmdLine = extractLinkNamesFromCmdLine(allLinksPairs,
-                                                                 settings.linksListToGen);
+    auto linksFromCmdLine = extractLinkNamesFromCmdLine(allLinksPairs, settings.linksListToGen);
     if (settings.allLinks)
+    {
         linksFromCmdLine = allLinksPairs;
+    }
 
     StudyParamsForLinkTS generalParams = readGeneralParamsForLinksTS(settings.studyFolder);
 

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -133,13 +133,13 @@ LinkPairs extractLinkNamesFromStudy(fs::path studyDir)
 {
     LinkPairs to_return;
     fs::path linksDir = studyDir / "input" / "links";
-    for (const auto& item: fs::directory_iterator{linksDir})
+    for (auto const& item : fs::directory_iterator{linksDir})
     {
         if (item.is_directory())
         {
             std::string sourceAreaName = item.path().filename().generic_string();
             auto targetAreas = extractTargetAreas(item);
-            for (auto& targetAreaName: targetAreas)
+            for (auto& targetAreaName : targetAreas)
             {
                 auto linkPair = std::make_pair(sourceAreaName, targetAreaName);
                 to_return.push_back(linkPair);
@@ -152,26 +152,25 @@ LinkPairs extractLinkNamesFromStudy(fs::path studyDir)
 bool pairs_match(const LinkPair& p1, const LinkPair& p2)
 {
     return (p1.first == p2.first && p1.second == p2.second)
-           || (p1.first == p2.second && p1.second == p2.first);
+            || (p1.first == p2.second && p1.second == p2.first);
 }
 
 const LinkPair* getMatchingPairInCollection(const LinkPair& pair, const LinkPairs& collection)
 {
-    for (const auto& p: collection)
+    for(const auto& p : collection)
     {
         if (pairs_match(pair, p))
-        {
             return &p;
-        }
     }
     return nullptr;
 }
 
-LinkPairs extractLinkNamesFromCmdLine(const LinkPairs& allLinks, const std::string linksFromCmdLine)
+LinkPairs extractLinkNamesFromCmdLine(const LinkPairs& allLinks,
+                                  const std::string linksFromCmdLine)
 {
     LinkPairs to_return;
     LinkPairs pairsFromCmdLine = splitStringIntoPairs(linksFromCmdLine, ';', '.');
-    for (auto& p: pairsFromCmdLine)
+    for (auto& p : pairsFromCmdLine)
     {
         if (const auto* found_pair = getMatchingPairInCollection(p, allLinks); found_pair)
         {
@@ -199,11 +198,9 @@ bool readLinkGeneralProperty(StudyParamsForLinkTS& params,
     }
     if (key == "seed-tsgen-links")
     {
-        unsigned int seed{0};
-        if (!value.to<unsigned int>(seed))
-        {
+        unsigned int seed {0};
+        if (! value.to<unsigned int>(seed))
             return false;
-        }
         params.random.reset(seed);
         return true;
     }
@@ -221,16 +218,14 @@ StudyParamsForLinkTS readGeneralParamsForLinksTS(fs::path studyDir)
         // Skipping sections useless in the current context
         Yuni::String sectionName = section->name;
         if (sectionName != "general" && sectionName != "seeds - Mersenne Twister")
-        {
             continue;
-        }
 
         for (const IniFile::Property* p = section->firstProperty; p; p = p->next)
         {
-            if (!readLinkGeneralProperty(to_return, p->key, p->value))
+            if (! readLinkGeneralProperty(to_return, p->key, p->value))
             {
-                logs.warning() << ini.filename() << ": reading value of '" << p->key
-                               << "' went wrong";
+                logs.warning() << ini.filename() << ": reading value of '"
+                               << p->key << "' went wrong";
             }
         }
     }
@@ -241,7 +236,7 @@ std::vector<LinkTSgenerationParams> CreateLinkList(const LinkPairs& linksFromCmd
 {
     std::vector<LinkTSgenerationParams> to_return;
     to_return.reserve(linksFromCmdLine.size());
-    for (const auto& link_pair: linksFromCmdLine)
+    for (const auto& link_pair : linksFromCmdLine)
     {
         LinkTSgenerationParams params;
         params.namesPair = link_pair;
@@ -253,12 +248,10 @@ std::vector<LinkTSgenerationParams> CreateLinkList(const LinkPairs& linksFromCmd
 LinkTSgenerationParams* findLinkInList(const LinkPair& link_to_find,
                                        std::vector<LinkTSgenerationParams>& linkList)
 {
-    for (auto& link: linkList)
+    for(auto& link : linkList)
     {
         if (link.namesPair == link_to_find)
-        {
             return &link;
-        }
     }
     return nullptr;
 }
@@ -304,15 +297,16 @@ bool readLinkIniProperty(LinkTSgenerationParams* link,
     return true;
 }
 
-void readLinkIniProperties(LinkTSgenerationParams* link, IniFile::Section* section)
+void readLinkIniProperties(LinkTSgenerationParams* link,
+                           IniFile::Section* section)
 {
     for (const IniFile::Property* p = section->firstProperty; p; p = p->next)
     {
-        if (!readLinkIniProperty(link, p->key, p->value))
+        if (! readLinkIniProperty(link, p->key, p->value))
         {
             std::string linkName = link->namesPair.first + "." + link->namesPair.second;
-            logs.warning() << "Link '" << linkName << "' : reading value of '" << p->key
-                           << "' went wrong";
+            logs.warning() << "Link '" << linkName << "' : reading value of '"
+                           << p->key << "' went wrong";
             link->hasValidData = false;
         }
     }
@@ -337,7 +331,7 @@ void readSourceAreaIniFile(fs::path pathToIni,
 
 void readIniProperties(std::vector<LinkTSgenerationParams>& linkList, fs::path toLinksDir)
 {
-    for (auto& link: linkList)
+    for(auto& link : linkList)
     {
         std::string sourceAreaName = link.namesPair.first;
         fs::path pathToIni = toLinksDir / sourceAreaName / "properties.ini";
@@ -345,7 +339,8 @@ void readIniProperties(std::vector<LinkTSgenerationParams>& linkList, fs::path t
     }
 }
 
-bool readLinkPreproTimeSeries(LinkTSgenerationParams& link, fs::path sourceAreaDir)
+bool readLinkPreproTimeSeries(LinkTSgenerationParams& link,
+                              fs::path sourceAreaDir)
 {
     bool to_return = true;
     const auto preproId = link.namesPair.first + "/" + link.namesPair.second;
@@ -358,19 +353,21 @@ bool readLinkPreproTimeSeries(LinkTSgenerationParams& link, fs::path sourceAreaD
     if (fs::exists(preproFile))
     {
         to_return = link.prepro->data.loadFromCSVFile(
-                      preproFile.string(),
-                      Data::PreproAvailability::preproAvailabilityMax,
-                      DAYS_PER_YEAR)
-                    && link.prepro->validate() && to_return;
+                                              preproFile.string(),
+                                              Data::PreproAvailability::preproAvailabilityMax,
+                                              DAYS_PER_YEAR)
+                    && link.prepro->validate()
+                    && to_return;
     }
 
     auto modulationFileDirect = preproFileRoot;
     modulationFileDirect += "_mod_direct.txt";
     if (fs::exists(modulationFileDirect))
     {
-        to_return = link.modulationCapacityDirect.loadFromCSVFile(modulationFileDirect.string(),
-                                                                  1,
-                                                                  HOURS_PER_YEAR)
+        to_return = link.modulationCapacityDirect.loadFromCSVFile(
+                                                modulationFileDirect.string(),
+                                                1,
+                                                HOURS_PER_YEAR)
                     && to_return;
     }
 
@@ -378,9 +375,10 @@ bool readLinkPreproTimeSeries(LinkTSgenerationParams& link, fs::path sourceAreaD
     modulationFileIndirect += "_mod_indirect.txt";
     if (fs::exists(modulationFileIndirect))
     {
-        to_return = link.modulationCapacityIndirect.loadFromCSVFile(modulationFileIndirect.string(),
-                                                                    1,
-                                                                    HOURS_PER_YEAR)
+        to_return = link.modulationCapacityIndirect.loadFromCSVFile(
+                                                modulationFileIndirect.string(),
+                                                1,
+                                                HOURS_PER_YEAR)
                     && to_return;
     }
     // Makes possible a skip of TS generation when time comes
@@ -388,16 +386,17 @@ bool readLinkPreproTimeSeries(LinkTSgenerationParams& link, fs::path sourceAreaD
     return to_return;
 }
 
-void readPreproTimeSeries(std::vector<LinkTSgenerationParams>& linkList, fs::path toLinksDir)
+void readPreproTimeSeries(std::vector<LinkTSgenerationParams>& linkList,
+                          fs::path toLinksDir)
 {
-    for (auto& link: linkList)
+    for(auto& link : linkList)
     {
         std::string sourceAreaName = link.namesPair.first;
         fs::path sourceAreaDir = toLinksDir / sourceAreaName;
-        if (!readLinkPreproTimeSeries(link, sourceAreaDir))
+        if (! readLinkPreproTimeSeries(link, sourceAreaDir))
         {
-            logs.warning() << "Could not load all prepro data for link '" << link.namesPair.first
-                           << "." << link.namesPair.second << "'";
+            logs.warning() << "Could not load all prepro data for link '"
+                         << link.namesPair.first << "." << link.namesPair.second << "'";
         }
     }
 }
@@ -417,7 +416,6 @@ std::string DateAndTime()
     Yuni::DateTime::TimestampToString(to_return, "%Y%m%d-%H%M", now);
     return to_return.to<std::string>();
 }
-
 // ============================================================================
 
 int main(int argc, char* argv[])
@@ -502,11 +500,10 @@ int main(int argc, char* argv[])
 
     // ============ LINKS : Getting data for generating LINKS time-series =====
     auto allLinksPairs = extractLinkNamesFromStudy(settings.studyFolder);
-    auto linksFromCmdLine = extractLinkNamesFromCmdLine(allLinksPairs, settings.linksListToGen);
+    auto linksFromCmdLine = extractLinkNamesFromCmdLine(allLinksPairs,
+                                                                 settings.linksListToGen);
     if (settings.allLinks)
-    {
         linksFromCmdLine = allLinksPairs;
-    }
 
     StudyParamsForLinkTS generalParams = readGeneralParamsForLinksTS(settings.studyFolder);
 


### PR DESCRIPTION
## Ensure workflow "Check cpp formatting" is passing

- Add `Yuni::` prefixing after some headers have been re-ordered
- Exclude directory antlr-interface (generated code)

NB clang-format is obtained using `pip install clang-format==18.3.1`