### PR TITLE
Fix launch studies with empty solver

### DIFF
--- a/src/ui/simulator/application/study.cpp
+++ b/src/ui/simulator/application/study.cpp
@@ -1207,7 +1207,10 @@ void RunSimulationOnTheStudy(Data::Study::Ptr study,
                 cmd << " --parallel";
 
             // add solver name for ortools
-            cmd << " --solver=" << solverName;
+            if (!solverName.empty())
+            {
+                cmd << " --solver=" << solverName;
+            }
 
             // Go go go !
             logs.debug() << "running " << cmd;


### PR DESCRIPTION
By default, the "solver" field is empty. So the command line looks like this

```
antares-solver --progress "029 Pumped storage" --solver=
```
which is invalid. Unless the user provides a solver, don't append "--solver=<solverName>" at the end of the command line.