### PR TITLE
Remove actions dependencies using node js 16

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -135,12 +135,12 @@ jobs:
            cpack -G TGZ
 
     - name: Installer TGZ push
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         path: _build/*.tar.gz
 
     - name: Installer RPM push
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         path: _build/*.rpm
 

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -136,12 +136,12 @@ jobs:
            cpack -G TGZ
 
     - name: Installer TGZ push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: _build/*.tar.gz
 
     - name: Installer RPM push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: _build/*.rpm
 

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -145,11 +145,13 @@ jobs:
     - name: Installer TGZ push
       uses: actions/upload-artifact@v4
       with:
+        name: targz
         path: _build/*.tar.gz
 
     - name: Installer RPM push
       uses: actions/upload-artifact@v4
       with:
+        name: rpm
         path: _build/*.rpm
 
     - name: Publish assets

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -142,12 +142,12 @@ jobs:
            cpack -G TGZ
 
     - name: Installer TGZ push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: _build/*.tar.gz
 
     - name: Installer RPM push
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: _build/*.rpm
 

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - develop
+      - fix/nodejs16
       - dependabot/*
 
   schedule:

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - develop
-      - fix/nodejs16
       - dependabot/*
 
   schedule:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -146,8 +146,6 @@ jobs:
           cat ./simtest.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
-          echo '${{ fromJson(env.simtest).version }}'
-
       - name: Init submodule
         run: |
           git submodule update --init --remote --recursive src/tests/resources/Antares_Simulator_Tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -133,12 +133,20 @@ jobs:
            ctest -C Release --output-on-failure
 
       # simtest
-      - name: Read simtest version
+      - name: Read simtest version old action
         id: simtest-version
         uses: notiz-dev/github-action-json-property@release
         with:
           path: 'simtest.json'
           prop_path: 'version'
+
+      - name: Read simtest version
+        - run: |
+          echo 'simtest<<EOF' >> $GITHUB_ENV
+          cat ./simtest.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+          echo '${{ fromJson(env.simtest).version }}'
 
       - name: Init submodule
         run: |
@@ -148,7 +156,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.PACKAGE_JSON).version }}
           batch-name: valid-named-mps
           os: ${{ env.os }}
           variant: "named-mps"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -137,6 +137,7 @@ jobs:
           echo 'simtest<<EOF' >> $GITHUB_ENV
           cat ./simtest.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+          echo "SIMTEST=${{ fromJson(env.SIMTEST_JSON).version }}" >> $GITHUB_ENV
 
       - name: Init submodule
         run: |
@@ -146,7 +147,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: valid-named-mps
           os: ${{ env.os }}
           variant: "named-mps"
@@ -174,7 +175,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: valid-v830
           os: ${{ env.os }}
 
@@ -182,7 +183,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: valid-milp
           variant: "milp-cbc"
           os: ${{ env.os }}
@@ -191,7 +192,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: valid-v860
           os: ${{ env.os }}
 
@@ -199,7 +200,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: valid-v870
           os: ${{ env.os }}
 
@@ -207,7 +208,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: valid-v910
           os: ${{ env.os }}
 
@@ -215,7 +216,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: short-tests
           os: ${{ env.os }}
 
@@ -223,7 +224,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: valid-mps
           os: ${{ env.os }}
 
@@ -231,7 +232,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: adequacy-patch-CSR
           os: ${{ env.os }}
 
@@ -239,7 +240,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: valid-parallel
           os: ${{ env.os }}
           variant: "parallel"
@@ -248,7 +249,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: ts-generator
           os: ${{ env.os }}
           variant: "tsgenerator"
@@ -257,7 +258,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: medium-tests
           os: ${{ env.os }}
 
@@ -265,7 +266,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: long-tests-1
           os: ${{ env.os }}
 
@@ -273,7 +274,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: long-tests-2
           os: ${{ env.os }}
 
@@ -281,7 +282,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ SIMTEST }}
           batch-name: long-tests-3
           os: ${{ env.os }}
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Read simtest version
         run: |
-          echo 'simtest<<EOF' >> $GITHUB_ENV
+          echo 'SIMTEST_JSON<<EOF' >> $GITHUB_ENV
           cat ./simtest.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -132,14 +132,6 @@ jobs:
            cd _build
            ctest -C Release --output-on-failure
 
-      # simtest
-      - name: Read simtest version old action
-        id: simtest-version
-        uses: notiz-dev/github-action-json-property@release
-        with:
-          path: 'simtest.json'
-          prop_path: 'version'
-
       - name: Read simtest version
         run: |
           echo 'simtest<<EOF' >> $GITHUB_ENV
@@ -182,7 +174,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-v830
           os: ${{ env.os }}
 
@@ -190,7 +182,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-milp
           variant: "milp-cbc"
           os: ${{ env.os }}
@@ -199,7 +191,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-v860
           os: ${{ env.os }}
 
@@ -207,7 +199,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-v870
           os: ${{ env.os }}
 
@@ -215,7 +207,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-v910
           os: ${{ env.os }}
 
@@ -223,7 +215,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: short-tests
           os: ${{ env.os }}
 
@@ -231,7 +223,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-mps
           os: ${{ env.os }}
 
@@ -239,7 +231,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: adequacy-patch-CSR
           os: ${{ env.os }}
 
@@ -247,7 +239,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-parallel
           os: ${{ env.os }}
           variant: "parallel"
@@ -256,7 +248,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: ts-generator
           os: ${{ env.os }}
           variant: "tsgenerator"
@@ -265,7 +257,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: medium-tests
           os: ${{ env.os }}
 
@@ -273,7 +265,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: long-tests-1
           os: ${{ env.os }}
 
@@ -281,7 +273,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: long-tests-2
           os: ${{ env.os }}
 
@@ -289,7 +281,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: long-tests-3
           os: ${{ env.os }}
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -147,7 +147,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-named-mps
           os: ${{ env.os }}
           variant: "named-mps"
@@ -175,7 +175,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-v830
           os: ${{ env.os }}
 
@@ -183,7 +183,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-milp
           variant: "milp-cbc"
           os: ${{ env.os }}
@@ -192,7 +192,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-v860
           os: ${{ env.os }}
 
@@ -200,7 +200,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-v870
           os: ${{ env.os }}
 
@@ -208,7 +208,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-v910
           os: ${{ env.os }}
 
@@ -216,7 +216,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: short-tests
           os: ${{ env.os }}
 
@@ -224,7 +224,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-mps
           os: ${{ env.os }}
 
@@ -232,7 +232,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: adequacy-patch-CSR
           os: ${{ env.os }}
 
@@ -240,7 +240,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-parallel
           os: ${{ env.os }}
           variant: "parallel"
@@ -249,7 +249,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: ts-generator
           os: ${{ env.os }}
           variant: "tsgenerator"
@@ -258,7 +258,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: medium-tests
           os: ${{ env.os }}
 
@@ -266,7 +266,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: long-tests-1
           os: ${{ env.os }}
 
@@ -274,7 +274,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: long-tests-2
           os: ${{ env.os }}
 
@@ -282,7 +282,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ SIMTEST }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: long-tests-3
           os: ${{ env.os }}
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -138,6 +138,7 @@ jobs:
           cat ./simtest.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
+      - name: Export simtest version
         run: |
           echo "SIMTEST=${{ fromJson(env.SIMTEST_JSON).version }}" >> $GITHUB_ENV
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -141,7 +141,7 @@ jobs:
           prop_path: 'version'
 
       - name: Read simtest version
-        - run: |
+        run: |
           echo 'simtest<<EOF' >> $GITHUB_ENV
           cat ./simtest.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -154,7 +154,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.PACKAGE_JSON).version }}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-named-mps
           os: ${{ env.os }}
           variant: "named-mps"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -137,6 +137,8 @@ jobs:
           echo 'simtest<<EOF' >> $GITHUB_ENV
           cat ./simtest.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+
+        run: |
           echo "SIMTEST=${{ fromJson(env.SIMTEST_JSON).version }}" >> $GITHUB_ENV
 
       - name: Init submodule

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -138,17 +138,20 @@ jobs:
           cmake --build _build --config Release -j$(nproc)
 
       - name: Read simtest version
-        shell: bash
         run: |
-          echo 'simtest<<EOF' >> $GITHUB_ENV
+          echo 'SIMTEST_JSON<<EOF' >> $GITHUB_ENV
           cat ./simtest.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+
+      - name: Export simtest version
+        run: |
+          echo "SIMTEST=${{ fromJson(env.SIMTEST_JSON).version }}" >> $GITHUB_ENV
 
       - name: Run named mps tests
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-named-mps
           os: ${{ env.test-platform }}
           variant: "named-mps"
@@ -176,7 +179,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: adequacy-patch-CSR
           os: ${{ env.test-platform }}
 
@@ -184,7 +187,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-v830
           os: ${{ env.test-platform }}
 
@@ -192,7 +195,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-milp
           variant: "milp-cbc"
           os: ${{ env.test-platform }}
@@ -201,7 +204,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-v860
           os: ${{ env.test-platform }}
 
@@ -209,7 +212,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-v870
           os: ${{ env.test-platform }}
 
@@ -217,7 +220,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-v910
           os: ${{ env.test-platform }}
 
@@ -225,7 +228,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: short-tests
           os: ${{ env.test-platform }}
 
@@ -233,7 +236,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-mps
           os: ${{ env.test-platform }}
 
@@ -241,7 +244,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: valid-parallel
           os: ${{ env.test-platform }}
           variant: "parallel"
@@ -250,7 +253,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: ts-generator
           os: ${{ env.test-platform }}
           variant: "tsgenerator"
@@ -259,7 +262,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: medium-tests
           os: ${{ env.test-platform }}
 
@@ -267,7 +270,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: long-tests-1
           os: ${{ env.test-platform }}
 
@@ -275,7 +278,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: long-tests-2
           os: ${{ env.test-platform }}
 
@@ -283,7 +286,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{ fromJson(env.simtest).version }}
+          simtest-tag: ${{ env.SIMTEST }}
           batch-name: long-tests-3
           os: ${{ env.test-platform }}
 

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -138,6 +138,7 @@ jobs:
           cmake --build _build --config Release -j$(nproc)
 
       - name: Read simtest version
+        shell: bash
         run: |
           echo 'simtest<<EOF' >> $GITHUB_ENV
           cat ./simtest.json >> $GITHUB_ENV

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -138,12 +138,14 @@ jobs:
           cmake --build _build --config Release -j$(nproc)
 
       - name: Read simtest version
+        shell: bash
         run: |
           echo 'SIMTEST_JSON<<EOF' >> $GITHUB_ENV
           cat ./simtest.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
       - name: Export simtest version
+        shell: bash
         run: |
           echo "SIMTEST=${{ fromJson(env.SIMTEST_JSON).version }}" >> $GITHUB_ENV
 

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -136,19 +136,18 @@ jobs:
         shell: bash
         run: |
           cmake --build _build --config Release -j$(nproc)
-      # simtest
+
       - name: Read simtest version
-        id: simtest-version
-        uses: notiz-dev/github-action-json-property@release
-        with:
-          path: 'simtest.json'
-          prop_path: 'version'
+        run: |
+          echo 'simtest<<EOF' >> $GITHUB_ENV
+          cat ./simtest.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
 
       - name: Run named mps tests
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-named-mps
           os: ${{ env.test-platform }}
           variant: "named-mps"
@@ -176,7 +175,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: adequacy-patch-CSR
           os: ${{ env.test-platform }}
 
@@ -184,7 +183,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-v830
           os: ${{ env.test-platform }}
 
@@ -192,7 +191,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-milp
           variant: "milp-cbc"
           os: ${{ env.test-platform }}
@@ -201,7 +200,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-v860
           os: ${{ env.test-platform }}
 
@@ -209,7 +208,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-v870
           os: ${{ env.test-platform }}
 
@@ -217,7 +216,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-v910
           os: ${{ env.test-platform }}
 
@@ -225,7 +224,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: short-tests
           os: ${{ env.test-platform }}
 
@@ -233,7 +232,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-mps
           os: ${{ env.test-platform }}
 
@@ -241,7 +240,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: valid-parallel
           os: ${{ env.test-platform }}
           variant: "parallel"
@@ -250,7 +249,7 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: ts-generator
           os: ${{ env.test-platform }}
           variant: "tsgenerator"
@@ -259,7 +258,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: medium-tests
           os: ${{ env.test-platform }}
 
@@ -267,7 +266,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: long-tests-1
           os: ${{ env.test-platform }}
 
@@ -275,7 +274,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: long-tests-2
           os: ${{ env.test-platform }}
 
@@ -283,7 +282,7 @@ jobs:
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' }}
         uses: ./.github/workflows/run-tests
         with:
-          simtest-tag: ${{steps.simtest-version.outputs.prop}}
+          simtest-tag: ${{ fromJson(env.simtest).version }}
           batch-name: long-tests-3
           os: ${{ env.test-platform }}
 


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: notiz-dev/github-action-json-property@release. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
