### PR TITLE
Minor fixes, use std::unique_ptr, add safety

### DIFF
--- a/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/watched-constraints.h
+++ b/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/watched-constraints.h
@@ -92,11 +92,11 @@ class ConstraintsFactory
 {
 public:
     ConstraintsFactory();
-    std::shared_ptr<WatchedConstraint> create(std::string pair) const;
+    std::unique_ptr<WatchedConstraint> create(const std::string& pair) const;
     std::regex constraintsFilter();
 
 private:
-    std::map<std::string, std::function<std::shared_ptr<WatchedConstraint>(std::string)>>
+    std::map<std::string, std::function<std::unique_ptr<WatchedConstraint>(const std::string&)>>
       regex_to_ctypes_;
 };
 

--- a/src/solver/infeasible-problem-analysis/report.cpp
+++ b/src/solver/infeasible-problem-analysis/report.cpp
@@ -40,7 +40,11 @@ void InfeasibleProblemReport::buildConstraintsFromSlackVars(
     const ConstraintsFactory constraintsFactory;
     for (const auto& slackVar: slackVariables)
     {
-        constraints_.push_back(constraintsFactory.create(slackVar->name()));
+        auto constraint = constraintsFactory.create(slackVar->name());
+        if (constraint)
+        {
+            constraints_.push_back(std::move(constraint));
+        }
     }
 }
 

--- a/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
+++ b/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
@@ -144,6 +144,8 @@ std::unique_ptr<MPSolver> createProblem(const std::string& constraintName)
 {
     std::unique_ptr<MPSolver> problem(MPSolver::CreateSolver("GLOP"));
     const double infinity = problem->infinity();
+    problem->MakeNumVar(1, infinity, "var1");
+    problem->MakeNumVar(-infinity, -1, "var2");
     auto constraint = problem->MakeRowConstraint(constraintName);
     constraint->SetBounds(0, infinity);
     return problem;

--- a/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
+++ b/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
@@ -144,8 +144,6 @@ std::unique_ptr<MPSolver> createProblem(const std::string& constraintName)
 {
     std::unique_ptr<MPSolver> problem(MPSolver::CreateSolver("GLOP"));
     const double infinity = problem->infinity();
-    auto var1 = problem->MakeNumVar(1, infinity, "var1");
-    auto var2 = problem->MakeNumVar(-infinity, -1, "var2");
     auto constraint = problem->MakeRowConstraint(constraintName);
     constraint->SetBounds(0, infinity);
     return problem;


### PR DESCRIPTION
- Use `std::unique_ptr` since we don't share objects
- Remove lambda functions (see https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique)
- Use `const std::string&`
- Make check on `create`, add safety on no result found
- Remove unused variables in tests