### PR TITLE
Fix function `ThermalCluster::getMarketBidCost` [ANT-2527]

### DIFF
--- a/src/libs/antares/study/parts/thermal/cluster.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster.cpp
@@ -386,8 +386,8 @@ void ThermalCluster::ComputeProductionCostTS()
 
         for (uint hour = 0; hour < HOURS_PER_YEAR; ++hour)
         {
-            double& houtlyModulation = modulation[Data::thermalModulationCost][hour];
-            productionCostTS[hour] = marginalCostTS[hour] * houtlyModulation;
+            double hourlyModulation = modulation[Data::thermalModulationCost][hour];
+            productionCostTS[hour] = marginalCostTS[hour] * hourlyModulation;
         }
     }
 }
@@ -748,9 +748,7 @@ double ThermalCluster::getMarginalCost(uint serieIndex, uint hourInTheYear) cons
 
 double ThermalCluster::getMarketBidCost(uint hourInTheYear, uint year) const
 {
-    uint serieIndex = series.getSeriesIndex(year);
-
-    double mod = modulation[thermalModulationMarketBid][serieIndex];
+    const double mod = modulation[thermalModulationMarketBid][hourInTheYear];
 
     if (costgeneration == Data::setManually)
     {
@@ -758,6 +756,7 @@ double ThermalCluster::getMarketBidCost(uint hourInTheYear, uint year) const
     }
     else
     {
+        const uint serieIndex = series.getSeriesIndex(year);
         const uint tsIndex = std::min(serieIndex, (uint)costsTimeSeries.size() - 1);
         return costsTimeSeries[tsIndex].marketBidCostTS[hourInTheYear] * mod;
     }

--- a/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
@@ -265,4 +265,27 @@ BOOST_FIXTURE_TEST_CASE(computeMarketBidCost, FixtureFull)
 
     BOOST_CHECK_CLOSE(cluster->computeMarketBidCost(1, 2, 1), 24.12, 0.001);
 }
+
+BOOST_AUTO_TEST_CASE(non_constant_marketbid_modulation)
+{
+    Area area;
+    ThermalCluster cluster(&area);
+    cluster.costgeneration = setManually;
+    cluster.marketBidCost = 120;
+
+    auto& mod = cluster.modulation;
+    mod.resize(thermalModulationMax, HOURS_PER_YEAR);
+    mod.fill(1.);
+
+    {
+        mod[thermalModulationMarketBid][0] = .5;
+        BOOST_CHECK_EQUAL(cluster.getMarketBidCost(0, 0), .5 * 120);
+    }
+
+    {
+        mod[thermalModulationMarketBid][1] = .8;
+        BOOST_CHECK_EQUAL(cluster.getMarketBidCost(1, 0), .8 * 120);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The index was wrong, we expected an hour in the year 0..8659, but got an index 0..infinity.