### PR TITLE
Headers files : remove useless inclusions 

### DIFF
--- a/src/solver/hydro/include/antares/solver/hydro/management/management.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/management.h
@@ -25,8 +25,8 @@
 
 #include <antares/mersenne-twister/mersenne-twister.h>
 #include <antares/study/area/area.h>
-#include <antares/study/parts/hydro/container.h>
 #include <antares/study/fwd.h>
+#include <antares/study/parts/hydro/container.h>
 #include "antares/date/date.h"
 #include "antares/writer/i_writer.h"
 

--- a/src/solver/hydro/include/antares/solver/hydro/management/management.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/management.h
@@ -23,13 +23,11 @@
 
 #include <unordered_map>
 
-#include <yuni/yuni.h>
-
 #include <antares/mersenne-twister/mersenne-twister.h>
 #include <antares/study/area/area.h>
+#include <antares/study/parts/hydro/container.h>
 #include <antares/study/fwd.h>
 #include "antares/date/date.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
 #include "antares/writer/i_writer.h"
 
 namespace Antares
@@ -113,7 +111,6 @@ private:
     const Data::AreaList& areas_;
     const Date::Calendar& calendar_;
     const Data::Parameters& parameters_;
-    unsigned int maxNbYearsInParallel_ = 0;
     Solver::IResultWriter& resultWriter_;
 
     HYDRO_VENTILATION_RESULTS ventilationResults_;

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -21,9 +21,9 @@
 
 #include <array>
 #include <cassert>
+#include <filesystem>
 #include <limits>
 #include <sstream>
-#include <filesystem>
 
 #include <antares/antares/fatal-error.h>
 #include <antares/study/area/scratchpad.h>
@@ -150,7 +150,8 @@ struct DebugData
                              const Data::AreaName& areaName) const
     {
         std::ostringstream buffer;
-        auto path = fs::path("debug") / "solver" / std::to_string(1 + y) / "daily." / areaName.c_str() / ".txt";
+        auto path = fs::path("debug") / "solver" / std::to_string(1 + y) / "daily."
+                    / areaName.c_str() / ".txt";
 
         buffer << "\tNiveau init : " << hydro_specific.monthly[initReservoirLvlMonth].MOL << "\n";
         for (uint month = 0; month != MONTHS_PER_YEAR; ++month)

--- a/src/solver/hydro/management/daily.cpp
+++ b/src/solver/hydro/management/daily.cpp
@@ -23,15 +23,10 @@
 #include <cassert>
 #include <limits>
 #include <sstream>
-
-#include <yuni/yuni.h>
-#include <yuni/io/directory.h>
-#include <yuni/io/file.h>
+#include <filesystem>
 
 #include <antares/antares/fatal-error.h>
 #include <antares/study/area/scratchpad.h>
-#include <antares/study/study.h>
-#include <antares/utils/utils.h>
 #include <antares/writer/i_writer.h>
 #include "antares/solver/hydro/daily/h2o_j_donnees_mensuelles.h"
 #include "antares/solver/hydro/daily/h2o_j_fonctions.h"
@@ -39,9 +34,7 @@
 #include "antares/solver/hydro/daily2/h2o2_j_fonctions.h"
 #include "antares/solver/hydro/management/management.h"
 
-using namespace Yuni;
-
-#define SEP IO::Separator
+namespace fs = std::filesystem;
 
 namespace
 {
@@ -135,8 +128,8 @@ struct DebugData
 
     void writeTurb(const std::string filename, uint y) const
     {
-        std::ostringstream buffer, path;
-        path << "debug" << SEP << "solver" << SEP << (1 + y) << SEP << filename;
+        std::ostringstream buffer;
+        auto path = fs::path("debug") / "solver" / std::to_string(1 + y) / filename;
 
         buffer << "\tTurbine\t\t\tOPP\t\t\t\tTurbine Cible\tDLE\t\t\t\tDLN\n";
         for (uint day = 0; day != 365; ++day)
@@ -148,7 +141,7 @@ struct DebugData
             buffer << '\n';
         }
         auto buffer_str = buffer.str();
-        pWriter.addEntryFromBuffer(path.str(), buffer_str);
+        pWriter.addEntryFromBuffer(path.string(), buffer_str);
     }
 
     void writeDailyDebugData(const Date::Calendar& calendar,
@@ -156,9 +149,8 @@ struct DebugData
                              uint y,
                              const Data::AreaName& areaName) const
     {
-        std::ostringstream buffer, path;
-        path << "debug" << SEP << "solver" << SEP << (1 + y) << SEP << "daily." << areaName.c_str()
-             << ".txt";
+        std::ostringstream buffer;
+        auto path = fs::path("debug") / "solver" / std::to_string(1 + y) / "daily." / areaName.c_str() / ".txt";
 
         buffer << "\tNiveau init : " << hydro_specific.monthly[initReservoirLvlMonth].MOL << "\n";
         for (uint month = 0; month != MONTHS_PER_YEAR; ++month)
@@ -217,7 +209,7 @@ struct DebugData
             }
         }
         auto buffer_str = buffer.str();
-        pWriter.addEntryFromBuffer(path.str(), buffer_str);
+        pWriter.addEntryFromBuffer(path.string(), buffer_str);
     }
 };
 

--- a/src/solver/hydro/management/management.cpp
+++ b/src/solver/hydro/management/management.cpp
@@ -24,10 +24,7 @@
 #include <cmath>
 #include <limits>
 
-#include <antares/antares/fatal-error.h>
 #include <antares/study/area/scratchpad.h>
-#include <antares/study/parts/hydro/container.h>
-#include <antares/study/study.h>
 
 namespace Antares
 {

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -199,7 +199,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(const double* random_rese
               case OUI:
               {
 #ifndef NDEBUG
-                      CheckHydroAllocationProblem(area, problem, initReservoirLvlMonth, lvi);
+                  CheckHydroAllocationProblem(area, problem, initReservoirLvlMonth, lvi);
 #endif
 
                   for (uint month = 0; month != MONTHS_PER_YEAR; ++month)

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -198,10 +198,9 @@ void HydroManagement::prepareMonthlyOptimalGenerations(const double* random_rese
               {
               case OUI:
               {
-                  if (false)
-                  {
+#ifndef NDEBUG
                       CheckHydroAllocationProblem(area, problem, initReservoirLvlMonth, lvi);
-                  }
+#endif
 
                   for (uint month = 0; month != MONTHS_PER_YEAR; ++month)
                   {

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -198,7 +198,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(const double* random_rese
               {
               case OUI:
               {
-                  if (Logs::Verbosity::Debug::enabled)
+                  if (false)
                   {
                       CheckHydroAllocationProblem(area, problem, initReservoirLvlMonth, lvi);
                   }

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -18,24 +18,17 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
+#include <filesystem>
 #include <iomanip>
 #include <limits>
 #include <sstream>
 
-#include <yuni/yuni.h>
-#include <yuni/io/directory.h>
-#include <yuni/io/file.h>
-
 #include <antares/antares/fatal-error.h>
-#include <antares/study/study.h>
-#include <antares/utils/utils.h>
 #include "antares/solver/hydro/management/management.h"
 #include "antares/solver/hydro/monthly/h2o_m_donnees_annuelles.h"
 #include "antares/solver/hydro/monthly/h2o_m_fonctions.h"
 
-using namespace Yuni;
-
-#define SEP IO::Separator
+namespace fs = std::filesystem;
 
 namespace Antares
 {
@@ -206,7 +199,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(const double* random_rese
               {
               case OUI:
               {
-                  if (Logs::Verbosity::Debug::enabled)
+                  if (false) // Put true to have extra check
                   {
                       CheckHydroAllocationProblem(area, problem, initReservoirLvlMonth, lvi);
                   }
@@ -269,9 +262,9 @@ void HydroManagement::prepareMonthlyOptimalGenerations(const double* random_rese
 #endif
           if (parameters_.hydroDebug)
           {
-              std::ostringstream buffer, path;
-              path << "debug" << SEP << "solver" << SEP << (1 + y) << SEP << "monthly." << area.name
-                   << ".txt";
+              std::ostringstream buffer;
+              auto path = fs::path("debug") / "solver" / std::to_string(1 + y) / "monthly."
+                          / area.name.c_str() / ".txt";
 
               if (area.hydro.reservoirManagement)
                   buffer << "Initial Reservoir Level\t" << lvi << "\n";
@@ -313,7 +306,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(const double* random_rese
                   buffer << '\n';
               }
               auto content = buffer.str();
-              resultWriter_.addEntryFromBuffer(path.str(), content);
+              resultWriter_.addEntryFromBuffer(path.string(), content);
           }
           indexArea++;
       });

--- a/src/solver/hydro/management/monthly.cpp
+++ b/src/solver/hydro/management/monthly.cpp
@@ -32,9 +32,8 @@ namespace fs = std::filesystem;
 
 namespace Antares
 {
-template<class ProblemT>
 static void CheckHydroAllocationProblem(Data::Area& area,
-                                        ProblemT& problem,
+                                        DONNEES_ANNUELLES& problem,
                                         int initLevelMonth,
                                         double lvi)
 {
@@ -199,7 +198,7 @@ void HydroManagement::prepareMonthlyOptimalGenerations(const double* random_rese
               {
               case OUI:
               {
-                  if (false) // Put true to have extra check
+                  if (Logs::Verbosity::Debug::enabled)
                   {
                       CheckHydroAllocationProblem(area, problem, initReservoirLvlMonth, lvi);
                   }

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
@@ -54,7 +54,6 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO*, int, int, 
 void OPT_InitialiserLeSecondMembreDuProblemeQuadratique(PROBLEME_HEBDO*, int);
 void OPT_InitialiserLesCoutsLineaire(PROBLEME_HEBDO*, const int, const int);
 void OPT_InitialiserLesCoutsQuadratiques(PROBLEME_HEBDO*, int);
-void OPT_ControleDesPminPmaxThermiques(PROBLEME_HEBDO*);
 bool OPT_AppelDuSolveurQuadratique(PROBLEME_ANTARES_A_RESOUDRE*, const int);
 
 using namespace Antares::Data::AdequacyPatch;

--- a/src/solver/optimisation/opt_alloc_probleme_a_optimiser.cpp
+++ b/src/solver/optimisation/opt_alloc_probleme_a_optimiser.cpp
@@ -20,17 +20,10 @@
 */
 
 #include <antares/logs/logs.h>
-#include "antares/solver/optimisation/opt_fonctions.h"
 #include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
-using namespace Antares;
-
-#ifdef _MSC_VER
-#define SNPRINTF sprintf_s
-#else
-#define SNPRINTF snprintf
-#endif
+int OPT_DecompteDesVariablesEtDesContraintesDuProblemeAOptimiser(PROBLEME_HEBDO*);
 
 void OPT_AllocateFromNumberOfVariableConstraints(PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre,
                                                  int NbTermes)

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -19,35 +19,23 @@
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
 
-#include <yuni/yuni.h>
-
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_probleme_economique.h"
-#include "antares/solver/simulation/simulation.h"
-#include "antares/solver/utils/basis_status.h"
-
-extern "C"
-{
-#include "spx_definition_arguments.h"
-#include "spx_fonctions.h"
-#include "srs_api.h"
-}
-
 #include <chrono>
+#include <spx_definition_arguments.h>
+#include <spx_fonctions.h>
 
 #include <antares/antares/fatal-error.h>
 #include <antares/logs/logs.h>
+#include "antares/optimization-options/options.h"
 #include "antares/solver/infeasible-problem-analysis/unfeasible-pb-analyzer.h"
+#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 #include "antares/solver/utils/filename.h"
 #include "antares/solver/utils/mps_utils.h"
 
 using namespace operations_research;
 
-using namespace Antares;
-using namespace Antares::Data;
-using namespace Yuni;
 using Antares::Solver::IResultWriter;
+using Antares::Solver::Optimization::OptimizationOptions;
 
 class TimeMeasurement
 {
@@ -268,7 +256,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
             logs.info() << " Solver: Standard resolution failed";
             logs.info() << " Solver: Retry in safe mode"; // second trial w/o scaling
 
-            if (Logs::Verbosity::Debug::enabled)
+            if (false) // To be turned to true if we want to print this
             {
                 logs.info() << " solver: resetting";
             }

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -255,11 +255,8 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
 
             logs.info() << " Solver: Standard resolution failed";
             logs.info() << " Solver: Retry in safe mode"; // second trial w/o scaling
+            logs.debug() << " solver: resetting";
 
-            if (false) // To be turned to true if we want to print this
-            {
-                logs.info() << " solver: resetting";
-            }
             return {.success = false,
                     .timeMeasure = timeMeasure,
                     .mps_writer_factory = mps_writer_factory};

--- a/src/solver/optimisation/opt_appel_solveur_quadratique.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_quadratique.cpp
@@ -21,24 +21,22 @@
 
 #include <limits>
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-
 /*
  pi_define.h doesn't include this header, yet it uses struct jmp_buf.
  It would be nice to remove this include, but would require to change pi_define.h,
  which isn't part of Antares
 */
-#include <setjmp.h>
 
+#include <setjmp.h>
 extern "C"
 {
-#include "pi_define.h"
-#include "pi_definition_arguments.h"
-#include "pi_fonctions.h"
+#include <pi_constantes_externes.h>
+#include <pi_definition_arguments.h>
+#include <pi_fonctions.h>
 }
 
 #include <antares/logs/logs.h>
+#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
 
 using namespace Antares;
 

--- a/src/solver/optimisation/opt_calcul_des_pmin_MUT_MDT.cpp
+++ b/src/solver/optimisation/opt_calcul_des_pmin_MUT_MDT.cpp
@@ -19,8 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <math.h>
-
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 constexpr double ZERO_PMIN = 1.e-2;

--- a/src/solver/optimisation/opt_calcul_des_pmin_MUT_MDT.cpp
+++ b/src/solver/optimisation/opt_calcul_des_pmin_MUT_MDT.cpp
@@ -21,10 +21,7 @@
 
 #include <math.h>
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 constexpr double ZERO_PMIN = 1.e-2;
 

--- a/src/solver/optimisation/opt_chainage_intercos.cpp
+++ b/src/solver/optimisation/opt_chainage_intercos.cpp
@@ -19,8 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_ChainagesDesIntercoPartantDUnNoeud(PROBLEME_HEBDO* problemeHebdo)
 {

--- a/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
+++ b/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
@@ -19,10 +19,11 @@
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
 
+#include <spx_constantes_externes.h>
+
 #include "antares/solver/optimisation/opt_rename_problem.h"
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
-#include "spx_constantes_externes.h"
 #include "variables/VariableManagerUtils.h"
 
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaireCoutsDeDemarrage(

--- a/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
+++ b/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
@@ -19,10 +19,8 @@
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 #include "antares/solver/optimisation/opt_rename_problem.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-
 #include "spx_constantes_externes.h"
 #include "variables/VariableManagerUtils.h"
 

--- a/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
+++ b/src/solver/optimisation/opt_construction_variables_couts_demarrages.cpp
@@ -19,8 +19,9 @@
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
 
-#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 #include "antares/solver/optimisation/opt_rename_problem.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
+
 #include "spx_constantes_externes.h"
 #include "variables/VariableManagerUtils.h"
 

--- a/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
@@ -25,9 +25,8 @@
 
 #include "variables/VariableManagerUtils.h"
 
-void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaireCoutsDeDemarrage(
-        PROBLEME_HEBDO* problemeHebdo,
-        bool Simulation);
+void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaireCoutsDeDemarrage(PROBLEME_HEBDO*,
+                                                                                   bool);
 
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(PROBLEME_HEBDO* problemeHebdo)
 {

--- a/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
@@ -20,11 +20,14 @@
  */
 #include <spx_constantes_externes.h>
 
-#include "antares/solver/optimisation/opt_fonctions.h"
 #include "antares/solver/optimisation/opt_rename_problem.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 #include "variables/VariableManagerUtils.h"
+
+void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaireCoutsDeDemarrage(
+        PROBLEME_HEBDO* problemeHebdo,
+        bool Simulation);
 
 void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(PROBLEME_HEBDO* problemeHebdo)
 {

--- a/src/solver/optimisation/opt_construction_variables_optimisees_quadratique.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_quadratique.cpp
@@ -19,10 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 #include "pi_constantes_externes.h"
 #include "variables/VariableManagerUtils.h"

--- a/src/solver/optimisation/opt_decompte_variables_et_contraintes.cpp
+++ b/src/solver/optimisation/opt_decompte_variables_et_contraintes.cpp
@@ -20,12 +20,11 @@
  */
 
 #include <antares/antares/fatal-error.h>
-#include <antares/logs/logs.h>
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 using namespace Antares;
+
+void OPT_DecompteDesVariablesEtDesContraintesCoutsDeDemarrage(PROBLEME_HEBDO*);
 
 int OPT_DecompteDesVariablesEtDesContraintesDuProblemeAOptimiser(PROBLEME_HEBDO* problemeHebdo)
 {

--- a/src/solver/optimisation/opt_decompte_variables_et_contraintes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_decompte_variables_et_contraintes_couts_demarrage.cpp
@@ -21,8 +21,6 @@
 
 #include "antares/solver/optimisation/LinearProblemMatrixStartUpCosts.h"
 #include "antares/solver/optimisation/constraints/constraint_builder_utils.h"
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/simulation.h"
 
 void OPT_DecompteDesVariablesEtDesContraintesCoutsDeDemarrage(PROBLEME_HEBDO* problemeHebdo)
 {
@@ -37,6 +35,4 @@ void OPT_DecompteDesVariablesEtDesContraintesCoutsDeDemarrage(PROBLEME_HEBDO* pr
 
     OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaireCoutsDeDemarrage(problemeHebdo,
                                                                                   true);
-
-    return;
 }

--- a/src/solver/optimisation/opt_export_structure.cpp
+++ b/src/solver/optimisation/opt_export_structure.cpp
@@ -21,7 +21,7 @@
 
 #include "antares/solver/optimisation/opt_export_structure.h"
 
-#include <sstream>
+#include <string>
 
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -20,20 +20,17 @@
 */
 
 #include <cmath>
+#include <spx_constantes_externes.h>
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
 #include "antares/solver/simulation/adequacy_patch_runtime_data.h"
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
-#include "spx_constantes_externes.h"
 #include "variables/VariableManagement.h"
 #include "variables/VariableManagerUtils.h"
 
-using namespace Antares;
-using namespace Antares::Data;
-
-using namespace Yuni;
+void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaireCoutsDeDemarrage(PROBLEME_HEBDO*,
+                                                                            const int,
+                                                                            const int);
 
 void OPT_MaxDesPmaxHydrauliques(PROBLEME_HEBDO* problemeHebdo)
 {
@@ -57,8 +54,6 @@ void OPT_MaxDesPmaxHydrauliques(PROBLEME_HEBDO* problemeHebdo)
 
         problemeHebdo->CaracteristiquesHydrauliques[pays].MaxDesPmaxHydrauliques = pmaxHyd;
     }
-
-    return;
 }
 
 double OPT_SommeDesPminThermiques(const PROBLEME_HEBDO* problemeHebdo, int Pays, uint pdtHebdo)
@@ -505,6 +500,4 @@ void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(PROBLEME_HEBDO* prob
           PremierPdtDeLIntervalle,
           DernierPdtDeLIntervalle);
     }
-
-    return;
 }

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp
@@ -19,11 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <cmath>
-
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 #include "pi_constantes_externes.h"
 #include "variables/VariableManagerUtils.h"

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp
@@ -18,15 +18,13 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
+#include <pi_constantes_externes.h>
 
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
-#include "pi_constantes_externes.h"
 #include "variables/VariableManagerUtils.h"
 
 #define ZERO_POUR_LES_VARIABLES_FIXES 1.e-6
-
-using namespace Yuni;
 
 void OPT_InitialiserLesBornesDesVariablesDuProblemeQuadratique(PROBLEME_HEBDO* problemeHebdo,
                                                                int PdtHebdo)

--- a/src/solver/optimisation/opt_gestion_des_bornes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_couts_demarrage.cpp
@@ -19,16 +19,10 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
-#include "antares/solver/simulation/simulation.h"
 
 #include "variables/VariableManagement.h"
 #include "variables/VariableManagerUtils.h"
-
-using namespace Yuni;
 
 void OPT_InitialiserLesBornesDesVariablesDuProblemeLineaireCoutsDeDemarrage(
   PROBLEME_HEBDO* problemeHebdo,

--- a/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_cas_lineaire.cpp
@@ -19,14 +19,11 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <yuni/yuni.h>
-
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 #include "variables/VariableManagerUtils.h"
+
+void OPT_InitialiserLesCoutsLineaireCoutsDeDemarrage(PROBLEME_HEBDO*, const int, const int);
 
 static void shortTermStorageCost(
   int PremierPdtDeLIntervalle,
@@ -343,6 +340,4 @@ void OPT_InitialiserLesCoutsLineaire(PROBLEME_HEBDO* problemeHebdo,
                                                         PremierPdtDeLIntervalle,
                                                         DernierPdtDeLIntervalle);
     }
-
-    return;
 }

--- a/src/solver/optimisation/opt_gestion_des_couts_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_des_couts_couts_demarrage.cpp
@@ -19,10 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 #include "variables/VariableManagerUtils.h"
 

--- a/src/solver/optimisation/opt_gestion_des_pmin.cpp
+++ b/src/solver/optimisation/opt_gestion_des_pmin.cpp
@@ -18,9 +18,8 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
+
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 #define ZERO 1.e-2
 

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -19,12 +19,10 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
-using namespace Antares;
-using namespace Antares::Data;
-using namespace Yuni;
+double OPT_SommeDesPminThermiques(const PROBLEME_HEBDO*, int, uint);
+void OPT_InitialiserLeSecondMembreDuProblemeLineaireCoutsDeDemarrage(PROBLEME_HEBDO*, int, int);
 
 static void shortTermStorageLevelsRHS(
   const std::vector<::ShortTermStorage::AREA_INPUT>& shortTermStorageInput,

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_quadratique.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_quadratique.cpp
@@ -19,9 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_InitialiserLeSecondMembreDuProblemeQuadratique(PROBLEME_HEBDO* problemeHebdo, int PdtHebdo)
 {

--- a/src/solver/optimisation/opt_gestion_second_membre_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_couts_demarrage.cpp
@@ -19,14 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <antares/study/study.h>
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-
-using namespace Antares;
-using namespace Antares::Data;
-using namespace Yuni;
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_InitialiserLeSecondMembreDuProblemeLineaireCoutsDeDemarrage(PROBLEME_HEBDO* problemeHebdo,
                                                                      int PremierPdtDeLIntervalle,
@@ -104,6 +97,4 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaireCoutsDeDemarrage(PROBLEME_HE
             }
         }
     }
-
-    return;
 }

--- a/src/solver/optimisation/opt_init_contraintes_hydrauliques.cpp
+++ b/src/solver/optimisation/opt_init_contraintes_hydrauliques.cpp
@@ -19,9 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_InitialiserLesContrainteDEnergieHydrauliqueParIntervalleOptimise(
   PROBLEME_HEBDO* problemeHebdo)
@@ -138,6 +136,4 @@ void OPT_InitialiserLesContrainteDEnergieHydrauliqueParIntervalleOptimise(
             InflowForTimeInterval[intervalle] = InflowSum;
         }
     }
-
-    return;
 }

--- a/src/solver/optimisation/opt_init_minmax_groupes_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_init_minmax_groupes_couts_demarrage.cpp
@@ -19,9 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage(PROBLEME_HEBDO* problemeHebdo)
 {
@@ -70,6 +68,4 @@ void OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage(PROBLEME_HEBDO* prob
             }
         }
     }
-
-    return;
 }

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -19,14 +19,11 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/utils/ortools_utils.h"
+#include <spx_fonctions.h>
+
 #include "antares/optimization-options/options.h"
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
-
-extern "C"
-{
-#include "spx_fonctions.h"
-}
+#include "antares/solver/utils/ortools_utils.h"
 
 using namespace Antares::Solver::Optimization;
 

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -19,18 +19,16 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
 #include "antares/solver/utils/ortools_utils.h"
+#include "antares/optimization-options/options.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 extern "C"
 {
 #include "spx_fonctions.h"
 }
 
-using namespace Antares;
+using namespace Antares::Solver::Optimization;
 
 void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options,
                                      const PROBLEME_HEBDO* problemeHebdo)
@@ -72,6 +70,4 @@ void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options,
             }
         }
     }
-
-    return;
 }

--- a/src/solver/optimisation/opt_nombre_min_groupes_demarres_couts_demarrage.cpp
+++ b/src/solver/optimisation/opt_nombre_min_groupes_demarres_couts_demarrage.cpp
@@ -18,27 +18,10 @@
 ** You should have received a copy of the Mozilla Public Licence 2.0
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
-#include <yuni/yuni.h>
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
+#include <spx_fonctions.h>
 
-extern "C"
-{
-#include "spx_definition_arguments.h"
-#include "spx_fonctions.h"
-}
-
-using namespace Antares;
-using namespace Antares::Data;
-using namespace Yuni;
-
-#ifdef _MSC_VER
-#define SNPRINTF sprintf_s
-#else
-#define SNPRINTF snprintf
-#endif
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_PbLineairePourAjusterLeNombreMinDeGroupesDemarresCoutsDeDemarrage(PROBLEME_HEBDO*,
                                                                            std::vector<int>&,
@@ -657,6 +640,4 @@ void OPT_PbLineairePourAjusterLeNombreMinDeGroupesDemarresCoutsDeDemarrage(
         printf("Pas de solution au probleme auxiliaire\n");
 #endif
     }
-
-    return;
 }

--- a/src/solver/optimisation/opt_numero_de_jour_du_pas_de_temps.cpp
+++ b/src/solver/optimisation/opt_numero_de_jour_du_pas_de_temps.cpp
@@ -19,10 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <math.h>
-
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_NumeroDeJourDuPasDeTemps(PROBLEME_HEBDO* problemeHebdo)
 {
@@ -33,7 +30,6 @@ void OPT_NumeroDeJourDuPasDeTemps(PROBLEME_HEBDO* problemeHebdo)
         double X = pdtHebdo / problemeHebdo->NombreDePasDeTempsDUneJournee;
         problemeHebdo->NumeroDeJourDuPasDeTemps[pdtHebdo] = (int)floor(X);
     }
-    return;
 }
 
 void OPT_NumeroDIntervalleOptimiseDuPasDeTemps(PROBLEME_HEBDO* problemeHebdo)
@@ -43,5 +39,4 @@ void OPT_NumeroDIntervalleOptimiseDuPasDeTemps(PROBLEME_HEBDO* problemeHebdo)
         double X = pdtHebdo / problemeHebdo->NombreDePasDeTempsPourUneOptimisation;
         problemeHebdo->NumeroDIntervalleOptimiseDuPasDeTemps[pdtHebdo] = (int)floor(X);
     }
-    return;
 }

--- a/src/solver/optimisation/opt_optimisation_hebdo.cpp
+++ b/src/solver/optimisation/opt_optimisation_hebdo.cpp
@@ -22,19 +22,19 @@
 #include <antares/antares/fatal-error.h>
 #include <antares/exception/UnfeasibleProblemError.hpp>
 #include <antares/logs/logs.h>
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
 #include "antares/solver/simulation/ISimulationObserver.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
-extern "C"
-{
-#include "spx_fonctions.h"
-}
-
-using namespace Antares;
 using namespace Antares::Data;
 
 using Antares::Solver::Optimization::OptimizationOptions;
+
+bool OPT_PilotageOptimisationLineaire(const OptimizationOptions&,
+                                      PROBLEME_HEBDO*,
+                                      Solver::IResultWriter&,
+                                      Solver::Simulation::ISimulationObserver&);
+bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO*);
+void OPT_LiberationProblemesSimplexe(const OptimizationOptions&, const PROBLEME_HEBDO*);
 
 void OPT_OptimisationHebdomadaire(const OptimizationOptions& options,
                                   PROBLEME_HEBDO* pProblemeHebdo,

--- a/src/solver/optimisation/opt_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_optimisation_lineaire.cpp
@@ -20,8 +20,6 @@
  */
 
 #include <antares/logs/logs.h>
-#include "antares/solver/lps/LpsFromAntares.h"
-#include "antares/solver/optimisation/HebdoProblemToLpsTranslator.h"
 #include "antares/solver/optimisation/LinearProblemMatrix.h"
 #include "antares/solver/optimisation/constraints/constraint_builder_utils.h"
 #include "antares/solver/optimisation/opt_export_structure.h"
@@ -29,8 +27,8 @@
 #include "antares/solver/simulation/ISimulationObserver.h"
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 #include "antares/solver/utils/filename.h"
-using namespace Antares;
-using namespace Yuni;
+
+using namespace Antares::Solver;
 using Antares::Solver::Optimization::OptimizationOptions;
 
 namespace

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -21,7 +21,7 @@
 
 #include "antares/optimization-options/options.h"
 #include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 #include "antares/solver/simulation/ISimulationObserver.h"
 
 using Antares::Solver::Optimization::OptimizationOptions;

--- a/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_lineaire.cpp
@@ -21,8 +21,8 @@
 
 #include "antares/optimization-options/options.h"
 #include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 #include "antares/solver/simulation/ISimulationObserver.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 using Antares::Solver::Optimization::OptimizationOptions;
 

--- a/src/solver/optimisation/opt_pilotage_optimisation_quadratique.cpp
+++ b/src/solver/optimisation/opt_pilotage_optimisation_quadratique.cpp
@@ -19,15 +19,9 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <cmath>
-
 #include "antares/solver/optimisation/QuadraticProblemMatrix.h"
 #include "antares/solver/optimisation/constraints/constraint_builder_utils.h"
 #include "antares/solver/optimisation/opt_fonctions.h"
-extern "C"
-{
-#include "spx_fonctions.h"
-}
 
 bool OPT_PilotageOptimisationQuadratique(PROBLEME_HEBDO* problemeHebdo)
 {

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -22,7 +22,7 @@
 #include "antares/solver/optimisation/opt_rename_problem.h"
 
 #include <map>
-#include <sstream>
+#include <string>
 
 const std::string HOUR("hour");
 const std::string DAY("day");

--- a/src/solver/optimisation/opt_restaurer_les_donnees.cpp
+++ b/src/solver/optimisation/opt_restaurer_les_donnees.cpp
@@ -19,10 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_RestaurerLesDonnees(PROBLEME_HEBDO* problemeHebdo)
 {
@@ -132,6 +129,4 @@ void OPT_RestaurerLesDonnees(PROBLEME_HEBDO* problemeHebdo)
             }
         }
     }
-
-    return;
 }

--- a/src/solver/optimisation/opt_verification_presence_reserve_jmoins1.cpp
+++ b/src/solver/optimisation/opt_verification_presence_reserve_jmoins1.cpp
@@ -19,12 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include "antares/solver/optimisation/opt_fonctions.h"
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
-#include "antares/solver/simulation/sim_structure_donnees.h"
-#include "antares/solver/simulation/simulation.h"
-
-#include "spx_fonctions.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 void OPT_VerifierPresenceReserveJmoins1(PROBLEME_HEBDO* problemeHebdo)
 {
@@ -45,6 +40,4 @@ void OPT_VerifierPresenceReserveJmoins1(PROBLEME_HEBDO* problemeHebdo)
             }
         }
     }
-
-    return;
 }

--- a/src/solver/optimisation/variables/VariableManagement.h
+++ b/src/solver/optimisation/variables/VariableManagement.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 
 namespace VariableManagement

--- a/src/solver/optimisation/variables/VariableManagerUtils.h
+++ b/src/solver/optimisation/variables/VariableManagerUtils.h
@@ -2,4 +2,4 @@
 
 #include "VariableManagement.h"
 
-VariableManagement::VariableManager VariableManagerFromProblemHebdo(PROBLEME_HEBDO* problemeHebdo);
+VariableManagement::VariableManager VariableManagerFromProblemHebdo(PROBLEME_HEBDO*);

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -19,11 +19,10 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <cmath>
+#include <algorithm>
 #include <sstream>
 
 #include <antares/antares/fatal-error.h>
-#include <antares/study/area/constants.h>
 #include <antares/study/area/scratchpad.h>
 #include <antares/study/study.h>
 #include <antares/utils/utils.h>
@@ -31,7 +30,6 @@
 #include "antares/solver/simulation/sim_structure_probleme_economique.h"
 #include "antares/solver/simulation/simulation.h"
 #include "antares/study/fwd.h"
-#include "antares/study/simulation.h"
 
 using namespace Antares;
 using namespace Antares::Data;

--- a/src/tools/ts-generator/main.cpp
+++ b/src/tools/ts-generator/main.cpp
@@ -28,7 +28,6 @@
 #include <antares/utils/utils.h>
 #include "antares/tools/ts-generator/linksTSgenerator.h"
 #include "antares/tools/ts-generator/tsGenerationOptions.h"
-using namespace Antares::TSGenerator;
 
 using namespace Antares::TSGenerator;
 


### PR DESCRIPTION
When reviewing PR #2410, we noticed that some headers inclusions are irrelevant, especially in the **OPT** part.
The current PR is about fixing this.