### PR TITLE
Hydro Reservoir Levels Check

### DIFF
--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -355,8 +355,8 @@ bool PartHydro::checkReservoirLevels(const Study& study)
         for (unsigned int day = 0; day < DAYS_PER_YEAR; day++)
         {
             if (!errorLevels
-                && (colMin[day] < 0 || colAvg[day] < 0 || colMin[day] > colMax[day]
-                    || colAvg[day] > 100 || colMax[day] > 100))
+                && (0 > colMin[day] || colMin[day] > colAvg[day] || colAvg[day] > colMax[day]
+                    || colMax[day] > 100))
             {
                 logs.error() << areaName << ": invalid reservoir level value";
                 errorLevels = true;


### PR DESCRIPTION
At the moment, minimum reservoir levels can be greater than average reservoir levels and average reservoir levels can be greater than maximum reservoir levels. 
This PR introduces new checking logic: 0 <= minLevel <= avgLevel <= maxLevel <= 100
With new checking logic minimum levels cannot be greater than average levels and average levels cannot be greater than maximum levels.
Note: Function where Antares is checking reservoir levels is called `checkReservoirLevels`, but also in this function Antares is checking inflow patterns (data that is used for TS generator) and credit modulation data. Maybe this function should be renamed or broken down into three separate functions.
