### PR TITLE
Legacy GUI : Restore grid statistics

### DIFF
--- a/src/ui/simulator/application/main/create.cpp
+++ b/src/ui/simulator/application/main/create.cpp
@@ -299,7 +299,13 @@ void ApplWnd::internalInitialize()
         statusbar->SetStatusStyles(2, styles);
 
         statusbar->SetMinHeight(14);
-        statusbar->SetStatusText(wxT(""), 1);
+        statusbar->Connect(statusbar->GetId(),
+                           wxEVT_CONTEXT_MENU,
+                           wxContextMenuEventHandler(ApplWnd::evtOnContextMenuStatusBar),
+                           nullptr,
+                           this);
+
+        statusbar->SetStatusText(wxT("|  "), 1);
 
         wxFont f = statusbar->GetFont();
         f.SetPointSize(f.GetPointSize() - 1);

--- a/src/ui/simulator/application/main/internal-ids.h
+++ b/src/ui/simulator/application/main/internal-ids.h
@@ -178,6 +178,16 @@ enum MenusID
     mnIDLaunchAnalyzer,
     mnIDLaunchConstraintsBuilder,
 
+    //! \name Popup Menu Operator for selected cells on any grid
+    //@{
+    mnIDPopupOpNone,
+    mnIDPopupOpAverage,
+    mnIDPopupOpCellCount,
+    mnIDPopupOpMinimum,
+    mnIDPopupOpMaximum,
+    mnIDPopupOpSum,
+    //@}
+
     //! \name Popup Menu Operator for selected nodes on any layer
     //@{
     mnIDPopupSelectionHide,

--- a/src/ui/simulator/application/main/main.cpp
+++ b/src/ui/simulator/application/main/main.cpp
@@ -187,6 +187,14 @@ EVT_MENU(mnInternalLogMessage, ApplWnd::onLogMessage)
 EVT_MENU(mnIDLaunchAnalyzer, ApplWnd::evtLaunchAnalyzer)
 EVT_MENU(mnIDLaunchConstraintsBuilder, ApplWnd::evtLaunchConstraintsBuilder)
 
+// Context menu : Operator for selected cells (grid)
+EVT_MENU(mnIDPopupOpNone, ApplWnd::evtOnContextMenuChangeOperator)
+EVT_MENU(mnIDPopupOpAverage, ApplWnd::evtOnContextMenuChangeOperator)
+EVT_MENU(mnIDPopupOpCellCount, ApplWnd::evtOnContextMenuChangeOperator)
+EVT_MENU(mnIDPopupOpMinimum, ApplWnd::evtOnContextMenuChangeOperator)
+EVT_MENU(mnIDPopupOpMaximum, ApplWnd::evtOnContextMenuChangeOperator)
+EVT_MENU(mnIDPopupOpSum, ApplWnd::evtOnContextMenuChangeOperator)
+
 EVT_MENU_OPEN(ApplWnd::evtOnMenuOpen)
 EVT_MENU_CLOSE(ApplWnd::evtOnMenuClose)
 
@@ -253,6 +261,8 @@ ApplWnd::ApplWnd() :
  pageRenewableCommon(nullptr),
  pageNodalOptim(nullptr),
  pWndBindingConstraints(nullptr),
+ pGridSelectionOperator(new Component::Datagrid::Selection::CellCount()),
+ pGridSelectionAttachedGrid(nullptr),
  pMapContextMenu(nullptr),
  pUserNotes(nullptr),
  pMainNotebookAlreadyHasItsComponents(false),
@@ -316,6 +326,13 @@ ApplWnd::~ApplWnd()
     OnStudyAreasChanged.clear();
     OnStudyAreaDelete.clear();
 
+    // Delete the grid operator
+    if (pGridSelectionOperator)
+    {
+        delete pGridSelectionOperator;
+        pGridSelectionOperator = nullptr; // May be needed in some cases
+    }
+
     // Disconnect all events
     destroyBoundEvents();
     // Unregister the global pointer to the instance
@@ -352,6 +369,34 @@ void ApplWnd::selectSystem()
 
     if (pNotebook)
         pNotebook->select(wxT("sys"), true);
+}
+
+void ApplWnd::evtOnContextMenuChangeOperator(wxCommandEvent& evt)
+{
+    switch (evt.GetId())
+    {
+    case mnIDPopupOpNone:
+        gridOperatorSelectedCells(nullptr);
+        break;
+    case mnIDPopupOpAverage:
+        gridOperatorSelectedCells(new Component::Datagrid::Selection::Average());
+        break;
+    case mnIDPopupOpCellCount:
+        gridOperatorSelectedCells(new Component::Datagrid::Selection::CellCount());
+        break;
+    case mnIDPopupOpMinimum:
+        gridOperatorSelectedCells(new Component::Datagrid::Selection::Minimum());
+        break;
+    case mnIDPopupOpMaximum:
+        gridOperatorSelectedCells(new Component::Datagrid::Selection::Maximum());
+        break;
+    case mnIDPopupOpSum:
+        gridOperatorSelectedCells(new Component::Datagrid::Selection::Sum());
+        break;
+    default:
+        break;
+    }
+    evt.Skip();
 }
 
 static inline void EnableItem(wxMenuBar* menu, int id, bool opened)
@@ -502,6 +547,7 @@ void ApplWnd::evtOnUpdateGUIAfterStudyIO(bool opened)
 
     // Reset the status bar
     resetDefaultStatusBarText();
+    gridOperatorSelectedCellsUpdateResult(pGridSelectionAttachedGrid);
 
     // reload the user notes and districts
     if (not aboutToQuit and study)
@@ -527,6 +573,7 @@ void ApplWnd::evtOnUpdateGUIAfterStudyIO(bool opened)
         {
             GetSizer()->Clear(true);
             pUserNotes = nullptr;
+            pGridSelectionAttachedGrid = nullptr;
             pBigDaddy = nullptr;
             pMainSizer = nullptr;
             pData->wipPanel = nullptr;
@@ -784,6 +831,24 @@ void ApplWnd::onRenewableGenerationModellingChanged(bool init)
     refreshHomePageOnRenewableModellingChanged(aggregated, init);
     refreshScenarioBuilderPagOnRenewableModellingChanged(aggregated);
     refreshInputMenuOnRenewableModellingChanged(aggregated);
+}
+
+void ApplWnd::gridOperatorSelectedCells(Component::Datagrid::Selection::IOperator* v)
+{
+    delete pGridSelectionOperator;
+    pGridSelectionOperator = v;
+    gridOperatorSelectedCellsUpdateResult(pGridSelectionAttachedGrid);
+}
+
+Component::Datagrid::Selection::IOperator* ApplWnd::gridOperatorSelectedCells() const
+{
+    return pGridSelectionOperator;
+}
+
+void ApplWnd::disableGridOperatorIfGrid(wxGrid* grid)
+{
+    if (pGridSelectionAttachedGrid == grid)
+        gridOperatorSelectedCellsUpdateResult(nullptr);
 }
 
 void ApplWnd::title()

--- a/src/ui/simulator/application/main/main.h
+++ b/src/ui/simulator/application/main/main.h
@@ -32,6 +32,7 @@
 #include <wx/aui/aui.h>
 
 #include "../../toolbox/components/notebook/notebook.h"
+#include "../../toolbox/components/datagrid/selectionoperation.h"
 #include "../../toolbox/components/map/settings.h"
 #include <list>
 #include "fwd.h"
@@ -110,6 +111,41 @@ public:
     ** \brief Get the component used for the map
     */
     Map::Component* map() const;
+
+    /*!
+    ** \name Grid operator (for selected cells)
+    **
+    ** A grid operator computes an operation (Sum, average...) on all selected
+    ** cells of the grid that currently has the focus. The result of this
+    ** computation is displayed in the status bar.
+    **
+    ** \see Antares::Component::Datagrid::Component::onGridEnter()
+    ** \see Antares::Component::Datagrid::Component::onGridLeave()
+    */
+    //@{
+    /*!
+    ** \brief Get the current grid operator for selected cells
+    */
+    Component::Datagrid::Selection::IOperator* gridOperatorSelectedCells() const;
+
+    /*!
+    ** \brief Set the grid operator for selected cells
+    */
+    void gridOperatorSelectedCells(Component::Datagrid::Selection::IOperator* v);
+
+    /*!
+    ** \brief Update the GUI to display the result of the grid operator
+    **
+    ** This method should be called each time the cells selection changes.
+    ** \param grid The `wxGrid` that has currently the focus (may be NULL)
+    */
+    void gridOperatorSelectedCellsUpdateResult(wxGrid* grid);
+
+    /*!
+    ** \brief Disable the grid operator
+    */
+    void disableGridOperatorIfGrid(wxGrid* grid);
+    //@}
 
     //! \name Title of the Window
     //@{
@@ -333,6 +369,8 @@ private:
 
     //! Create a complete menu for the window
     wxMenuBar* createMenu();
+    //! Create a popup menu for all available operators on selected cells (grid)
+    wxMenu* createPopupMenuOperatorsOnGrid();
 
     //! Create menu: File
     wxMenu* createMenuFiles();
@@ -404,6 +442,9 @@ private:
 
     //! \name Event: Context menu
     //@{
+    //! Show the context menu associated to the status bar
+    void evtOnContextMenuStatusBar(wxContextMenuEvent& evt);
+    void evtOnContextMenuChangeOperator(wxCommandEvent& evt);
     void evtOnContextMenuMap(int x, int y);
     //@}
 
@@ -704,6 +745,10 @@ private:
     Component::Notebook::Page* pageScBuilderNTC;
     Component::Notebook::Page* pageScBuilderRenewable;
     Component::Notebook::Page* pageScBuilderHydroLevels;
+
+    //! The current grid operator to use on selected cells
+    Component::Datagrid::Selection::IOperator* pGridSelectionOperator;
+    wxGrid* pGridSelectionAttachedGrid;
 
     //! A context menu for the map
     wxMenu* pMapContextMenu;

--- a/src/ui/simulator/application/main/menu.cpp
+++ b/src/ui/simulator/application/main/menu.cpp
@@ -70,6 +70,21 @@ wxMenuBar* ApplWnd::createMenu()
     return ret;
 }
 
+wxMenu* ApplWnd::createPopupMenuOperatorsOnGrid()
+{
+    auto* menu = new wxMenu();
+
+    // Wizard
+    Menu::CreateItem(menu, mnIDPopupOpNone, wxT("None"), "images/16x16/empty.png");
+    menu->AppendSeparator();
+    Menu::CreateItem(menu, mnIDPopupOpAverage, wxT("Average "));
+    Menu::CreateItem(menu, mnIDPopupOpCellCount, wxT("Cell count "));
+    Menu::CreateItem(menu, mnIDPopupOpMinimum, wxT("Minimum "));
+    Menu::CreateItem(menu, mnIDPopupOpMaximum, wxT("Maximum "));
+    Menu::CreateItem(menu, mnIDPopupOpSum, wxT("Sum "));
+    return menu;
+}
+
 wxMenu* ApplWnd::createMenuFiles()
 {
     delete pMenuFile;

--- a/src/ui/simulator/application/main/statusbar.cpp
+++ b/src/ui/simulator/application/main/statusbar.cpp
@@ -47,5 +47,149 @@ void ApplWnd::resetDefaultStatusBarText()
 #endif
 }
 
+/*
+** Applies a functor to all selected cells. Returns the number of selected
+** cells.
+*/
+static size_t ForAllSelectedCells(wxGrid& grid,
+                                  Component::Datagrid::VGridHelper* gridHelper,
+                                  Component::Datagrid::Selection::IOperator* op)
+{
+    assert(wxIsMainThread() == true and "Must be ran from the main thread");
+
+    size_t totalCell = 0;
+
+    // Singly selected cells.
+    const wxGridCellCoordsArray& cells(grid.GetSelectedCells());
+    for (uint i = 0; i < (uint)cells.size(); ++i)
+    {
+        auto& cell = cells[i];
+        op->appendValue(gridHelper->GetNumericValue(cell.GetRow(), cell.GetCol()));
+        ++totalCell;
+    }
+
+    // Whole selected rows.
+    int colCount = grid.GetNumberCols();
+    const wxArrayInt& rows(grid.GetSelectedRows());
+    for (uint i = 0; i < (uint)rows.size(); ++i)
+    {
+        for (int col = 0; col < colCount; ++col)
+        {
+            op->appendValue(gridHelper->GetNumericValue(rows[i], col));
+            ++totalCell;
+        }
+    }
+
+    // Whole selected columns.
+    int rowCount = grid.GetNumberRows();
+    const wxArrayInt& cols(grid.GetSelectedCols());
+    for (uint i = 0; i < (uint)cols.size(); ++i)
+    {
+        for (int row = 0; row < rowCount; ++row)
+        {
+            op->appendValue(gridHelper->GetNumericValue(row, cols[i]));
+            ++totalCell;
+        }
+    }
+
+    // Blocks. We always expect btl and bbr to have the same size, since their
+    // entries are supposed to correspond.
+    const wxGridCellCoordsArray& btl(grid.GetSelectionBlockTopLeft());
+    const wxGridCellCoordsArray& bbr(grid.GetSelectionBlockBottomRight());
+    size_t count = btl.size();
+    if (count == bbr.size())
+    {
+        for (uint i = 0; i < count; ++i)
+        {
+            const wxGridCellCoords& tl = btl[i];
+            const wxGridCellCoords& br = bbr[i];
+            for (int row = tl.GetRow(); row <= br.GetRow(); ++row)
+            {
+                for (int col = tl.GetCol(); col <= br.GetCol(); ++col)
+                {
+                    op->appendValue(gridHelper->GetNumericValue(row, col));
+                    ++totalCell;
+                }
+            }
+        }
+    }
+    return totalCell;
+}
+
+void ApplWnd::gridOperatorSelectedCellsUpdateResult(wxGrid* grid)
+{
+    assert(wxIsMainThread() == true and "Must be ran from the main thread");
+    enum
+    {
+        fieldIndex = 1,
+    };
+    // The status bar
+    auto* statusBar = GetStatusBar();
+    pGridSelectionAttachedGrid = grid;
+    if (statusBar)
+    {
+        if (not CurrentStudyIsValid())
+        {
+            statusBar->SetStatusText(wxEmptyString, fieldIndex);
+            return;
+        }
+        if (not pGridSelectionOperator)
+        {
+            statusBar->SetStatusText(wxT("|   (none)"), fieldIndex);
+            return;
+        }
+
+        if (grid and grid->GetTable())
+        {
+            auto* gridHelper = dynamic_cast<Component::Datagrid::VGridHelper*>(grid->GetTable());
+            if (gridHelper)
+            {
+                // Reset of the operator
+                pGridSelectionOperator->reset();
+                // Browse all selected cells
+                if (ForAllSelectedCells(*grid, gridHelper, pGridSelectionOperator))
+                {
+                    // Update the GUI
+                    statusBar->SetStatusText(wxString()
+                                               << wxT("|  ") << pGridSelectionOperator->caption()
+                                               << wxT(" = ") << pGridSelectionOperator->result(),
+                                             fieldIndex);
+                    return;
+                }
+            }
+        }
+        // Empty
+        statusBar->SetStatusText(
+          wxString(wxT("|   (")) << pGridSelectionOperator->caption() << wxT(')'), fieldIndex);
+    }
+}
+
+void ApplWnd::evtOnContextMenuStatusBar(wxContextMenuEvent& evt)
+{
+    if (GUIIsLock())
+        return;
+
+    wxStatusBar* statusBar = GetStatusBar();
+    if (statusBar)
+    {
+        wxRect rect;
+        if (statusBar->GetFieldRect(1, rect))
+        {
+            const wxPoint pos = statusBar->ScreenToClient(evt.GetPosition());
+            if (rect.Contains(pos))
+            {
+                if (!pPopupMenuOperatorsGrid)
+                {
+                    // Popup menu: Operators for selected cells on any grid
+                    pPopupMenuOperatorsGrid = createPopupMenuOperatorsOnGrid();
+                }
+
+                statusBar->PopupMenu(pPopupMenuOperatorsGrid);
+            }
+        }
+    }
+    evt.Skip();
+}
+
 } // namespace Forms
 } // namespace Antares

--- a/src/ui/simulator/application/main/statusbar.cpp
+++ b/src/ui/simulator/application/main/statusbar.cpp
@@ -35,10 +35,11 @@
 #include <wx/statusbr.h>
 #include <ui/common/lock.h>
 
-namespace Antares
+using namespace Component::Datagrid;
+
+namespace Antares::Forms
 {
-namespace Forms
-{
+
 void ApplWnd::resetDefaultStatusBarText()
 {
     assert(wxIsMainThread() == true && "Must be ran from the main thread");
@@ -47,19 +48,18 @@ void ApplWnd::resetDefaultStatusBarText()
 #endif
 }
 
-/*
-** Applies a functor to all selected cells. Returns the number of selected
-** cells.
-*/
-static size_t ForAllSelectedCells(wxGrid& grid,
-                                  Component::Datagrid::VGridHelper* gridHelper,
-                                  Component::Datagrid::Selection::IOperator* op)
+
+bool oneCellSelected(wxGrid& grid)
 {
-    assert(wxIsMainThread() == true and "Must be ran from the main thread");
+    const wxGridCellCoordsArray& cells(grid.GetSelectedCells());
+    return cells.size() > 0;
+}
 
+size_t updateStatisticsOpForOneCell(wxGrid& grid,
+                                     VGridHelper* gridHelper,
+                                     Selection::IOperator* op)
+{
     size_t totalCell = 0;
-
-    // Singly selected cells.
     const wxGridCellCoordsArray& cells(grid.GetSelectedCells());
     for (uint i = 0; i < (uint)cells.size(); ++i)
     {
@@ -67,8 +67,20 @@ static size_t ForAllSelectedCells(wxGrid& grid,
         op->appendValue(gridHelper->GetNumericValue(cell.GetRow(), cell.GetCol()));
         ++totalCell;
     }
+    return totalCell;
+}
 
-    // Whole selected rows.
+bool rowsSelected(wxGrid& grid)
+{
+    const wxArrayInt& rows(grid.GetSelectedRows());
+    return rows.size() > 0;
+}
+
+size_t updateStatisticsOpForRows(wxGrid& grid,
+                                  VGridHelper* gridHelper,
+                                  Selection::IOperator* op)
+{
+    size_t totalCell = 0;
     int colCount = grid.GetNumberCols();
     const wxArrayInt& rows(grid.GetSelectedRows());
     for (uint i = 0; i < (uint)rows.size(); ++i)
@@ -79,8 +91,20 @@ static size_t ForAllSelectedCells(wxGrid& grid,
             ++totalCell;
         }
     }
+    return totalCell;
+}
 
-    // Whole selected columns.
+bool columnsSelected(wxGrid& grid)
+{
+    const wxArrayInt& cols(grid.GetSelectedCols());
+    return cols.size() > 0;
+}
+
+size_t updateStatisticsOpForColumns(wxGrid& grid,
+                                     VGridHelper* gridHelper,
+                                     Selection::IOperator* op)
+{
+    size_t totalCell = 0;
     int rowCount = grid.GetNumberRows();
     const wxArrayInt& cols(grid.GetSelectedCols());
     for (uint i = 0; i < (uint)cols.size(); ++i)
@@ -91,29 +115,74 @@ static size_t ForAllSelectedCells(wxGrid& grid,
             ++totalCell;
         }
     }
+    return totalCell;
+}
 
-    // Blocks. We always expect btl and bbr to have the same size, since their
+bool blockSelected(wxGrid& grid)
+{
+    // Blocks. We always expect blocks top left and bottom right to have the same size, since their
     // entries are supposed to correspond.
-    const wxGridCellCoordsArray& btl(grid.GetSelectionBlockTopLeft());
-    const wxGridCellCoordsArray& bbr(grid.GetSelectionBlockBottomRight());
-    size_t count = btl.size();
-    if (count == bbr.size())
+    const wxGridCellCoordsArray& blockTopLeft(grid.GetSelectionBlockTopLeft());
+    const wxGridCellCoordsArray& blockBottomRight(grid.GetSelectionBlockBottomRight());
+    return (blockTopLeft.size() == blockBottomRight.size()) && (blockTopLeft.size() > 0);
+}
+
+size_t updateStatisticsOpForBlock(wxGrid& grid,
+                                   VGridHelper* gridHelper,
+                                   Selection::IOperator* op)
+{
+    size_t totalCell = 0;
+    const wxGridCellCoordsArray& blockTopLeft(grid.GetSelectionBlockTopLeft());
+    const wxGridCellCoordsArray& blockBottomRight(grid.GetSelectionBlockBottomRight());
+    size_t blockSize = blockTopLeft.size();
+
+    for (uint i = 0; i < blockSize; ++i)
     {
-        for (uint i = 0; i < count; ++i)
+        const wxGridCellCoords& topLeft = blockTopLeft[i];
+        const wxGridCellCoords& bottomRight = blockBottomRight[i];
+        for (int row = topLeft.GetRow(); row <= bottomRight.GetRow(); ++row)
         {
-            const wxGridCellCoords& tl = btl[i];
-            const wxGridCellCoords& br = bbr[i];
-            for (int row = tl.GetRow(); row <= br.GetRow(); ++row)
+            for (int col = topLeft.GetCol(); col <= bottomRight.GetCol(); ++col)
             {
-                for (int col = tl.GetCol(); col <= br.GetCol(); ++col)
-                {
-                    op->appendValue(gridHelper->GetNumericValue(row, col));
-                    ++totalCell;
-                }
+                op->appendValue(gridHelper->GetNumericValue(row, col));
+                ++totalCell;
             }
         }
     }
     return totalCell;
+}
+
+/*
+** Applies a functor to all selected cells. Returns the number of selected
+** cells.
+*/
+static size_t ForAllSelectedCells(wxGrid& grid,
+                                  VGridHelper* gridHelper,
+                                  Selection::IOperator* op)
+{
+    assert(wxIsMainThread() == true and "Must be ran from the main thread");
+
+    if (oneCellSelected(grid))
+    {
+        return updateStatisticsOpForOneCell(grid, gridHelper, op);
+    }
+
+    if (rowsSelected(grid))
+    {
+        return updateStatisticsOpForRows(grid, gridHelper, op);
+    }
+    
+    if (columnsSelected(grid))
+    {
+        return updateStatisticsOpForColumns(grid, gridHelper, op);
+    }
+
+    if (blockSelected(grid))
+    {
+        return updateStatisticsOpForBlock(grid, gridHelper, op);
+    }
+    
+    return 0;
 }
 
 void ApplWnd::gridOperatorSelectedCellsUpdateResult(wxGrid* grid)
@@ -191,5 +260,4 @@ void ApplWnd::evtOnContextMenuStatusBar(wxContextMenuEvent& evt)
     evt.Skip();
 }
 
-} // namespace Forms
-} // namespace Antares
+} // namespace Antares::Forms

--- a/src/ui/simulator/cmake/components.cmake
+++ b/src/ui/simulator/cmake/components.cmake
@@ -48,6 +48,7 @@ SET(SRC_TOOLBOX_COM_DBGRID_RENDERERS
 		toolbox/components/datagrid/renderer.h
 		toolbox/components/datagrid/renderer.hxx
 		toolbox/components/datagrid/renderer.cpp
+		toolbox/components/datagrid/selectionoperation.h
 		toolbox/components/datagrid/renderer/adequacy-patch-area-grid.h
 		toolbox/components/datagrid/renderer/adequacy-patch-area-grid.cpp
 		toolbox/components/datagrid/renderer/area.h

--- a/src/ui/simulator/toolbox/components/datagrid/dbgrid.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/dbgrid.cpp
@@ -126,6 +126,11 @@ DBGrid::DBGrid(Component* parent) :
 
 DBGrid::~DBGrid()
 {
+    // Remove any remaining reference
+    auto* mainFrm = Forms::ApplWnd::Instance();
+    if (mainFrm)
+        mainFrm->disableGridOperatorIfGrid(this);
+
     pParentComponent = nullptr;
     otherGrid_ = nullptr;
 }
@@ -134,6 +139,10 @@ void DBGrid::onGridSelectCell(wxGridEvent& evt)
 {
     assert(GetParent() && "invalid parent");
 
+    auto* mainFrm = Forms::ApplWnd::Instance();
+    if (mainFrm)
+        mainFrm->gridOperatorSelectedCellsUpdateResult(this);
+    pCurrentPosition.x = evt.GetCol();
     pCurrentPosition.y = evt.GetRow();
 
     auto* r = ((Component*)GetParent())->renderer();
@@ -147,6 +156,9 @@ void DBGrid::onGridRangeSelect(wxGridRangeSelectEvent& evt)
 {
     assert(GetGridWindow() && "invalid grid window");
 
+    Forms::ApplWnd* mainFrm = Forms::ApplWnd::Instance();
+    if (mainFrm)
+        mainFrm->gridOperatorSelectedCellsUpdateResult(this);
     if (GetGridWindow())
         GetGridWindow()->SetFocus();
     evt.Skip();
@@ -154,6 +166,9 @@ void DBGrid::onGridRangeSelect(wxGridRangeSelectEvent& evt)
 
 void DBGrid::onGridLeave(wxFocusEvent& evt)
 {
+    auto* mainFrm = Forms::ApplWnd::Instance();
+    if (mainFrm)
+        mainFrm->gridOperatorSelectedCellsUpdateResult(nullptr);
     evt.Skip();
 }
 
@@ -207,6 +222,10 @@ void DBGrid::ensureDataAreLoaded()
     {
         r->invalidate = false;
         // Post an event to update the gui after the data are loaded
+
+        Forms::ApplWnd* mainFrm = Forms::ApplWnd::Instance();
+        if (mainFrm)
+            mainFrm->disableGridOperatorIfGrid(this);
 
         assert(pAllowRefresh == true);
         parent->forceRefresh();

--- a/src/ui/simulator/toolbox/components/datagrid/selectionoperation.h
+++ b/src/ui/simulator/toolbox/components/datagrid/selectionoperation.h
@@ -1,0 +1,247 @@
+/*
+** Copyright 2007-2018 RTE
+** Authors: Antares_Simulator Team
+**
+** This file is part of Antares_Simulator.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** There are special exceptions to the terms and conditions of the
+** license as they are applied to this software. View the full text of
+** the exceptions in file COPYING.txt in the directory of this software
+** distribution
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with Antares_Simulator. If not, see <http://www.gnu.org/licenses/>.
+**
+** SPDX-License-Identifier: licenceRef-GPL3_WITH_RTE-Exceptions
+*/
+#ifndef __ANTARES_TOOLBOX_COMPONENT_DATAGRID_SELECTION_OPERATION_H__
+#define __ANTARES_TOOLBOX_COMPONENT_DATAGRID_SELECTION_OPERATION_H__
+
+#include "wx-wrapper.h"
+#include <math.h>
+#include <limits>
+
+namespace Antares
+{
+namespace Component
+{
+namespace Datagrid
+{
+namespace Selection
+{
+class IOperator
+{
+public:
+    IOperator()
+    {
+    }
+    virtual ~IOperator()
+    {
+    }
+
+    /*!
+    ** \brief Caption of the operator
+    */
+    virtual const wxChar* caption() const = 0;
+
+    /*!
+    ** \brief Reset all internal values
+    */
+    virtual void reset() = 0;
+
+    /*!
+    ** \brief Manage a new value
+    */
+    virtual void appendValue(const double v) = 0;
+
+    /*!
+    ** \brief Get the result
+    */
+    virtual double result() const = 0;
+
+}; // class IOperator
+
+class Average final : public IOperator
+{
+public:
+    Average() : pValue(0.), pCount(0)
+    {
+    }
+
+    virtual ~Average()
+    {
+    }
+
+    virtual const wxChar* caption() const
+    {
+        return wxT("Average");
+    }
+
+    virtual void reset()
+    {
+        pValue = 0.;
+        pCount = 0;
+    }
+
+    virtual void appendValue(const double v)
+    {
+        pValue += v;
+        ++pCount;
+    }
+
+    virtual double result() const
+    {
+        return pValue / (double)pCount;
+    }
+
+private:
+    double pValue;
+    uint pCount;
+
+}; // class Average
+
+class Sum final : public IOperator
+{
+public:
+    Sum() : pValue(0.)
+    {
+    }
+
+    virtual const wxChar* caption() const
+    {
+        return wxT("Sum");
+    }
+
+    virtual void reset()
+    {
+        pValue = 0.;
+    }
+
+    virtual void appendValue(const double v)
+    {
+        pValue += v;
+    }
+
+    virtual double result() const
+    {
+        return pValue;
+    }
+
+private:
+    double pValue;
+
+}; // class Sum
+
+class CellCount final : public IOperator
+{
+public:
+    CellCount() : pCount(0)
+    {
+    }
+
+    virtual const wxChar* caption() const
+    {
+        return wxT("Cell Count");
+    }
+
+    virtual void reset()
+    {
+        pCount = 0;
+    }
+
+    virtual void appendValue(const double)
+    {
+        ++pCount;
+    }
+
+    virtual double result() const
+    {
+        return (double)pCount;
+    }
+
+private:
+    uint pCount;
+
+}; // class Average
+
+class Minimum final : public IOperator
+{
+public:
+    Minimum() : pValue(std::numeric_limits<double>::infinity())
+    {
+    }
+
+    virtual const wxChar* caption() const
+    {
+        return wxT("Minimum");
+    }
+
+    virtual void reset()
+    {
+        pValue = std::numeric_limits<double>::infinity();
+    }
+
+    virtual void appendValue(const double v)
+    {
+        if (v < pValue)
+            pValue = v;
+    }
+
+    virtual double result() const
+    {
+        return pValue;
+    }
+
+private:
+    double pValue;
+
+}; // class Sum
+
+class Maximum final : public IOperator
+{
+public:
+    Maximum() : pValue(-std::numeric_limits<double>::infinity())
+    {
+    }
+
+    virtual const wxChar* caption() const
+    {
+        return wxT("Maximum");
+    }
+    virtual void reset()
+    {
+        pValue = -std::numeric_limits<double>::infinity();
+    }
+
+    virtual void appendValue(const double v)
+    {
+        if (v > pValue)
+            pValue = v;
+    }
+
+    virtual double result() const
+    {
+        return pValue;
+    }
+
+private:
+    double pValue;
+
+}; // class Sum
+
+} // namespace Selection
+} // namespace Datagrid
+} // namespace Component
+} // namespace Antares
+
+#endif // __ANTARES_TOOLBOX_COMPONENT_DATAGRID_SELECTION_OPERATION_H__


### PR DESCRIPTION
Related ticket is [here](https://gopro-tickets.rte-france.com/browse/ANT-2381).

**What was done** : 
- Restore the functionality of statistics computation on grids (number of cells selected, **sum** of their content, **min** of their content, ...), previously removed.
- Fix the issue previously noticed : select a column, stats are wrong, especially the number of selected cells, which is twice the number it should be. 