### PR TITLE
Call to solver : trial for simplification

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -257,7 +257,7 @@ jobs:
           os: ${{ env.os }}
 
       - name: Run parallel tests
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}
@@ -275,7 +275,7 @@ jobs:
           variant: "tsgenerator"
 
       - name: Run medium-tests
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}
@@ -288,7 +288,7 @@ jobs:
           feature: "features/medium_tests.feature"
 
       - name: Run long-tests-1
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}
@@ -296,7 +296,7 @@ jobs:
           os: ${{ env.os }}
 
       - name: Run long-tests-2
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}
@@ -304,7 +304,7 @@ jobs:
           os: ${{ env.os }}
 
       - name: Run long-tests-3
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -150,14 +150,14 @@ jobs:
         run: |
           git submodule update --init --remote --recursive src/tests/resources/Antares_Simulator_Tests_NR
 
-      - name: Run named mps tests
-        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
-        uses: ./.github/workflows/run-tests
-        with:
-          simtest-tag: ${{ env.SIMTEST }}
-          batch-name: valid-named-mps
-          os: ${{ env.os }}
-          variant: "named-mps"
+    #- name: Run named mps tests
+    #  if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+    #  uses: ./.github/workflows/run-tests
+    #  with:
+    #    simtest-tag: ${{ env.SIMTEST }}
+    #    batch-name: valid-named-mps
+    #    os: ${{ env.os }}
+    #    variant: "named-mps"
 
       - name: Run unfeasibility-related tests
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
@@ -240,13 +240,13 @@ jobs:
         with:
           feature: "features/short_tests.feature"
 
-      - name: Run mps tests
-        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
-        uses: ./.github/workflows/run-tests
-        with:
-          simtest-tag: ${{ env.SIMTEST }}
-          batch-name: valid-mps
-          os: ${{ env.os }}
+      # - name: Run mps tests
+      #   if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+      #   uses: ./.github/workflows/run-tests
+      #   with:
+      #     simtest-tag: ${{ env.SIMTEST }}
+      #     batch-name: valid-mps
+      #     os: ${{ env.os }}
 
       - name: Run tests for adequacy patch (CSR)
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -259,7 +259,7 @@ jobs:
       #     os: ${{ env.os }}
 
       - name: Run parallel tests
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}
@@ -277,7 +277,7 @@ jobs:
           variant: "tsgenerator"
 
       - name: Run medium-tests
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}
@@ -290,7 +290,7 @@ jobs:
           feature: "features/medium_tests.feature"
 
       - name: Run long-tests-1
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}
@@ -298,7 +298,7 @@ jobs:
           os: ${{ env.os }}
 
       - name: Run long-tests-2
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}
@@ -306,7 +306,7 @@ jobs:
           os: ${{ env.os }}
 
       - name: Run long-tests-3
-        if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         uses: ./.github/workflows/run-tests
         with:
           simtest-tag: ${{ env.SIMTEST }}

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -110,6 +110,14 @@ jobs:
       - name: Install pip dependencies if necessary
         run: pip install -r src/tests/examples/requirements.txt
 
+      - name: Init submodule Antares_Simulator_Tests
+        run: |
+          git submodule update --init --remote src/tests/resources/Antares_Simulator_Tests
+
+      - name: Init submodule Antares_Simulator_Tests_NR
+        run: |
+          git submodule update --init --remote src/tests/resources/Antares_Simulator_Tests_NR
+
       - name: Enable git longpaths
         run: git config --system core.longpaths true
 
@@ -144,22 +152,14 @@ jobs:
         run: |
           echo "SIMTEST=${{ fromJson(env.SIMTEST_JSON).version }}" >> $GITHUB_ENV
 
-      - name: Init submodule Antares_Simulator_Tests
-        run: |
-          git submodule update --init --remote src/tests/resources/Antares_Simulator_Tests
-
-      - name: Init submodule Antares_Simulator_Tests_NR
-        run: |
-          git submodule update --init --remote src/tests/resources/Antares_Simulator_Tests_NR
-
-      - name: Run named mps tests
-        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && ! cancelled() }}
-        uses: ./.github/workflows/run-tests
-        with:
-          simtest-tag: ${{ env.SIMTEST }}
-          batch-name: valid-named-mps
-          os: ${{ env.os }}
-          variant: "named-mps"
+      # - name: Run named mps tests
+      #   if: ${{ env.RUN_SIMPLE_TESTS == 'true' && ! cancelled() }}
+      #   uses: ./.github/workflows/run-tests
+      #   with:
+      #     simtest-tag: ${{ env.SIMTEST }}
+      #     batch-name: valid-named-mps
+      #     os: ${{ env.os }}
+      #     variant: "named-mps"
 
       - name: Run unfeasibility-related tests
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && ! cancelled() }}
@@ -250,13 +250,13 @@ jobs:
         with:
           feature: "features/short_tests.feature"
 
-      - name: Run mps tests
-        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
-        uses: ./.github/workflows/run-tests
-        with:
-          simtest-tag: ${{ env.SIMTEST }}
-          batch-name: valid-mps
-          os: ${{ env.os }}
+      # - name: Run mps tests
+      #   if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+      #   uses: ./.github/workflows/run-tests
+      #   with:
+      #     simtest-tag: ${{ env.SIMTEST }}
+      #     batch-name: valid-mps
+      #     os: ${{ env.os }}
 
       - name: Run parallel tests
         if: ${{ env.RUN_EXTENDED_TESTS == 'true' && !cancelled() }}

--- a/src/libs/antares/InfoCollection/StudyInfoCollector.cpp
+++ b/src/libs/antares/InfoCollection/StudyInfoCollector.cpp
@@ -45,7 +45,6 @@ void StudyInfoCollector::toFileContent(FileContent& file_content)
     unitCommitmentModeToFileContent(file_content);
     maxNbYearsInParallelToFileContent(file_content);
     solverVersionToFileContent(file_content);
-    ORToolsUsed(file_content);
     ORToolsSolver(file_content);
 }
 
@@ -144,21 +143,10 @@ void StudyInfoCollector::solverVersionToFileContent(FileContent& file_content)
     file_content.addItemToSection("study", "antares version", version);
 }
 
-void StudyInfoCollector::ORToolsUsed(FileContent& file_content)
-{
-    const bool& ortoolsUsed = study_.parameters.optOptions.ortoolsUsed;
-    file_content.addItemToSection("study", "ortools used", ortoolsUsed ? "true" : "false");
-}
-
 void StudyInfoCollector::ORToolsSolver(FileContent& file_content)
 {
-    const bool& ortoolsUsed = study_.parameters.optOptions.ortoolsUsed;
-    std::string ortoolsSolver = "none";
-    if (ortoolsUsed)
-    {
-        ortoolsSolver = study_.parameters.optOptions.ortoolsSolver;
-    }
-    file_content.addItemToSection("study", "ortools solver", ortoolsSolver);
+    std::string solverName = study_.parameters.optOptions.ortoolsSolver;
+    file_content.addItemToSection("study", "ortools solver", solverName);
 }
 
 // Collecting data optimization problem

--- a/src/libs/antares/InfoCollection/include/antares/infoCollection/StudyInfoCollector.h
+++ b/src/libs/antares/InfoCollection/include/antares/infoCollection/StudyInfoCollector.h
@@ -51,7 +51,6 @@ private:
     void maxNbYearsInParallelToFileContent(FileContent& file_content);
     void solverVersionToFileContent(FileContent& file_content);
 
-    void ORToolsUsed(FileContent& file_content);
     void ORToolsSolver(FileContent& file_content);
 
     // Member data

--- a/src/libs/antares/checks/checkLoadedInputData.cpp
+++ b/src/libs/antares/checks/checkLoadedInputData.cpp
@@ -29,8 +29,7 @@
 
 namespace Antares::Check
 {
-void checkOrtoolsUsage(Antares::Data::UnitCommitmentMode ucMode,
-                       const std::string& solverName)
+void checkOrtoolsUsage(Antares::Data::UnitCommitmentMode ucMode, const std::string& solverName)
 {
     using namespace Antares::Data;
     if (ucMode == UnitCommitmentMode::ucMILP && solverName == "sirius")

--- a/src/libs/antares/checks/checkLoadedInputData.cpp
+++ b/src/libs/antares/checks/checkLoadedInputData.cpp
@@ -30,21 +30,12 @@
 namespace Antares::Check
 {
 void checkOrtoolsUsage(Antares::Data::UnitCommitmentMode ucMode,
-                       bool ortoolsUsed,
                        const std::string& solverName)
 {
     using namespace Antares::Data;
-    if (ucMode == UnitCommitmentMode::ucMILP)
+    if (ucMode == UnitCommitmentMode::ucMILP && solverName == "sirius")
     {
-        if (!ortoolsUsed)
-        {
-            throw Error::IncompatibleMILPWithoutOrtools();
-        }
-
-        if (solverName == "sirius")
-        {
-            throw Error::IncompatibleMILPOrtoolsSolver();
-        }
+        throw Error::IncompatibleMILPOrtoolsSolver();
     }
 }
 

--- a/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
+++ b/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
@@ -24,8 +24,7 @@
 namespace Antares::Check
 {
 
-void checkOrtoolsUsage(Antares::Data::UnitCommitmentMode ucMode,
-                       const std::string& solverName);
+void checkOrtoolsUsage(Antares::Data::UnitCommitmentMode ucMode, const std::string& solverName);
 
 void checkStudyVersion(const AnyString& optStudyFolder);
 

--- a/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
+++ b/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
@@ -25,7 +25,6 @@ namespace Antares::Check
 {
 
 void checkOrtoolsUsage(Antares::Data::UnitCommitmentMode ucMode,
-                       bool ortoolsUsed,
                        const std::string& solverName);
 
 void checkStudyVersion(const AnyString& optStudyFolder);

--- a/src/libs/antares/optimization-options/include/antares/optimization-options/options.h
+++ b/src/libs/antares/optimization-options/include/antares/optimization-options/options.h
@@ -27,8 +27,6 @@ namespace Antares::Solver::Optimization
 
 struct OptimizationOptions
 {
-    //! Force ortools use
-    bool ortoolsUsed = false;
     //! The solver name, sirius is the default
     std::string ortoolsSolver = "sirius";
     bool solverLogs = false;

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1729,7 +1729,8 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
         logs.info() << "  :: ignoring hurdle costs";
     }
 
-    logs.info() << "  :: solver " << options.optOptions.ortoolsSolver << " is used for problem resolution";
+    logs.info() << "  :: solver " << options.optOptions.ortoolsSolver
+                << " is used for problem resolution";
 
     // indicated that Problems will be named
     if (namedProblems)

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -1230,7 +1230,6 @@ bool Parameters::loadFromINI(const IniFile& ini, const StudyVersion& version)
 void Parameters::handleOptimizationOptions(const StudyLoadOptions& options)
 {
     // Options only set from the command-line
-    optOptions.ortoolsUsed = options.optOptions.ortoolsUsed;
     optOptions.ortoolsSolver = options.optOptions.ortoolsSolver;
     optOptions.solverParameters = options.optOptions.solverParameters;
 
@@ -1730,12 +1729,7 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
         logs.info() << "  :: ignoring hurdle costs";
     }
 
-    // Indicate ortools solver used
-    if (options.optOptions.ortoolsUsed)
-    {
-        logs.info() << "  :: ortools solver " << options.optOptions.ortoolsSolver
-                    << " used for problem resolution";
-    }
+    logs.info() << "  :: solver " << options.optOptions.ortoolsSolver << " is used for problem resolution";
 
     // indicated that Problems will be named
     if (namedProblems)

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -277,8 +277,7 @@ void Application::startSimulation(Data::StudyLoadOptions& options)
 void Application::postParametersChecks() const
 { // Some more checks require the existence of pParameters, hence of a study.
     // Their execution is delayed up to this point.
-    checkOrtoolsUsage(pParameters->unitCommitment.ucMode,
-                      pParameters->optOptions.ortoolsSolver);
+    checkOrtoolsUsage(pParameters->unitCommitment.ucMode, pParameters->optOptions.ortoolsSolver);
 
     checkSimplexRangeHydroPricing(pParameters->simplexOptimizationRange,
                                   pParameters->hydroPricing.hpMode);

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -278,7 +278,6 @@ void Application::postParametersChecks() const
 { // Some more checks require the existence of pParameters, hence of a study.
     // Their execution is delayed up to this point.
     checkOrtoolsUsage(pParameters->unitCommitment.ucMode,
-                      pParameters->optOptions.ortoolsUsed,
                       pParameters->optOptions.ortoolsSolver);
 
     checkSimplexRangeHydroPricing(pParameters->simplexOptimizationRange,

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -76,19 +76,11 @@ std::unique_ptr<Yuni::GetOpt::Parser> CreateParser(Settings& settings, StudyLoad
                 "force-parallel",
                 "Override the max number of years computed simultaneously");
 
-    // add option for ortools use
-    // --use-ortools
-    parser->addFlag(options.optOptions.ortoolsUsed,
-                    ' ',
-                    "use-ortools",
-                    "Use ortools library to launch solver");
-
     //--ortools-solver
     parser->add(options.optOptions.ortoolsSolver,
                 ' ',
-                "ortools-solver",
-                "Ortools solver used for simulation (only available with use-ortools "
-                "option)\nAvailable solver list : "
+                "solver",
+                "Solver used for simulation\nAvailable solver list : "
                   + availableOrToolsSolversString());
 
     //--xpress-parameters
@@ -266,18 +258,15 @@ void checkAndCorrectSettingsAndOptions(Settings& settings, Data::StudyLoadOption
 
 void checkOrtoolsSolver(const Antares::Solver::Optimization::OptimizationOptions& optOptions)
 {
-    if (optOptions.ortoolsUsed)
-    {
-        const std::string& solverName = optOptions.ortoolsSolver;
-        const std::list<std::string> availableSolverList = getAvailableOrtoolsSolverName();
+    const std::string& solverName = optOptions.ortoolsSolver;
+    const std::list<std::string> availableSolverList = getAvailableOrtoolsSolverName();
 
-        // Check if solver is available
-        bool found = (std::find(availableSolverList.begin(), availableSolverList.end(), solverName)
-                      != availableSolverList.end());
-        if (!found)
-        {
-            throw Error::InvalidSolver(optOptions.ortoolsSolver, availableOrToolsSolversString());
-        }
+    // Check if solver is available
+    bool found = (std::find(availableSolverList.begin(), availableSolverList.end(), solverName)
+                  != availableSolverList.end());
+    if (!found)
+    {
+        throw Error::InvalidSolver(optOptions.ortoolsSolver, availableOrToolsSolversString());
     }
 }
 

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_structure_probleme_a_resoudre.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_structure_probleme_a_resoudre.h
@@ -107,9 +107,6 @@ struct PROBLEME_ANTARES_A_RESOUDRE
     std::vector<std::string> NomDesContraintes;
 
     std::vector<bool> VariablesEntieres; // true = int, false = continuous
-
-    // PIMPL is used to break dependency to OR-Tools' linear_solver.h (big header)
-    Antares::Optimization::BasisStatus basisStatus;
 };
 
 #endif /* __SOLVER_OPTIMISATION_STRUCTURE_PROBLEME_A_RESOUDRE_H__ */

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_structure_probleme_a_resoudre.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_structure_probleme_a_resoudre.h
@@ -29,6 +29,7 @@
 
 #include "opt_constants.h"
 
+using namespace operations_research;
 /*--------------------------------------------------------------------------------------*/
 
 /* Le probleme a resoudre */
@@ -90,7 +91,7 @@ struct PROBLEME_ANTARES_A_RESOUDRE
                                   matrice de base reguliere, et dans ce cas il n'y a pas de solution
                                 */
 
-    std::vector<void*> ProblemesSpx;
+    std::vector<MPSolver*> ProblemesSpx;
 
     std::vector<int>
       PositionDeLaVariable; /* Vecteur a passer au Simplexe pour recuperer la base optimale */

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -91,10 +91,6 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     assert(opt >= 0 && opt < 2);
     OptimizationStatistics& optimizationStatistics = problemeHebdo->optimizationStatistics[opt];
     TIME_MEASURE timeMeasure;
-    if (!PremierPassage)
-    {
-        solver = nullptr;
-    }
 
     if (solver == nullptr)
     {
@@ -105,14 +101,11 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     {
         if (problemeHebdo->ReinitOptimisation)
         {
-            if (solver != nullptr)
-            {
-                ORTOOLS_LibererProbleme(solver);
-            }
+
+            ORTOOLS_LibererProbleme(solver);
 
             ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
 
-            solver = nullptr;
             Probleme.Contexte = SIMPLEXE_SEUL;
             Probleme.BaseDeDepartFournie = NON_SPX;
         }
@@ -184,7 +177,11 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
 
     Probleme.NombreDeContraintesCoupes = 0;
 
-    solver = ORTOOLS_ConvertIfNeeded(options.ortoolsSolver, &Probleme, solver);
+    if (solver == nullptr)
+    {
+        solver = ORTOOLS_Convert(options.ortoolsSolver, &Probleme);
+    }
+
     const std::string filename = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
 
     mpsWriterFactory mps_writer_factory(problemeHebdo->ExportMPS,

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -97,8 +97,6 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
         if (problemeHebdo->ReinitOptimisation)
         {
             solver = ORTOOLS_LibererProbleme(solver);
-            Probleme.Contexte = SIMPLEXE_SEUL;
-            Probleme.BaseDeDepartFournie = NON_SPX;
         }
         else
         {
@@ -170,6 +168,8 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
 
     if (solver == nullptr)
     {
+        Probleme.Contexte = SIMPLEXE_SEUL;
+        Probleme.BaseDeDepartFournie = NON_SPX;
         solver = ORTOOLS_Convert(options.ortoolsSolver, &Probleme);
     }
 
@@ -199,8 +199,6 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
         if (ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE)
         {
             solver = ORTOOLS_LibererProbleme(solver);
-            Probleme.Contexte = SIMPLEXE_SEUL;
-            Probleme.BaseDeDepartFournie = NON_SPX;
 
             logs.info() << " Solver: Standard resolution failed";
             logs.info() << " Solver: Retry in safe mode"; // second trial w/o scaling

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -211,10 +211,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     {
         if (ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE)
         {
-            if (solver != nullptr)
-            {
-                ORTOOLS_LibererProbleme(solver);
-            }
+            ORTOOLS_LibererProbleme(solver);
 
             logs.info() << " Solver: Standard resolution failed";
             logs.info() << " Solver: Retry in safe mode"; // second trial w/o scaling

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -212,6 +212,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
         if (ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE)
         {
             ORTOOLS_LibererProbleme(solver);
+            ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
 
             logs.info() << " Solver: Standard resolution failed";
             logs.info() << " Solver: Retry in safe mode"; // second trial w/o scaling

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -196,23 +196,15 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     ProblemeAResoudre->ExistenceDUneSolution = Probleme.ExistenceDUneSolution;
     if (ProblemeAResoudre->ExistenceDUneSolution != OUI_SPX && PremierPassage)
     {
-        if (ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE)
-        {
-            solver = ORTOOLS_LibererProbleme(solver);
+        solver = ORTOOLS_LibererProbleme(solver);
 
-            logs.info() << " Solver: Standard resolution failed";
-            logs.info() << " Solver: Retry in safe mode"; // second trial w/o scaling
-            logs.debug() << " solver: resetting";
+        logs.info() << " Solver: Standard resolution failed";
+        logs.info() << " Solver: Retry in safe mode"; // second trial w/o scaling
+        logs.debug() << " solver: resetting";
 
-            return {.success = false,
-                    .timeMeasure = timeMeasure,
-                    .mps_writer_factory = mps_writer_factory};
-        }
-
-        else
-        {
-            throw FatalError("Internal error: insufficient memory");
-        }
+        return {.success = false,
+                .timeMeasure = timeMeasure,
+                .mps_writer_factory = mps_writer_factory};
     }
     return {.success = true, .timeMeasure = timeMeasure, .mps_writer_factory = mps_writer_factory};
 }

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -85,7 +85,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
                                           IResultWriter& writer)
 {
     const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
-    auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[NumIntervalle]);
+    MPSolver*& solver = ProblemeAResoudre->ProblemesSpx[NumIntervalle];
 
     const int opt = optimizationNumber - 1;
     assert(opt >= 0 && opt < 2);
@@ -97,7 +97,6 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
         if (problemeHebdo->ReinitOptimisation)
         {
             solver = ORTOOLS_LibererProbleme(solver);
-            ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
             Probleme.Contexte = SIMPLEXE_SEUL;
             Probleme.BaseDeDepartFournie = NON_SPX;
         }
@@ -189,10 +188,6 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
 
     const bool keepBasis = (optimizationNumber == PREMIERE_OPTIMISATION);
     solver = ORTOOLS_Simplexe(&Probleme, solver, keepBasis, options);
-    if (solver != nullptr)
-    {
-        ProblemeAResoudre->ProblemesSpx[NumIntervalle] = (void*)solver;
-    }
 
     measure.tick();
     timeMeasure.solveTime = measure.duration_ms();
@@ -204,7 +199,6 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
         if (ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE)
         {
             solver = ORTOOLS_LibererProbleme(solver);
-            ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
             Probleme.Contexte = SIMPLEXE_SEUL;
             Probleme.BaseDeDepartFournie = NON_SPX;
 

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -102,8 +102,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
         if (problemeHebdo->ReinitOptimisation)
         {
 
-            ORTOOLS_LibererProbleme(solver);
-
+            solver = ORTOOLS_LibererProbleme(solver);
             ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
 
             Probleme.Contexte = SIMPLEXE_SEUL;
@@ -211,7 +210,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     {
         if (ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE)
         {
-            ORTOOLS_LibererProbleme(solver);
+            solver = ORTOOLS_LibererProbleme(solver);
             ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
 
             logs.info() << " Solver: Standard resolution failed";

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -92,19 +92,12 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     OptimizationStatistics& optimizationStatistics = problemeHebdo->optimizationStatistics[opt];
     TIME_MEASURE timeMeasure;
 
-    if (solver == nullptr)
-    {
-        Probleme.Contexte = SIMPLEXE_SEUL;
-        Probleme.BaseDeDepartFournie = NON_SPX;
-    }
-    else
+    if (solver != nullptr)
     {
         if (problemeHebdo->ReinitOptimisation)
         {
-
             solver = ORTOOLS_LibererProbleme(solver);
             ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
-
             Probleme.Contexte = SIMPLEXE_SEUL;
             Probleme.BaseDeDepartFournie = NON_SPX;
         }
@@ -212,6 +205,8 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
         {
             solver = ORTOOLS_LibererProbleme(solver);
             ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
+            Probleme.Contexte = SIMPLEXE_SEUL;
+            Probleme.BaseDeDepartFournie = NON_SPX;
 
             logs.info() << " Solver: Standard resolution failed";
             logs.info() << " Solver: Retry in safe mode"; // second trial w/o scaling

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -228,7 +228,6 @@ bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
     Optimization::PROBLEME_SIMPLEXE_NOMME Probleme(ProblemeAResoudre->NomDesVariables,
                                                    ProblemeAResoudre->NomDesContraintes,
                                                    ProblemeAResoudre->VariablesEntieres,
-                                                   ProblemeAResoudre->basisStatus,
                                                    problemeHebdo->NamedProblems,
                                                    options.solverLogs);
 

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -123,17 +123,18 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
 
             TimeMeasurement updateMeasure;
 
-            ORTOOLS_ModifierLeVecteurCouts(
-                solver, ProblemeAResoudre->CoutLineaire.data(), ProblemeAResoudre->NombreDeVariables);
+            ORTOOLS_ModifierLeVecteurCouts(solver,
+                                           ProblemeAResoudre->CoutLineaire.data(),
+                                           ProblemeAResoudre->NombreDeVariables);
             ORTOOLS_ModifierLeVecteurSecondMembre(solver,
-                                                    ProblemeAResoudre->SecondMembre.data(),
-                                                    ProblemeAResoudre->Sens.data(),
-                                                    ProblemeAResoudre->NombreDeContraintes);
+                                                  ProblemeAResoudre->SecondMembre.data(),
+                                                  ProblemeAResoudre->Sens.data(),
+                                                  ProblemeAResoudre->NombreDeContraintes);
             ORTOOLS_CorrigerLesBornes(solver,
-                                        ProblemeAResoudre->Xmin.data(),
-                                        ProblemeAResoudre->Xmax.data(),
-                                        ProblemeAResoudre->TypeDeVariable.data(),
-                                        ProblemeAResoudre->NombreDeVariables);
+                                      ProblemeAResoudre->Xmin.data(),
+                                      ProblemeAResoudre->Xmax.data(),
+                                      ProblemeAResoudre->TypeDeVariable.data(),
+                                      ProblemeAResoudre->NombreDeVariables);
 
             updateMeasure.tick();
             timeMeasure.updateTime = updateMeasure.duration_ms();

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -85,8 +85,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
                                           IResultWriter& writer)
 {
     const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
-    auto ProbSpx = (PROBLEME_SPX*)(ProblemeAResoudre->ProblemesSpx[(int)NumIntervalle]);
-    auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[(int)NumIntervalle]);
+    auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[NumIntervalle]);
 
     const int opt = optimizationNumber - 1;
     assert(opt >= 0 && opt < 2);
@@ -94,11 +93,10 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     TIME_MEASURE timeMeasure;
     if (!PremierPassage)
     {
-        ProbSpx = nullptr;
         solver = nullptr;
     }
 
-    if (ProbSpx == nullptr && solver == nullptr)
+    if (solver == nullptr)
     {
         Probleme.Contexte = SIMPLEXE_SEUL;
         Probleme.BaseDeDepartFournie = NON_SPX;
@@ -107,17 +105,13 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     {
         if (problemeHebdo->ReinitOptimisation)
         {
-            if (options.ortoolsUsed && solver)
+            if (solver != nullptr)
             {
                 ORTOOLS_LibererProbleme(solver);
             }
-            else if (ProbSpx != nullptr)
-            {
-                SPX_LibererProbleme(ProbSpx);
-            }
+
             ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
 
-            ProbSpx = nullptr;
             solver = nullptr;
             Probleme.Contexte = SIMPLEXE_SEUL;
             Probleme.BaseDeDepartFournie = NON_SPX;
@@ -128,31 +122,19 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
             Probleme.BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
 
             TimeMeasurement updateMeasure;
-            if (options.ortoolsUsed)
-            {
-                ORTOOLS_ModifierLeVecteurCouts(solver,
-                                               ProblemeAResoudre->CoutLineaire.data(),
-                                               ProblemeAResoudre->NombreDeVariables);
-                ORTOOLS_ModifierLeVecteurSecondMembre(solver,
-                                                      ProblemeAResoudre->SecondMembre.data(),
-                                                      ProblemeAResoudre->Sens.data(),
-                                                      ProblemeAResoudre->NombreDeContraintes);
-                ORTOOLS_CorrigerLesBornes(solver,
-                                          ProblemeAResoudre->Xmin.data(),
-                                          ProblemeAResoudre->Xmax.data(),
-                                          ProblemeAResoudre->TypeDeVariable.data(),
-                                          ProblemeAResoudre->NombreDeVariables);
-            }
-            else
-            {
-                SPX_ModifierLeVecteurCouts(ProbSpx,
-                                           ProblemeAResoudre->CoutLineaire.data(),
-                                           ProblemeAResoudre->NombreDeVariables);
-                SPX_ModifierLeVecteurSecondMembre(ProbSpx,
-                                                  ProblemeAResoudre->SecondMembre.data(),
-                                                  ProblemeAResoudre->Sens.data(),
-                                                  ProblemeAResoudre->NombreDeContraintes);
-            }
+
+            ORTOOLS_ModifierLeVecteurCouts(
+                solver, ProblemeAResoudre->CoutLineaire.data(), ProblemeAResoudre->NombreDeVariables);
+            ORTOOLS_ModifierLeVecteurSecondMembre(solver,
+                                                    ProblemeAResoudre->SecondMembre.data(),
+                                                    ProblemeAResoudre->Sens.data(),
+                                                    ProblemeAResoudre->NombreDeContraintes);
+            ORTOOLS_CorrigerLesBornes(solver,
+                                        ProblemeAResoudre->Xmin.data(),
+                                        ProblemeAResoudre->Xmax.data(),
+                                        ProblemeAResoudre->TypeDeVariable.data(),
+                                        ProblemeAResoudre->NombreDeVariables);
+
             updateMeasure.tick();
             timeMeasure.updateTime = updateMeasure.duration_ms();
             optimizationStatistics.addUpdateTime(timeMeasure.updateTime);
@@ -201,40 +183,27 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
 
     Probleme.NombreDeContraintesCoupes = 0;
 
-    if (options.ortoolsUsed)
-    {
-        solver = ORTOOLS_ConvertIfNeeded(options.ortoolsSolver, &Probleme, solver);
-    }
+    solver = ORTOOLS_ConvertIfNeeded(options.ortoolsSolver, &Probleme, solver);
     const std::string filename = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
 
     mpsWriterFactory mps_writer_factory(problemeHebdo->ExportMPS,
                                         problemeHebdo->exportMPSOnError,
                                         optimizationNumber,
                                         &Probleme,
-                                        options.ortoolsUsed,
                                         solver);
 
     auto mps_writer = mps_writer_factory.create();
     mps_writer->runIfNeeded(writer, filename);
 
     TimeMeasurement measure;
-    if (options.ortoolsUsed)
+
+    const bool keepBasis = (optimizationNumber == PREMIERE_OPTIMISATION);
+    solver = ORTOOLS_Simplexe(&Probleme, solver, keepBasis, options);
+    if (solver != nullptr)
     {
-        const bool keepBasis = (optimizationNumber == PREMIERE_OPTIMISATION);
-        solver = ORTOOLS_Simplexe(&Probleme, solver, keepBasis, options);
-        if (solver != nullptr)
-        {
-            ProblemeAResoudre->ProblemesSpx[NumIntervalle] = (void*)solver;
-        }
+        ProblemeAResoudre->ProblemesSpx[NumIntervalle] = (void*)solver;
     }
-    else
-    {
-        ProbSpx = SPX_Simplexe(&Probleme, ProbSpx);
-        if (ProbSpx != nullptr)
-        {
-            ProblemeAResoudre->ProblemesSpx[NumIntervalle] = (void*)ProbSpx;
-        }
-    }
+
     measure.tick();
     timeMeasure.solveTime = measure.duration_ms();
     optimizationStatistics.addSolveTime(timeMeasure.solveTime);
@@ -244,13 +213,9 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     {
         if (ProblemeAResoudre->ExistenceDUneSolution != SPX_ERREUR_INTERNE)
         {
-            if (options.ortoolsUsed && solver)
+            if (solver != nullptr)
             {
                 ORTOOLS_LibererProbleme(solver);
-            }
-            else if (ProbSpx != nullptr)
-            {
-                SPX_LibererProbleme(ProbSpx);
             }
 
             logs.info() << " Solver: Standard resolution failed";

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -52,18 +52,12 @@ void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options,
     {
         for (int numIntervalle = 0; numIntervalle < nbIntervalles; numIntervalle++)
         {
-            auto ProbSpx = (PROBLEME_SPX*)(ProblemeAResoudre->ProblemesSpx[numIntervalle]);
             auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[numIntervalle]);
 
-            if (options.ortoolsUsed && solver)
+            if (solver != NULL)
             {
                 ORTOOLS_LibererProbleme(solver);
                 solver = nullptr;
-            }
-            else if (ProbSpx)
-            {
-                SPX_LibererProbleme(ProbSpx);
-                ProbSpx = nullptr;
             }
         }
     }

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -56,7 +56,7 @@ void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options,
 
             if (solver != NULL)
             {
-                ORTOOLS_LibererProbleme(solver);
+                solver = ORTOOLS_LibererProbleme(solver);
             }
         }
     }

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -57,7 +57,6 @@ void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options,
             if (solver != NULL)
             {
                 ORTOOLS_LibererProbleme(solver);
-                solver = nullptr;
             }
         }
     }

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -52,7 +52,7 @@ void OPT_LiberationProblemesSimplexe(const OptimizationOptions& options,
     {
         for (int numIntervalle = 0; numIntervalle < nbIntervalles; numIntervalle++)
         {
-            auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[numIntervalle]);
+            MPSolver*& solver = ProblemeAResoudre->ProblemesSpx[numIntervalle];
 
             if (solver != NULL)
             {

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -51,7 +51,7 @@ public:
             randomNumbers& pRandomForParallelYears,
             bool pPerformCalculations,
             Data::Study& pStudy,
-            Variable::State& pState,
+            std::vector<Variable::State>& pStates,
             bool pYearByYear,
             Benchmarking::DurationCollector& durationCollector,
             IResultWriter& resultWriter,
@@ -65,14 +65,13 @@ public:
         randomForParallelYears(pRandomForParallelYears),
         performCalculations(pPerformCalculations),
         study(pStudy),
-        state(pState),
+        states(pStates),
         yearByYear(pYearByYear),
         pDurationCollector(durationCollector),
         pResultWriter(resultWriter),
         simulationObserver_(simulationObserver),
         hydroManagement(study.areas, study.parameters, study.calendar, resultWriter)
     {
-        scratchmap = study.areas.buildScratchMap(numSpace);
     }
 
     yearJob(const yearJob&) = delete;
@@ -89,13 +88,12 @@ private:
     randomNumbers& randomForParallelYears;
     bool performCalculations;
     Data::Study& study;
-    Variable::State& state;
+    std::vector<Variable::State>& states;
     bool yearByYear;
     Benchmarking::DurationCollector& pDurationCollector;
     IResultWriter& pResultWriter;
     std::reference_wrapper<ISimulationObserver> simulationObserver_;
     HydroManagement hydroManagement;
-    Antares::Data::Area::ScratchMap scratchmap;
 
 private:
     /*
@@ -147,17 +145,18 @@ public:
             // 1 - Applying random levels for current year
             auto randomReservoirLevel = randomForCurrentYear.pReservoirLevels;
 
-            // 2 - Preparing the Time-series numbers
-            // removed
+            // Getting the scratchMap associated to the current year
+            Antares::Data::Area::ScratchMap scratchmap = study.areas.buildScratchMap(numSpace);
 
             // 3 - Preparing data related to Clusters in 'must-run' mode
             simulation_->prepareClustersInMustRunMode(scratchmap, y);
 
             // 4 - Hydraulic ventilation
-            pDurationCollector("hydro_ventilation") << [this, &randomReservoirLevel]
+            pDurationCollector("hydro_ventilation") << [this, &scratchmap, &randomReservoirLevel]
             { hydroManagement.makeVentilation(randomReservoirLevel.data(), y, scratchmap); };
 
             // Updating the state
+            auto& state = states[numSpace];
             state.year = y;
 
             // 5 - Resetting all variables for the output
@@ -1016,20 +1015,20 @@ void ISimulation<ImplementationType>::loopThroughYears(uint firstYear,
             // continue;
 
             auto task = std::make_shared<yearJob<ImplementationType>>(
-              this,
-              y,
-              batch.yearFailed,
-              batch.isFirstPerformedYearOfASet,
-              pFirstSetParallelWithAPerformedYearWasRun,
-              numSpace,
-              randomForParallelYears,
-              performCalculations,
-              study,
-              state[numSpace],
-              pYearByYear,
-              pDurationCollector,
-              pResultWriter,
-              simulationObserver_.get());
+                    this,
+                    y,
+                    batch.yearFailed,
+                    batch.isFirstPerformedYearOfASet,
+                    pFirstSetParallelWithAPerformedYearWasRun,
+                    numSpace,
+                    randomForParallelYears,
+                    performCalculations,
+                    study,
+                    state,
+                    pYearByYear,
+                    pDurationCollector,
+                    pResultWriter,
+                    simulationObserver_.get());
             results.add(Concurrency::AddTask(*pQueueService, task));
         } // End loop over years of the current set of parallel years
 

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -1015,20 +1015,20 @@ void ISimulation<ImplementationType>::loopThroughYears(uint firstYear,
             // continue;
 
             auto task = std::make_shared<yearJob<ImplementationType>>(
-                    this,
-                    y,
-                    batch.yearFailed,
-                    batch.isFirstPerformedYearOfASet,
-                    pFirstSetParallelWithAPerformedYearWasRun,
-                    numSpace,
-                    randomForParallelYears,
-                    performCalculations,
-                    study,
-                    state,
-                    pYearByYear,
-                    pDurationCollector,
-                    pResultWriter,
-                    simulationObserver_.get());
+              this,
+              y,
+              batch.yearFailed,
+              batch.isFirstPerformedYearOfASet,
+              pFirstSetParallelWithAPerformedYearWasRun,
+              numSpace,
+              randomForParallelYears,
+              performCalculations,
+              study,
+              state,
+              pYearByYear,
+              pDurationCollector,
+              pResultWriter,
+              simulationObserver_.get());
             results.add(Concurrency::AddTask(*pQueueService, task));
         } // End loop over years of the current set of parallel years
 

--- a/src/solver/utils/include/antares/solver/utils/mps_utils.h
+++ b/src/solver/utils/include/antares/solver/utils/mps_utils.h
@@ -57,6 +57,9 @@ protected:
     uint current_optim_number_ = 0;
 };
 
+// Caution : this class should be removed if we want Sirius behind or-tools
+// But we want to keep the way we write MPS files for a named problem,
+// so we keep it for now.
 class fullMPSwriter final: public I_MPS_writer
 {
 public:
@@ -98,7 +101,6 @@ public:
                      bool exportMPSOnError,
                      const int current_optim_number,
                      PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
-                     bool ortoolsUsed,
                      MPSolver* solver);
 
     std::unique_ptr<I_MPS_writer> create();
@@ -113,7 +115,6 @@ private:
     Data::mpsExportStatus export_mps_;
     bool export_mps_on_error_;
     PROBLEME_SIMPLEXE_NOMME* named_splx_problem_ = nullptr;
-    bool ortools_used_;
     MPSolver* solver_ = nullptr;
     uint current_optim_number_;
 };

--- a/src/solver/utils/include/antares/solver/utils/named_problem.h
+++ b/src/solver/utils/include/antares/solver/utils/named_problem.h
@@ -27,6 +27,7 @@
 
 #include "spx_definition_arguments.h"
 #include "spx_fonctions.h"
+#include "basis_status.h"
 
 namespace Antares
 {
@@ -40,7 +41,6 @@ public:
     PROBLEME_SIMPLEXE_NOMME(const std::vector<std::string>& NomDesVariables,
                             const std::vector<std::string>& NomDesContraintes,
                             const std::vector<bool>& VariablesEntieres,
-                            BasisStatus& basisStatus,
                             bool UseNamedProblems,
                             bool SolverLogs);
 
@@ -51,7 +51,7 @@ private:
 
 public:
     const std::vector<bool>& VariablesEntieres;
-    BasisStatus& basisStatus;
+    BasisStatus basisStatus;
 
     bool isMIP() const;
     bool basisExists() const;

--- a/src/solver/utils/include/antares/solver/utils/ortools_wrapper.h
+++ b/src/solver/utils/include/antares/solver/utils/ortools_wrapper.h
@@ -47,6 +47,6 @@ void ORTOOLS_CorrigerLesBornes(MPSolver* ProbSpx,
                                const double* bMax,
                                const int* typeVar,
                                int nbVar);
-void ORTOOLS_LibererProbleme(MPSolver*& ProbSpx);
+MPSolver* ORTOOLS_LibererProbleme(MPSolver* ProbSpx);
 
 #endif

--- a/src/solver/utils/include/antares/solver/utils/ortools_wrapper.h
+++ b/src/solver/utils/include/antares/solver/utils/ortools_wrapper.h
@@ -34,9 +34,8 @@ MPSolver* ORTOOLS_Simplexe(Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probl
                            bool keepBasis,
                            const Antares::Solver::Optimization::OptimizationOptions& options);
 
-MPSolver* ORTOOLS_ConvertIfNeeded(const std::string& solverName,
-                                  const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme,
-                                  MPSolver* solver);
+MPSolver* ORTOOLS_Convert(const std::string& solverName,
+                          const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme);
 
 void ORTOOLS_ModifierLeVecteurCouts(MPSolver* ProbSpx, const double* costs, int nbVar);
 void ORTOOLS_ModifierLeVecteurSecondMembre(MPSolver* ProbSpx,

--- a/src/solver/utils/include/antares/solver/utils/ortools_wrapper.h
+++ b/src/solver/utils/include/antares/solver/utils/ortools_wrapper.h
@@ -47,6 +47,6 @@ void ORTOOLS_CorrigerLesBornes(MPSolver* ProbSpx,
                                const double* bMax,
                                const int* typeVar,
                                int nbVar);
-void ORTOOLS_LibererProbleme(MPSolver* ProbSpx);
+void ORTOOLS_LibererProbleme(MPSolver*& ProbSpx);
 
 #endif

--- a/src/solver/utils/mps_utils.cpp
+++ b/src/solver/utils/mps_utils.cpp
@@ -163,12 +163,10 @@ mpsWriterFactory::mpsWriterFactory(Data::mpsExportStatus exportMPS,
                                    bool exportMPSOnError,
                                    const int current_optim_number,
                                    PROBLEME_SIMPLEXE_NOMME* named_splx_problem,
-                                   bool ortoolsUsed,
                                    MPSolver* solver):
     export_mps_(exportMPS),
     export_mps_on_error_(exportMPSOnError),
     named_splx_problem_(named_splx_problem),
-    ortools_used_(ortoolsUsed),
     solver_(solver),
     current_optim_number_(current_optim_number)
 {
@@ -211,12 +209,5 @@ std::unique_ptr<I_MPS_writer> mpsWriterFactory::createOnOptimizationError()
 
 std::unique_ptr<I_MPS_writer> mpsWriterFactory::createFullmpsWriter()
 {
-    if (ortools_used_)
-    {
-        return std::make_unique<fullOrToolsMPSwriter>(solver_, current_optim_number_);
-    }
-    else
-    {
-        return std::make_unique<fullMPSwriter>(named_splx_problem_, current_optim_number_);
-    }
+    return std::make_unique<fullOrToolsMPSwriter>(solver_, current_optim_number_);
 }

--- a/src/solver/utils/named_problem.cpp
+++ b/src/solver/utils/named_problem.cpp
@@ -29,14 +29,12 @@ namespace Antares::Optimization
 PROBLEME_SIMPLEXE_NOMME::PROBLEME_SIMPLEXE_NOMME(const std::vector<std::string>& NomDesVariables,
                                                  const std::vector<std::string>& NomDesContraintes,
                                                  const std::vector<bool>& VariablesEntieres,
-                                                 BasisStatus& basisStatus,
                                                  bool UseNamedProblems,
                                                  bool SolverLogs):
     NomDesVariables(NomDesVariables),
     NomDesContraintes(NomDesContraintes),
     useNamedProblems_(UseNamedProblems),
-    VariablesEntieres(VariablesEntieres),
-    basisStatus(basisStatus)
+    VariablesEntieres(VariablesEntieres)
 {
     AffichageDesTraces = SolverLogs ? OUI_SPX : NON_SPX;
 }

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -349,10 +349,21 @@ MPSolver* ORTOOLS_Simplexe(Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probl
         solver->EnableOutput();
     }
     TuneSolverSpecificOptions(solver, options.ortoolsSolver, options.solverParameters);
+    const bool warmStart = solverSupportsWarmStart(solver->ProblemType());
+    // Provide an initial simplex basis, if any
+    if (warmStart && Probleme->basisExists())
+    {
+        Probleme->basisStatus.setStartingBasis(solver);
+    }
 
     if (solveAndManageStatus(solver, Probleme->ExistenceDUneSolution, params))
     {
         extract_from_MPSolver(solver, Probleme);
+        // Save the final simplex basis for next resolutions
+        if (warmStart && keepBasis)
+        {
+            Probleme->basisStatus.extractBasis(solver);
+        }
     }
 
     return solver;

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -342,8 +342,8 @@ MPSolver* ORTOOLS_Simplexe(Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probl
                            const OptimizationOptions& options)
 {
     MPSolverParameters params;
-    setGenericParameters(
-      params);              // Keep generic params for default settings working for all solvers
+    // Keep generic params for default settings working for all solvers
+    setGenericParameters(params);
     if (options.solverLogs) // May be overriden by log level if set as specific parameters
     {
         solver->EnableOutput();

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -329,19 +329,11 @@ bool solveAndManageStatus(MPSolver* solver, int& resultStatus, const MPSolverPar
     return resultStatus == OUI_SPX;
 }
 
-MPSolver* ORTOOLS_ConvertIfNeeded(const std::string& solverName,
-                                  const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme,
-                                  MPSolver* solver)
+MPSolver* ORTOOLS_Convert(const std::string& solverName,
+                          const Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme)
 {
-    if (solver == nullptr)
-    {
-        Antares::Optimization::ProblemSimplexeNommeConverter converter(solverName, Probleme);
-        return converter.Convert();
-    }
-    else
-    {
-        return solver;
-    }
+    Antares::Optimization::ProblemSimplexeNommeConverter converter(solverName, Probleme);
+    return converter.Convert();
 }
 
 MPSolver* ORTOOLS_Simplexe(Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probleme,
@@ -435,6 +427,7 @@ void ORTOOLS_CorrigerLesBornes(MPSolver* solver,
 void ORTOOLS_LibererProbleme(MPSolver* solver)
 {
     delete solver;
+    solver = nullptr;
 }
 
 const std::map<std::string, struct OrtoolsUtils::SolverNames> OrtoolsUtils::solverMap = {

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -349,21 +349,10 @@ MPSolver* ORTOOLS_Simplexe(Antares::Optimization::PROBLEME_SIMPLEXE_NOMME* Probl
         solver->EnableOutput();
     }
     TuneSolverSpecificOptions(solver, options.ortoolsSolver, options.solverParameters);
-    const bool warmStart = solverSupportsWarmStart(solver->ProblemType());
-    // Provide an initial simplex basis, if any
-    if (warmStart && Probleme->basisExists())
-    {
-        Probleme->basisStatus.setStartingBasis(solver);
-    }
 
     if (solveAndManageStatus(solver, Probleme->ExistenceDUneSolution, params))
     {
         extract_from_MPSolver(solver, Probleme);
-        // Save the final simplex basis for next resolutions
-        if (warmStart && keepBasis)
-        {
-            Probleme->basisStatus.extractBasis(solver);
-        }
     }
 
     return solver;

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -424,10 +424,10 @@ void ORTOOLS_CorrigerLesBornes(MPSolver* solver,
     }
 }
 
-void ORTOOLS_LibererProbleme(MPSolver*& solver)
+MPSolver* ORTOOLS_LibererProbleme(MPSolver* solver)
 {
     delete solver;
-    solver = nullptr;
+    return nullptr;
 }
 
 const std::map<std::string, struct OrtoolsUtils::SolverNames> OrtoolsUtils::solverMap = {

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -424,7 +424,7 @@ void ORTOOLS_CorrigerLesBornes(MPSolver* solver,
     }
 }
 
-void ORTOOLS_LibererProbleme(MPSolver* solver)
+void ORTOOLS_LibererProbleme(MPSolver*& solver)
 {
     delete solver;
     solver = nullptr;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ if(Python3_Interpreter_FOUND)
 
       add_test(
         NAME milp-cbc
-        COMMAND Python3::Interpreter -m pytest -m json --solver-path=$<TARGET_FILE:antares-solver> --use-ortools --ortools-solver coin
+        COMMAND Python3::Interpreter -m pytest -m json --solver-path=$<TARGET_FILE:antares-solver> --solver coin
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/run-study-tests"
         )
 

--- a/src/tests/cucumber/features/steps/simulator_utils.py
+++ b/src/tests/cucumber/features/steps/simulator_utils.py
@@ -36,9 +36,7 @@ def activate_simu_outputs(context):
 
 def build_antares_solver_command(context):
     command = [SOLVER_PATH, "-i", str(context.study_path)]
-    if context.use_ortools:
-        command.append('--use-ortools')
-        command.append('--ortools-solver=' + context.ortools_solver)
+    command.append('--solver=' + context.ortools_solver)
     if context.named_mps_problems:
         command.append('--named-mps-problems')
     if context.parallel:

--- a/src/tests/cucumber/features/steps/steps.py
+++ b/src/tests/cucumber/features/steps/steps.py
@@ -12,7 +12,6 @@ def study_path_is(context, string):
 
 @when('I run antares simulator')
 def run_antares(context):
-    context.use_ortools = True
     context.ortools_solver = "sirius"
     context.named_mps_problems = False
     context.parallel = False

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -201,7 +201,6 @@ BOOST_FIXTURE_TEST_CASE(milp_two_mc_single_unit_single_scenario, StudyFixture)
     // Use OR-Tools / COIN for MILP
     auto& p = study->parameters;
     p.unitCommitment.ucMode = ucMILP;
-    p.optOptions.ortoolsUsed = true;
     p.optOptions.ortoolsSolver = "coin";
 
     simulation->create();
@@ -230,7 +229,6 @@ BOOST_FIXTURE_TEST_CASE(milp_two_mc_two_unit_single_scenario, StudyFixture)
     // Use OR-Tools / COIN for MILP
     auto& p = study->parameters;
     p.unitCommitment.ucMode = ucMILP;
-    p.optOptions.ortoolsUsed = true;
     p.optOptions.ortoolsSolver = "coin";
 
     simulation->create();

--- a/src/tests/run-study-tests/actions_on_study/study_run.py
+++ b/src/tests/run-study-tests/actions_on_study/study_run.py
@@ -4,11 +4,10 @@ from pathlib import Path
 from utils.assertions import check
 
 class study_run:
-    def __init__(self, study_path, solver_path, use_ortools, ortools_solver, named_mps_problems, parallel):
+    def __init__(self, study_path, solver_path, solver_name, named_mps_problems, parallel):
         self.study_path = study_path
         self.solver_path = solver_path
-        self.use_ortools = use_ortools
-        self.ortools_solver = ortools_solver
+        self.solverName = solver_name
         self.named_mps_problems = named_mps_problems
         self.parallel = parallel
         self.raise_exception_on_failure = True
@@ -23,9 +22,7 @@ class study_run:
         solver_full_path = str(Path(self.solver_path).resolve())
 
         command = [solver_full_path, "-i", str(self.study_path)]
-        if self.use_ortools:
-            command.append('--use-ortools')
-            command.append('--ortools-solver=' + self.ortools_solver)
+        command.append('--solver=' + self.solverName)
         if self.named_mps_problems:
             command.append('--named-mps-problems')
         if self.parallel:

--- a/src/tests/run-study-tests/conftest.py
+++ b/src/tests/run-study-tests/conftest.py
@@ -1,20 +1,15 @@
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--use-ortools", action="store_true", default=False)
-    parser.addoption("--ortools-solver", action="store", default="sirius")
+    parser.addoption("--solver", action="store", default="sirius")
     parser.addoption("--solver-path", action="store")
     parser.addoption("--named-mps-problems", action="store_true", default=False)
     parser.addoption("--force-parallel", action="store_true", default=False)
     parser.addoption("--ts-generator", action="store_true", default=False)
 
 @pytest.fixture()
-def ortools_solver(request):
-    return request.config.getoption("--ortools-solver")
-
-@pytest.fixture()
-def use_ortools(request):
-    return request.config.getoption("--use-ortools")
+def solver_name(request):
+    return request.config.getoption("--solver")
 
 @pytest.fixture()
 def solver_path(request):

--- a/src/tests/run-study-tests/fixtures.py
+++ b/src/tests/run-study-tests/fixtures.py
@@ -40,8 +40,8 @@ def resultsRemover(study_path):
     return results_remover(study_path)
 
 @pytest.fixture
-def simulation(study_path, solver_path, use_ortools, ortools_solver, named_mps_problems, parallel):
-    return study_run(study_path, solver_path, use_ortools, ortools_solver, named_mps_problems, parallel)
+def simulation(study_path, solver_path, solver_name, named_mps_problems, parallel):
+    return study_run(study_path, solver_path, solver_name, named_mps_problems, parallel)
 
 @pytest.fixture(autouse=True)
 def check_runner(simulation, resultsRemover):

--- a/src/tests/run-study-tests/readme.md
+++ b/src/tests/run-study-tests/readme.md
@@ -5,8 +5,11 @@ Here is an automatic testing python script system.
 This program performs the following : 
 1. Searches for all studies in a given directory
 2. From each study, retrieves the specifications to make checks on the simulation results of that study (see items below)
-3. Runs a simlulation on each study
-4. Given the results of the simulation on a study, makes the checks retrieved at step 2 on these results (for instance : make sure current results and reference resuts are identical, check for existence or content of output files,...)
+3. Runs a simulation on each study
+4. Given the results of the simulation on a study, makes the checks retrieved at step 2 on these results.
+   Examples :
+    - make sure current results and reference resuts are identical
+    - check for existence or even content of output files
 
 Note that each study found is supposed to contain the definition of checks performed by scripts after the simulation on the study is completed.
 So, each study is supposed to contain a file **check-config.json** for that purpose. This file is build manually for each study.
@@ -42,7 +45,7 @@ In the following, we comment the content of this script. Lines of this scripts a
 
 ## Fixtures
 **pytest** comes with the notion of **fixture**. Fixtures allow executing a piece of code just before a test runs.
-To take bebefit of a fixture, a test needs to be given this fixture as argument. 
+To take benefit of a fixture, a test needs to be given this fixture as argument. 
 Fixture themselves can also be given arguments, we'll see how we do it (in the context of the current testing system) when we talk about **parametrization**.
 Fixtures return a result to be used in the test.
 Let's look at a simple test :

--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -1091,7 +1091,7 @@ void RunSimulationOnTheStudy(Data::Study::Ptr study,
                              Solver::Feature features,
                              bool preproOnly,
                              bool useOrtools,
-                             const std::string& ortoolsSolver)
+                             const std::string& solverName)
 {
     if (!study) // A valid study would be better
     {
@@ -1212,7 +1212,7 @@ void RunSimulationOnTheStudy(Data::Study::Ptr study,
                 cmd << " --use-ortools";
 
                 // add solver name for ortools
-                cmd << " --ortools-solver=" << ortoolsSolver;
+                cmd << " --ortools-solver=" << solverName;
             }
 
             // Go go go !

--- a/src/ui/simulator/application/study.h
+++ b/src/ui/simulator/application/study.h
@@ -114,7 +114,7 @@ bool CheckIfInsideAStudyFolder(const AnyString& path, bool quiet = false);
 ** \param simuComments Comments for the simulation
 ** \param ignoreWarnings True if warnings can be silently ignored
 ** \param useOrtools True if ortools must be used by antares-solver
-** \param ortoolsSolver Ortools solver used in case of ortools use by antares-solver
+** \param solverName Solver used
 */
 void RunSimulationOnTheStudy(Data::Study::Ptr study,
                              const YString& simuName,
@@ -123,7 +123,7 @@ void RunSimulationOnTheStudy(Data::Study::Ptr study,
                              Solver::Feature features = Solver::standard,
                              bool preproOnly = false,
                              bool useOrtools = false,
-                             const std::string& ortoolsSolver = "sirius");
+                             const std::string& solverName = "sirius");
 
 /*!
 ** \brief Update the state of controls

--- a/src/ui/simulator/windows/simulation/run.cpp
+++ b/src/ui/simulator/windows/simulation/run.cpp
@@ -323,10 +323,10 @@ Run::Run(wxWindow* parent, bool preproOnly) :
           = Antares::Component::CreateLabel(pBigDaddy, wxT("Ortools solver : "));
 
         pOrtoolsSolverCombox = new wxComboBox(pBigDaddy, wxID_ANY);
-        std::list<std::string> ortoolsSolverList = getAvailableOrtoolsSolverName();
-        for (const std::string& ortoolsSolver : ortoolsSolverList)
+        std::list<std::string> solverList = getAvailableOrtoolsSolverName();
+        for (const std::string& solverName : solverList)
         {
-            pOrtoolsSolverCombox->Append(ortoolsSolver);
+            pOrtoolsSolverCombox->Append(solverName);
         }
 
         // Ortools solver selection visibility


### PR DESCRIPTION
This PR follows PR #2450 (that removes direct call to **Sirius** and forces Sirius behind **ortools**).
This is a trial for simplifications of code calling the optimization weekly solver call (mainly in **opt_appel_solveur_lineaire.cpp**)

What was done : 
- Correlate **solver** destruction (delete) with setting **solver** to null
  (to keep in mind : deleting a **nullptr** is harmless)
- what else ?

To be done : 
- in **ORTOOLS_Simplexe(...)**, instead of updating `Probleme->ExistenceDUneSolution` and use it in , we could use solver (type **MPSolver**) returned status.
# CAUTION : 
Remove changes on CI yaml files !