### PR TITLE
Allow the passing of optimization options through the API

### DIFF
--- a/src/api/API.cpp
+++ b/src/api/API.cpp
@@ -66,19 +66,16 @@ SimulationResults APIInternal::execute(
         return {.simulationPath{}, .antares_problems{}, .error = err};
     }
 
-    // Only those two fields are used un simulation
     Settings settings;
-    settings.tsGeneratorsOnly = false;
-    settings.noOutput = false;
-
-    settings.optOptions = optOptions;
+    auto& parameters = study_->parameters;
+    parameters.optOptions = optOptions;
 
     Benchmarking::DurationCollector durationCollector;
     Benchmarking::OptimizationInfo optimizationInfo;
     auto ioQueueService = std::make_shared<Yuni::Job::QueueService>();
     ioQueueService->maximumThreadCount(1);
     ioQueueService->start();
-    auto resultWriter = Solver::resultWriterFactory(study_->parameters.resultFormat,
+    auto resultWriter = Solver::resultWriterFactory(parameters.resultFormat,
                                                     study_->folderOutput,
                                                     ioQueueService,
                                                     durationCollector);

--- a/src/api/API.cpp
+++ b/src/api/API.cpp
@@ -32,7 +32,9 @@
 
 namespace Antares::API
 {
-SimulationResults APIInternal::run(const IStudyLoader& study_loader)
+SimulationResults APIInternal::run(
+  const IStudyLoader& study_loader,
+  const Antares::Solver::Optimization::OptimizationOptions& optOptions)
 {
     try
     {
@@ -43,7 +45,7 @@ SimulationResults APIInternal::run(const IStudyLoader& study_loader)
         Antares::API::Error err{.reason = e.what()};
         return {.simulationPath = "", .antares_problems = {}, .error = err};
     }
-    return execute();
+    return execute(optOptions);
 }
 
 /**
@@ -53,7 +55,8 @@ SimulationResults APIInternal::run(const IStudyLoader& study_loader)
  * This method is initialy a copy of Application::execute with some modifications hence the apparent
  * dupllication
  */
-SimulationResults APIInternal::execute() const
+SimulationResults APIInternal::execute(
+  const Antares::Solver::Optimization::OptimizationOptions& optOptions) const
 {
     // study_ == nullptr e.g when the -h flag is given
     if (!study_)
@@ -67,6 +70,8 @@ SimulationResults APIInternal::execute() const
     Settings settings;
     settings.tsGeneratorsOnly = false;
     settings.noOutput = false;
+
+    settings.optOptions = optOptions;
 
     Benchmarking::DurationCollector durationCollector;
     Benchmarking::OptimizationInfo optimizationInfo;

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -30,11 +30,12 @@ target_include_directories(solver_api
 
 target_link_libraries(solver_api
         PRIVATE
+        Antares::file-tree-study-loader
         Antares::study
         Antares::study-loader
-        Antares::file-tree-study-loader
         antares-solver-simulation
         PUBLIC
+        Antares::optimization-options
         Antares::lps
 )
 install(DIRECTORY include/antares

--- a/src/api/include/antares/api/solver.h
+++ b/src/api/include/antares/api/solver.h
@@ -21,6 +21,9 @@
  */
 
 #pragma once
+
+#include <antares/optimization-options/options.h>
+
 #include "SimulationResults.h"
 
 namespace Antares::API
@@ -31,5 +34,7 @@ namespace Antares::API
  * @return SimulationResults object which contains the results of the simulation.
  * @exception noexcept This function does not throw exceptions.
  */
-SimulationResults PerformSimulation(const std::filesystem::path& study_path) noexcept;
+SimulationResults PerformSimulation(
+  const std::filesystem::path& study_path,
+  const Antares::Solver::Optimization::OptimizationOptions& optOptions) noexcept;
 } // namespace Antares::API

--- a/src/api/private/API.h
+++ b/src/api/private/API.h
@@ -22,6 +22,7 @@
 #pragma once
 #include <filesystem>
 
+#include <antares/optimization-options/options.h>
 #include <antares/study-loader/IStudyLoader.h>
 #include "antares/api/SimulationResults.h"
 
@@ -46,11 +47,13 @@ public:
      * load the study that will be simulated.
      * @return SimulationResults object which contains the results of the simulation.
      */
-    SimulationResults run(const IStudyLoader& study_loader);
+    SimulationResults run(const IStudyLoader& study_loader,
+                          const Antares::Solver::Optimization::OptimizationOptions& optOptions);
 
 private:
     std::shared_ptr<Antares::Data::Study> study_;
-    SimulationResults execute() const;
+    SimulationResults execute(
+      const Antares::Solver::Optimization::OptimizationOptions& optOptions) const;
 };
 
 } // namespace Antares::API

--- a/src/api/solver.cpp
+++ b/src/api/solver.cpp
@@ -28,13 +28,15 @@
 namespace Antares::API
 {
 
-SimulationResults PerformSimulation(const std::filesystem::path& study_path) noexcept
+SimulationResults PerformSimulation(
+  const std::filesystem::path& study_path,
+  const Antares::Solver::Optimization::OptimizationOptions& optOptions) noexcept
 {
     try
     {
         APIInternal api;
         FileTreeStudyLoader study_loader(study_path);
-        return api.run(study_loader);
+        return api.run(study_loader, optOptions);
     }
     catch (const std::exception& e)
     {

--- a/src/api_client_example/src/API_client.cpp
+++ b/src/api_client_example/src/API_client.cpp
@@ -19,12 +19,11 @@
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
 
-
 #include "API_client.h"
 
 #include <utility>
 
-Antares::API::SimulationResults solve(std::filesystem::path study_path) {
-    return Antares::API::PerformSimulation(std::move(study_path));
+Antares::API::SimulationResults solve(std::filesystem::path study_path)
+{
+    return Antares::API::PerformSimulation(std::move(study_path), {});
 }
-

--- a/src/libs/antares/exception/include/antares/exception/AssertionError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/AssertionError.hpp
@@ -31,8 +31,7 @@ class AssertionError: public std::runtime_error
 {
 public:
     explicit AssertionError(const std::string& message);
-
-    ~AssertionError() noexcept override = default;
+    ~AssertionError() = default;
 };
 
 } // namespace Data

--- a/src/libs/antares/exception/include/antares/exception/AssertionError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/AssertionError.hpp
@@ -31,7 +31,6 @@ class AssertionError: public std::runtime_error
 {
 public:
     explicit AssertionError(const std::string& message);
-    ~AssertionError() = default;
 };
 
 } // namespace Data

--- a/src/libs/antares/optimization-options/CMakeLists.txt
+++ b/src/libs/antares/optimization-options/CMakeLists.txt
@@ -8,3 +8,6 @@ target_include_directories(${PROJ}
 )
 
 add_library(Antares::${PROJ} ALIAS ${PROJ})
+
+install(DIRECTORY   include/antares
+        DESTINATION "include")

--- a/src/libs/antares/optimization-options/include/antares/optimization-options/options.h
+++ b/src/libs/antares/optimization-options/include/antares/optimization-options/options.h
@@ -20,7 +20,7 @@
 */
 
 #pragma once
-#include <antares/logs/logs.h>
+#include <string>
 
 namespace Antares::Solver::Optimization
 {

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -30,7 +30,6 @@
 #include <yuni/yuni.h>
 
 #include <antares/antares/constants.h>
-#include <antares/exception/AssertionError.hpp>
 #include <antares/exception/LoadingError.hpp>
 #include <antares/logs/logs.h>
 #include <antares/study/study.h>

--- a/src/solver/modeler/ortoolsImpl/linearProblem.cpp
+++ b/src/solver/modeler/ortoolsImpl/linearProblem.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <ortools/linear_solver/linear_solver.h>
 
+#include <antares/logs/logs.h>
 #include <antares/solver/modeler/ortoolsImpl/linearProblem.h>
 #include <antares/solver/utils/ortools_utils.h>
 

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -21,6 +21,7 @@
 #include "antares/solver/utils/ortools_utils.h"
 
 #include <filesystem>
+#include <optional>
 
 #include <antares/exception/AssertionError.hpp>
 #include <antares/exception/LoadingError.hpp>
@@ -354,33 +355,42 @@ std::string availableOrToolsSolversString()
     return solvers.str();
 }
 
-MPSolver* MPSolverFactory(const bool isMip, const std::string& solverName)
+static std::optional<std::string> translateSolverName(const std::string& solverName, bool isMip)
 {
-    MPSolver* solver;
     try
     {
         if (isMip)
         {
-            solver = MPSolver::CreateSolver((OrtoolsUtils::solverMap.at(solverName)).MIPSolverName);
+            return OrtoolsUtils::solverMap.at(solverName).MIPSolverName;
         }
         else
         {
-            solver = MPSolver::CreateSolver((OrtoolsUtils::solverMap.at(solverName)).LPSolverName);
-        }
-
-        if (!solver)
-        {
-            std::string msg_to_throw = "Solver " + solverName + " not found. \n";
-            msg_to_throw += "Please make sure that your OR-Tools install supports solver "
-                            + solverName + ".";
-
-            throw Antares::Data::AssertionError(msg_to_throw);
+            return OrtoolsUtils::solverMap.at(solverName).LPSolverName;
         }
     }
-    catch (...)
+    catch (const std::out_of_range& oor)
     {
-        Antares::logs.error() << "Solver creation failed.";
-        throw;
+        return {};
+    }
+}
+
+MPSolver* MPSolverFactory(const bool isMip, const std::string& solverName)
+{
+    const std::string notFound = "Solver " + solverName
+                                 + " not found. Please use one of the following "
+                                 + availableOrToolsSolversString();
+    const Antares::Data::AssertionError assertionError(notFound);
+
+    auto internalSolverName = translateSolverName(solverName, isMip);
+    if (!internalSolverName)
+    {
+        throw assertionError;
+    }
+
+    MPSolver* solver = MPSolver::CreateSolver(*internalSolverName);
+    if (!solver)
+    {
+        throw assertionError;
     }
 
     return solver;

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -23,7 +23,6 @@
 #include <filesystem>
 #include <optional>
 
-#include <antares/exception/AssertionError.hpp>
 #include <antares/exception/LoadingError.hpp>
 #include <antares/logs/logs.h>
 #include "antares/antares/Enum.hpp"
@@ -379,18 +378,18 @@ MPSolver* MPSolverFactory(const bool isMip, const std::string& solverName)
     const std::string notFound = "Solver " + solverName
                                  + " not found. Please use one of the following "
                                  + availableOrToolsSolversString();
-    const Antares::Data::AssertionError assertionError(notFound);
+    const std::invalid_argument except(notFound);
 
     auto internalSolverName = translateSolverName(solverName, isMip);
     if (!internalSolverName)
     {
-        throw assertionError;
+        throw except;
     }
 
     MPSolver* solver = MPSolver::CreateSolver(*internalSolverName);
     if (!solver)
     {
-        throw assertionError;
+        throw except;
     }
 
     return solver;

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -368,7 +368,7 @@ static std::optional<std::string> translateSolverName(const std::string& solverN
             return OrtoolsUtils::solverMap.at(solverName).LPSolverName;
         }
     }
-    catch (const std::out_of_range& oor)
+    catch (const std::out_of_range&)
     {
         return {};
     }

--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -375,9 +375,7 @@ static std::optional<std::string> translateSolverName(const std::string& solverN
 
 MPSolver* MPSolverFactory(const bool isMip, const std::string& solverName)
 {
-    const std::string notFound = "Solver " + solverName
-                                 + " not found. Please use one of the following "
-                                 + availableOrToolsSolversString();
+    const std::string notFound = "Solver " + solverName + " not found";
     const std::invalid_argument except(notFound);
 
     auto internalSolverName = translateSolverName(solverName, isMip);

--- a/src/tests/src/api_internal/CMakeLists.txt
+++ b/src/tests/src/api_internal/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(${EXECUTABLE_NAME}
         Boost::unit_test_framework
         Antares::solver_api
         Antares::tests::in-memory-study
+	test_utils_unit
 )
 
 target_include_directories(${EXECUTABLE_NAME}

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -96,3 +96,20 @@ BOOST_AUTO_TEST_CASE(result_contains_problems)
     BOOST_CHECK(!results.error);
     BOOST_CHECK_EQUAL(results.antares_problems.weeklyProblems.size(), 52);
 }
+
+// Test where data in problems are consistant with data in study
+BOOST_AUTO_TEST_CASE(result_with_ortools_coin)
+{
+    Antares::API::APIInternal api;
+    auto study_loader = std::make_unique<InMemoryStudyLoader>();
+    const Antares::Solver::Optimization::OptimizationOptions opt{.ortoolsUsed = true,
+                                                                 .ortoolsSolver = "coin",
+                                                                 .solverLogs = false,
+                                                                 .solverParameters = ""};
+
+    auto results = api.run(*study_loader.get(), opt);
+
+    BOOST_CHECK(!results.antares_problems.empty());
+    BOOST_CHECK(!results.error);
+    BOOST_CHECK_EQUAL(results.antares_problems.weeklyProblems.size(), 52);
+}

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -128,5 +128,5 @@ BOOST_AUTO_TEST_CASE(invalid_ortools_solver)
       .solverParameters = ""};
 
     auto shouldThrow = [&api, &study_loader, &opt] { return api.run(*study_loader.get(), opt); };
-    BOOST_CHECK_THROW(shouldThrow(), Antares::FatalError);
+    BOOST_CHECK_THROW(shouldThrow(), std::invalid_argument);
 }

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -26,6 +26,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <antares/antares/fatal-error.h>
+
 #include "API.h"
 #include "in-memory-study.h"
 
@@ -112,4 +114,19 @@ BOOST_AUTO_TEST_CASE(result_with_ortools_coin)
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);
     BOOST_CHECK_EQUAL(results.antares_problems.weeklyProblems.size(), 52);
+}
+
+// Test where we use an invalid OR-Tools
+BOOST_AUTO_TEST_CASE(invalid_ortools_solver)
+{
+    Antares::API::APIInternal api;
+    auto study_loader = std::make_unique<InMemoryStudyLoader>();
+    const Antares::Solver::Optimization::OptimizationOptions opt{
+      .ortoolsUsed = true,
+      .ortoolsSolver = "this-solver-does-not-exist",
+      .solverLogs = true,
+      .solverParameters = ""};
+
+    auto shouldThrow = [&api, &study_loader, &opt] { return api.run(*study_loader.get(), opt); };
+    BOOST_CHECK_THROW(shouldThrow(), Antares::FatalError);
 }

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(simulation_path_points_to_results)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    auto results = api.run(*study_loader.get());
+    auto results = api.run(*study_loader.get(), {});
     BOOST_CHECK_EQUAL(results.simulationPath, std::filesystem::path{"no_output"});
     // Testing for "no_output" is a bit weird, but it's the only way to test this without actually
     // running the simulation
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(api_run_contains_antares_problem)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    auto results = api.run(*study_loader.get());
+    auto results = api.run(*study_loader.get(), {});
 
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(result_failure_when_study_is_null)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>(false);
-    auto results = api.run(*study_loader.get());
+    auto results = api.run(*study_loader.get(), {});
 
     BOOST_CHECK(results.error);
 }
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(result_contains_problems)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    auto results = api.run(*study_loader.get());
+    auto results = api.run(*study_loader.get(), {});
 
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(result_with_ortools_coin)
     BOOST_CHECK_EQUAL(results.antares_problems.weeklyProblems.size(), 52);
 }
 
-// Test where we use an invalid OR-Tools
+// Test where we use an invalid OR-Tools solver
 BOOST_AUTO_TEST_CASE(invalid_ortools_solver)
 {
     Antares::API::APIInternal api;

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -28,6 +28,7 @@
 
 #include <antares/antares/fatal-error.h>
 
+#include "../../src/utils/unit_test_utils.h"
 #include "API.h"
 #include "in-memory-study.h"
 
@@ -128,5 +129,7 @@ BOOST_AUTO_TEST_CASE(invalid_ortools_solver)
       .solverParameters = ""};
 
     auto shouldThrow = [&api, &study_loader, &opt] { return api.run(*study_loader.get(), opt); };
-    BOOST_CHECK_THROW(shouldThrow(), std::invalid_argument);
+    BOOST_CHECK_EXCEPTION(shouldThrow(),
+                          std::invalid_argument,
+                          checkMessage("Solver this-solver-does-not-exist not found"));
 }

--- a/src/tests/src/api_lib/test_api.cpp
+++ b/src/tests/src/api_lib/test_api.cpp
@@ -29,7 +29,7 @@
 BOOST_AUTO_TEST_CASE(result_failure_when_study_path_invalid)
 {
     using namespace std::string_literals;
-    auto results = Antares::API::PerformSimulation("dummy"s);
+    auto results = Antares::API::PerformSimulation("dummy"s, {});
     BOOST_CHECK(results.error);
     BOOST_CHECK(!results.error->reason.empty());
 }

--- a/src/tests/src/study/system-model/CMakeLists.txt
+++ b/src/tests/src/study/system-model/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(${EXECUTABLE_NAME}
         PRIVATE
         Boost::unit_test_framework
         antares-study-system-model
+	test_utils_unit
 )
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)

--- a/src/tests/src/utils/CMakeLists.txt
+++ b/src/tests/src/utils/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(test_utils_unit
         files-system.cpp
         files-system.h
+	unit_test_utils.h
+	unit_test_utils.cpp
         )
 
 target_include_directories(

--- a/src/tests/src/utils/CMakeLists.txt
+++ b/src/tests/src/utils/CMakeLists.txt
@@ -5,6 +5,10 @@ add_library(test_utils_unit
 	unit_test_utils.cpp
         )
 
+target_link_libraries(test_utils_unit
+       PRIVATE
+       Boost::unit_test_framework)
+
 target_include_directories(
         test_utils_unit
                 PUBLIC

--- a/src/tests/src/utils/unit_test_utils.cpp
+++ b/src/tests/src/utils/unit_test_utils.cpp
@@ -1,0 +1,13 @@
+#include "unit_test_utils.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <boost/test/unit_test.hpp>
+
+std::function<bool(const std::exception&)> checkMessage(std::string expected_message)
+{
+    return [expected_message](const std::exception& e)
+    {
+        BOOST_CHECK_EQUAL(e.what(), expected_message);
+        return true;
+    };
+}

--- a/src/tests/src/utils/unit_test_utils.h
+++ b/src/tests/src/utils/unit_test_utils.h
@@ -21,18 +21,7 @@
 
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
-
+#include <functional>
 #include <string>
 
-#include <boost/test/unit_test.hpp>
-
-inline std::function<bool(const std::exception&)> checkMessage(std::string expected_message)
-{
-    auto predicate = [expected_message](const std::exception& e)
-    {
-        BOOST_CHECK_EQUAL(e.what(), expected_message);
-        return true;
-    };
-    return predicate;
-}
+std::function<bool(const std::exception&)> checkMessage(std::string expected_message);


### PR DESCRIPTION
- Add an `OptimizationOptions` argument to public function `PerformSimulation`
- Add an `OptimizationOptions` argument to private methods `API::run` and `API::execute`
- In the existing tests, use the default instance for `OptimizationOptions`, that is

```cpp
struct OptimizationOptions
{
    //! Force ortools use
    bool ortoolsUsed = false;
    //! The solver name, sirius is the default
    std::string ortoolsSolver = "sirius";
    bool solverLogs = false;
    std::string solverParameters;
};
```
- Add a test with COIN
- Move headers around (remove unused logs.h causing issues, etc.)