### PR TITLE
Remove useless ;, macro definition

### DIFF
--- a/src/libs/antares/InfoCollection/include/antares/infoCollection/StudyInfoCollector.h
+++ b/src/libs/antares/InfoCollection/include/antares/infoCollection/StudyInfoCollector.h
@@ -69,7 +69,9 @@ class SimulationInfoCollector
 {
 public:
     SimulationInfoCollector(const OptimizationInfo& optInfo):
-        opt_info_(optInfo){};
+        opt_info_(optInfo)
+    {
+    }
 
     void toFileContent(FileContent& file_content);
 

--- a/src/libs/antares/locator/locator.cpp
+++ b/src/libs/antares/locator/locator.cpp
@@ -31,10 +31,6 @@
 
 using namespace Yuni;
 
-#define SEP \
-    Yuni:;  \
-    IO::Separator
-
 namespace Antares::Solver
 {
 bool FindLocation(String& location)

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -33,7 +33,9 @@ class InMemoryStudyLoader: public Antares::IStudyLoader
 {
 public:
     explicit InMemoryStudyLoader(bool success = true):
-        success_(success){};
+        success_(success)
+    {
+    }
 
     [[nodiscard]] std::unique_ptr<Antares::Data::Study> load() const override
     {

--- a/src/tests/src/libs/antares/array/matrix-bypass-load.h
+++ b/src/tests/src/libs/antares/array/matrix-bypass-load.h
@@ -49,15 +49,21 @@ class Matrix_load_bypass: public Matrix_easy_to_fill<T, ReadWriteT>
 public:
     Matrix_load_bypass():
         Matrix_easy_to_fill<T, ReadWriteT>(),
-        loadFromCSVFile_called(false){};
+        loadFromCSVFile_called(false)
+    {
+    }
 
     Matrix_load_bypass(uint height, uint width):
         Matrix_easy_to_fill<T, ReadWriteT>(height, width),
-        loadFromCSVFile_called(false){};
+        loadFromCSVFile_called(false)
+    {
+    }
 
     Matrix_load_bypass(uint height, uint width, const vector<T>& vec):
         Matrix_easy_to_fill<T, ReadWriteT>(height, width, vec),
-        loadFromCSVFile_called(false){};
+        loadFromCSVFile_called(false)
+    {
+    }
 
     bool loadFromCSVFile(const AnyString& /* filename */,
                          uint /* minWidth */,
@@ -128,15 +134,21 @@ class Matrix_mock_load_to_buffer: public Matrix<T, ReadWriteT>
 public:
     Matrix_mock_load_to_buffer():
         Matrix<T, ReadWriteT>(),
-        fake_mtx_error_when_loading_(IO::errNone){};
+        fake_mtx_error_when_loading_(IO::errNone)
+    {
+    }
 
     Matrix_mock_load_to_buffer(uint height, uint width):
         Matrix<T, ReadWriteT>(height, width),
-        fake_mtx_error_when_loading_(IO::errNone){};
+        fake_mtx_error_when_loading_(IO::errNone)
+    {
+    }
 
     Matrix_mock_load_to_buffer(uint height, uint width, const vector<T>& vec):
         Matrix<T, ReadWriteT>(height, width, vec),
-        fake_mtx_error_when_loading_(IO::errNone){};
+        fake_mtx_error_when_loading_(IO::errNone)
+    {
+    }
 
     IO::Error loadFromFileToBuffer(typename Matrix<T, ReadWriteT>::BufferType& /* buffer */,
                                    const AnyString& /* filename */) const override


### PR DESCRIPTION
So that clang-format==18.3.7 does not change the format (from current 18.3.1)