### PR TITLE
Fix a crash occurring when first year not played

### DIFF
--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -51,7 +51,7 @@ public:
             randomNumbers& pRandomForParallelYears,
             bool pPerformCalculations,
             Data::Study& pStudy,
-            Variable::State& pState,
+            std::vector<Variable::State>& pStates,
             bool pYearByYear,
             Benchmarking::DurationCollector& durationCollector,
             IResultWriter& resultWriter,
@@ -65,14 +65,14 @@ public:
         randomForParallelYears(pRandomForParallelYears),
         performCalculations(pPerformCalculations),
         study(pStudy),
-        state(pState),
+        states(pStates),
         yearByYear(pYearByYear),
         pDurationCollector(durationCollector),
         pResultWriter(resultWriter),
         simulationObserver_(simulationObserver),
         hydroManagement(study.areas, study.parameters, study.calendar, resultWriter)
     {
-        scratchmap = study.areas.buildScratchMap(numSpace);
+        // scratchmap = study.areas.buildScratchMap(numSpace);
     }
 
     yearJob(const yearJob&) = delete;
@@ -89,13 +89,13 @@ private:
     randomNumbers& randomForParallelYears;
     bool performCalculations;
     Data::Study& study;
-    Variable::State& state;
+    std::vector<Variable::State>& states;
     bool yearByYear;
     Benchmarking::DurationCollector& pDurationCollector;
     IResultWriter& pResultWriter;
     std::reference_wrapper<ISimulationObserver> simulationObserver_;
     HydroManagement hydroManagement;
-    Antares::Data::Area::ScratchMap scratchmap;
+    // Antares::Data::Area::ScratchMap scratchmap;
 
 private:
     /*
@@ -147,17 +147,18 @@ public:
             // 1 - Applying random levels for current year
             auto randomReservoirLevel = randomForCurrentYear.pReservoirLevels;
 
-            // 2 - Preparing the Time-series numbers
-            // removed
+            // Getting the scratchMap associated to the current year
+            Antares::Data::Area::ScratchMap scratchmap = study.areas.buildScratchMap(numSpace);
 
             // 3 - Preparing data related to Clusters in 'must-run' mode
             simulation_->prepareClustersInMustRunMode(scratchmap, y);
 
             // 4 - Hydraulic ventilation
-            pDurationCollector("hydro_ventilation") << [this, &randomReservoirLevel]
+            pDurationCollector("hydro_ventilation") << [this, &scratchmap, &randomReservoirLevel]
             { hydroManagement.makeVentilation(randomReservoirLevel.data(), y, scratchmap); };
 
             // Updating the state
+            auto& state = states[numSpace];
             state.year = y;
 
             // 5 - Resetting all variables for the output
@@ -1016,20 +1017,20 @@ void ISimulation<ImplementationType>::loopThroughYears(uint firstYear,
             // continue;
 
             auto task = std::make_shared<yearJob<ImplementationType>>(
-              this,
-              y,
-              batch.yearFailed,
-              batch.isFirstPerformedYearOfASet,
-              pFirstSetParallelWithAPerformedYearWasRun,
-              numSpace,
-              randomForParallelYears,
-              performCalculations,
-              study,
-              state[numSpace],
-              pYearByYear,
-              pDurationCollector,
-              pResultWriter,
-              simulationObserver_.get());
+                    this,
+                    y,
+                    batch.yearFailed,
+                    batch.isFirstPerformedYearOfASet,
+                    pFirstSetParallelWithAPerformedYearWasRun,
+                    numSpace,
+                    randomForParallelYears,
+                    performCalculations,
+                    study,
+                    state,
+                    pYearByYear,
+                    pDurationCollector,
+                    pResultWriter,
+                    simulationObserver_.get());
             results.add(Concurrency::AddTask(*pQueueService, task));
         } // End loop over years of the current set of parallel years
 

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -1017,20 +1017,20 @@ void ISimulation<ImplementationType>::loopThroughYears(uint firstYear,
             // continue;
 
             auto task = std::make_shared<yearJob<ImplementationType>>(
-                    this,
-                    y,
-                    batch.yearFailed,
-                    batch.isFirstPerformedYearOfASet,
-                    pFirstSetParallelWithAPerformedYearWasRun,
-                    numSpace,
-                    randomForParallelYears,
-                    performCalculations,
-                    study,
-                    state,
-                    pYearByYear,
-                    pDurationCollector,
-                    pResultWriter,
-                    simulationObserver_.get());
+              this,
+              y,
+              batch.yearFailed,
+              batch.isFirstPerformedYearOfASet,
+              pFirstSetParallelWithAPerformedYearWasRun,
+              numSpace,
+              randomForParallelYears,
+              performCalculations,
+              study,
+              state,
+              pYearByYear,
+              pDurationCollector,
+              pResultWriter,
+              simulationObserver_.get());
             results.add(Concurrency::AddTask(*pQueueService, task));
         } // End loop over years of the current set of parallel years
 

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -72,7 +72,6 @@ public:
         simulationObserver_(simulationObserver),
         hydroManagement(study.areas, study.parameters, study.calendar, resultWriter)
     {
-        // scratchmap = study.areas.buildScratchMap(numSpace);
     }
 
     yearJob(const yearJob&) = delete;
@@ -95,7 +94,6 @@ private:
     IResultWriter& pResultWriter;
     std::reference_wrapper<ISimulationObserver> simulationObserver_;
     HydroManagement hydroManagement;
-    // Antares::Data::Area::ScratchMap scratchmap;
 
 private:
     /*


### PR DESCRIPTION
Sometimes, a unit test from **simple-study.cpp** won't pass. 
This test is named **two_MC_years__thermal_cluster_fullfills_area_demand_on_2nd_year_as_well**.

**Cause** : 
when executing code (see **solver.hxx**) : 
```c++
auto task = std::make_shared<yearJob<ImplementationType>>(
        ...
        y,
        ...
        numSpace,
        ...
        state[numSpace],
        ...);
```
When a year **y** is inactive in the playlist, variable **numSpace** is 99999, and `state[numSpace]` is undefined.

**More thoughts** : 
- this crash was first introduced in PR #2128 
- Associated commit : **be3301cdb3b2b7ed232db72e68a874c353d51609**
- It's unclear why we did not catch this crash sooner. Test **two_MC_years__thermal_cluster_fullfills_area_demand_on_2nd_year_as_well** should have failed already.
  Anyway, it fails at every run on **Windows** and in **debug** mode

