### PR TITLE
Fix infeasible analyzer

### DIFF
--- a/src/solver/infeasible-problem-analysis/constraint.cpp
+++ b/src/solver/infeasible-problem-analysis/constraint.cpp
@@ -34,21 +34,21 @@ const std::string kUnknown = "<unknown>";
 
 namespace Antares::Optimization
 {
-Constraint::Constraint(const std::string& input, const double slackValue):
-    mInput(input),
-    mSlackValue(slackValue)
+Constraint::Constraint(const std::string& name, const double slackValue):
+    name_(name),
+    slackValue_(slackValue)
 {
 }
 
-std::size_t Constraint::extractItems()
+std::size_t Constraint::extractComponentsFromName()
 {
-    boost::algorithm::split_regex(mItems, mInput, boost::regex("::"));
-    return mItems.size();
+    boost::algorithm::split_regex(nameComponents_, name_, boost::regex("::"));
+    return nameComponents_.size();
 }
 
 double Constraint::getSlackValue() const
 {
-    return mSlackValue;
+    return slackValue_;
 }
 
 class StringIsNotWellFormated: public std::runtime_error
@@ -102,7 +102,7 @@ std::string Constraint::getAreaName() const
     {
         return "<none>";
     }
-    return StringBetweenAngleBrackets(mItems.at(1));
+    return StringBetweenAngleBrackets(nameComponents_.at(1));
 }
 
 std::string Constraint::getTimeStepInYear() const
@@ -114,7 +114,7 @@ std::string Constraint::getTimeStepInYear() const
     case ConstraintType::fictitious_load:
     case ConstraintType::hydro_reservoir_level:
     case ConstraintType::short_term_storage_level:
-        return StringBetweenAngleBrackets(mItems.at(mItems.size() - 2));
+        return StringBetweenAngleBrackets(nameComponents_.at(nameComponents_.size() - 2));
     default:
         return kUnknown;
     }
@@ -122,32 +122,32 @@ std::string Constraint::getTimeStepInYear() const
 
 ConstraintType Constraint::getType() const
 {
-    assert(mItems.size() > 1);
-    if (mItems.at(1) == "hourly")
+    assert(nameComponents_.size() > 1);
+    if (nameComponents_.at(1) == "hourly")
     {
         return ConstraintType::binding_constraint_hourly;
     }
-    if (mItems.at(1) == "daily")
+    if (nameComponents_.at(1) == "daily")
     {
         return ConstraintType::binding_constraint_daily;
     }
-    if (mItems.at(1) == "weekly")
+    if (nameComponents_.at(1) == "weekly")
     {
         return ConstraintType::binding_constraint_weekly;
     }
-    if (mItems.at(0) == "FictiveLoads")
+    if (nameComponents_.at(0) == "FictiveLoads")
     {
         return ConstraintType::fictitious_load;
     }
-    if (mItems.at(0) == "AreaHydroLevel")
+    if (nameComponents_.at(0) == "AreaHydroLevel")
     {
         return ConstraintType::hydro_reservoir_level;
     }
-    if (mItems.at(0) == "HydroPower")
+    if (nameComponents_.at(0) == "HydroPower")
     {
         return ConstraintType::hydro_production_weekly;
     }
-    if (mItems.at(0) == "Level")
+    if (nameComponents_.at(0) == "Level")
     {
         return ConstraintType::short_term_storage_level;
     }
@@ -161,7 +161,7 @@ std::string Constraint::getBindingConstraintName() const
     case ConstraintType::binding_constraint_hourly:
     case ConstraintType::binding_constraint_daily:
     case ConstraintType::binding_constraint_weekly:
-        return mItems.at(0);
+        return nameComponents_.at(0);
     default:
         return kUnknown;
     }
@@ -171,7 +171,7 @@ std::string Constraint::getSTSName() const
 {
     if (getType() == ConstraintType::short_term_storage_level)
     {
-        return StringBetweenAngleBrackets(mItems.at(2));
+        return StringBetweenAngleBrackets(nameComponents_.at(2));
     }
     else
     {

--- a/src/solver/infeasible-problem-analysis/constraint.cpp
+++ b/src/solver/infeasible-problem-analysis/constraint.cpp
@@ -24,6 +24,8 @@
 #include <cassert>
 #include <iomanip>
 #include <sstream>
+#include <boost/regex.hpp>
+#include <boost/algorithm/string/regex.hpp>
 
 namespace
 {
@@ -40,24 +42,7 @@ Constraint::Constraint(const std::string& input, const double slackValue):
 
 std::size_t Constraint::extractItems()
 {
-    const auto beg = mInput.begin();
-    const auto end = mInput.end();
-    std::size_t newPos = 0;
-    const std::size_t sepSize = 2;
-    const std::size_t inputSize = mInput.size();
-    for (std::size_t pos = 0; pos < inputSize; pos = newPos + sepSize)
-    {
-        newPos = mInput.find("::", pos);
-        if (newPos == std::string::npos)
-        {
-            mItems.emplace_back(beg + pos, end);
-            break;
-        }
-        if (newPos > pos)
-        {
-            mItems.emplace_back(beg + pos, beg + newPos);
-        }
-    }
+    boost::algorithm::split_regex(mItems, mInput, boost::regex("::"));
     return mItems.size();
 }
 
@@ -158,6 +143,10 @@ ConstraintType Constraint::getType() const
     {
         return ConstraintType::hydro_reservoir_level;
     }
+    if (mItems.at(0) == "HydroPower")
+    {
+        return ConstraintType::hydro_production_weekly;
+    }
     if (mItems.at(0) == "Level")
     {
         return ConstraintType::short_term_storage_level;
@@ -209,6 +198,8 @@ std::string Constraint::prettyPrint() const
     case ConstraintType::hydro_reservoir_level:
         return "Hydro reservoir constraint at area '" + getAreaName() + "' at hour "
                + getTimeStepInYear();
+    case ConstraintType::hydro_production_weekly:
+        return "Hydro weekly production at area '" + getAreaName() + "'";
     case ConstraintType::short_term_storage_level:
         return "Short-term-storage reservoir constraint at area '" + getAreaName() + "' in STS '"
                + getSTSName() + "' at hour " + getTimeStepInYear();

--- a/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/constraint-slack-analysis.h
+++ b/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/constraint-slack-analysis.h
@@ -57,7 +57,8 @@ private:
 
     std::vector<const operations_research::MPVariable*> slackVariables_;
     const std::string constraint_name_pattern = "^AreaHydroLevel::|::hourly::|::daily::|::weekly::|"
-                                                "^FictiveLoads::|^Level::";
+                                                "^FictiveLoads::|^Level::|"
+                                                "^HydroPower::";
 };
 
 } // namespace Antares::Optimization

--- a/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/constraint.h
+++ b/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/constraint.h
@@ -48,14 +48,14 @@ public:
     double getSlackValue() const;
 
     // Extract items, check consistency
-    std::size_t extractItems();
+    std::size_t extractComponentsFromName();
     std::string prettyPrint() const;
     ConstraintType getType() const;
 
 private:
-    std::string mInput;
-    std::vector<std::string> mItems;
-    double mSlackValue;
+    std::string name_;
+    std::vector<std::string> nameComponents_;
+    double slackValue_;
 
     // Get specific items
     std::string getAreaName() const;

--- a/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/constraint.h
+++ b/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/constraint.h
@@ -32,6 +32,7 @@ enum class ConstraintType
     binding_constraint_weekly,
     fictitious_load,
     hydro_reservoir_level,
+    hydro_production_weekly,
     short_term_storage_level,
     none
 };

--- a/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/report.h
+++ b/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/report.h
@@ -49,8 +49,8 @@ private:
     void extractItems();
     void logSuspiciousConstraints();
 
-    std::vector<Constraint> mConstraints;
-    std::map<ConstraintType, unsigned int> mTypes;
-    const unsigned int nbVariables = 10;
+    std::vector<Constraint> constraints_;
+    std::map<ConstraintType, unsigned int> nbConstraintsByType_;
+    const unsigned int nbMaxVariables = 10;
 };
 } // namespace Antares::Optimization

--- a/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/report.h
+++ b/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/report.h
@@ -46,7 +46,7 @@ private:
       const std::vector<const operations_research::MPVariable*>& slackVariables);
     void sortConstraints();
     void trimConstraints();
-    void extractItems();
+    void sortConstraintsByType();
     void logSuspiciousConstraints();
 
     std::vector<Constraint> constraints_;

--- a/src/solver/infeasible-problem-analysis/report.cpp
+++ b/src/solver/infeasible-problem-analysis/report.cpp
@@ -67,11 +67,11 @@ void InfeasibleProblemReport::trimConstraints()
     constraints_.resize(std::min(nbMaxVariables, nbConstraints));
 }
 
-void InfeasibleProblemReport::extractItems()
+void InfeasibleProblemReport::sortConstraintsByType()
 {
     for (auto& c: constraints_)
     {
-        if (c.extractItems() == 0)
+        if (c.extractComponentsFromName() == 0)
         {
             return;
         }
@@ -118,7 +118,7 @@ void InfeasibleProblemReport::logSuspiciousConstraints()
 
 void InfeasibleProblemReport::prettyPrint()
 {
-    extractItems();
+    sortConstraintsByType();
     logSuspiciousConstraints();
 }
 

--- a/src/solver/infeasible-problem-analysis/report.cpp
+++ b/src/solver/infeasible-problem-analysis/report.cpp
@@ -40,7 +40,7 @@ static bool compareSlackSolutions(const Antares::Optimization::Constraint& a,
 namespace Antares::Optimization
 {
 InfeasibleProblemReport::InfeasibleProblemReport(
-  const std::vector<const MPVariable*>& slackVariables)
+    const std::vector<const MPVariable*>& slackVariables)
 {
     turnSlackVarsIntoConstraints(slackVariables);
     sortConstraints();
@@ -48,72 +48,72 @@ InfeasibleProblemReport::InfeasibleProblemReport(
 }
 
 void InfeasibleProblemReport::turnSlackVarsIntoConstraints(
-  const std::vector<const MPVariable*>& slackVariables)
+    const std::vector<const MPVariable*>& slackVariables)
 {
     for (const MPVariable* slack: slackVariables)
     {
-        mConstraints.emplace_back(slack->name(), slack->solution_value());
+        constraints_.emplace_back(slack->name(), slack->solution_value());
     }
 }
 
 void InfeasibleProblemReport::sortConstraints()
 {
-    std::sort(std::begin(mConstraints), std::end(mConstraints), ::compareSlackSolutions);
+    std::sort(std::begin(constraints_), std::end(constraints_), ::compareSlackSolutions);
 }
 
 void InfeasibleProblemReport::trimConstraints()
 {
-    if (nbVariables <= mConstraints.size())
-    {
-        mConstraints.resize(nbVariables);
-    }
+    unsigned int nbConstraints = constraints_.size();
+    constraints_.resize(std::min(nbMaxVariables, nbConstraints));
 }
 
 void InfeasibleProblemReport::extractItems()
 {
-    for (auto& c: mConstraints)
+    for (auto& c: constraints_)
     {
         if (c.extractItems() == 0)
         {
             return;
         }
-        mTypes[c.getType()]++;
+        nbConstraintsByType_[c.getType()]++;
     }
 }
 
 void InfeasibleProblemReport::logSuspiciousConstraints()
 {
     Antares::logs.error() << "The following constraints are suspicious (first = most suspicious)";
-    for (const auto& c: mConstraints)
+    for (const auto& c: constraints_)
     {
         Antares::logs.error() << c.prettyPrint();
     }
     Antares::logs.error() << "Possible causes of infeasibility:";
-    if (mTypes[ConstraintType::hydro_reservoir_level] > 0)
+    if (nbConstraintsByType_[ConstraintType::hydro_reservoir_level] > 0)
     {
         Antares::logs.error() << "* Hydro reservoir impossible to manage with cumulative options "
                                  "\"hard bounds without heuristic\"";
     }
-    if (mTypes[ConstraintType::fictitious_load] > 0)
+    if (nbConstraintsByType_[ConstraintType::hydro_production_weekly] > 0)
+    {
+        Antares::logs.error() << "* impossible to generate exactly the weekly hydro target";
+    }
+    if (nbConstraintsByType_[ConstraintType::fictitious_load] > 0)
     {
         Antares::logs.error() << "* Last resort shedding status,";
     }
-    if (mTypes[ConstraintType::short_term_storage_level] > 0)
+    if (nbConstraintsByType_[ConstraintType::short_term_storage_level] > 0)
     {
         Antares::logs.error()
           << "* Short-term storage reservoir level impossible to manage. Please check inflows, "
              "lower & upper curves and initial level (if prescribed),";
     }
 
-    const unsigned int bcCount = mTypes[ConstraintType::binding_constraint_hourly]
-                                 + mTypes[ConstraintType::binding_constraint_daily]
-                                 + mTypes[ConstraintType::binding_constraint_weekly];
+    const unsigned int bcCount = nbConstraintsByType_[ConstraintType::binding_constraint_hourly]
+                                 + nbConstraintsByType_[ConstraintType::binding_constraint_daily]
+                                 + nbConstraintsByType_[ConstraintType::binding_constraint_weekly];
     if (bcCount > 0)
     {
         Antares::logs.error() << "* Binding constraints,";
     }
-
-    Antares::logs.error() << "* Negative hurdle costs on lines with infinite capacity (rare).";
 }
 
 void InfeasibleProblemReport::prettyPrint()

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -321,6 +321,9 @@ void ISimulation<ImplementationType>::run()
     }
     else
     {
+        // Export ts-numbers into output
+        TimeSeriesNumbers::StoreTimeSeriesNumbersIntoOuput(study, pResultWriter);
+
         if (not ImplementationType::simulationBegin())
         {
             return;
@@ -357,9 +360,6 @@ void ISimulation<ImplementationType>::run()
         pDurationCollector("post_processing") << [this] { ImplementationType::simulationEnd(); };
 
         ImplementationType::variables.simulationEnd();
-
-        // Export ts-numbers into output
-        TimeSeriesNumbers::StoreTimeSeriesNumbersIntoOuput(study, pResultWriter);
 
         // Spatial clusters
         // Notifying all variables to perform the final spatial clusters.


### PR DESCRIPTION
This PR is attached to ticket [ticket ANT-1825](https://gopro-tickets.rte-france.com/browse/ANT-1825).
Some improvements were made or tried by taking care of the ticket.
The result is this PR.

**What was done** : 
- hydro scope :
  - [x] move the code that prints the TS numbers on disk :  due to recent changes it was moved after the loop through MC years. So, we have to wait until simulation ends to know which TS numbers where drawn. So we move that code back.
- infeasibility analyzer scope 
  - [x] **Constraint :: extractItems()** was simplified
  - [x] Some renaming, meant to be more expressive
  - [x] Add a type of constraint to be spotted by the analyzer in case of infeasibility    
  - [ ] what else ?
