### PR TITLE
Add comparison visitor, using variadic template arguments

### DIFF
--- a/src/solver/expressions/CMakeLists.txt
+++ b/src/solver/expressions/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRC_Expressions
         visitors/EvalVisitor.cpp
         visitors/LinearityVisitor.cpp
         visitors/EvaluationContext.cpp
+        visitors/CompareVisitor.cpp
 
         include/antares/solver/expressions/nodes/AddNode.h
         include/antares/solver/expressions/nodes/BinaryNode.h
@@ -35,6 +36,7 @@ set(SRC_Expressions
         include/antares/solver/expressions/nodes/VariableNode.h
 
         include/antares/solver/expressions/visitors/CloneVisitor.h
+        include/antares/solver/expressions/visitors/CompareVisitor.h
         include/antares/solver/expressions/visitors/EvalVisitor.h
         include/antares/solver/expressions/visitors/EvaluationContext.h
         include/antares/solver/expressions/visitors/LinearStatus.h

--- a/src/solver/expressions/include/antares/solver/expressions/nodes/ComponentNode.h
+++ b/src/solver/expressions/include/antares/solver/expressions/nodes/ComponentNode.h
@@ -32,6 +32,8 @@ public:
     const std::string& getComponentId() const;
     const std::string& getComponentName() const;
 
+    bool operator==(const ComponentNode& other) const;
+
 private:
     std::string component_id_;
     std::string component_name_;

--- a/src/solver/expressions/include/antares/solver/expressions/nodes/PortFieldNode.h
+++ b/src/solver/expressions/include/antares/solver/expressions/nodes/PortFieldNode.h
@@ -33,6 +33,8 @@ public:
     const std::string& getPortName() const;
     const std::string& getFieldName() const;
 
+    bool operator==(const PortFieldNode& other) const;
+
 private:
     std::string port_name_;
     std::string field_name_;

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
@@ -36,24 +36,15 @@ public:
     bool visit(const Nodes::DivisionNode& add, const Nodes::Node& other) override;
     bool visit(const Nodes::EqualNode& add, const Nodes::Node& other) override;
     bool visit(const Nodes::LessThanOrEqualNode& add, const Nodes::Node& other) override;
-
     bool visit(const Nodes::GreaterThanOrEqualNode& add, const Nodes::Node& other) override;
-
-    bool visit(const Nodes::NegationNode& neg, const Nodes::Node& other) override
-    {
-        return false;
-    }
-
+    bool visit(const Nodes::NegationNode& neg, const Nodes::Node& other) override;
     bool visit(const Nodes::VariableNode& param, const Nodes::Node& other) override;
 
     bool visit(const Nodes::ParameterNode& param, const Nodes::Node& other) override;
     bool visit(const Nodes::LiteralNode& param, const Nodes::Node& other) override;
-
     bool visit(const Nodes::PortFieldNode& port_field_node, const Nodes::Node& other) override;
-
     bool visit(const Nodes::ComponentVariableNode& component_node,
                const Nodes::Node& other) override;
-
     bool visit(const Nodes::ComponentParameterNode& component_node,
                const Nodes::Node& other) override;
 };

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
@@ -1,0 +1,95 @@
+/*
+** Copyright 2007-2024, RTE (https://www.rte-france.com)
+** See AUTHORS.txt
+** SPDX-License-Identifier: MPL-2.0
+** This file is part of Antares-Simulator,
+** Adequacy and Performance assessment for interconnected energy networks.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the Mozilla Public Licence 2.0 as published by
+** the Mozilla Foundation, either version 2 of the License, or
+** (at your option) any later version.
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** Mozilla Public Licence 2.0 for more details.
+**
+** You should have received a copy of the Mozilla Public Licence 2.0
+** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+*/
+#pragma once
+
+#include <antares/solver/expressions/Registry.hxx>
+#include "antares/solver/expressions/visitors/NodeVisitor.h"
+
+namespace Antares::Solver::Visitors
+{
+class CompareVisitor: public Nodes::NodeVisitor<bool, const Nodes::Node&>
+{
+public:
+    CompareVisitor() = default;
+
+    bool visit(const Nodes::AddNode& add, const Nodes::Node& other) override;
+
+    bool visit(const Nodes::SubtractionNode& add, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::MultiplicationNode& add, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::DivisionNode& add, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::EqualNode& add, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::LessThanOrEqualNode& add, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::GreaterThanOrEqualNode& add, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::NegationNode& neg, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::VariableNode& param, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::ParameterNode& param, const Nodes::Node& other) override;
+    bool visit(const Nodes::LiteralNode& param, const Nodes::Node& other) override;
+
+    bool visit(const Nodes::PortFieldNode& port_field_node, const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::ComponentVariableNode& component_node,
+               const Nodes::Node& other) override
+    {
+        return false;
+    }
+
+    bool visit(const Nodes::ComponentParameterNode& component_node,
+               const Nodes::Node& other) override
+    {
+        return false;
+    }
+};
+} // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
@@ -31,65 +31,30 @@ public:
     CompareVisitor() = default;
 
     bool visit(const Nodes::AddNode& add, const Nodes::Node& other) override;
+    bool visit(const Nodes::SubtractionNode& add, const Nodes::Node& other) override;
+    bool visit(const Nodes::MultiplicationNode& add, const Nodes::Node& other) override;
+    bool visit(const Nodes::DivisionNode& add, const Nodes::Node& other) override;
+    bool visit(const Nodes::EqualNode& add, const Nodes::Node& other) override;
+    bool visit(const Nodes::LessThanOrEqualNode& add, const Nodes::Node& other) override;
 
-    bool visit(const Nodes::SubtractionNode& add, const Nodes::Node& other) override
-    {
-        return false;
-    }
-
-    bool visit(const Nodes::MultiplicationNode& add, const Nodes::Node& other) override
-    {
-        return false;
-    }
-
-    bool visit(const Nodes::DivisionNode& add, const Nodes::Node& other) override
-    {
-        return false;
-    }
-
-    bool visit(const Nodes::EqualNode& add, const Nodes::Node& other) override
-    {
-        return false;
-    }
-
-    bool visit(const Nodes::LessThanOrEqualNode& add, const Nodes::Node& other) override
-    {
-        return false;
-    }
-
-    bool visit(const Nodes::GreaterThanOrEqualNode& add, const Nodes::Node& other) override
-    {
-        return false;
-    }
+    bool visit(const Nodes::GreaterThanOrEqualNode& add, const Nodes::Node& other) override;
 
     bool visit(const Nodes::NegationNode& neg, const Nodes::Node& other) override
     {
         return false;
     }
 
-    bool visit(const Nodes::VariableNode& param, const Nodes::Node& other) override
-    {
-        return false;
-    }
+    bool visit(const Nodes::VariableNode& param, const Nodes::Node& other) override;
 
     bool visit(const Nodes::ParameterNode& param, const Nodes::Node& other) override;
     bool visit(const Nodes::LiteralNode& param, const Nodes::Node& other) override;
 
-    bool visit(const Nodes::PortFieldNode& port_field_node, const Nodes::Node& other) override
-    {
-        return false;
-    }
+    bool visit(const Nodes::PortFieldNode& port_field_node, const Nodes::Node& other) override;
 
     bool visit(const Nodes::ComponentVariableNode& component_node,
-               const Nodes::Node& other) override
-    {
-        return false;
-    }
+               const Nodes::Node& other) override;
 
     bool visit(const Nodes::ComponentParameterNode& component_node,
-               const Nodes::Node& other) override
-    {
-        return false;
-    }
+               const Nodes::Node& other) override;
 };
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
@@ -29,44 +29,44 @@ namespace Antares::Solver::Nodes
 {
 namespace
 {
-template<class RetT, class VisitorT, class NodeT>
-std::optional<RetT> tryVisit(const Node& node, VisitorT& visitor)
+template<class RetT, class VisitorT, class NodeT, class... Args>
+std::optional<RetT> tryVisit(const Node& node, VisitorT& visitor, Args... args)
 {
     if (auto* x = dynamic_cast<const NodeT*>(&node))
     {
-        return visitor.visit(*x);
+        return visitor.visit(*x, args...);
     }
     return std::nullopt;
 }
 } // namespace
 
-template<class R>
+template<class R, class... Args>
 class NodeVisitor
 {
 public:
     virtual ~NodeVisitor() = default;
 
-    R dispatch(const Node& node)
+    R dispatch(const Node& node, Args... args)
     {
-        using FunctionT = std::optional<R> (*)(const Node&, NodeVisitor<R>&);
+        using FunctionT = std::optional<R> (*)(const Node&, NodeVisitor<R, Args...>&, Args... args);
         static const std::vector<FunctionT> allNodeVisitList{
-          &tryVisit<R, NodeVisitor<R>, AddNode>,
-          &tryVisit<R, NodeVisitor<R>, SubtractionNode>,
-          &tryVisit<R, NodeVisitor<R>, MultiplicationNode>,
-          &tryVisit<R, NodeVisitor<R>, DivisionNode>,
-          &tryVisit<R, NodeVisitor<R>, EqualNode>,
-          &tryVisit<R, NodeVisitor<R>, LessThanOrEqualNode>,
-          &tryVisit<R, NodeVisitor<R>, GreaterThanOrEqualNode>,
-          &tryVisit<R, NodeVisitor<R>, NegationNode>,
-          &tryVisit<R, NodeVisitor<R>, ParameterNode>,
-          &tryVisit<R, NodeVisitor<R>, VariableNode>,
-          &tryVisit<R, NodeVisitor<R>, LiteralNode>,
-          &tryVisit<R, NodeVisitor<R>, PortFieldNode>,
-          &tryVisit<R, NodeVisitor<R>, ComponentVariableNode>,
-          &tryVisit<R, NodeVisitor<R>, ComponentParameterNode>};
+          &tryVisit<R, NodeVisitor<R, Args...>, AddNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, SubtractionNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, MultiplicationNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, DivisionNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, EqualNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, LessThanOrEqualNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, GreaterThanOrEqualNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, NegationNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, ParameterNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, VariableNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, LiteralNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, PortFieldNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, ComponentVariableNode>,
+          &tryVisit<R, NodeVisitor<R, Args...>, ComponentParameterNode>};
         for (auto f: allNodeVisitList)
         {
-            if (auto ret = f(node, *this); ret.has_value())
+            if (auto ret = f(node, *this, args...); ret.has_value())
             {
                 return ret.value();
             }
@@ -75,21 +75,19 @@ public:
         return R();
     }
 
-    virtual R visit(const AddNode&) = 0;
-
-    virtual R visit(const SubtractionNode&) = 0;
-    virtual R visit(const MultiplicationNode&) = 0;
-    virtual R visit(const DivisionNode&) = 0;
-    virtual R visit(const EqualNode&) = 0;
-    virtual R visit(const LessThanOrEqualNode&) = 0;
-    virtual R visit(const GreaterThanOrEqualNode&) = 0;
-    virtual R visit(const NegationNode&) = 0;
-    virtual R visit(const LiteralNode&) = 0;
-    virtual R visit(const VariableNode&) = 0;
-    virtual R visit(const ParameterNode&) = 0;
-    virtual R visit(const PortFieldNode&) = 0;
-    virtual R visit(const ComponentVariableNode&) = 0;
-    virtual R visit(const ComponentParameterNode&) = 0;
+    virtual R visit(const AddNode&, Args... args) = 0;
+    virtual R visit(const SubtractionNode&, Args... args) = 0;
+    virtual R visit(const MultiplicationNode&, Args... args) = 0;
+    virtual R visit(const DivisionNode&, Args... args) = 0;
+    virtual R visit(const EqualNode&, Args... args) = 0;
+    virtual R visit(const LessThanOrEqualNode&, Args... args) = 0;
+    virtual R visit(const GreaterThanOrEqualNode&, Args... args) = 0;
+    virtual R visit(const NegationNode&, Args... args) = 0;
+    virtual R visit(const LiteralNode&, Args... args) = 0;
+    virtual R visit(const VariableNode&, Args... args) = 0;
+    virtual R visit(const ParameterNode&, Args... args) = 0;
+    virtual R visit(const PortFieldNode&, Args... args) = 0;
+    virtual R visit(const ComponentVariableNode&, Args... args) = 0;
+    virtual R visit(const ComponentParameterNode&, Args... args) = 0;
 };
-
 } // namespace Antares::Solver::Nodes

--- a/src/solver/expressions/nodes/ComponentNode.cpp
+++ b/src/solver/expressions/nodes/ComponentNode.cpp
@@ -28,6 +28,11 @@ ComponentNode::ComponentNode(const std::string& component_id, const std::string&
 {
 }
 
+bool ComponentNode::operator==(const ComponentNode& other) const
+{
+    return component_id_ == other.component_id_ && component_name_ == other.component_name_;
+}
+
 const std::string& ComponentNode::getComponentId() const
 {
     return component_id_;

--- a/src/solver/expressions/nodes/PortFieldNode.cpp
+++ b/src/solver/expressions/nodes/PortFieldNode.cpp
@@ -28,6 +28,11 @@ PortFieldNode::PortFieldNode(const std::string& port_name, const std::string& fi
 {
 }
 
+bool PortFieldNode::operator==(const PortFieldNode& other) const
+{
+    return port_name_ == other.port_name_ && field_name_ == other.field_name_;
+}
+
 const std::string& PortFieldNode::getPortName() const
 {
     return port_name_;

--- a/src/solver/expressions/visitors/CompareVisitor.cpp
+++ b/src/solver/expressions/visitors/CompareVisitor.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2007-2024, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
+#include <antares/solver/expressions/nodes/ExpressionsNodes.h>
+#include <antares/solver/expressions/visitors/CompareVisitor.h>
+
+namespace Antares::Solver::Visitors
+{
+bool CompareVisitor::visit(const Nodes::AddNode& add, const Nodes::Node& other)
+{
+    if (auto* other_add = dynamic_cast<const Nodes::AddNode*>(&other))
+    {
+        bool left = dispatch(*add.left(), *other_add->left());
+        bool right = dispatch(*add.right(), *other_add->right());
+        return left && right;
+    }
+    return false;
+}
+
+bool CompareVisitor::visit(const Nodes::ParameterNode& parameter, const Nodes::Node& other)
+{
+    if (auto* other_parameter = dynamic_cast<const Nodes::ParameterNode*>(&other))
+    {
+        return parameter.getValue() == other_parameter->getValue();
+    }
+    return false;
+}
+
+bool CompareVisitor::visit(const Nodes::LiteralNode& literal, const Nodes::Node& other)
+{
+    if (auto* other_literal = dynamic_cast<const Nodes::LiteralNode*>(&other))
+    {
+        return literal.getValue() == other_literal->getValue();
+    }
+    return false;
+}
+} // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/visitors/CompareVisitor.cpp
+++ b/src/solver/expressions/visitors/CompareVisitor.cpp
@@ -21,34 +21,105 @@
 #include <antares/solver/expressions/nodes/ExpressionsNodes.h>
 #include <antares/solver/expressions/visitors/CompareVisitor.h>
 
-namespace Antares::Solver::Visitors
+template<class T, class V>
+static bool compareBinaryNode(V& visitor, const T& node, const Antares::Solver::Nodes::Node& other)
 {
-bool CompareVisitor::visit(const Nodes::AddNode& add, const Nodes::Node& other)
-{
-    if (auto* other_add = dynamic_cast<const Nodes::AddNode*>(&other))
+    if (const T* other_node = dynamic_cast<const T*>(&other))
     {
-        bool left = dispatch(*add.left(), *other_add->left());
-        bool right = dispatch(*add.right(), *other_add->right());
+        bool left = visitor.dispatch(*node.left(), *other_node->left());
+        bool right = visitor.dispatch(*node.right(), *other_node->right());
         return left && right;
     }
     return false;
 }
 
-bool CompareVisitor::visit(const Nodes::ParameterNode& parameter, const Nodes::Node& other)
+template<class T, class V>
+static bool compareGetValue(V& visitor, const T& node, const Antares::Solver::Nodes::Node& other)
 {
-    if (auto* other_parameter = dynamic_cast<const Nodes::ParameterNode*>(&other))
+    if (const T* other_node = dynamic_cast<const T*>(&other))
     {
-        return parameter.getValue() == other_parameter->getValue();
+        return node.getValue() == other_node->getValue();
     }
     return false;
 }
 
-bool CompareVisitor::visit(const Nodes::LiteralNode& literal, const Nodes::Node& other)
+template<class T, class V>
+static bool compareEqualOperator(V& visitor,
+                                 const T& node,
+                                 const Antares::Solver::Nodes::Node& other)
 {
-    if (auto* other_literal = dynamic_cast<const Nodes::LiteralNode*>(&other))
+    if (const T* other_node = dynamic_cast<const T*>(&other))
     {
-        return literal.getValue() == other_literal->getValue();
+        return node == *other_node;
     }
     return false;
 }
+
+namespace Antares::Solver::Visitors
+{
+bool CompareVisitor::visit(const Nodes::AddNode& node, const Nodes::Node& other)
+{
+    return compareBinaryNode<Nodes::AddNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::SubtractionNode& node, const Nodes::Node& other)
+{
+    return compareBinaryNode<Nodes::SubtractionNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::MultiplicationNode& node, const Nodes::Node& other)
+{
+    return compareBinaryNode<Nodes::MultiplicationNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::DivisionNode& node, const Nodes::Node& other)
+{
+    return compareBinaryNode<Nodes::DivisionNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::EqualNode& node, const Nodes::Node& other)
+{
+    return compareBinaryNode<Nodes::EqualNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::LessThanOrEqualNode& node, const Nodes::Node& other)
+{
+    return compareBinaryNode<Nodes::LessThanOrEqualNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::GreaterThanOrEqualNode& node, const Nodes::Node& other)
+{
+    return compareBinaryNode<Nodes::GreaterThanOrEqualNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::ParameterNode& node, const Nodes::Node& other)
+{
+    return compareGetValue<Nodes::ParameterNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::LiteralNode& node, const Nodes::Node& other)
+{
+    return compareGetValue<Nodes::LiteralNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::VariableNode& node, const Nodes::Node& other)
+{
+    return compareGetValue<Nodes::VariableNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::PortFieldNode& node, const Nodes::Node& other)
+{
+    return compareEqualOperator<Nodes::PortFieldNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::ComponentVariableNode& node, const Nodes::Node& other)
+{
+    return compareEqualOperator<Nodes::ComponentVariableNode>(*this, node, other);
+}
+
+bool CompareVisitor::visit(const Nodes::ComponentParameterNode& node, const Nodes::Node& other)
+{
+    return compareEqualOperator<Nodes::ComponentParameterNode>(*this, node, other);
+}
+
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/visitors/CompareVisitor.cpp
+++ b/src/solver/expressions/visitors/CompareVisitor.cpp
@@ -57,37 +57,37 @@ namespace Antares::Solver::Visitors
 {
 bool CompareVisitor::visit(const Nodes::AddNode& node, const Nodes::Node& other)
 {
-    return compareBinaryNode<Nodes::AddNode>(*this, node, other);
+    return compareBinaryNode(*this, node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::SubtractionNode& node, const Nodes::Node& other)
 {
-    return compareBinaryNode<Nodes::SubtractionNode>(*this, node, other);
+    return compareBinaryNode(*this, node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::MultiplicationNode& node, const Nodes::Node& other)
 {
-    return compareBinaryNode<Nodes::MultiplicationNode>(*this, node, other);
+    return compareBinaryNode(*this, node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::DivisionNode& node, const Nodes::Node& other)
 {
-    return compareBinaryNode<Nodes::DivisionNode>(*this, node, other);
+    return compareBinaryNode(*this, node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::EqualNode& node, const Nodes::Node& other)
 {
-    return compareBinaryNode<Nodes::EqualNode>(*this, node, other);
+    return compareBinaryNode(*this, node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::LessThanOrEqualNode& node, const Nodes::Node& other)
 {
-    return compareBinaryNode<Nodes::LessThanOrEqualNode>(*this, node, other);
+    return compareBinaryNode(*this, node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::GreaterThanOrEqualNode& node, const Nodes::Node& other)
 {
-    return compareBinaryNode<Nodes::GreaterThanOrEqualNode>(*this, node, other);
+    return compareBinaryNode(*this, node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::NegationNode& node, const Nodes::Node& other)

--- a/src/solver/expressions/visitors/CompareVisitor.cpp
+++ b/src/solver/expressions/visitors/CompareVisitor.cpp
@@ -33,8 +33,8 @@ static bool compareBinaryNode(V& visitor, const T& node, const Antares::Solver::
     return false;
 }
 
-template<class T, class V>
-static bool compareGetValue(V& visitor, const T& node, const Antares::Solver::Nodes::Node& other)
+template<class T>
+static bool compareGetValue(const T& node, const Antares::Solver::Nodes::Node& other)
 {
     if (const T* other_node = dynamic_cast<const T*>(&other))
     {
@@ -43,10 +43,8 @@ static bool compareGetValue(V& visitor, const T& node, const Antares::Solver::No
     return false;
 }
 
-template<class T, class V>
-static bool compareEqualOperator(V& visitor,
-                                 const T& node,
-                                 const Antares::Solver::Nodes::Node& other)
+template<class T>
+static bool compareEqualOperator(const T& node, const Antares::Solver::Nodes::Node& other)
 {
     if (const T* other_node = dynamic_cast<const T*>(&other))
     {
@@ -103,32 +101,32 @@ bool CompareVisitor::visit(const Nodes::NegationNode& node, const Nodes::Node& o
 
 bool CompareVisitor::visit(const Nodes::ParameterNode& node, const Nodes::Node& other)
 {
-    return compareGetValue<Nodes::ParameterNode>(*this, node, other);
+    return compareGetValue<Nodes::ParameterNode>(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::LiteralNode& node, const Nodes::Node& other)
 {
-    return compareGetValue<Nodes::LiteralNode>(*this, node, other);
+    return compareGetValue<Nodes::LiteralNode>(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::VariableNode& node, const Nodes::Node& other)
 {
-    return compareGetValue<Nodes::VariableNode>(*this, node, other);
+    return compareGetValue<Nodes::VariableNode>(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::PortFieldNode& node, const Nodes::Node& other)
 {
-    return compareEqualOperator<Nodes::PortFieldNode>(*this, node, other);
+    return compareEqualOperator<Nodes::PortFieldNode>(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::ComponentVariableNode& node, const Nodes::Node& other)
 {
-    return compareEqualOperator<Nodes::ComponentVariableNode>(*this, node, other);
+    return compareEqualOperator<Nodes::ComponentVariableNode>(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::ComponentParameterNode& node, const Nodes::Node& other)
 {
-    return compareEqualOperator<Nodes::ComponentParameterNode>(*this, node, other);
+    return compareEqualOperator<Nodes::ComponentParameterNode>(node, other);
 }
 
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/visitors/CompareVisitor.cpp
+++ b/src/solver/expressions/visitors/CompareVisitor.cpp
@@ -92,6 +92,15 @@ bool CompareVisitor::visit(const Nodes::GreaterThanOrEqualNode& node, const Node
     return compareBinaryNode<Nodes::GreaterThanOrEqualNode>(*this, node, other);
 }
 
+bool CompareVisitor::visit(const Nodes::NegationNode& node, const Nodes::Node& other)
+{
+    if (auto other_node = dynamic_cast<const Nodes::NegationNode*>(&other))
+    {
+        return dispatch(*node.child(), *other_node->child());
+    }
+    return false;
+}
+
 bool CompareVisitor::visit(const Nodes::ParameterNode& node, const Nodes::Node& other)
 {
     return compareGetValue<Nodes::ParameterNode>(*this, node, other);

--- a/src/solver/expressions/visitors/CompareVisitor.cpp
+++ b/src/solver/expressions/visitors/CompareVisitor.cpp
@@ -101,32 +101,32 @@ bool CompareVisitor::visit(const Nodes::NegationNode& node, const Nodes::Node& o
 
 bool CompareVisitor::visit(const Nodes::ParameterNode& node, const Nodes::Node& other)
 {
-    return compareGetValue<Nodes::ParameterNode>(node, other);
+    return compareGetValue(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::LiteralNode& node, const Nodes::Node& other)
 {
-    return compareGetValue<Nodes::LiteralNode>(node, other);
+    return compareGetValue(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::VariableNode& node, const Nodes::Node& other)
 {
-    return compareGetValue<Nodes::VariableNode>(node, other);
+    return compareGetValue(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::PortFieldNode& node, const Nodes::Node& other)
 {
-    return compareEqualOperator<Nodes::PortFieldNode>(node, other);
+    return compareEqualOperator(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::ComponentVariableNode& node, const Nodes::Node& other)
 {
-    return compareEqualOperator<Nodes::ComponentVariableNode>(node, other);
+    return compareEqualOperator(node, other);
 }
 
 bool CompareVisitor::visit(const Nodes::ComponentParameterNode& node, const Nodes::Node& other)
 {
-    return compareEqualOperator<Nodes::ComponentParameterNode>(node, other);
+    return compareEqualOperator(node, other);
 }
 
 } // namespace Antares::Solver::Visitors

--- a/src/tests/src/solver/expressions/test_expressions.cpp
+++ b/src/tests/src/solver/expressions/test_expressions.cpp
@@ -363,9 +363,9 @@ BOOST_FIXTURE_TEST_CASE(simple_constant_expression, Registry<Node>)
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(*expr), LinearStatus::CONSTANT);
 }
 
-static Node* createSimpleExpression(Registry<Node>& registry)
+static Node* createSimpleExpression(Registry<Node>& registry, double param)
 {
-    Node* var1 = registry.create<LiteralNode>(65.);
+    Node* var1 = registry.create<LiteralNode>(param);
     Node* param1 = registry.create<ParameterNode>("param1");
     Node* expr = registry.create<AddNode>(var1, param1);
     return expr;
@@ -374,14 +374,23 @@ static Node* createSimpleExpression(Registry<Node>& registry)
 BOOST_FIXTURE_TEST_CASE(comparison_to_self, Registry<Node>)
 {
     CompareVisitor cmp;
-    Node* expr = createSimpleExpression(*this);
+    Node* expr = createSimpleExpression(*this, 65.);
     BOOST_CHECK(cmp.dispatch(*expr, *expr));
 }
 
-BOOST_FIXTURE_TEST_CASE(comparison_to_other, Registry<Node>)
+BOOST_FIXTURE_TEST_CASE(comparison_to_other_same, Registry<Node>)
 {
     CompareVisitor cmp;
-    Node* expr1 = createSimpleExpression(*this);
-    Node* expr2 = createSimpleExpression(*this);
+    auto create = [this] { return createSimpleExpression(*this, 65.); };
+    Node* expr1 = create();
+    Node* expr2 = create();
     BOOST_CHECK(cmp.dispatch(*expr1, *expr2));
+}
+
+BOOST_FIXTURE_TEST_CASE(comparison_to_other_different, Registry<Node>)
+{
+    CompareVisitor cmp;
+    Node* expr1 = createSimpleExpression(*this, 64.);
+    Node* expr2 = createSimpleExpression(*this, 65.);
+    BOOST_CHECK(!cmp.dispatch(*expr1, *expr2));
 }

--- a/src/tests/src/solver/expressions/test_expressions.cpp
+++ b/src/tests/src/solver/expressions/test_expressions.cpp
@@ -397,7 +397,7 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_other_different, Registry<Node>)
 
 static Node* createComplexExpression(Registry<Node>& registry)
 {
-    // NOTE : this expression makes no sense
+    // NOTE : this expression makes no sense, only for testing purposes
     // NOTE2 : Some elements are re-used (e.g simple), this is valid since memory is handled
     // separately (no double free)
 
@@ -420,4 +420,20 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_self_complex, Registry<Node>)
     CompareVisitor cmp;
     Node* expr = createComplexExpression(*this);
     BOOST_CHECK(cmp.dispatch(*expr, *expr));
+}
+
+BOOST_FIXTURE_TEST_CASE(comparison_to_other_complex, Registry<Node>)
+{
+    CompareVisitor cmp;
+    Node* expr1 = createComplexExpression(*this);
+    Node* expr2 = createComplexExpression(*this);
+    BOOST_CHECK(cmp.dispatch(*expr1, *expr2));
+}
+
+BOOST_FIXTURE_TEST_CASE(comparison_to_other_different_complex, Registry<Node>)
+{
+    CompareVisitor cmp;
+    Node* expr1 = createComplexExpression(*this);
+    Node* expr2 = create<NegationNode>(expr1);
+    BOOST_CHECK(!cmp.dispatch(*expr1, *expr2));
 }

--- a/src/tests/src/solver/expressions/test_expressions.cpp
+++ b/src/tests/src/solver/expressions/test_expressions.cpp
@@ -27,6 +27,7 @@
 #include <antares/solver/expressions/Registry.hxx>
 #include <antares/solver/expressions/nodes/ExpressionsNodes.h>
 #include <antares/solver/expressions/visitors/CloneVisitor.h>
+#include <antares/solver/expressions/visitors/CompareVisitor.h>
 #include <antares/solver/expressions/visitors/EvalVisitor.h>
 #include <antares/solver/expressions/visitors/LinearStatus.h>
 #include <antares/solver/expressions/visitors/LinearityVisitor.h>
@@ -360,4 +361,27 @@ BOOST_FIXTURE_TEST_CASE(simple_constant_expression, Registry<Node>)
     Node* expr = create<AddNode>(mult, &portFieldNode);
     BOOST_CHECK_EQUAL(printVisitor.dispatch(*expr), "((65.000000*p1)+port.field)");
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(*expr), LinearStatus::CONSTANT);
+}
+
+static AddNode* createSimpleExpression(Registry<Node>& registry)
+{
+    Node* var1 = registry.create<LiteralNode>(65.);
+    Node* param1 = registry.create<ParameterNode>("param1");
+    Node* expr = registry.create<AddNode>(var1, param1);
+    return dynamic_cast<AddNode*>(expr);
+}
+
+BOOST_FIXTURE_TEST_CASE(comparison_to_self, Registry<Node>)
+{
+    CompareVisitor cmp;
+    Node* expr = createSimpleExpression(*this);
+    BOOST_CHECK(cmp.dispatch(*expr, *expr));
+}
+
+BOOST_FIXTURE_TEST_CASE(comparison_to_other, Registry<Node>)
+{
+    CompareVisitor cmp;
+    Node* expr1 = createSimpleExpression(*this);
+    Node* expr2 = createSimpleExpression(*this);
+    BOOST_CHECK(cmp.dispatch(*expr1, *expr2));
 }

--- a/src/tests/src/solver/expressions/test_expressions.cpp
+++ b/src/tests/src/solver/expressions/test_expressions.cpp
@@ -363,12 +363,12 @@ BOOST_FIXTURE_TEST_CASE(simple_constant_expression, Registry<Node>)
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(*expr), LinearStatus::CONSTANT);
 }
 
-static AddNode* createSimpleExpression(Registry<Node>& registry)
+static Node* createSimpleExpression(Registry<Node>& registry)
 {
     Node* var1 = registry.create<LiteralNode>(65.);
     Node* param1 = registry.create<ParameterNode>("param1");
     Node* expr = registry.create<AddNode>(var1, param1);
-    return dynamic_cast<AddNode*>(expr);
+    return expr;
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_to_self, Registry<Node>)


### PR DESCRIPTION
- Add variadic argument to `NodeVisitor::visit` methods. This argument is optional, meaning we don't break existing visitors
- Add `CompareVisitor` a non-commutative comparison visitor to another expression (a+b != b+a)
- Add simple & complex tests, both in the case where expressions are expected to be equal, and different.
- Add comparison operators (`operator==`) for some nodes, but not all. Open to remarks