### PR TITLE
Disable CMAKE_COLOR_DIAGNOSTICS

### DIFF
--- a/src/cmake/common-settings.cmake
+++ b/src/cmake/common-settings.cmake
@@ -14,7 +14,6 @@ set(COMMON_MSVC_FLAGS "/W3 /MP4")
 set(COMMON_MSVC_FLAGS "${COMMON_MSVC_FLAGS} /we4715 /we4716") #adding no return or no return for all code paths as errors
 set(ADDITIONAL_C_FLAGS " -Wconversion -Wmissing-prototypes -Wstrict-prototypes")
 set(ADDITIONAL_C_FLAGS "${ADDITIONAL_C_FLAGS} -Wmissing-noreturn -Wpacked -Wredundant-decls -Wbad-function-cast -W -Wcast-align -Wcast-qual -Wsign-compare -fno-exceptions -Wdeclaration-after-statement")
-set(CMAKE_COLOR_DIAGNOSTICS on)
 
 
 Set(ANTARES_VERSION_TARGET "unknown")


### PR DESCRIPTION
Revert #2320

It completely messes with my editor (emacs), to the point where I'm no longer able to navigate to files.

![image](https://github.com/user-attachments/assets/af5c9a9e-52d6-442b-b92d-2080ca827204)


@payetvin You can force this option locally using -DXXXX=ON
