### PR TITLE
Unit test for reverse calculation

### DIFF
--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -210,6 +210,8 @@ BOOST_FIXTURE_TEST_CASE(WithForceNoGenOptionTimeSeriesNotGeneratedForReverseSpin
                         ThermalClusterStudy)
 {
     cluster->tsGenBehavior = LocalTSGenerationBehavior::forceNoGen;
+    cluster->spinning = 0.9; // An arbitrary value != 1.0 is chosen here, otherwise the reverse
+                             // calculation of spinning does nothing
     auto& ts = cluster->series.timeSeries;
 
     ts.resize(1, 8760);

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -199,6 +199,16 @@ BOOST_FIXTURE_TEST_CASE(thermal_cluster_delete, ThermalClusterStudy)
     BOOST_CHECK(areaA->thermal.list.empty());
 }
 
+BOOST_FIXTURE_TEST_CASE(thermal_cluster_forceNoGen, ThermalClusterStudy)
+{
+    cluster->tsGenBehavior = LocalTSGenerationBehavior::forceNoGen;
+    cluster->series.timeSeries.resize(1, 8760);
+    cluster->series.timeSeries.fill(100);
+    cluster->reverseCalculationOfSpinning();
+
+    BOOST_CHECK_EQUAL(cluster->series[0][0], 100);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // thermal clusters
 
 BOOST_AUTO_TEST_SUITE(renewable_clusters_operations)

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -207,13 +207,27 @@ BOOST_FIXTURE_TEST_CASE(WithForceNoGenOptionTimeSeriesNotGeneratedForReverseSpin
     cluster->series.timeSeries.fill(100);
     cluster->reverseCalculationOfSpinning();
 
-    for (unsigned int i = 0; i < cluster->series.timeSeries.width; ++i)
+    bool all_equals = true;
+    unsigned i = 0;
+    unsigned j = 0;
+    for (i = 0; i < cluster->series.timeSeries.width && all_equals; ++i)
     {
-        for (unsigned int j = 0; j < cluster->series.timeSeries.height; ++i)
+        for (j = 0; j < cluster->series.timeSeries.height; ++j)
         {
-            BOOST_CHECK_EQUAL(cluster->series[i][j], 100);
+            if (cluster->series[i][j] != 100)
+            {
+                all_equals = false;
+                break;
+            }
         }
     }
+    if (!all_equals)
+    {
+        std::ostringstream msg("Error at :");
+        msg << i << "," << j << std::endl;
+        BOOST_TEST_INFO(msg.str());
+    }
+    BOOST_CHECK(all_equals);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // thermal clusters

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -186,49 +186,48 @@ struct ThermalClusterStudy: public OneAreaStudy
 BOOST_FIXTURE_TEST_CASE(thermal_cluster_rename, ThermalClusterStudy)
 {
     BOOST_CHECK(study->clusterRename(cluster, "Renamed"));
-    BOOST_CHECK(cluster->name() == "Renamed");
-    BOOST_CHECK(cluster->id() == "renamed");
+    BOOST_CHECK_EQUAL(cluster->name(), "Renamed");
+    BOOST_CHECK_EQUAL(cluster->id(), "renamed");
 }
 
 BOOST_FIXTURE_TEST_CASE(thermal_cluster_delete, ThermalClusterStudy)
 {
     // gp : remove() only used in GUI (will go away when removing the GUI)
-    BOOST_CHECK(areaA->thermal.list.findInAll("cluster") == cluster);
+    BOOST_CHECK_EQUAL(areaA->thermal.list.findInAll("cluster"), cluster);
     areaA->thermal.list.remove("cluster");
-    BOOST_CHECK(areaA->thermal.list.findInAll("cluster") == nullptr);
+    BOOST_CHECK_EQUAL(areaA->thermal.list.findInAll("cluster"), nullptr);
     BOOST_CHECK(areaA->thermal.list.empty());
 }
+
+// Custom macro
+#define BOOST_CHECK_EQUAL_MESSAGE(L, R, M) \
+    {                                      \
+        BOOST_TEST_INFO(M);                \
+        BOOST_CHECK_EQUAL(L, R);           \
+    }
 
 BOOST_FIXTURE_TEST_CASE(WithForceNoGenOptionTimeSeriesNotGeneratedForReverseSpinning,
                         ThermalClusterStudy)
 {
     cluster->tsGenBehavior = LocalTSGenerationBehavior::forceNoGen;
-    cluster->series.timeSeries.resize(1, 8760);
-    cluster->series.timeSeries.fill(100);
+    auto& ts = cluster->series.timeSeries;
+
+    ts.resize(1, 8760);
+    ts.fill(100);
     cluster->reverseCalculationOfSpinning();
 
-    bool all_equals = true;
-    unsigned i = 0;
-    unsigned j = 0;
-    for (i = 0; i < cluster->series.timeSeries.width && all_equals; ++i)
+    for (unsigned i = 0; i < ts.width; ++i)
     {
-        for (j = 0; j < cluster->series.timeSeries.height; ++j)
+        for (unsigned j = 0; j < ts.height; ++j)
         {
-            if (cluster->series[i][j] != 100)
-            {
-                all_equals = false;
-                break;
-            }
+            BOOST_CHECK_EQUAL_MESSAGE(ts[i][j],
+                                      100,
+                                      "Error at " + std::to_string(i) + ", " + std::to_string(j));
         }
     }
-    if (!all_equals)
-    {
-        std::ostringstream msg("Error at :");
-        msg << i << "," << j << std::endl;
-        BOOST_TEST_INFO(msg.str());
-    }
-    BOOST_CHECK(all_equals);
 }
+
+#undef BOOST_CHECK_EQUAL_MESSAGE
 
 BOOST_AUTO_TEST_SUITE_END() // thermal clusters
 

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -199,14 +199,21 @@ BOOST_FIXTURE_TEST_CASE(thermal_cluster_delete, ThermalClusterStudy)
     BOOST_CHECK(areaA->thermal.list.empty());
 }
 
-BOOST_FIXTURE_TEST_CASE(thermal_cluster_forceNoGen, ThermalClusterStudy)
+BOOST_FIXTURE_TEST_CASE(WithForceNoGenOptionTimeSeriesNotGeneratedForReverseSpinning,
+                        ThermalClusterStudy)
 {
     cluster->tsGenBehavior = LocalTSGenerationBehavior::forceNoGen;
     cluster->series.timeSeries.resize(1, 8760);
     cluster->series.timeSeries.fill(100);
     cluster->reverseCalculationOfSpinning();
 
-    BOOST_CHECK_EQUAL(cluster->series[0][0], 100);
+    for (unsigned int i = 0; i < cluster->series.timeSeries.width; ++i)
+    {
+        for (unsigned int j = 0; j < cluster->series.timeSeries.height; ++i)
+        {
+            BOOST_CHECK_EQUAL(cluster->series[i][j], 100);
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END() // thermal clusters


### PR DESCRIPTION
Add new test checks the behavior of the `thermal_cluster` when the generation behavior is forced to no generation.
Verify the `thermal_cluster` behavior when `tsGenBehavior` is set to `LocalTSGenerationBehavior::forceNoGen` and the time series is filled with a constant value.