### PR TITLE
Fix clang++ warning about typeid

### DIFF
--- a/src/solver/infeasible-problem-analysis/report.cpp
+++ b/src/solver/infeasible-problem-analysis/report.cpp
@@ -49,13 +49,18 @@ void InfeasibleProblemReport::buildConstraintsFromSlackVars(
 bool lessTypeName(const std::shared_ptr<WatchedConstraint> a,
                   const std::shared_ptr<WatchedConstraint> b)
 {
-    return std::type_index(typeid(*a)) < std::type_index(typeid(*b));
+    const WatchedConstraint* a_raw = a.get();
+    const WatchedConstraint* b_raw = b.get();
+    // TODO Compiler-dependent behavior
+    return std::type_index(typeid(*a_raw)) < std::type_index(typeid(*b_raw));
 }
 
 bool sameType(const std::shared_ptr<WatchedConstraint> a,
               const std::shared_ptr<WatchedConstraint> b)
 {
-    return std::type_index(typeid(*a)) == std::type_index(typeid(*b));
+    const WatchedConstraint* a_raw = a.get();
+    const WatchedConstraint* b_raw = b.get();
+    return std::type_index(typeid(*a_raw)) == std::type_index(typeid(*b_raw));
 }
 
 bool greaterValue(const std::shared_ptr<WatchedConstraint> a, std::shared_ptr<WatchedConstraint> b)

--- a/src/ui/simulator/application/application.cpp
+++ b/src/ui/simulator/application/application.cpp
@@ -246,7 +246,7 @@ bool Application::OnInit()
     {
         String s;
         wxStringToString(wxString(argv[0]), s);
-        const char* c_argv[] = {s.data(), nullptr};
+        char* c_argv[] = {s.data(), nullptr};
 
         // Load the local policy settings
         LocalPolicy::Open();

--- a/src/ui/simulator/application/application.cpp
+++ b/src/ui/simulator/application/application.cpp
@@ -246,7 +246,7 @@ bool Application::OnInit()
     {
         String s;
         wxStringToString(wxString(argv[0]), s);
-        char* c_argv[] = {s.data(), nullptr};
+        const char* c_argv[] = {s.data(), nullptr};
 
         // Load the local policy settings
         LocalPolicy::Open();


### PR DESCRIPTION
 Expression with side effects will be evaluated despite being used as an operand to 'typeid'