### PR TITLE
API modeller : apply remarks

### DIFF
--- a/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/linearProblem.h
+++ b/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/linearProblem.h
@@ -59,7 +59,7 @@ public:
     OrtoolsMipSolution* solve(bool verboseSolver) override;
 
 private:
-    std::unique_ptr<operations_research::MPSolver> mpSolver_;
+    std::shared_ptr<operations_research::MPSolver> mpSolver_;
     operations_research::MPObjective* objective_;
     operations_research::MPSolverParameters params_;
 

--- a/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/linearProblem.h
+++ b/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/linearProblem.h
@@ -25,14 +25,7 @@
 #include <antares/solver/optim/ortoolsImpl/mipConstraint.h>
 #include <antares/solver/optim/ortoolsImpl/mipSolution.h>
 #include <antares/solver/optim/ortoolsImpl/mipVariable.h>
-
-// forward declaration
-namespace operations_research
-{
-class MPSolver;
-class MPSolverParameters;
-class MPObjective;
-} // namespace operations_research
+#include <ortools/linear_solver/linear_solver.h>
 
 namespace Antares::Solver::Optim::OrtoolsImpl
 {

--- a/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/linearProblem.h
+++ b/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/linearProblem.h
@@ -21,11 +21,12 @@
 
 #pragma once
 
+#include <ortools/linear_solver/linear_solver.h>
+
 #include <antares/solver/optim/api/linearProblem.h>
 #include <antares/solver/optim/ortoolsImpl/mipConstraint.h>
 #include <antares/solver/optim/ortoolsImpl/mipSolution.h>
 #include <antares/solver/optim/ortoolsImpl/mipVariable.h>
-#include <ortools/linear_solver/linear_solver.h>
 
 namespace Antares::Solver::Optim::OrtoolsImpl
 {

--- a/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/linearProblem.h
+++ b/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/linearProblem.h
@@ -21,12 +21,17 @@
 
 #pragma once
 
-#include <ortools/linear_solver/linear_solver.h>
-
 #include <antares/solver/optim/api/linearProblem.h>
 #include <antares/solver/optim/ortoolsImpl/mipConstraint.h>
 #include <antares/solver/optim/ortoolsImpl/mipSolution.h>
 #include <antares/solver/optim/ortoolsImpl/mipVariable.h>
+
+namespace operations_research
+{
+class MPSolver;
+class MPSolverParameters;
+class MPObjective;
+} // namespace operations_research
 
 namespace Antares::Solver::Optim::OrtoolsImpl
 {

--- a/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/mipSolution.h
+++ b/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/mipSolution.h
@@ -22,11 +22,11 @@
 #pragma once
 
 #include <map>
+#include <ortools/linear_solver/linear_solver.h>
 #include <string>
 #include <vector>
 
 #include <antares/solver/optim/api/mipSolution.h>
-#include <ortools/linear_solver/linear_solver.h>
 
 namespace Antares::Solver::Optim::OrtoolsImpl
 {

--- a/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/mipSolution.h
+++ b/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/mipSolution.h
@@ -46,10 +46,9 @@ public:
       const std::vector<Api::IMipVariable*>& vars) const override;
 
 private:
-    Api::MipStatus responseStatus_;
+    operations_research::MPSolver::ResultStatus status_;
     std::shared_ptr<operations_research::MPSolver> mpSolver_;
     std::map<std::string, double> solution_;
-    double objectiveValue_;
 };
 
 } // namespace Antares::Solver::Optim::OrtoolsImpl

--- a/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/mipSolution.h
+++ b/src/solver/optim/ortoolsImpl/include/antares/solver/optim/ortoolsImpl/mipSolution.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <antares/solver/optim/api/mipSolution.h>
+#include <ortools/linear_solver/linear_solver.h>
 
 namespace Antares::Solver::Optim::OrtoolsImpl
 {
@@ -33,9 +34,8 @@ namespace Antares::Solver::Optim::OrtoolsImpl
 class OrtoolsMipSolution final: public Api::IMipSolution
 {
 public:
-    OrtoolsMipSolution(const std::map<std::string, double>& solution,
-                       Api::MipStatus& responseStatus,
-                       double objectiveValue);
+    OrtoolsMipSolution(operations_research::MPSolver::ResultStatus& responseStatus,
+                       std::shared_ptr<operations_research::MPSolver> solver);
 
     ~OrtoolsMipSolution() final = default;
 
@@ -47,9 +47,8 @@ public:
 
 private:
     Api::MipStatus responseStatus_;
-
+    std::shared_ptr<operations_research::MPSolver> mpSolver_;
     std::map<std::string, double> solution_;
-
     double objectiveValue_;
 };
 

--- a/src/solver/optim/ortoolsImpl/linearProblem.cpp
+++ b/src/solver/optim/ortoolsImpl/linearProblem.cpp
@@ -64,21 +64,14 @@ OrtoolsMipVariable* OrtoolsLinearProblem::addVariable(double lb,
     }
 
     auto* mpVar = mpSolver_->MakeVar(lb, ub, integer, name);
-    auto mipVar = std::make_unique<OrtoolsMipVariable>(mpVar);
 
-    if (!mpVar || !mipVar)
+    if (!mpVar)
     {
         logs.error() << "Couldn't add variable to Ortools MPSolver: " << name;
     }
 
-    const auto& mapIteratorPair = variables_.try_emplace(name, std::move(mipVar));
-
-    if (!mapIteratorPair.second)
-    {
-        logs.error() << "Error adding variable: " << name;
-    }
-
-    return mapIteratorPair.first->second.get(); // <<name, var>, bool>
+    const auto& pair = variables_.try_emplace(name, std::make_unique<OrtoolsMipVariable>(mpVar));
+    return pair.first->second.get(); // <<name, var>, bool>
 }
 
 OrtoolsMipVariable* OrtoolsLinearProblem::addNumVariable(double lb,

--- a/src/solver/optim/ortoolsImpl/linearProblem.cpp
+++ b/src/solver/optim/ortoolsImpl/linearProblem.cpp
@@ -110,7 +110,8 @@ OrtoolsMipConstraint* OrtoolsLinearProblem::addConstraint(double lb,
         logs.error() << "Couldn't add variable to Ortools MPSolver: " << name;
     }
 
-    const auto& pair = constraints_.emplace(name, std::make_unique<OrtoolsMipConstraint>(mpConstraint));
+    const auto& pair = constraints_.emplace(name,
+                                            std::make_unique<OrtoolsMipConstraint>(mpConstraint));
     return pair.first->second.get(); // <<name, constraint>, bool>
 }
 

--- a/src/solver/optim/ortoolsImpl/mipSolution.cpp
+++ b/src/solver/optim/ortoolsImpl/mipSolution.cpp
@@ -40,15 +40,15 @@ Api::MipStatus OrtoolsMipSolution::getStatus() const
 {
     switch (status_)
     {
-        case operations_research::MPSolver::ResultStatus::OPTIMAL:
-            return Api::MipStatus::OPTIMAL;
-        case operations_research::MPSolver::ResultStatus::FEASIBLE:
-            return Api::MipStatus::FEASIBLE;
-        case operations_research::MPSolver::ResultStatus::UNBOUNDED:
-            return Api::MipStatus::UNBOUNDED;
-        default:
-            logs.warning() << "Solve returned an error status";
-            break;
+    case operations_research::MPSolver::ResultStatus::OPTIMAL:
+        return Api::MipStatus::OPTIMAL;
+    case operations_research::MPSolver::ResultStatus::FEASIBLE:
+        return Api::MipStatus::FEASIBLE;
+    case operations_research::MPSolver::ResultStatus::UNBOUNDED:
+        return Api::MipStatus::UNBOUNDED;
+    default:
+        logs.warning() << "Solve returned an error status";
+        break;
     }
     return Api::MipStatus::MIP_ERROR;
 }

--- a/src/solver/optim/ortoolsImpl/mipSolution.cpp
+++ b/src/solver/optim/ortoolsImpl/mipSolution.cpp
@@ -25,16 +25,31 @@
 namespace Antares::Solver::Optim::OrtoolsImpl
 {
 
-OrtoolsMipSolution::OrtoolsMipSolution(const std::map<std::string, double>& solution,
-                                       Api::MipStatus& responseStatus,
-                                       double objectiveValue):
-    responseStatus_(responseStatus),
-    objectiveValue_(objectiveValue)
+static Api::MipStatus convertStatus(operations_research::MPSolver::ResultStatus& status)
 {
-    // store all solutions, even zeros
-    for (const auto& varAndValue: solution)
+    switch (status)
     {
-        solution_.insert(varAndValue);
+        case operations_research::MPSolver::ResultStatus::OPTIMAL:
+            return Api::MipStatus::OPTIMAL;
+        case operations_research::MPSolver::ResultStatus::FEASIBLE:
+            return Api::MipStatus::FEASIBLE;
+        case operations_research::MPSolver::ResultStatus::UNBOUNDED:
+            return Api::MipStatus::UNBOUNDED;
+        default:
+            logs.warning() << "Solve returned an error status";
+            break;
+    }
+    return Api::MipStatus::MIP_ERROR;
+}
+
+OrtoolsMipSolution::OrtoolsMipSolution(operations_research::MPSolver::ResultStatus& status,
+                                       std::shared_ptr<operations_research::MPSolver> solver):
+    responseStatus_(convertStatus(status)),
+    mpSolver_(solver)
+{
+    for (const auto* var: mpSolver_->variables())
+    {
+        solution_.try_emplace(var->name(), var->solution_value());
     }
 }
 
@@ -45,7 +60,7 @@ Api::MipStatus OrtoolsMipSolution::getStatus() const
 
 double OrtoolsMipSolution::getObjectiveValue() const
 {
-    return objectiveValue_;
+    return mpSolver_->MutableObjective()->Value();
 }
 
 double OrtoolsMipSolution::getOptimalValue(const Api::IMipVariable* var) const

--- a/src/solver/optim/ortoolsImpl/mipSolution.cpp
+++ b/src/solver/optim/ortoolsImpl/mipSolution.cpp
@@ -25,9 +25,20 @@
 namespace Antares::Solver::Optim::OrtoolsImpl
 {
 
-static Api::MipStatus convertStatus(operations_research::MPSolver::ResultStatus& status)
+OrtoolsMipSolution::OrtoolsMipSolution(operations_research::MPSolver::ResultStatus& status,
+                                       std::shared_ptr<operations_research::MPSolver> solver):
+    status_(status),
+    mpSolver_(solver)
 {
-    switch (status)
+    for (const auto* var: mpSolver_->variables())
+    {
+        solution_.try_emplace(var->name(), var->solution_value());
+    }
+}
+
+Api::MipStatus OrtoolsMipSolution::getStatus() const
+{
+    switch (status_)
     {
         case operations_research::MPSolver::ResultStatus::OPTIMAL:
             return Api::MipStatus::OPTIMAL;
@@ -40,22 +51,6 @@ static Api::MipStatus convertStatus(operations_research::MPSolver::ResultStatus&
             break;
     }
     return Api::MipStatus::MIP_ERROR;
-}
-
-OrtoolsMipSolution::OrtoolsMipSolution(operations_research::MPSolver::ResultStatus& status,
-                                       std::shared_ptr<operations_research::MPSolver> solver):
-    responseStatus_(convertStatus(status)),
-    mpSolver_(solver)
-{
-    for (const auto* var: mpSolver_->variables())
-    {
-        solution_.try_emplace(var->name(), var->solution_value());
-    }
-}
-
-Api::MipStatus OrtoolsMipSolution::getStatus() const
-{
-    return responseStatus_;
 }
 
 double OrtoolsMipSolution::getObjectiveValue() const

--- a/src/tests/src/solver/optim/api/testApiOrtoolsLinearProblem.cpp
+++ b/src/tests/src/solver/optim/api/testApiOrtoolsLinearProblem.cpp
@@ -44,15 +44,15 @@ struct Fixture
 
 void Fixture::createProblemMaximize()
 {
-    auto* a = pb->addNumVariable(0, 1, "a");
-    auto* b = pb->addNumVariable(0, 1, "b");
-    auto* c = pb->addConstraint(1, 1, "c");
+    auto* var1 = pb->addNumVariable(0, 1, "var1");
+    auto* var2 = pb->addNumVariable(0, 1, "var2");
+    auto* constraint = pb->addConstraint(1, 1, "constraint");
 
-    c->setCoefficient(a, 1);
-    c->setCoefficient(b, 1);
+    constraint->setCoefficient(var1, 1);
+    constraint->setCoefficient(var2, 1);
 
-    pb->setObjectiveCoefficient(a, 1);
-    pb->setObjectiveCoefficient(b, 1);
+    pb->setObjectiveCoefficient(var1, 1);
+    pb->setObjectiveCoefficient(var1, 1);
     pb->setMaximization();
 }
 
@@ -65,22 +65,22 @@ BOOST_AUTO_TEST_CASE(solverMip)
 
 BOOST_FIXTURE_TEST_CASE(basicLinearProblemAdd, Fixture)
 {
-    pb->addIntVariable(0, 1, "a");
-    pb->addNumVariable(0, 1, "b");
+    pb->addIntVariable(0, 1, "var1");
+    pb->addNumVariable(0, 1, "var2");
 
-    pb->addConstraint(0, 1, "c");
+    pb->addConstraint(0, 1, "constraint");
 }
 
 BOOST_FIXTURE_TEST_CASE(linearProblemGetAndConstraintSetCoeff, Fixture)
 {
-    pb->addVariable(0, 1, true, "a");
-    pb->addConstraint(0, 1, "c");
+    pb->addVariable(0, 1, true, "var");
+    pb->addConstraint(0, 1, "constraint");
 
-    auto* var = pb->getVariable("a");
-    auto* cons = pb->getConstraint("c");
+    auto* var = pb->getVariable("var");
+    auto* cons = pb->getConstraint("constraint");
 
-    BOOST_CHECK_EQUAL(var->getName(), "a");
-    BOOST_CHECK_EQUAL(cons->getName(), "c");
+    BOOST_CHECK_EQUAL(var->getName(), "var");
+    BOOST_CHECK_EQUAL(cons->getName(), "constraint");
 
     cons->setCoefficient(var, 3.2);
     BOOST_CHECK_EQUAL(cons->getCoefficient(var), 3.2);
@@ -97,11 +97,11 @@ bool correctMessage(const std::exception& ex)
 
 BOOST_FIXTURE_TEST_CASE(nameOrConstraintAlreadyExists, Fixture)
 {
-    pb->addNumVariable(0, 1, "a");
-    BOOST_CHECK_EXCEPTION(pb->addNumVariable(0, 1, "a"), std::exception, correctMessage);
+    pb->addNumVariable(0, 1, "var");
+    BOOST_CHECK_EXCEPTION(pb->addNumVariable(0, 1, "var"), std::exception, correctMessage);
 
-    pb->addConstraint(0, 1, "c");
-    BOOST_CHECK_EXCEPTION(pb->addConstraint(0, 1, "c"), std::exception, correctMessage);
+    pb->addConstraint(0, 1, "constraint");
+    BOOST_CHECK_EXCEPTION(pb->addConstraint(0, 1, "constraint"), std::exception, correctMessage);
 }
 
 BOOST_FIXTURE_TEST_CASE(getVarOrConstraintDoesntExist, Fixture)
@@ -121,7 +121,7 @@ BOOST_FIXTURE_TEST_CASE(maximizeMinimize, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(mipVariableBounds, Fixture)
 {
-    auto* var = pb->addNumVariable(0, 1, "a");
+    auto* var = pb->addNumVariable(0, 1, "var");
 
     var->setLb(-4);
     var->setUb(7);
@@ -134,14 +134,14 @@ BOOST_FIXTURE_TEST_CASE(mipVariableBounds, Fixture)
     BOOST_CHECK_EQUAL(var->getLb(), 2);
     BOOST_CHECK_EQUAL(var->getUb(), 13);
 
-    auto* sameVar = pb->getVariable("a");
+    auto* sameVar = pb->getVariable("var");
     BOOST_CHECK_EQUAL(sameVar->getLb(), 2);
     BOOST_CHECK_EQUAL(sameVar->getUb(), 13);
 }
 
 BOOST_FIXTURE_TEST_CASE(mipConstraintBounds, Fixture)
 {
-    auto* constraint = pb->addConstraint(0, 1, "a");
+    auto* constraint = pb->addConstraint(0, 1, "var");
 
     constraint->setLb(-4);
     constraint->setUb(7);
@@ -157,7 +157,7 @@ BOOST_FIXTURE_TEST_CASE(mipConstraintBounds, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(objectiveCoeff, Fixture)
 {
-    auto* var = pb->addVariable(0, 1, true, "a");
+    auto* var = pb->addVariable(0, 1, true, "var");
     pb->setObjectiveCoefficient(var, 1);
     BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(var), 1);
 
@@ -167,15 +167,15 @@ BOOST_FIXTURE_TEST_CASE(objectiveCoeff, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(infeasibleProblem, Fixture)
 {
-    auto* a = pb->addIntVariable(0, 10, "a");
-    auto* b = pb->addNumVariable(0, 10, "b");
-    auto* c = pb->addConstraint(1, 1, "c");
+    auto* var1 = pb->addIntVariable(0, 10, "var1");
+    auto* var2 = pb->addNumVariable(0, 10, "var2");
+    auto* constraint = pb->addConstraint(1, 1, "constraint");
 
-    c->setCoefficient(a, 1);
-    c->setCoefficient(b, 1);
+    constraint->setCoefficient(var1, 1);
+    constraint->setCoefficient(var2, 1);
 
-    pb->setObjectiveCoefficient(a, 1);
-    pb->setObjectiveCoefficient(b, 1);
+    pb->setObjectiveCoefficient(var1, 1);
+    pb->setObjectiveCoefficient(var2, 1);
     pb->setMinimization();
 
     auto* solution = pb->solve(true);
@@ -183,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE(infeasibleProblem, Fixture)
     BOOST_CHECK(solution->getStatus() == Api::MipStatus::MIP_ERROR);
 
     BOOST_CHECK_EQUAL(solution->getObjectiveValue(), 0);
-    BOOST_CHECK_EQUAL(solution->getOptimalValue(a), 0);
+    BOOST_CHECK_EQUAL(solution->getOptimalValue(var1), 0);
 }
 
 BOOST_FIXTURE_TEST_CASE(problemMaximize, Fixture)
@@ -201,12 +201,12 @@ BOOST_FIXTURE_TEST_CASE(solutionOpimalValues, Fixture)
     createProblemMaximize();
     auto* solution = pb->solve(true);
 
-    auto* a = pb->getVariable("a");
-    BOOST_CHECK_EQUAL(solution->getOptimalValue(a), 1);
+    auto* var1 = pb->getVariable("var1");
+    BOOST_CHECK_EQUAL(solution->getOptimalValue(var1), 1);
 
-    auto* b = pb->getVariable("b");
+    auto* var2 = pb->getVariable("var2");
 
-    std::vector<Api::IMipVariable*> v = {a, b};
+    std::vector<Api::IMipVariable*> v = {var1, var2};
     auto res = solution->getOptimalValues(v);
 
     auto* varNotInSolution = pb->addNumVariable(0, 1, "f");

--- a/src/tests/src/solver/optim/api/testApiOrtoolsLinearProblem.cpp
+++ b/src/tests/src/solver/optim/api/testApiOrtoolsLinearProblem.cpp
@@ -22,8 +22,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 
-#include <ortools/linear_solver/linear_solver.h>
-
 #include <boost/test/unit_test.hpp>
 
 #include <antares/solver/optim/ortoolsImpl/linearProblem.h>


### PR DESCRIPTION
This PR applies several remarks from #2286.
Mostly simplifications :
- code has shrunk a bit (less lines).
- class **OrtoolsLinearProblem** is smaller now, because : 
  - **solve** method was simplified a bit, and some tasks were delegated to class **OrtoolsMipSolution**
  - **add** (variables & constraints) methods were a bit simplified
