### PR TITLE
Remove unused adqPatchParams argument, class member

### DIFF
--- a/src/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.cpp
@@ -50,10 +50,7 @@ AdqPatchPostProcessList::AdqPatchPostProcessList(const AdqPatchParams& adqPatchP
                                                                            thread_number));
     // Here a post process particular to adq patch
     post_process_list.push_back(
-      std::make_unique<DTGmarginForAdqPatchPostProcessCmd>(adqPatchParams,
-                                                           problemeHebdo_,
-                                                           areas,
-                                                           thread_number));
+      std::make_unique<DTGmarginForAdqPatchPostProcessCmd>(problemeHebdo_, areas, thread_number));
     post_process_list.push_back(
       std::make_unique<HydroLevelsUpdatePostProcessCmd>(problemeHebdo_, areas, true, false));
     post_process_list.push_back(

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
@@ -36,7 +36,6 @@ using OptimizationOptions = Antares::Solver::Optimization::OptimizationOptions;
 
 void OPT_OptimisationHebdomadaire(const OptimizationOptions& options,
                                   PROBLEME_HEBDO* pProblemeHebdo,
-                                  const AdqPatchParams& adqPatchParams,
                                   Solver::IResultWriter& writer,
                                   Solver::Simulation::ISimulationObserver& simulationObserver);
 void OPT_NumeroDeJourDuPasDeTemps(PROBLEME_HEBDO*);
@@ -47,7 +46,6 @@ void OPT_InitialiserLesPminHebdo(PROBLEME_HEBDO*);
 void OPT_InitialiserLesContrainteDEnergieHydrauliqueParIntervalleOptimise(PROBLEME_HEBDO*);
 void OPT_MaxDesPmaxHydrauliques(PROBLEME_HEBDO*);
 void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO*,
-                                                            const AdqPatchParams&,
                                                             const int,
                                                             const int,
                                                             const int);
@@ -68,7 +66,6 @@ bool ADQ_PATCH_CSR(PROBLEME_ANTARES_A_RESOUDRE&,
 
 bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options,
                                       PROBLEME_HEBDO* problemeHebdo,
-                                      const AdqPatchParams& adqPatchParams,
                                       Solver::IResultWriter& writer,
                                       Solver::Simulation::ISimulationObserver& simulationObserver);
 void OPT_VerifierPresenceReserveJmoins1(PROBLEME_HEBDO*);
@@ -89,7 +86,6 @@ void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options, const P
 
 bool OPT_OptimisationLineaire(const OptimizationOptions& options,
                               PROBLEME_HEBDO* problemeHebdo,
-                              const AdqPatchParams& adqPatchParams,
                               Solver::IResultWriter& writer,
                               Solver::Simulation::ISimulationObserver& simulationObserver);
 void OPT_RestaurerLesDonnees(PROBLEME_HEBDO*);

--- a/src/solver/optimisation/include/antares/solver/optimisation/post_process_commands.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/post_process_commands.h
@@ -74,15 +74,13 @@ class DTGmarginForAdqPatchPostProcessCmd: public basePostProcessCommand
     using AdqPatchParams = Antares::Data::AdequacyPatch::AdqPatchParams;
 
 public:
-    DTGmarginForAdqPatchPostProcessCmd(const AdqPatchParams& adqPatchParams,
-                                       PROBLEME_HEBDO* problemeHebdo,
+    DTGmarginForAdqPatchPostProcessCmd(PROBLEME_HEBDO* problemeHebdo,
                                        AreaList& areas,
                                        unsigned int thread_number);
 
     void execute(const optRuntimeData& opt_runtime_data) override;
 
 private:
-    const AdqPatchParams& adqPatchParams_;
     const AreaList& area_list_;
     unsigned int thread_number_ = 0;
 };

--- a/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
@@ -32,7 +32,6 @@ class WeeklyOptimization
 public:
     WeeklyOptimization(const OptimizationOptions& options,
                        PROBLEME_HEBDO* problemeHebdo,
-                       Antares::Data::AdequacyPatch::AdqPatchParams&,
                        uint numSpace,
                        IResultWriter& writer,
                        Simulation::ISimulationObserver& simulationObserver);
@@ -41,7 +40,6 @@ public:
 
     Antares::Solver::Optimization::OptimizationOptions options_;
     PROBLEME_HEBDO* const problemeHebdo_ = nullptr;
-    Antares::Data::AdequacyPatch::AdqPatchParams& adqPatchParams_;
     const uint thread_number_ = 0;
     IResultWriter& writer_;
     std::reference_wrapper<Simulation::ISimulationObserver> simulationObserver_;

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -79,7 +79,6 @@ double OPT_SommeDesPminThermiques(const PROBLEME_HEBDO* problemeHebdo, int Pays,
 }
 
 void setBoundsForUnsuppliedEnergy(PROBLEME_HEBDO* problemeHebdo,
-                                  const AdqPatchParams& adqPatchParams,
                                   const int PremierPdtDeLIntervalle,
                                   const int DernierPdtDeLIntervalle,
                                   const int optimizationNumber)
@@ -205,7 +204,6 @@ static void setBoundsForShortTermStorage(PROBLEME_HEBDO* problemeHebdo,
 }
 
 void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO* problemeHebdo,
-                                                            const AdqPatchParams& adqPatchParams,
                                                             const int PremierPdtDeLIntervalle,
                                                             const int DernierPdtDeLIntervalle,
                                                             const int optimizationNumber)
@@ -459,7 +457,6 @@ void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO* prob
     }
 
     setBoundsForUnsuppliedEnergy(problemeHebdo,
-                                 adqPatchParams,
                                  PremierPdtDeLIntervalle,
                                  DernierPdtDeLIntervalle,
                                  optimizationNumber);

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -39,17 +39,12 @@ using Antares::Solver::Optimization::OptimizationOptions;
 
 void OPT_OptimisationHebdomadaire(const OptimizationOptions& options,
                                   PROBLEME_HEBDO* pProblemeHebdo,
-                                  const AdqPatchParams& adqPatchParams,
                                   Solver::IResultWriter& writer,
                                   Solver::Simulation::ISimulationObserver& simulationObserver)
 {
     if (pProblemeHebdo->TypeDOptimisation == OPTIMISATION_LINEAIRE)
     {
-        if (!OPT_PilotageOptimisationLineaire(options,
-                                              pProblemeHebdo,
-                                              adqPatchParams,
-                                              writer,
-                                              simulationObserver))
+        if (!OPT_PilotageOptimisationLineaire(options, pProblemeHebdo, writer, simulationObserver))
         {
             logs.error() << "Linear optimization failed";
             throw UnfeasibleProblemError("Linear optimization failed");

--- a/src/solver/optimisation/opt_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_optimisation_lineaire.cpp
@@ -80,7 +80,6 @@ void notifyProblemHebdo(const PROBLEME_HEBDO* problemeHebdo,
 
 bool runWeeklyOptimization(const OptimizationOptions& options,
                            PROBLEME_HEBDO* problemeHebdo,
-                           const AdqPatchParams& adqPatchParams,
                            Solver::IResultWriter& writer,
                            int optimizationNumber,
                            Solver::Simulation::ISimulationObserver& simulationObserver)
@@ -96,7 +95,6 @@ bool runWeeklyOptimization(const OptimizationOptions& options,
         DernierPdtDeLIntervalle = pdtHebdo + NombreDePasDeTempsPourUneOptimisation;
 
         OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(problemeHebdo,
-                                                               adqPatchParams,
                                                                PremierPdtDeLIntervalle,
                                                                DernierPdtDeLIntervalle,
                                                                optimizationNumber);
@@ -190,7 +188,6 @@ void resizeProbleme(PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre,
 
 bool OPT_OptimisationLineaire(const OptimizationOptions& options,
                               PROBLEME_HEBDO* problemeHebdo,
-                              const AdqPatchParams& adqPatchParams,
                               Solver::IResultWriter& writer,
                               Solver::Simulation::ISimulationObserver& simulationObserver)
 {
@@ -226,7 +223,6 @@ bool OPT_OptimisationLineaire(const OptimizationOptions& options,
 
     bool ret = runWeeklyOptimization(options,
                                      problemeHebdo,
-                                     adqPatchParams,
                                      writer,
                                      PREMIERE_OPTIMISATION,
                                      simulationObserver);
@@ -240,7 +236,6 @@ bool OPT_OptimisationLineaire(const OptimizationOptions& options,
         runThermalHeuristic(problemeHebdo);
         return runWeeklyOptimization(options,
                                      problemeHebdo,
-                                     adqPatchParams,
                                      writer,
                                      DEUXIEME_OPTIMISATION,
                                      simulationObserver);

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -29,7 +29,6 @@ using Antares::Solver::Optimization::OptimizationOptions;
 
 bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options,
                                       PROBLEME_HEBDO* problemeHebdo,
-                                      const AdqPatchParams& adqPatchParams,
                                       Solver::IResultWriter& writer,
                                       Solver::Simulation::ISimulationObserver& simulationObserver)
 {
@@ -77,9 +76,5 @@ bool OPT_PilotageOptimisationLineaire(const OptimizationOptions& options,
         OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage(problemeHebdo);
     }
 
-    return OPT_OptimisationLineaire(options,
-                                    problemeHebdo,
-                                    adqPatchParams,
-                                    writer,
-                                    simulationObserver);
+    return OPT_OptimisationLineaire(options, problemeHebdo, writer, simulationObserver);
 }

--- a/src/solver/optimisation/post_process_commands.cpp
+++ b/src/solver/optimisation/post_process_commands.cpp
@@ -122,12 +122,10 @@ void RemixHydroPostProcessCmd::execute(const optRuntimeData& opt_runtime_data)
 using namespace Antares::Data::AdequacyPatch;
 
 DTGmarginForAdqPatchPostProcessCmd::DTGmarginForAdqPatchPostProcessCmd(
-  const AdqPatchParams& adqPatchParams,
   PROBLEME_HEBDO* problemeHebdo,
   AreaList& areas,
   unsigned int thread_number):
     basePostProcessCommand(problemeHebdo),
-    adqPatchParams_(adqPatchParams),
     area_list_(areas),
     thread_number_(thread_number)
 {

--- a/src/solver/optimisation/weekly_optimization.cpp
+++ b/src/solver/optimisation/weekly_optimization.cpp
@@ -27,13 +27,11 @@ namespace Antares::Solver::Optimization
 {
 WeeklyOptimization::WeeklyOptimization(const OptimizationOptions& options,
                                        PROBLEME_HEBDO* problemeHebdo,
-                                       AdqPatchParams& adqPatchParams,
                                        uint thread_number,
                                        IResultWriter& writer,
                                        Simulation::ISimulationObserver& simulationObserver):
     options_(options),
     problemeHebdo_(problemeHebdo),
-    adqPatchParams_(adqPatchParams),
     thread_number_(thread_number),
     writer_(writer),
     simulationObserver_(simulationObserver)
@@ -42,11 +40,7 @@ WeeklyOptimization::WeeklyOptimization(const OptimizationOptions& options,
 
 void WeeklyOptimization::solve()
 {
-    OPT_OptimisationHebdomadaire(options_,
-                                 problemeHebdo_,
-                                 adqPatchParams_,
-                                 writer_,
-                                 simulationObserver_.get());
+    OPT_OptimisationHebdomadaire(options_, problemeHebdo_, writer_, simulationObserver_.get());
 }
 
 } // namespace Antares::Solver::Optimization

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -211,7 +211,6 @@ bool Adequacy::year(Progression::Task& progression,
             {
                 OPT_OptimisationHebdomadaire(createOptimizationOptions(study),
                                              &currentProblem,
-                                             study.parameters.adqPatchParams,
                                              resultWriter,
                                              simulationObserver_.get());
 

--- a/src/solver/simulation/common-eco-adq.cpp
+++ b/src/solver/simulation/common-eco-adq.cpp
@@ -94,7 +94,6 @@ static void RecalculDesEchangesMoyens(Data::Study& study,
         NullSimulationObserver simulationObserver;
         OPT_OptimisationHebdomadaire(createOptimizationOptions(study),
                                      &problem,
-                                     study.parameters.adqPatchParams,
                                      resultWriter,
                                      simulationObserver);
     }

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -85,7 +85,6 @@ bool Economy::simulationBegin()
 
             weeklyOptProblems_.emplace_back(options,
                                             &pProblemesHebdo[numSpace],
-                                            study.parameters.adqPatchParams,
                                             numSpace,
                                             resultWriter,
                                             simulationObserver_.get());


### PR DESCRIPTION
This follows the removal of the "adequacy patch - local matching" feature.