### PR TITLE
Protect study path with space when using cucumber

### DIFF
--- a/src/tests/cucumber/features/steps/common_steps/simulator_utils.py
+++ b/src/tests/cucumber/features/steps/common_steps/simulator_utils.py
@@ -27,7 +27,7 @@ def init_simu(context):
 
 
 def build_antares_solver_command(context):
-    command = [context.config.userdata["antares-solver"], "-i", str(context.study_path)]
+    command = [context.config.userdata["antares-solver"], "-i", f'"{context.study_path}"']
     solver = "sirius"
     if "solver" in context.config.userdata:
         solver = context.config.userdata["solver"]


### PR DESCRIPTION
Study path with spaces can lead to error if the CLI interpreter assume the path being multiple space separated parameters.

- Surround study path parameter with double quotes
- Update documentation: use `python -m pip` instead of `pip`