### PR TITLE
Migration doc : move final hydro level from v8.7.0 to v9.2.0

### DIFF
--- a/docs/user-guide/04-migration-guides.md
+++ b/docs/user-guide/04-migration-guides.md
@@ -28,6 +28,10 @@ with XXX in
 #### Short term storage: efficiency for withdrawal
 In input/st-storage/area/list.ini add property: `efficiencywithdrawal` [double] in range 0-1
 
+#### Hydro Final Reservoir Level
+In the existing file **settings/scenariobuilder.dat**, under **&lt;ruleset&gt;** section following properties added (if final reservoir level specified, different from `init`):
+* **hfl,&lt;area&gt;,&lt;year&gt; = &lt;hfl-value&gt;**
+
 ### Output
 - Remove column SPIL ENRG CSR (adequacy patch)
 - Add DTG MRG CSR and UNSP ENRG CSR variables
@@ -140,10 +144,6 @@ For each thermal cluster, in existing file **input/thermal/clusters/&lt;area&gt;
 * `variableomcost` [float] excluded from the section if default value 0 is selected (default behavior). Unit is Euro / MWh
 
 For each thermal cluster, new files added **input/thermal/series/&lt;area&gt;/&lt;cluster&gt;/CO2Cost.txt** and **input/thermal/series/&lt;area&gt;/&lt;cluster&gt;/fuelCost.txt**. **fuelCost.txt** and **CO2Cost.txt** must either have one column, or the same number of columns as existing file **series.txt** (availability). The number of rows for these new matrices is 8760.
-
-#### Hydro Final Reservoir Level
-In the existing file **settings/scenariobuilder.dat**, under **&lt;ruleset&gt;** section following properties added (if final reservoir level specified, different from `init`):
-* **hfl,&lt;area&gt;,&lt;year&gt; = &lt;hfl-value&gt;**
 
 ### Output
 #### Scenarized RHS for binding constraints


### PR DESCRIPTION
Upon a remark from @nikolaredstork, we make this correction (see title).
Indeed, this functionality (final hydro levels) can't be found in **v8.7.0**, but will be delivered within **v9.2.0**.
