### PR TITLE
Fix operator for boost data

### DIFF
--- a/src/tests/src/solver/expressions/test_LinearVisitor.cpp
+++ b/src/tests/src/solver/expressions/test_LinearVisitor.cpp
@@ -107,7 +107,7 @@ BOOST_DATA_TEST_CASE(linear_status_minus, bdata::make(LinearStatus_ALL), x)
 }
 
 BOOST_DATA_TEST_CASE(linear_plus_commutative,
-                     bdata::make(LinearStatus_ALL) ^ bdata::make(LinearStatus_ALL),
+                     bdata::make(LinearStatus_ALL) * bdata::make(LinearStatus_ALL),
                      x,
                      y)
 {
@@ -115,7 +115,7 @@ BOOST_DATA_TEST_CASE(linear_plus_commutative,
 }
 
 BOOST_DATA_TEST_CASE(linear_subtract_same_as_plus,
-                     bdata::make(LinearStatus_ALL) ^ bdata::make(LinearStatus_ALL),
+                     bdata::make(LinearStatus_ALL) * bdata::make(LinearStatus_ALL),
                      x,
                      y)
 {
@@ -123,7 +123,7 @@ BOOST_DATA_TEST_CASE(linear_subtract_same_as_plus,
 }
 
 BOOST_DATA_TEST_CASE(linear_multiply_commutative,
-                     bdata::make(LinearStatus_ALL) ^ bdata::make(LinearStatus_ALL),
+                     bdata::make(LinearStatus_ALL) * bdata::make(LinearStatus_ALL),
                      x,
                      y)
 {


### PR DESCRIPTION
`bdata::make(...) ^ bdata::make(...)` zips datasets 

{a1, a2} ^ {b1, b2} = {{a1, b1}, {a2, b2}}

https://www.boost.org/doc/libs/1_85_0/boost/test/data/monomorphic/zip.hpp

`bdata::make(...) * bdata::make(...)` makes a grid of datasets (all (x,y) pairs) 

{a1, a2} * {b1, b2} = {{a1, b1}, {a1, b2}, {a2, b1}, {a2, b2}}


https://www.boost.org/doc/libs/1_85_0/boost/test/data/monomorphic/grid.hpp