### PR TITLE
use raw ptr instead of ref

### DIFF
--- a/src/solver/expressions/include/antares/solver/expressions/visitors/CloneVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/CloneVisitor.h
@@ -30,20 +30,20 @@ class CloneVisitor: public Nodes::NodeVisitor<Nodes::Node*>
 public:
     explicit CloneVisitor(Registry<Nodes::Node>& registry);
 
-    Nodes::Node* visit(const Nodes::AddNode& node) override;
-    Nodes::Node* visit(const Nodes::SubtractionNode& node) override;
-    Nodes::Node* visit(const Nodes::MultiplicationNode& node) override;
-    Nodes::Node* visit(const Nodes::DivisionNode& node) override;
-    Nodes::Node* visit(const Nodes::EqualNode& node) override;
-    Nodes::Node* visit(const Nodes::LessThanOrEqualNode& node) override;
-    Nodes::Node* visit(const Nodes::GreaterThanOrEqualNode& node) override;
-    Nodes::Node* visit(const Nodes::NegationNode& node) override;
-    Nodes::Node* visit(const Nodes::VariableNode& node) override;
-    Nodes::Node* visit(const Nodes::ParameterNode& node) override;
-    Nodes::Node* visit(const Nodes::LiteralNode& node) override;
-    Nodes::Node* visit(const Nodes::PortFieldNode& node) override;
-    Nodes::Node* visit(const Nodes::ComponentVariableNode& node) override;
-    Nodes::Node* visit(const Nodes::ComponentParameterNode& node) override;
+    Nodes::Node* visit(const Nodes::AddNode* node) override;
+    Nodes::Node* visit(const Nodes::SubtractionNode* node) override;
+    Nodes::Node* visit(const Nodes::MultiplicationNode* node) override;
+    Nodes::Node* visit(const Nodes::DivisionNode* node) override;
+    Nodes::Node* visit(const Nodes::EqualNode* node) override;
+    Nodes::Node* visit(const Nodes::LessThanOrEqualNode* node) override;
+    Nodes::Node* visit(const Nodes::GreaterThanOrEqualNode* node) override;
+    Nodes::Node* visit(const Nodes::NegationNode* node) override;
+    Nodes::Node* visit(const Nodes::VariableNode* node) override;
+    Nodes::Node* visit(const Nodes::ParameterNode* node) override;
+    Nodes::Node* visit(const Nodes::LiteralNode* node) override;
+    Nodes::Node* visit(const Nodes::PortFieldNode* node) override;
+    Nodes::Node* visit(const Nodes::ComponentVariableNode* node) override;
+    Nodes::Node* visit(const Nodes::ComponentParameterNode* node) override;
 
 private:
     Registry<Nodes::Node>& registry_;

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
@@ -25,27 +25,26 @@
 
 namespace Antares::Solver::Visitors
 {
-class CompareVisitor: public Nodes::NodeVisitor<bool, const Nodes::Node&>
+class CompareVisitor: public Nodes::NodeVisitor<bool, const Nodes::Node*>
 {
 public:
     CompareVisitor() = default;
 
-    bool visit(const Nodes::AddNode& add, const Nodes::Node& other) override;
-    bool visit(const Nodes::SubtractionNode& add, const Nodes::Node& other) override;
-    bool visit(const Nodes::MultiplicationNode& add, const Nodes::Node& other) override;
-    bool visit(const Nodes::DivisionNode& add, const Nodes::Node& other) override;
-    bool visit(const Nodes::EqualNode& add, const Nodes::Node& other) override;
-    bool visit(const Nodes::LessThanOrEqualNode& add, const Nodes::Node& other) override;
-    bool visit(const Nodes::GreaterThanOrEqualNode& add, const Nodes::Node& other) override;
-    bool visit(const Nodes::NegationNode& neg, const Nodes::Node& other) override;
-    bool visit(const Nodes::VariableNode& param, const Nodes::Node& other) override;
-
-    bool visit(const Nodes::ParameterNode& param, const Nodes::Node& other) override;
-    bool visit(const Nodes::LiteralNode& param, const Nodes::Node& other) override;
-    bool visit(const Nodes::PortFieldNode& port_field_node, const Nodes::Node& other) override;
-    bool visit(const Nodes::ComponentVariableNode& component_node,
-               const Nodes::Node& other) override;
-    bool visit(const Nodes::ComponentParameterNode& component_node,
-               const Nodes::Node& other) override;
+    bool visit(const Nodes::AddNode* add, const Nodes::Node* other) override;
+    bool visit(const Nodes::SubtractionNode* add, const Nodes::Node* other) override;
+    bool visit(const Nodes::MultiplicationNode* add, const Nodes::Node* other) override;
+    bool visit(const Nodes::DivisionNode* add, const Nodes::Node* other) override;
+    bool visit(const Nodes::EqualNode* add, const Nodes::Node* other) override;
+    bool visit(const Nodes::LessThanOrEqualNode* add, const Nodes::Node* other) override;
+    bool visit(const Nodes::GreaterThanOrEqualNode* add, const Nodes::Node* other) override;
+    bool visit(const Nodes::NegationNode* neg, const Nodes::Node* other) override;
+    bool visit(const Nodes::VariableNode* param, const Nodes::Node* other) override;
+    bool visit(const Nodes::ParameterNode* param, const Nodes::Node* other) override;
+    bool visit(const Nodes::LiteralNode* param, const Nodes::Node* other) override;
+    bool visit(const Nodes::PortFieldNode* port_field_node, const Nodes::Node* other) override;
+    bool visit(const Nodes::ComponentVariableNode* component_node,
+               const Nodes::Node* other) override;
+    bool visit(const Nodes::ComponentParameterNode* component_node,
+               const Nodes::Node* other) override;
 };
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/CompareVisitor.h
@@ -25,11 +25,10 @@
 
 namespace Antares::Solver::Visitors
 {
-class CompareVisitor: public Nodes::NodeVisitor<bool, const Nodes::Node*>
 /**
  * @brief Represents a visitor for comparing nodes in a syntax tree.
  */
-class CompareVisitor: public Nodes::NodeVisitor<bool, const Nodes::Node&>
+class CompareVisitor: public Nodes::NodeVisitor<bool, const Nodes::Node*>
 {
 public:
     CompareVisitor() = default;

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/EvalVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/EvalVisitor.h
@@ -41,19 +41,19 @@ public:
 
 private:
     const EvaluationContext context_;
-    double visit(const Nodes::AddNode& node) override;
-    double visit(const Nodes::SubtractionNode& node) override;
-    double visit(const Nodes::MultiplicationNode& node) override;
-    double visit(const Nodes::DivisionNode& node) override;
-    double visit(const Nodes::EqualNode& node) override;
-    double visit(const Nodes::LessThanOrEqualNode& node) override;
-    double visit(const Nodes::GreaterThanOrEqualNode& node) override;
-    double visit(const Nodes::NegationNode& node) override;
-    double visit(const Nodes::VariableNode& node) override;
-    double visit(const Nodes::ParameterNode& node) override;
-    double visit(const Nodes::LiteralNode& node) override;
-    double visit(const Nodes::PortFieldNode& node) override;
-    double visit(const Nodes::ComponentVariableNode& node) override;
-    double visit(const Nodes::ComponentParameterNode& node) override;
+    double visit(const Nodes::AddNode* node) override;
+    double visit(const Nodes::SubtractionNode* node) override;
+    double visit(const Nodes::MultiplicationNode* node) override;
+    double visit(const Nodes::DivisionNode* node) override;
+    double visit(const Nodes::EqualNode* node) override;
+    double visit(const Nodes::LessThanOrEqualNode* node) override;
+    double visit(const Nodes::GreaterThanOrEqualNode* node) override;
+    double visit(const Nodes::NegationNode* node) override;
+    double visit(const Nodes::VariableNode* node) override;
+    double visit(const Nodes::ParameterNode* node) override;
+    double visit(const Nodes::LiteralNode* node) override;
+    double visit(const Nodes::PortFieldNode* node) override;
+    double visit(const Nodes::ComponentVariableNode* node) override;
+    double visit(const Nodes::ComponentParameterNode* node) override;
 };
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/LinearityVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/LinearityVisitor.h
@@ -29,19 +29,19 @@ namespace Antares::Solver::Visitors
 class LinearityVisitor: public Nodes::NodeVisitor<LinearStatus>
 {
 private:
-    LinearStatus visit(const Nodes::AddNode& add) override;
-    LinearStatus visit(const Nodes::SubtractionNode& add) override;
-    LinearStatus visit(const Nodes::MultiplicationNode& add) override;
-    LinearStatus visit(const Nodes::DivisionNode& add) override;
-    LinearStatus visit(const Nodes::EqualNode& add) override;
-    LinearStatus visit(const Nodes::LessThanOrEqualNode& add) override;
-    LinearStatus visit(const Nodes::GreaterThanOrEqualNode& add) override;
-    LinearStatus visit(const Nodes::NegationNode& neg) override;
-    LinearStatus visit(const Nodes::VariableNode& param) override;
-    LinearStatus visit(const Nodes::ParameterNode& param) override;
-    LinearStatus visit(const Nodes::LiteralNode& lit) override;
-    LinearStatus visit(const Nodes::PortFieldNode& port_field_node) override;
-    LinearStatus visit(const Nodes::ComponentVariableNode& component_variable_node) override;
-    LinearStatus visit(const Nodes::ComponentParameterNode& component_parameter_node) override;
+    LinearStatus visit(const Nodes::AddNode* add) override;
+    LinearStatus visit(const Nodes::SubtractionNode* add) override;
+    LinearStatus visit(const Nodes::MultiplicationNode* add) override;
+    LinearStatus visit(const Nodes::DivisionNode* add) override;
+    LinearStatus visit(const Nodes::EqualNode* add) override;
+    LinearStatus visit(const Nodes::LessThanOrEqualNode* add) override;
+    LinearStatus visit(const Nodes::GreaterThanOrEqualNode* add) override;
+    LinearStatus visit(const Nodes::NegationNode* neg) override;
+    LinearStatus visit(const Nodes::VariableNode* param) override;
+    LinearStatus visit(const Nodes::ParameterNode* param) override;
+    LinearStatus visit(const Nodes::LiteralNode* lit) override;
+    LinearStatus visit(const Nodes::PortFieldNode* port_field_node) override;
+    LinearStatus visit(const Nodes::ComponentVariableNode* component_variable_node) override;
+    LinearStatus visit(const Nodes::ComponentParameterNode* component_parameter_node) override;
 };
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
@@ -40,6 +40,15 @@ std::optional<RetT> tryVisit(const Node* node, VisitorT& visitor, Args... args)
 }
 } // namespace
 
+class InvalidNode: std::invalid_argument
+{
+public:
+    explicit InvalidNode():
+        std::invalid_argument("Antares::Solver::Nodes Visitor: invalid node type")
+    {
+    }
+};
+
 template<class R, class... Args>
 class NodeVisitor
 {
@@ -48,10 +57,10 @@ public:
 
     R dispatch(const Node* node, Args... args)
     {
-        /*
-         * TODO check Node nullity ->
-         * https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/2354
-         * */
+        if (!node)
+        {
+            throw InvalidNode();
+        }
         using FunctionT = std::optional<R> (*)(const Node*, NodeVisitor<R, Args...>&, Args... args);
         static const std::vector<FunctionT> allNodeVisitList{
           &tryVisit<R, NodeVisitor<R, Args...>, AddNode>,

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
@@ -30,11 +30,11 @@ namespace Antares::Solver::Nodes
 namespace
 {
 template<class RetT, class VisitorT, class NodeT, class... Args>
-std::optional<RetT> tryVisit(const Node& node, VisitorT& visitor, Args... args)
+std::optional<RetT> tryVisit(const Node* node, VisitorT& visitor, Args... args)
 {
-    if (auto* x = dynamic_cast<const NodeT*>(&node))
+    if (auto* x = dynamic_cast<const NodeT*>(node))
     {
-        return visitor.visit(*x, args...);
+        return visitor.visit(x, args...);
     }
     return std::nullopt;
 }
@@ -46,9 +46,13 @@ class NodeVisitor
 public:
     virtual ~NodeVisitor() = default;
 
-    R dispatch(const Node& node, Args... args)
+    R dispatch(const Node* node, Args... args)
     {
-        using FunctionT = std::optional<R> (*)(const Node&, NodeVisitor<R, Args...>&, Args... args);
+        /*
+         * TODO check Node nullity ->
+         * https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/2354
+         * */
+        using FunctionT = std::optional<R> (*)(const Node*, NodeVisitor<R, Args...>&, Args... args);
         static const std::vector<FunctionT> allNodeVisitList{
           &tryVisit<R, NodeVisitor<R, Args...>, AddNode>,
           &tryVisit<R, NodeVisitor<R, Args...>, SubtractionNode>,
@@ -75,19 +79,19 @@ public:
         return R();
     }
 
-    virtual R visit(const AddNode&, Args... args) = 0;
-    virtual R visit(const SubtractionNode&, Args... args) = 0;
-    virtual R visit(const MultiplicationNode&, Args... args) = 0;
-    virtual R visit(const DivisionNode&, Args... args) = 0;
-    virtual R visit(const EqualNode&, Args... args) = 0;
-    virtual R visit(const LessThanOrEqualNode&, Args... args) = 0;
-    virtual R visit(const GreaterThanOrEqualNode&, Args... args) = 0;
-    virtual R visit(const NegationNode&, Args... args) = 0;
-    virtual R visit(const LiteralNode&, Args... args) = 0;
-    virtual R visit(const VariableNode&, Args... args) = 0;
-    virtual R visit(const ParameterNode&, Args... args) = 0;
-    virtual R visit(const PortFieldNode&, Args... args) = 0;
-    virtual R visit(const ComponentVariableNode&, Args... args) = 0;
-    virtual R visit(const ComponentParameterNode&, Args... args) = 0;
+    virtual R visit(const AddNode*, Args... args) = 0;
+    virtual R visit(const SubtractionNode*, Args... args) = 0;
+    virtual R visit(const MultiplicationNode*, Args... args) = 0;
+    virtual R visit(const DivisionNode*, Args... args) = 0;
+    virtual R visit(const EqualNode*, Args... args) = 0;
+    virtual R visit(const LessThanOrEqualNode*, Args... args) = 0;
+    virtual R visit(const GreaterThanOrEqualNode*, Args... args) = 0;
+    virtual R visit(const NegationNode*, Args... args) = 0;
+    virtual R visit(const LiteralNode*, Args... args) = 0;
+    virtual R visit(const VariableNode*, Args... args) = 0;
+    virtual R visit(const ParameterNode*, Args... args) = 0;
+    virtual R visit(const PortFieldNode*, Args... args) = 0;
+    virtual R visit(const ComponentVariableNode*, Args... args) = 0;
+    virtual R visit(const ComponentParameterNode*, Args... args) = 0;
 };
 } // namespace Antares::Solver::Nodes

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
@@ -31,10 +31,10 @@ namespace Antares::Solver::Nodes
 namespace
 {
 template<class RetT, class VisitorT, class NodeT, class... Args>
-RetT tryVisit(const Node& node, VisitorT& visitor, Args... args)
+RetT tryVisit(const Node* node, VisitorT& visitor, Args... args)
 {
-    auto* x = dynamic_cast<const NodeT*>(&node);
-    return visitor.visit(*x, args...);
+    auto* x = dynamic_cast<const NodeT*>(node);
+    return visitor.visit(x, args...);
 }
 } // namespace
 template<class R, class... Args>
@@ -43,7 +43,7 @@ class NodeVisitor;
 template<class R, class... Args>
 struct NodeVisitsProvider
 {
-    using FunctionT = R (*)(const Node&, NodeVisitor<R, Args...>&, Args... args);
+    using FunctionT = R (*)(const Node*, NodeVisitor<R, Args...>&, Args... args);
 
     /**
      * Creates a map associating node types with corresponding visitor functions.
@@ -121,7 +121,7 @@ public:
 
         try
         {
-            return nodeVisitList.at(typeid(*node))(*node, *this, args...);
+            return nodeVisitList.at(typeid(*node))(node, *this, args...);
         }
         catch (std::exception&)
         {

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
@@ -67,7 +67,7 @@ struct NodeVisitsProvider
     }
 };
 
-class InvalidNode: std::invalid_argument
+class InvalidNode: public std::invalid_argument
 {
 public:
     explicit InvalidNode():

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/NodeVisitor.h
@@ -29,6 +29,21 @@ namespace Antares::Solver::Nodes
 {
 namespace
 {
+/**
+ * @brief Tries to visit a given node using a specified visitor object.
+ *
+ * @tparam RetT The return type of the visitor's `visit` method.
+ * @tparam VisitorT The type of the visitor object.
+ * @tparam NodeT The type of the node to be visited.
+ * @tparam Args... Additional arguments to be passed to the visitor's `visit` method.
+ *
+ * @param node A pointer to the node to be visited.
+ * @param visitor A reference to the visitor object.
+ * @param args... Additional arguments to be passed to the visitor's `visit` method.
+ *
+ * @return An `std::optional` containing the result of the visit, or `std::nullopt` if the node is
+ * not of the correct type.
+ */
 template<class RetT, class VisitorT, class NodeT, class... Args>
 std::optional<RetT> tryVisit(const Node* node, VisitorT& visitor, Args... args)
 {
@@ -55,6 +70,18 @@ class NodeVisitor
 public:
     virtual ~NodeVisitor() = default;
 
+    /**
+     * Dispatches a node to an appropriate visitor function based on its type.
+     *
+     * Iterates through a list of visitor functions, attempting to call each one until a successful
+     * visit is made.
+     *
+     * @param node A pointer to the Node object to be visited.
+     * @param args Variadic template arguments to be passed to the visitor functions.
+     * @return An optional value of type `R` representing the result of the visit.
+     *         If no visitor function handles the node, an empty optional is returned.
+     * @throws InvalidNode If the provided `node` is null.
+     */
     R dispatch(const Node* node, Args... args)
     {
         if (!node)
@@ -88,19 +115,140 @@ public:
         return R();
     }
 
+    /**
+     * @brief Visits an AddNode and processes its children.
+     *
+     * @param node A pointer to the AddNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the AddNode.
+     */
     virtual R visit(const AddNode*, Args... args) = 0;
+    /**
+     * @brief Visits a SubtractionNode and processes its children.
+     *
+     * @param node A pointer to the SubtractionNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the SubtractionNode.
+     */
     virtual R visit(const SubtractionNode*, Args... args) = 0;
+    /**
+     * @brief Visits a MultiplicationNode and processes its children.
+     *
+     * @param node A pointer to the MultiplicationNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the MultiplicationNode.
+     */
     virtual R visit(const MultiplicationNode*, Args... args) = 0;
+    /**
+     * @brief Visits a DivisionNode and processes its children.
+     *
+     * @param node A pointer to the DivisionNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the DivisionNode.
+     */
     virtual R visit(const DivisionNode*, Args... args) = 0;
+    /**
+     * @brief Visits an EqualNode and processes its children.
+     *
+     * @param node A pointer to the EqualNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the EqualNode.
+     */
     virtual R visit(const EqualNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a LessThanOrEqualNode and processes its children.
+     *
+     * @param node A pointer to the LessThanOrEqualNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the LessThanOrEqualNode.
+     */
     virtual R visit(const LessThanOrEqualNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a GreaterThanOrEqualNode and processes its children.
+     *
+     * @param node A pointer to the GreaterThanOrEqualNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the GreaterThanOrEqualNode.
+     */
     virtual R visit(const GreaterThanOrEqualNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a NegationNode and processes its child.
+     *
+     * @param node A pointer to the NegationNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the NegationNode.
+     */
     virtual R visit(const NegationNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a LiteralNode.
+     *
+     * @param node A pointer to the LiteralNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the LiteralNode.
+     */
     virtual R visit(const LiteralNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a VariableNode.
+     *
+     * @param node A pointer to the VariableNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the VariableNode.
+     */
     virtual R visit(const VariableNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a ParameterNode.
+     *
+     * @param node A pointer to the ParameterNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the ParameterNode.
+     */
     virtual R visit(const ParameterNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a PortFieldNode.
+     *
+     * @param node A pointer to the PortFieldNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the PortFieldNode.
+     */
     virtual R visit(const PortFieldNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a ComponentVariableNode.
+     *
+     * @param node A pointer to the ComponentVariableNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the ComponentVariableNode.
+     */
     virtual R visit(const ComponentVariableNode*, Args... args) = 0;
+
+    /**
+     * @brief Visits a ComponentParameterNode.
+     *
+     * @param node A pointer to the ComponentParameterNode to be visited.
+     * @param args Additional arguments to be passed to the visitor's methods.
+     *
+     * @return The result of processing the ComponentParameterNode.
+     */
     virtual R visit(const ComponentParameterNode*, Args... args) = 0;
 };
 } // namespace Antares::Solver::Nodes

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/PrintVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/PrintVisitor.h
@@ -27,19 +27,19 @@ namespace Antares::Solver::Visitors
 class PrintVisitor: public Nodes::NodeVisitor<std::string>
 {
 private:
-    std::string visit(const Nodes::AddNode& node) override;
-    std::string visit(const Nodes::SubtractionNode& node) override;
-    std::string visit(const Nodes::MultiplicationNode& node) override;
-    std::string visit(const Nodes::DivisionNode& node) override;
-    std::string visit(const Nodes::EqualNode& node) override;
-    std::string visit(const Nodes::LessThanOrEqualNode& node) override;
-    std::string visit(const Nodes::GreaterThanOrEqualNode& node) override;
-    std::string visit(const Nodes::NegationNode& node) override;
-    std::string visit(const Nodes::VariableNode& node) override;
-    std::string visit(const Nodes::ParameterNode& node) override;
-    std::string visit(const Nodes::LiteralNode& node) override;
-    std::string visit(const Nodes::PortFieldNode& node) override;
-    std::string visit(const Nodes::ComponentVariableNode& node) override;
-    std::string visit(const Nodes::ComponentParameterNode& node) override;
+    std::string visit(const Nodes::AddNode* node) override;
+    std::string visit(const Nodes::SubtractionNode* node) override;
+    std::string visit(const Nodes::MultiplicationNode* node) override;
+    std::string visit(const Nodes::DivisionNode* node) override;
+    std::string visit(const Nodes::EqualNode* node) override;
+    std::string visit(const Nodes::LessThanOrEqualNode* node) override;
+    std::string visit(const Nodes::GreaterThanOrEqualNode* node) override;
+    std::string visit(const Nodes::NegationNode* node) override;
+    std::string visit(const Nodes::VariableNode* node) override;
+    std::string visit(const Nodes::ParameterNode* node) override;
+    std::string visit(const Nodes::LiteralNode* node) override;
+    std::string visit(const Nodes::PortFieldNode* node) override;
+    std::string visit(const Nodes::ComponentVariableNode* node) override;
+    std::string visit(const Nodes::ComponentParameterNode* node) override;
 };
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/SubstitutionVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/SubstitutionVisitor.h
@@ -45,6 +45,6 @@ public:
 
 private:
     // Only override visit method for ComponentVariableNode, clone the rest
-    Nodes::Node* visit(const Nodes::ComponentVariableNode& node) override;
+    Nodes::Node* visit(const Nodes::ComponentVariableNode* node) override;
 };
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/include/antares/solver/expressions/visitors/TimeIndexVisitor.h
+++ b/src/solver/expressions/include/antares/solver/expressions/visitors/TimeIndexVisitor.h
@@ -33,19 +33,19 @@ public:
 
 private:
     std::unordered_map<const Nodes::Node*, TimeIndex> context_;
-    TimeIndex visit(const Nodes::AddNode& add) override;
-    TimeIndex visit(const Nodes::SubtractionNode& add) override;
-    TimeIndex visit(const Nodes::MultiplicationNode& add) override;
-    TimeIndex visit(const Nodes::DivisionNode& add) override;
-    TimeIndex visit(const Nodes::EqualNode& add) override;
-    TimeIndex visit(const Nodes::LessThanOrEqualNode& add) override;
-    TimeIndex visit(const Nodes::GreaterThanOrEqualNode& add) override;
-    TimeIndex visit(const Nodes::NegationNode& neg) override;
-    TimeIndex visit(const Nodes::VariableNode& param) override;
-    TimeIndex visit(const Nodes::ParameterNode& param) override;
-    TimeIndex visit(const Nodes::LiteralNode& lit) override;
-    TimeIndex visit(const Nodes::PortFieldNode& port_field_node) override;
-    TimeIndex visit(const Nodes::ComponentVariableNode& component_variable_node) override;
-    TimeIndex visit(const Nodes::ComponentParameterNode& component_parameter_node) override;
+    TimeIndex visit(const Nodes::AddNode* add) override;
+    TimeIndex visit(const Nodes::SubtractionNode* add) override;
+    TimeIndex visit(const Nodes::MultiplicationNode* add) override;
+    TimeIndex visit(const Nodes::DivisionNode* add) override;
+    TimeIndex visit(const Nodes::EqualNode* add) override;
+    TimeIndex visit(const Nodes::LessThanOrEqualNode* add) override;
+    TimeIndex visit(const Nodes::GreaterThanOrEqualNode* add) override;
+    TimeIndex visit(const Nodes::NegationNode* neg) override;
+    TimeIndex visit(const Nodes::VariableNode* param) override;
+    TimeIndex visit(const Nodes::ParameterNode* param) override;
+    TimeIndex visit(const Nodes::LiteralNode* lit) override;
+    TimeIndex visit(const Nodes::PortFieldNode* port_field_node) override;
+    TimeIndex visit(const Nodes::ComponentVariableNode* component_variable_node) override;
+    TimeIndex visit(const Nodes::ComponentParameterNode* component_parameter_node) override;
 };
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/visitors/CloneVisitor.cpp
+++ b/src/solver/expressions/visitors/CloneVisitor.cpp
@@ -28,82 +28,82 @@ CloneVisitor::CloneVisitor(Registry<Nodes::Node>& registry):
 {
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::AddNode& node)
+Nodes::Node* CloneVisitor::visit(const Nodes::AddNode* node)
 {
-    return registry_.create<Nodes::AddNode>(dispatch(*node.left()), dispatch(*node.right()));
+    return registry_.create<Nodes::AddNode>(dispatch(node->left()), dispatch(node->right()));
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::SubtractionNode& node)
+Nodes::Node* CloneVisitor::visit(const Nodes::SubtractionNode* node)
 {
-    return registry_.create<Nodes::SubtractionNode>(dispatch(*node.left()),
-                                                    dispatch(*node.right()));
+    return registry_.create<Nodes::SubtractionNode>(dispatch(node->left()),
+                                                    dispatch(node->right()));
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::MultiplicationNode& node)
+Nodes::Node* CloneVisitor::visit(const Nodes::MultiplicationNode* node)
 {
-    return registry_.create<Nodes::MultiplicationNode>(dispatch(*node.left()),
-                                                       dispatch(*node.right()));
+    return registry_.create<Nodes::MultiplicationNode>(dispatch(node->left()),
+                                                       dispatch(node->right()));
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::DivisionNode& node)
+Nodes::Node* CloneVisitor::visit(const Nodes::DivisionNode* node)
 {
-    return registry_.create<Nodes::DivisionNode>(dispatch(*node.left()), dispatch(*node.right()));
+    return registry_.create<Nodes::DivisionNode>(dispatch(node->left()), dispatch(node->right()));
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::EqualNode& node)
+Nodes::Node* CloneVisitor::visit(const Nodes::EqualNode* node)
 {
-    return registry_.create<Nodes::EqualNode>(dispatch(*node.left()), dispatch(*node.right()));
+    return registry_.create<Nodes::EqualNode>(dispatch(node->left()), dispatch(node->right()));
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::LessThanOrEqualNode& node)
+Nodes::Node* CloneVisitor::visit(const Nodes::LessThanOrEqualNode* node)
 {
-    return registry_.create<Nodes::LessThanOrEqualNode>(dispatch(*node.left()),
-                                                        dispatch(*node.right()));
+    return registry_.create<Nodes::LessThanOrEqualNode>(dispatch(node->left()),
+                                                        dispatch(node->right()));
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::GreaterThanOrEqualNode& node)
+Nodes::Node* CloneVisitor::visit(const Nodes::GreaterThanOrEqualNode* node)
 {
-    return registry_.create<Nodes::GreaterThanOrEqualNode>(dispatch(*node.left()),
-                                                           dispatch(*node.right()));
+    return registry_.create<Nodes::GreaterThanOrEqualNode>(dispatch(node->left()),
+                                                           dispatch(node->right()));
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::NegationNode& neg)
+Nodes::Node* CloneVisitor::visit(const Nodes::NegationNode* negationNode)
 {
-    return registry_.create<Nodes::NegationNode>(dispatch(*neg.child()));
+    return registry_.create<Nodes::NegationNode>(dispatch(negationNode->child()));
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::VariableNode& param)
+Nodes::Node* CloneVisitor::visit(const Nodes::VariableNode* variableNode)
 {
-    return registry_.create<Nodes::VariableNode>(param.value());
+    return registry_.create<Nodes::VariableNode>(variableNode->value());
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::ParameterNode& param)
+Nodes::Node* CloneVisitor::visit(const Nodes::ParameterNode* parameterNode)
 {
-    return registry_.create<Nodes::ParameterNode>(param.value());
+    return registry_.create<Nodes::ParameterNode>(parameterNode->value());
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::LiteralNode& param)
+Nodes::Node* CloneVisitor::visit(const Nodes::LiteralNode* literalNode)
 {
-    return registry_.create<Nodes::LiteralNode>(param.value());
+    return registry_.create<Nodes::LiteralNode>(literalNode->value());
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::PortFieldNode& port_field_node)
+Nodes::Node* CloneVisitor::visit(const Nodes::PortFieldNode* port_field_node)
 {
-    return registry_.create<Nodes::PortFieldNode>(port_field_node.getPortName(),
-                                                  port_field_node.getFieldName());
+    return registry_.create<Nodes::PortFieldNode>(port_field_node->getPortName(),
+                                                  port_field_node->getFieldName());
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::ComponentVariableNode& component_variable_node)
+Nodes::Node* CloneVisitor::visit(const Nodes::ComponentVariableNode* component_variable_node)
 {
     return registry_.create<Nodes::ComponentVariableNode>(
-      component_variable_node.getComponentId(),
-      component_variable_node.getComponentName());
+      component_variable_node->getComponentId(),
+      component_variable_node->getComponentName());
 }
 
-Nodes::Node* CloneVisitor::visit(const Nodes::ComponentParameterNode& component_parameter_node)
+Nodes::Node* CloneVisitor::visit(const Nodes::ComponentParameterNode* component_parameter_node)
 {
     return registry_.create<Nodes::ComponentParameterNode>(
-      component_parameter_node.getComponentId(),
-      component_parameter_node.getComponentName());
+      component_parameter_node->getComponentId(),
+      component_parameter_node->getComponentName());
 }
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/visitors/CompareVisitor.cpp
+++ b/src/solver/expressions/visitors/CompareVisitor.cpp
@@ -22,109 +22,109 @@
 #include <antares/solver/expressions/visitors/CompareVisitor.h>
 
 template<class T, class V>
-static bool compareBinaryNode(V& visitor, const T& node, const Antares::Solver::Nodes::Node& other)
+static bool compareBinaryNode(V& visitor, const T* node, const Antares::Solver::Nodes::Node* other)
 {
-    if (const T* other_node = dynamic_cast<const T*>(&other))
+    if (const T* other_node = dynamic_cast<const T*>(other))
     {
-        bool left = visitor.dispatch(*node.left(), *other_node->left());
-        bool right = visitor.dispatch(*node.right(), *other_node->right());
+        bool left = visitor.dispatch(node->left(), other_node->left());
+        bool right = visitor.dispatch(node->right(), other_node->right());
         return left && right;
     }
     return false;
 }
 
 template<class T>
-static bool compareGetValue(const T& node, const Antares::Solver::Nodes::Node& other)
+static bool compareGetValue(const T* node, const Antares::Solver::Nodes::Node* other)
 {
-    if (const T* other_node = dynamic_cast<const T*>(&other))
+    if (const T* other_node = dynamic_cast<const T*>(other))
     {
-        return node.value() == other_node->value();
+        return node->value() == other_node->value();
     }
     return false;
 }
 
 template<class T>
-static bool compareEqualOperator(const T& node, const Antares::Solver::Nodes::Node& other)
+static bool compareEqualOperator(const T* node, const Antares::Solver::Nodes::Node* other)
 {
-    if (const T* other_node = dynamic_cast<const T*>(&other))
+    if (const T* other_node = dynamic_cast<const T*>(other))
     {
-        return node == *other_node;
+        return *node == *other_node;
     }
     return false;
 }
 
 namespace Antares::Solver::Visitors
 {
-bool CompareVisitor::visit(const Nodes::AddNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::AddNode* node, const Nodes::Node* other)
 {
     return compareBinaryNode(*this, node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::SubtractionNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::SubtractionNode* node, const Nodes::Node* other)
 {
     return compareBinaryNode(*this, node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::MultiplicationNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::MultiplicationNode* node, const Nodes::Node* other)
 {
     return compareBinaryNode(*this, node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::DivisionNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::DivisionNode* node, const Nodes::Node* other)
 {
     return compareBinaryNode(*this, node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::EqualNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::EqualNode* node, const Nodes::Node* other)
 {
     return compareBinaryNode(*this, node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::LessThanOrEqualNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::LessThanOrEqualNode* node, const Nodes::Node* other)
 {
     return compareBinaryNode(*this, node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::GreaterThanOrEqualNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::GreaterThanOrEqualNode* node, const Nodes::Node* other)
 {
     return compareBinaryNode(*this, node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::NegationNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::NegationNode* node, const Nodes::Node* other)
 {
-    if (auto* other_node = dynamic_cast<const Nodes::NegationNode*>(&other))
+    if (auto* other_node = dynamic_cast<const Nodes::NegationNode*>(other))
     {
-        return dispatch(*node.child(), *other_node->child());
+        return dispatch(node->child(), other_node->child());
     }
     return false;
 }
 
-bool CompareVisitor::visit(const Nodes::ParameterNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::ParameterNode* node, const Nodes::Node* other)
 {
     return compareGetValue(node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::LiteralNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::LiteralNode* node, const Nodes::Node* other)
 {
     return compareGetValue(node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::VariableNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::VariableNode* node, const Nodes::Node* other)
 {
     return compareGetValue(node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::PortFieldNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::PortFieldNode* node, const Nodes::Node* other)
 {
     return compareEqualOperator(node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::ComponentVariableNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::ComponentVariableNode* node, const Nodes::Node* other)
 {
     return compareEqualOperator(node, other);
 }
 
-bool CompareVisitor::visit(const Nodes::ComponentParameterNode& node, const Nodes::Node& other)
+bool CompareVisitor::visit(const Nodes::ComponentParameterNode* node, const Nodes::Node* other)
 {
     return compareEqualOperator(node, other);
 }

--- a/src/solver/expressions/visitors/EvalVisitor.cpp
+++ b/src/solver/expressions/visitors/EvalVisitor.cpp
@@ -30,82 +30,82 @@ EvalVisitor::EvalVisitor(EvaluationContext context):
 {
 }
 
-double EvalVisitor::visit(const Nodes::AddNode& node)
+double EvalVisitor::visit(const Nodes::AddNode* node)
 {
-    return dispatch(*node.left()) + dispatch(*node.right());
+    return dispatch(node->left()) + dispatch(node->right());
 }
 
-double EvalVisitor::visit(const Nodes::SubtractionNode& node)
+double EvalVisitor::visit(const Nodes::SubtractionNode* node)
 {
-    return dispatch(*node.left()) - dispatch(*node.right());
+    return dispatch(node->left()) - dispatch(node->right());
 }
 
-double EvalVisitor::visit(const Nodes::MultiplicationNode& node)
+double EvalVisitor::visit(const Nodes::MultiplicationNode* node)
 {
-    return dispatch(*node.left()) * dispatch(*node.right());
+    return dispatch(node->left()) * dispatch(node->right());
 }
 
-double EvalVisitor::visit(const Nodes::DivisionNode& node)
+double EvalVisitor::visit(const Nodes::DivisionNode* node)
 {
-    if (auto divisor = dispatch(*node.right()); divisor == 0.0)
+    if (auto divisor = dispatch(node->right()); divisor == 0.0)
     {
         throw EvalVisitorDivisionException("DivisionNode Division by zero");
     }
     else
     {
-        return dispatch(*node.left()) / divisor;
+        return dispatch(node->left()) / divisor;
     }
 }
 
-double EvalVisitor::visit(const Nodes::EqualNode& node)
+double EvalVisitor::visit(const Nodes::EqualNode* node)
 {
     // not implemented for comparison node
     return 0.;
 }
 
-double EvalVisitor::visit(const Nodes::LessThanOrEqualNode& node)
+double EvalVisitor::visit(const Nodes::LessThanOrEqualNode* node)
 {
     // not implemented for comparison node
     return 0.;
 }
 
-double EvalVisitor::visit(const Nodes::GreaterThanOrEqualNode& node)
+double EvalVisitor::visit(const Nodes::GreaterThanOrEqualNode* node)
 {
     // not implemented for comparison node
     return 0.;
 }
 
-double EvalVisitor::visit(const Nodes::VariableNode& node)
+double EvalVisitor::visit(const Nodes::VariableNode* node)
 {
-    return context_.getVariableValue(node.value());
+    return context_.getVariableValue(node->value());
 }
 
-double EvalVisitor::visit(const Nodes::ParameterNode& node)
+double EvalVisitor::visit(const Nodes::ParameterNode* node)
 {
-    return context_.getParameterValue(node.value());
+    return context_.getParameterValue(node->value());
 }
 
-double EvalVisitor::visit(const Nodes::LiteralNode& node)
+double EvalVisitor::visit(const Nodes::LiteralNode* node)
 {
-    return node.value();
+    return node->value();
 }
 
-double EvalVisitor::visit(const Nodes::NegationNode& node)
+double EvalVisitor::visit(const Nodes::NegationNode* node)
 {
-    return -dispatch(*node.child());
+    return -dispatch(node->child());
 }
 
-double EvalVisitor::visit(const Nodes::PortFieldNode& node)
-{
-    return 0.;
-}
-
-double EvalVisitor::visit(const Nodes::ComponentVariableNode& node)
+double EvalVisitor::visit(const Nodes::PortFieldNode* node)
 {
     return 0.;
 }
 
-double EvalVisitor::visit(const Nodes::ComponentParameterNode& node)
+double EvalVisitor::visit(const Nodes::ComponentVariableNode* node)
+{
+    return 0.;
+}
+
+double EvalVisitor::visit(const Nodes::ComponentParameterNode* node)
 {
     // TODO
     return 0.;

--- a/src/solver/expressions/visitors/LinearityVisitor.cpp
+++ b/src/solver/expressions/visitors/LinearityVisitor.cpp
@@ -27,73 +27,73 @@
 namespace Antares::Solver::Visitors
 {
 
-LinearStatus LinearityVisitor::visit(const Nodes::AddNode& node)
+LinearStatus LinearityVisitor::visit(const Nodes::AddNode* node)
 {
-    return dispatch(*node.left()) + dispatch(*node.right());
+    return dispatch(node->left()) + dispatch(node->right());
 }
 
-LinearStatus LinearityVisitor::visit(const Nodes::SubtractionNode& node)
+LinearStatus LinearityVisitor::visit(const Nodes::SubtractionNode* node)
 {
-    return dispatch(*node.left()) - dispatch(*node.right());
+    return dispatch(node->left()) - dispatch(node->right());
 }
 
-LinearStatus LinearityVisitor::visit(const Nodes::MultiplicationNode& node)
+LinearStatus LinearityVisitor::visit(const Nodes::MultiplicationNode* node)
 {
-    return dispatch(*node.left()) * dispatch(*node.right());
+    return dispatch(node->left()) * dispatch(node->right());
 }
 
-LinearStatus LinearityVisitor::visit(const Nodes::DivisionNode& node)
+LinearStatus LinearityVisitor::visit(const Nodes::DivisionNode* node)
 {
-    return dispatch(*node.left()) / dispatch(*node.right());
+    return dispatch(node->left()) / dispatch(node->right());
 }
 
-LinearStatus LinearityVisitor::visit(const Nodes::EqualNode& node)
+LinearStatus LinearityVisitor::visit(const Nodes::EqualNode* node)
 {
-    return dispatch(*node.left()) + dispatch(*node.right());
+    return dispatch(node->left()) + dispatch(node->right());
 }
 
-LinearStatus LinearityVisitor::visit(const Nodes::LessThanOrEqualNode& node)
+LinearStatus LinearityVisitor::visit(const Nodes::LessThanOrEqualNode* node)
 {
-    return dispatch(*node.left()) + dispatch(*node.right());
+    return dispatch(node->left()) + dispatch(node->right());
 }
 
-LinearStatus LinearityVisitor::visit(const Nodes::GreaterThanOrEqualNode& node)
+LinearStatus LinearityVisitor::visit(const Nodes::GreaterThanOrEqualNode* node)
 {
-    return dispatch(*node.left()) + dispatch(*node.right());
+    return dispatch(node->left()) + dispatch(node->right());
 }
 
-LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::VariableNode&)
+LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::VariableNode*)
 {
     return LinearStatus::LINEAR;
 }
 
-LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::ParameterNode&)
+LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::ParameterNode*)
 {
     return LinearStatus::CONSTANT;
 }
 
-LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::LiteralNode&)
+LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::LiteralNode*)
 {
     return LinearStatus::CONSTANT;
 }
 
-LinearStatus LinearityVisitor::visit(const Nodes::NegationNode& node)
+LinearStatus LinearityVisitor::visit(const Nodes::NegationNode* node)
 {
-    return -dispatch(*node.child());
+    return -dispatch(node->child());
 }
 
-LinearStatus LinearityVisitor::visit(const Nodes::PortFieldNode&)
+LinearStatus LinearityVisitor::visit(const Nodes::PortFieldNode*)
 {
     // TODO
     return LinearStatus::CONSTANT;
 }
 
-LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::ComponentVariableNode&)
+LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::ComponentVariableNode*)
 {
     return LinearStatus::LINEAR;
 }
 
-LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::ComponentParameterNode&)
+LinearStatus LinearityVisitor::visit([[maybe_unused]] const Nodes::ComponentParameterNode*)
 {
     return LinearStatus::CONSTANT;
 }

--- a/src/solver/expressions/visitors/PrintVisitor.cpp
+++ b/src/solver/expressions/visitors/PrintVisitor.cpp
@@ -25,75 +25,75 @@
 
 namespace Antares::Solver::Visitors
 {
-std::string PrintVisitor::visit(const Nodes::AddNode& node)
+std::string PrintVisitor::visit(const Nodes::AddNode* node)
 {
     // Ici le compilateur (g++) a besoin de savoir qu'on veut le visit du type de base
     // sinon erreur de compil 'fonction non trouvée'
-    return "(" + dispatch(*node.left()) + "+" + dispatch(*node.right()) + ")";
+    return "(" + dispatch(node->left()) + "+" + dispatch(node->right()) + ")";
 }
 
-std::string PrintVisitor::visit(const Nodes::SubtractionNode& node)
+std::string PrintVisitor::visit(const Nodes::SubtractionNode* node)
 {
-    return "(" + dispatch(*node.left()) + "-" + dispatch(*node.right()) + ")";
+    return "(" + dispatch(node->left()) + "-" + dispatch(node->right()) + ")";
 }
 
-std::string PrintVisitor::visit(const Nodes::MultiplicationNode& node)
+std::string PrintVisitor::visit(const Nodes::MultiplicationNode* node)
 {
-    return "(" + dispatch(*node.left()) + "*" + dispatch(*node.right()) + ")";
+    return "(" + dispatch(node->left()) + "*" + dispatch(node->right()) + ")";
 }
 
-std::string PrintVisitor::visit(const Nodes::DivisionNode& node)
+std::string PrintVisitor::visit(const Nodes::DivisionNode* node)
 {
-    return "(" + dispatch(*node.left()) + "/" + dispatch(*node.right()) + ")";
+    return "(" + dispatch(node->left()) + "/" + dispatch(node->right()) + ")";
 }
 
-std::string PrintVisitor::visit(const Nodes::EqualNode& node)
+std::string PrintVisitor::visit(const Nodes::EqualNode* node)
 {
-    return dispatch(*node.left()) + "==" + dispatch(*node.right());
+    return dispatch(node->left()) + "==" + dispatch(node->right());
 }
 
-std::string PrintVisitor::visit(const Nodes::LessThanOrEqualNode& node)
+std::string PrintVisitor::visit(const Nodes::LessThanOrEqualNode* node)
 {
-    return dispatch(*node.left()) + "<=" + dispatch(*node.right());
+    return dispatch(node->left()) + "<=" + dispatch(node->right());
 }
 
-std::string PrintVisitor::visit(const Nodes::GreaterThanOrEqualNode& node)
+std::string PrintVisitor::visit(const Nodes::GreaterThanOrEqualNode* node)
 {
-    return dispatch(*node.left()) + ">=" + dispatch(*node.right());
+    return dispatch(node->left()) + ">=" + dispatch(node->right());
 }
 
-std::string PrintVisitor::visit(const Nodes::NegationNode& node)
+std::string PrintVisitor::visit(const Nodes::NegationNode* node)
 {
-    return "-(" + dispatch(*node.child()) + ")";
+    return "-(" + dispatch(node->child()) + ")";
 }
 
-std::string PrintVisitor::visit(const Nodes::ParameterNode& node)
+std::string PrintVisitor::visit(const Nodes::ParameterNode* node)
 {
-    return node.value();
+    return node->value();
 }
 
-std::string PrintVisitor::visit(const Nodes::VariableNode& node)
+std::string PrintVisitor::visit(const Nodes::VariableNode* node)
 {
-    return node.value();
+    return node->value();
 }
 
-std::string PrintVisitor::visit(const Nodes::LiteralNode& node)
+std::string PrintVisitor::visit(const Nodes::LiteralNode* node)
 {
-    return std::to_string(node.value());
+    return std::to_string(node->value());
 }
 
-std::string PrintVisitor::visit(const Nodes::PortFieldNode& node)
+std::string PrintVisitor::visit(const Nodes::PortFieldNode* node)
 {
-    return node.getPortName() + "." + node.getFieldName();
+    return node->getPortName() + "." + node->getFieldName();
 }
 
-std::string PrintVisitor::visit(const Nodes::ComponentVariableNode& node)
+std::string PrintVisitor::visit(const Nodes::ComponentVariableNode* node)
 {
-    return node.getComponentId() + "." + node.getComponentName();
+    return node->getComponentId() + "." + node->getComponentName();
 }
 
-std::string PrintVisitor::visit(const Nodes::ComponentParameterNode& node)
+std::string PrintVisitor::visit(const Nodes::ComponentParameterNode* node)
 {
-    return node.getComponentId() + "." + node.getComponentName();
+    return node->getComponentId() + "." + node->getComponentName();
 }
 } // namespace Antares::Solver::Visitors

--- a/src/solver/expressions/visitors/SubstitutionVisitor.cpp
+++ b/src/solver/expressions/visitors/SubstitutionVisitor.cpp
@@ -33,14 +33,14 @@ SubstitutionVisitor::SubstitutionVisitor(Registry<Nodes::Node>& registry, Substi
 {
 }
 
-Nodes::Node* SubstitutionVisitor::visit(const Nodes::ComponentVariableNode& node)
+Nodes::Node* SubstitutionVisitor::visit(const Nodes::ComponentVariableNode* node)
 {
     // This search has linear complexity
     // To get a search of log complexity, we need to use std::unordered_set::find
     // But std::unordered_set::find_if does not exist
     auto it = std::find_if(ctx_.variables.begin(),
                            ctx_.variables.end(),
-                           [&node](auto* x) { return *x == node; });
+                           [&node](auto* x) { return *x == *node; });
     if (it != ctx_.variables.end())
     {
         return *it;

--- a/src/solver/expressions/visitors/TimeIndexVisitor.cpp
+++ b/src/solver/expressions/visitors/TimeIndexVisitor.cpp
@@ -25,74 +25,74 @@
 namespace Antares::Solver::Visitors
 {
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::AddNode& add)
+TimeIndex TimeIndexVisitor::visit(const Nodes::AddNode* add)
 {
-    return dispatch(*add.left()) | dispatch(*add.right());
+    return dispatch(add->left()) | dispatch(add->right());
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::SubtractionNode& sub)
+TimeIndex TimeIndexVisitor::visit(const Nodes::SubtractionNode* sub)
 {
-    return dispatch(*sub.left()) | dispatch(*sub.right());
+    return dispatch(sub->left()) | dispatch(sub->right());
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::MultiplicationNode& mult)
+TimeIndex TimeIndexVisitor::visit(const Nodes::MultiplicationNode* mult)
 {
-    return dispatch(*mult.left()) | dispatch(*mult.right());
+    return dispatch(mult->left()) | dispatch(mult->right());
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::DivisionNode& div)
+TimeIndex TimeIndexVisitor::visit(const Nodes::DivisionNode* div)
 {
-    return dispatch(*div.left()) | dispatch(*div.right());
+    return dispatch(div->left()) | dispatch(div->right());
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::EqualNode& equ)
+TimeIndex TimeIndexVisitor::visit(const Nodes::EqualNode* equ)
 {
-    return dispatch(*equ.left()) | dispatch(*equ.right());
+    return dispatch(equ->left()) | dispatch(equ->right());
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::LessThanOrEqualNode& lt)
+TimeIndex TimeIndexVisitor::visit(const Nodes::LessThanOrEqualNode* lt)
 {
-    return dispatch(*lt.left()) | dispatch(*lt.right());
+    return dispatch(lt->left()) | dispatch(lt->right());
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::GreaterThanOrEqualNode& gt)
+TimeIndex TimeIndexVisitor::visit(const Nodes::GreaterThanOrEqualNode* gt)
 {
-    return dispatch(*gt.left()) | dispatch(*gt.right());
+    return dispatch(gt->left()) | dispatch(gt->right());
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::VariableNode& var)
+TimeIndex TimeIndexVisitor::visit(const Nodes::VariableNode* var)
 {
-    return context_.at(&var);
+    return context_.at(var);
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::ParameterNode& param)
+TimeIndex TimeIndexVisitor::visit(const Nodes::ParameterNode* param)
 {
-    return context_.at(&param);
+    return context_.at(param);
 }
 
-TimeIndex TimeIndexVisitor::visit([[maybe_unused]] const Nodes::LiteralNode& lit)
+TimeIndex TimeIndexVisitor::visit([[maybe_unused]] const Nodes::LiteralNode* lit)
 {
     return TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO;
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::NegationNode& neg)
+TimeIndex TimeIndexVisitor::visit(const Nodes::NegationNode* neg)
 {
-    return dispatch(*neg.child());
+    return dispatch(neg->child());
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::PortFieldNode& port_field_node)
+TimeIndex TimeIndexVisitor::visit(const Nodes::PortFieldNode* port_field_node)
 {
-    return context_.at(&port_field_node);
+    return context_.at(port_field_node);
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::ComponentVariableNode& component_variable_node)
+TimeIndex TimeIndexVisitor::visit(const Nodes::ComponentVariableNode* component_variable_node)
 {
-    return context_.at(&component_variable_node);
+    return context_.at(component_variable_node);
 }
 
-TimeIndex TimeIndexVisitor::visit(const Nodes::ComponentParameterNode& component_parameter_node)
+TimeIndex TimeIndexVisitor::visit(const Nodes::ComponentParameterNode* component_parameter_node)
 {
-    return context_.at(&component_parameter_node);
+    return context_.at(component_parameter_node);
 }
 
 TimeIndexVisitor::TimeIndexVisitor(std::unordered_map<const Nodes::Node*, TimeIndex> context):

--- a/src/tests/src/solver/expressions/test_CloneVisitor.cpp
+++ b/src/tests/src/solver/expressions/test_CloneVisitor.cpp
@@ -52,11 +52,11 @@ BOOST_FIXTURE_TEST_CASE(cloneVisitor_With_Add_Neg_ComponentVariableNode, Registr
     Node* root = create<AddNode>(create<NegationNode>(add_node), &cpp);
 
     PrintVisitor printVisitor;
-    const auto printed = printVisitor.dispatch(*root);
+    const auto printed = printVisitor.dispatch(root);
 
     BOOST_CHECK_EQUAL(printed, "(-((-((22.000000+8.000000))+id1.var))+id2.par)");
     CloneVisitor cloneVisitor(*this);
-    Node* cloned = cloneVisitor.dispatch(*root);
-    BOOST_CHECK_EQUAL(printed, printVisitor.dispatch(*cloned));
+    Node* cloned = cloneVisitor.dispatch(root);
+    BOOST_CHECK_EQUAL(printed, printVisitor.dispatch(cloned));
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/expressions/test_CompareVisitor.cpp
+++ b/src/tests/src/solver/expressions/test_CompareVisitor.cpp
@@ -49,7 +49,7 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_self_simple, Registry<Node>)
 {
     CompareVisitor cmp;
     Node* expr = createSimpleExpression(*this, 65.);
-    BOOST_CHECK(cmp.dispatch(*expr, *expr));
+    BOOST_CHECK(cmp.dispatch(expr, expr));
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_to_other_same, Registry<Node>)
@@ -58,7 +58,7 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_other_same, Registry<Node>)
     auto create = [this] { return createSimpleExpression(*this, 65.); };
     Node* expr1 = create();
     Node* expr2 = create();
-    BOOST_CHECK(cmp.dispatch(*expr1, *expr2));
+    BOOST_CHECK(cmp.dispatch(expr1, expr2));
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_to_other_different, Registry<Node>)
@@ -66,7 +66,7 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_other_different, Registry<Node>)
     CompareVisitor cmp;
     Node* expr1 = createSimpleExpression(*this, 64.);
     Node* expr2 = createSimpleExpression(*this, 65.);
-    BOOST_CHECK(!cmp.dispatch(*expr1, *expr2));
+    BOOST_CHECK(!cmp.dispatch(expr1, expr2));
 }
 
 static Node* createComplexExpression(Registry<Node>& registry)
@@ -93,7 +93,7 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_self_complex, Registry<Node>)
 {
     CompareVisitor cmp;
     Node* expr = createComplexExpression(*this);
-    BOOST_CHECK(cmp.dispatch(*expr, *expr));
+    BOOST_CHECK(cmp.dispatch(expr, expr));
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_to_clone_complex, Registry<Node>)
@@ -101,8 +101,8 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_clone_complex, Registry<Node>)
     CompareVisitor cmp;
     Node* expr = createComplexExpression(*this);
     CloneVisitor cloneVisitor(*this);
-    Node* expr_cloned = cloneVisitor.dispatch(*expr);
-    BOOST_CHECK(cmp.dispatch(*expr, *expr_cloned));
+    Node* expr_cloned = cloneVisitor.dispatch(expr);
+    BOOST_CHECK(cmp.dispatch(expr, expr_cloned));
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_to_other_complex, Registry<Node>)
@@ -110,7 +110,7 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_other_complex, Registry<Node>)
     CompareVisitor cmp;
     Node* expr1 = createComplexExpression(*this);
     Node* expr2 = createComplexExpression(*this);
-    BOOST_CHECK(cmp.dispatch(*expr1, *expr2));
+    BOOST_CHECK(cmp.dispatch(expr1, expr2));
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_to_other_different_complex, Registry<Node>)
@@ -118,6 +118,6 @@ BOOST_FIXTURE_TEST_CASE(comparison_to_other_different_complex, Registry<Node>)
     CompareVisitor cmp;
     Node* expr1 = createComplexExpression(*this);
     Node* expr2 = create<NegationNode>(expr1);
-    BOOST_CHECK(!cmp.dispatch(*expr1, *expr2));
+    BOOST_CHECK(!cmp.dispatch(expr1, expr2));
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/expressions/test_DeepWideTrees.cpp
+++ b/src/tests/src/solver/expressions/test_DeepWideTrees.cpp
@@ -49,7 +49,7 @@ BOOST_FIXTURE_TEST_CASE(deep_tree_even, Registry<Node>)
     Node* node = deepNegationTree(*this, 42., 1000);
     EvalVisitor evalVisitor;
     // (-1)^1000 = 1
-    BOOST_CHECK_EQUAL(evalVisitor.dispatch(*node), 42.);
+    BOOST_CHECK_EQUAL(evalVisitor.dispatch(node), 42.);
 }
 
 BOOST_FIXTURE_TEST_CASE(deep_tree_odd, Registry<Node>)
@@ -57,7 +57,7 @@ BOOST_FIXTURE_TEST_CASE(deep_tree_odd, Registry<Node>)
     Node* node = deepNegationTree(*this, 42., 1001);
     EvalVisitor evalVisitor;
     // (-1)^1001 = -1
-    BOOST_CHECK_EQUAL(evalVisitor.dispatch(*node), -42.);
+    BOOST_CHECK_EQUAL(evalVisitor.dispatch(node), -42.);
 }
 
 static Node* deepAddTree(Registry<Node>& registry, AddNode* root, size_t depth, size_t depth_max)
@@ -81,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE(binary_tree, Registry<Node>)
     Node* node = deepAddTree(*this, root, 0, 10);
     EvalVisitor evalVisitor;
     // We expect 1024 = 2^10 literal nodes, each carrying value 42.
-    BOOST_CHECK_EQUAL(evalVisitor.dispatch(*node), 42. * 1024);
+    BOOST_CHECK_EQUAL(evalVisitor.dispatch(node), 42. * 1024);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/expressions/test_LinearVisitor.cpp
+++ b/src/tests/src/solver/expressions/test_LinearVisitor.cpp
@@ -140,16 +140,16 @@ BOOST_FIXTURE_TEST_CASE(comparison_nodes_variable_variable_is_linear, Registry<N
     VariableNode var2("y");
     // x==y
     Node* eq = create<EqualNode>(&var1, &var2);
-    BOOST_CHECK_EQUAL(printVisitor.dispatch(*eq), "x==y");
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*eq), LinearStatus::LINEAR);
+    BOOST_CHECK_EQUAL(printVisitor.dispatch(eq), "x==y");
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(eq), LinearStatus::LINEAR);
     // x<=y
     Node* lt = create<LessThanOrEqualNode>(&var1, &var2);
-    BOOST_CHECK_EQUAL(printVisitor.dispatch(*lt), "x<=y");
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*lt), LinearStatus::LINEAR);
+    BOOST_CHECK_EQUAL(printVisitor.dispatch(lt), "x<=y");
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(lt), LinearStatus::LINEAR);
     // x>=y
     Node* gt = create<GreaterThanOrEqualNode>(&var1, &var2);
-    BOOST_CHECK_EQUAL(printVisitor.dispatch(*gt), "x>=y");
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*gt), LinearStatus::LINEAR);
+    BOOST_CHECK_EQUAL(printVisitor.dispatch(gt), "x>=y");
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(gt), LinearStatus::LINEAR);
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_nodes_variable_constant_is_linear, Registry<Node>)
@@ -162,13 +162,13 @@ BOOST_FIXTURE_TEST_CASE(comparison_nodes_variable_constant_is_linear, Registry<N
     LiteralNode literal(21.);
     // x==21
     Node* eq = create<EqualNode>(&var1, &literal);
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*eq), LinearStatus::LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(eq), LinearStatus::LINEAR);
     // x<=21
     Node* lt = create<LessThanOrEqualNode>(&var1, &literal);
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*lt), LinearStatus::LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(lt), LinearStatus::LINEAR);
     // x>=21
     Node* gt = create<GreaterThanOrEqualNode>(&var1, &literal);
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*gt), LinearStatus::LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(gt), LinearStatus::LINEAR);
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_nodes_constant_constant_is_constant, Registry<Node>)
@@ -180,13 +180,13 @@ BOOST_FIXTURE_TEST_CASE(comparison_nodes_constant_constant_is_constant, Registry
     LiteralNode literal2(21.);
     // 2==21
     Node* eq = create<EqualNode>(&literal1, &literal2);
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*eq), LinearStatus::CONSTANT);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(eq), LinearStatus::CONSTANT);
     // 2<=21
     Node* lt = create<LessThanOrEqualNode>(&literal1, &literal2);
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*lt), LinearStatus::CONSTANT);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(lt), LinearStatus::CONSTANT);
     // 2>=21
     Node* gt = create<GreaterThanOrEqualNode>(&literal1, &literal2);
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*gt), LinearStatus::CONSTANT);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(gt), LinearStatus::CONSTANT);
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_nodes_non_lin_constant_is_constant, Registry<Node>)
@@ -198,11 +198,11 @@ BOOST_FIXTURE_TEST_CASE(comparison_nodes_non_lin_constant_is_constant, Registry<
     // variable
     VariableNode var2("y");
     MultiplicationNode mult(&var1, &var2);
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(mult), LinearStatus::NON_LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(&mult), LinearStatus::NON_LINEAR);
 
     AddNode add(&mult, &var1);
     Node* gt = create<GreaterThanOrEqualNode>(&mult, &var2);
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*gt), LinearStatus::NON_LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(gt), LinearStatus::NON_LINEAR);
 }
 
 BOOST_FIXTURE_TEST_CASE(simple_linear, Registry<Node>)
@@ -220,9 +220,9 @@ BOOST_FIXTURE_TEST_CASE(simple_linear, Registry<Node>)
     Node* expr = create<AddNode>(u, v);
 
     PrintVisitor printVisitor;
-    BOOST_CHECK_EQUAL(printVisitor.dispatch(*expr), "((10.000000*x)+(20.000000*id.y))");
+    BOOST_CHECK_EQUAL(printVisitor.dispatch(expr), "((10.000000*x)+(20.000000*id.y))");
     LinearityVisitor linearVisitor;
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*expr), LinearStatus::LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::LINEAR);
 }
 
 BOOST_FIXTURE_TEST_CASE(simple_not_linear, Registry<Node>)
@@ -233,9 +233,9 @@ BOOST_FIXTURE_TEST_CASE(simple_not_linear, Registry<Node>)
     Node* expr = create<MultiplicationNode>(&var1, &var2);
 
     PrintVisitor printVisitor;
-    BOOST_CHECK_EQUAL(printVisitor.dispatch(*expr), "(x*id.y)");
+    BOOST_CHECK_EQUAL(printVisitor.dispatch(expr), "(x*id.y)");
     LinearityVisitor linearVisitor;
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*expr), LinearStatus::NON_LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::NON_LINEAR);
 }
 
 BOOST_FIXTURE_TEST_CASE(simple_linear_division, Registry<Node>)
@@ -247,9 +247,9 @@ BOOST_FIXTURE_TEST_CASE(simple_linear_division, Registry<Node>)
     Node* expr = create<DivisionNode>(&var1, &param);
 
     PrintVisitor printVisitor;
-    BOOST_CHECK_EQUAL(printVisitor.dispatch(*expr), "(x/y)");
+    BOOST_CHECK_EQUAL(printVisitor.dispatch(expr), "(x/y)");
     LinearityVisitor linearVisitor;
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*expr), LinearStatus::LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::LINEAR);
 }
 
 BOOST_FIXTURE_TEST_CASE(simple_non_linear_division, Registry<Node>)
@@ -261,9 +261,9 @@ BOOST_FIXTURE_TEST_CASE(simple_non_linear_division, Registry<Node>)
     Node* expr = create<DivisionNode>(&var1, &var2);
 
     PrintVisitor printVisitor;
-    BOOST_CHECK_EQUAL(printVisitor.dispatch(*expr), "(x/y)");
+    BOOST_CHECK_EQUAL(printVisitor.dispatch(expr), "(x/y)");
     LinearityVisitor linearVisitor;
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*expr), LinearStatus::NON_LINEAR);
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::NON_LINEAR);
 }
 
 BOOST_FIXTURE_TEST_CASE(simple_constant_expression, Registry<Node>)
@@ -281,7 +281,7 @@ BOOST_FIXTURE_TEST_CASE(simple_constant_expression, Registry<Node>)
     Node* mult = create<MultiplicationNode>(&var1, &par);
     // ((65.*p1)+port.field)
     Node* expr = create<AddNode>(mult, &portFieldNode);
-    BOOST_CHECK_EQUAL(printVisitor.dispatch(*expr), "((65.000000*p1)+port.field)");
-    BOOST_CHECK_EQUAL(linearVisitor.dispatch(*expr), LinearStatus::CONSTANT);
+    BOOST_CHECK_EQUAL(printVisitor.dispatch(expr), "((65.000000*p1)+port.field)");
+    BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::CONSTANT);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/expressions/test_PrintAndEvalNodes.cpp
+++ b/src/tests/src/solver/expressions/test_PrintAndEvalNodes.cpp
@@ -232,4 +232,11 @@ BOOST_FIXTURE_TEST_CASE(comparison_node, Registry<Node>)
     BOOST_CHECK_EQUAL(printed, "(22.000000-8.000000)>=(8.000000-22.000000)");
 }
 
+BOOST_AUTO_TEST_CASE(invalidNode)
+{
+    AddNode* null_node = nullptr;
+    EvalVisitor evalVisitor;
+    BOOST_CHECK_THROW(evalVisitor.dispatch(null_node), InvalidNode);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/expressions/test_PrintAndEvalNodes.cpp
+++ b/src/tests/src/solver/expressions/test_PrintAndEvalNodes.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(print_single_literal)
     LiteralNode literal(21);
 
     PrintVisitor printVisitor;
-    const auto printed = printVisitor.dispatch(literal);
+    const auto printed = printVisitor.dispatch(&literal);
 
     BOOST_CHECK_EQUAL(printed, "21.000000"); // TODO Number of decimals implementation dependent ?
 }
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(eval_single_literal)
     LiteralNode literal(21);
 
     EvalVisitor evalVisitor;
-    const double eval = evalVisitor.dispatch(literal);
+    const double eval = evalVisitor.dispatch(&literal);
 
     BOOST_CHECK_EQUAL(eval, 21.); // TODO Number of decimals implementation dependent ?
 }
@@ -71,7 +71,7 @@ BOOST_FIXTURE_TEST_CASE(print_add_two_literals, Registry<Node>)
     Node* root = create<AddNode>(create<LiteralNode>(21), create<LiteralNode>(2));
 
     PrintVisitor printVisitor;
-    const auto printed = printVisitor.dispatch(*root);
+    const auto printed = printVisitor.dispatch(root);
 
     BOOST_CHECK_EQUAL(printed,
                       "(21.000000+2.000000)"); // TODO Number of decimals implementation dependent ?
@@ -81,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE(eval_add_two_literals, Registry<Node>)
 {
     Node* root = create<AddNode>(create<LiteralNode>(21), create<LiteralNode>(2));
     EvalVisitor evalVisitor;
-    double eval = evalVisitor.dispatch(*root);
+    double eval = evalVisitor.dispatch(root);
 
     BOOST_CHECK_EQUAL(eval, 23.);
 }
@@ -91,7 +91,7 @@ BOOST_FIXTURE_TEST_CASE(eval_negation_literal, Registry<Node>)
     const double num = 1428.0;
     Node* root = create<NegationNode>(create<LiteralNode>(num));
     EvalVisitor evalVisitor;
-    double eval = evalVisitor.dispatch(*root);
+    double eval = evalVisitor.dispatch(root);
 
     BOOST_CHECK_EQUAL(eval, -num);
 }
@@ -103,7 +103,7 @@ BOOST_FIXTURE_TEST_CASE(eval_Add_And_Negation_Nodes, Registry<Node>)
     Node* negative_num2 = create<NegationNode>(create<LiteralNode>(num2));
     Node* root = create<AddNode>(create<LiteralNode>(num1), negative_num2);
     EvalVisitor evalVisitor;
-    double eval = evalVisitor.dispatch(*root);
+    double eval = evalVisitor.dispatch(root);
 
     BOOST_CHECK_EQUAL(eval, num1 - num2);
 }
@@ -115,7 +115,7 @@ BOOST_FIXTURE_TEST_CASE(Negative_of_AddNode, Registry<Node>)
     Node* add_node = create<AddNode>(create<LiteralNode>(num1), create<LiteralNode>(num2));
     Node* neg = create<NegationNode>(add_node);
     EvalVisitor evalVisitor;
-    double eval = evalVisitor.dispatch(*neg);
+    double eval = evalVisitor.dispatch(neg);
 
     BOOST_CHECK_EQUAL(eval, -(num1 + num2));
 }
@@ -124,7 +124,7 @@ BOOST_FIXTURE_TEST_CASE(print_port_field_node, Registry<Node>)
 {
     PortFieldNode pt_fd("august", "2024");
     PrintVisitor printVisitor;
-    const auto printed = printVisitor.dispatch(pt_fd);
+    const auto printed = printVisitor.dispatch(&pt_fd);
 
     BOOST_CHECK_EQUAL(printed, "august.2024");
 }
@@ -136,7 +136,7 @@ BOOST_FIXTURE_TEST_CASE(evaluate_param, Registry<Node>)
     EvaluationContext context({{"my-param", value}}, {});
 
     EvalVisitor evalVisitor(context);
-    const double eval = evalVisitor.dispatch(root);
+    const double eval = evalVisitor.dispatch(&root);
 
     BOOST_CHECK_EQUAL(value, eval);
 }
@@ -148,7 +148,7 @@ BOOST_FIXTURE_TEST_CASE(evaluate_variable, Registry<Node>)
     EvaluationContext context({}, {{"my-variable", value}});
 
     EvalVisitor evalVisitor(context);
-    const double eval = evalVisitor.dispatch(root);
+    const double eval = evalVisitor.dispatch(&root);
 
     BOOST_CHECK_EQUAL(value, eval);
 }
@@ -159,11 +159,11 @@ BOOST_FIXTURE_TEST_CASE(multiplication_node, Registry<Node>)
     Node* mult = create<MultiplicationNode>(create<LiteralNode>(num1), create<LiteralNode>(num2));
 
     PrintVisitor printVisitor;
-    const auto printed = printVisitor.dispatch(*mult);
+    const auto printed = printVisitor.dispatch(mult);
 
     BOOST_CHECK_EQUAL(printed, "(22.000000*8.000000)");
     EvalVisitor evalVisitor;
-    BOOST_CHECK_EQUAL(evalVisitor.dispatch(*mult), num1 * num2);
+    BOOST_CHECK_EQUAL(evalVisitor.dispatch(mult), num1 * num2);
 }
 
 BOOST_FIXTURE_TEST_CASE(division_node, Registry<Node>)
@@ -172,11 +172,11 @@ BOOST_FIXTURE_TEST_CASE(division_node, Registry<Node>)
     Node* div = create<DivisionNode>(create<LiteralNode>(num1), create<LiteralNode>(num2));
 
     PrintVisitor printVisitor;
-    const auto printed = printVisitor.dispatch(*div);
+    const auto printed = printVisitor.dispatch(div);
 
     BOOST_CHECK_EQUAL(printed, "(22.000000/8.000000)");
     EvalVisitor evalVisitor;
-    BOOST_CHECK_EQUAL(evalVisitor.dispatch(*div), num1 / num2);
+    BOOST_CHECK_EQUAL(evalVisitor.dispatch(div), num1 / num2);
 }
 
 BOOST_FIXTURE_TEST_CASE(division_by_zero, Registry<Node>)
@@ -185,12 +185,12 @@ BOOST_FIXTURE_TEST_CASE(division_by_zero, Registry<Node>)
     Node* div = create<DivisionNode>(create<LiteralNode>(num1), create<LiteralNode>(num2));
 
     PrintVisitor printVisitor;
-    const auto printed = printVisitor.dispatch(*div);
+    const auto printed = printVisitor.dispatch(div);
 
     BOOST_CHECK_EQUAL(printed, "(22.000000/0.000000)");
     EvalVisitor evalVisitor;
 
-    BOOST_CHECK_EXCEPTION(evalVisitor.dispatch(*div),
+    BOOST_CHECK_EXCEPTION(evalVisitor.dispatch(div),
                           EvalVisitorDivisionException,
                           [](const EvalVisitorDivisionException& ex)
                           { return strcmp(ex.what(), "DivisionNode Division by zero") == 0; });
@@ -202,11 +202,11 @@ BOOST_FIXTURE_TEST_CASE(subtraction_node, Registry<Node>)
     Node* sub = create<SubtractionNode>(create<LiteralNode>(num1), create<LiteralNode>(num2));
 
     PrintVisitor printVisitor;
-    const auto printed = printVisitor.dispatch(*sub);
+    const auto printed = printVisitor.dispatch(sub);
 
     BOOST_CHECK_EQUAL(printed, "(22.000000-8.000000)");
     EvalVisitor evalVisitor;
-    BOOST_CHECK_EQUAL(evalVisitor.dispatch(*sub), num1 - num2);
+    BOOST_CHECK_EQUAL(evalVisitor.dispatch(sub), num1 - num2);
 }
 
 BOOST_FIXTURE_TEST_CASE(comparison_node, Registry<Node>)
@@ -220,15 +220,15 @@ BOOST_FIXTURE_TEST_CASE(comparison_node, Registry<Node>)
     PrintVisitor printVisitor;
 
     EqualNode equ(&sub1, &sub2);
-    auto printed = printVisitor.dispatch(equ);
+    auto printed = printVisitor.dispatch(&equ);
     BOOST_CHECK_EQUAL(printed, "(22.000000-8.000000)==(8.000000-22.000000)");
 
     LessThanOrEqualNode lt(&sub1, &sub2);
-    printed = printVisitor.dispatch(lt);
+    printed = printVisitor.dispatch(&lt);
     BOOST_CHECK_EQUAL(printed, "(22.000000-8.000000)<=(8.000000-22.000000)");
 
     GreaterThanOrEqualNode gt(&sub1, &sub2);
-    printed = printVisitor.dispatch(gt);
+    printed = printVisitor.dispatch(&gt);
     BOOST_CHECK_EQUAL(printed, "(22.000000-8.000000)>=(8.000000-22.000000)");
 }
 

--- a/src/tests/src/solver/expressions/test_SubstitutionVisitor.cpp
+++ b/src/tests/src/solver/expressions/test_SubstitutionVisitor.cpp
@@ -59,7 +59,7 @@ BOOST_FIXTURE_TEST_CASE(SubstitutionVisitor_substitute_one_node, Registry<Node>)
     Node* root = create<AddNode>(create<ComponentVariableNode>("component1", "variable1"),
                                  component_original);
     SubstitutionVisitor sub(*this, ctx);
-    Node* subsd = sub.dispatch(*root);
+    Node* subsd = sub.dispatch(root);
 
     // The root of the new tree should be different
     BOOST_CHECK_NE(root, subsd);

--- a/src/tests/src/solver/expressions/test_TimeIndexVisitor.cpp
+++ b/src/tests/src/solver/expressions/test_TimeIndexVisitor.cpp
@@ -72,15 +72,15 @@ BOOST_FIXTURE_TEST_CASE(simple_time_dependant_expression, Registry<Node>)
     context[&variableNode1] = TimeIndex::VARYING_IN_TIME_ONLY;
     TimeIndexVisitor timeIndexVisitor(context);
 
-    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(literalNode),
+    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(&literalNode),
                       TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO);
-    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(parameterNode1),
+    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(&parameterNode1),
                       TimeIndex::VARYING_IN_SCENARIO_ONLY);
-    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(variableNode1), TimeIndex::VARYING_IN_TIME_ONLY);
+    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(&variableNode1), TimeIndex::VARYING_IN_TIME_ONLY);
 
     // addition of parameterNode1 and variableNode1 is time and scenario dependent
     Node* expr = create<AddNode>(&parameterNode1, &variableNode1);
-    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(*expr), TimeIndex::VARYING_IN_TIME_AND_SCENARIO);
+    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(expr), TimeIndex::VARYING_IN_TIME_AND_SCENARIO);
 }
 
 static const std::vector<TimeIndex> TimeIndex_ALL{TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO,
@@ -115,9 +115,9 @@ BOOST_DATA_TEST_CASE_F(Registry<Node>,
     std::unordered_map<const Node*, TimeIndex> context;
     context[parameter] = timeIndex;
     TimeIndexVisitor timeIndexVisitor(context);
-    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(*root), timeIndex);
+    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(root), timeIndex);
     Node* neg = create<NegationNode>(root);
-    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(*neg), timeIndex);
+    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(neg), timeIndex);
 }
 
 template<class T>
@@ -141,9 +141,9 @@ BOOST_DATA_TEST_CASE_F(Registry<Node>,
     std::unordered_map<const Node*, TimeIndex> context;
     context[root] = timeIndex;
     TimeIndexVisitor timeIndexVisitor(context);
-    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(*root), timeIndex);
+    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(root), timeIndex);
     Node* neg = create<NegationNode>(root);
-    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(*neg), timeIndex);
+    BOOST_CHECK_EQUAL(timeIndexVisitor.dispatch(neg), timeIndex);
 }
 
 BOOST_AUTO_TEST_CASE(test_time_index_logical_operator)


### PR DESCRIPTION
* control nullity of input node (will be done in #2354 )
* avoid de-referencing Nodes::Node* -> visitor(Node&) (null ref can be obtained from null ptr )
* avoid indirection: visitor was working with Node& and Nodes::Node childs are Node* (Node& --> Node*)