### PR TITLE
Fix build after the removal of bool OptimizationOptions::ortoolsUsed

### DIFF
--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -105,8 +105,7 @@ BOOST_AUTO_TEST_CASE(result_with_ortools_coin)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    const Antares::Solver::Optimization::OptimizationOptions opt{.ortoolsUsed = true,
-                                                                 .ortoolsSolver = "coin",
+    const Antares::Solver::Optimization::OptimizationOptions opt{.ortoolsSolver = "coin",
                                                                  .solverLogs = false,
                                                                  .solverParameters = ""};
 
@@ -123,7 +122,6 @@ BOOST_AUTO_TEST_CASE(invalid_ortools_solver)
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
     const Antares::Solver::Optimization::OptimizationOptions opt{
-      .ortoolsUsed = true,
       .ortoolsSolver = "this-solver-does-not-exist",
       .solverLogs = true,
       .solverParameters = ""};


### PR DESCRIPTION
We missed out some instances of `ortoolsUsed` because the PRs #2450 and #2502 were concurrent.