### PR TITLE
Add and use add_boost_test CMake helper function

### DIFF
--- a/src/tests/end-to-end/binding_constraints/CMakeLists.txt
+++ b/src/tests/end-to-end/binding_constraints/CMakeLists.txt
@@ -3,7 +3,6 @@ include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 add_boost_test(tests-binding_constraints
      SRC test_binding_constraints.cpp
      LIBS
-     Boost::unit_test_framework
      model_antares
      antares-solver-simulation
      antares-solver-hydro

--- a/src/tests/end-to-end/binding_constraints/CMakeLists.txt
+++ b/src/tests/end-to-end/binding_constraints/CMakeLists.txt
@@ -1,30 +1,11 @@
-find_package(Boost COMPONENTS unit_test_framework REQUIRED)
-enable_testing()
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-#bigobj support needed for windows compilation
-if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-endif(MSVC)
-
-add_executable(tests-binding_constraints
-        test_binding_constraints.cpp
-    )
-
-target_link_libraries(tests-binding_constraints
-        PRIVATE
-        Boost::unit_test_framework
-        model_antares
-        antares-solver-simulation
-        antares-solver-hydro
-        antares-solver-ts-generator
-        Antares::tests::in-memory-study
-    )
-
-target_include_directories(tests-binding_constraints
-        PRIVATE
-        ${CMAKE_SOURCE_DIR}/solver
-        )
-
-add_test(NAME end-to-end-binding_constraints COMMAND tests-binding_constraints)
-set_property(TEST end-to-end-binding_constraints PROPERTY LABELS end-to-end)
-set_target_properties(tests-binding_constraints PROPERTIES FOLDER Unit-tests/end_to_end)
+add_boost_test(tests-binding_constraints
+     SRC test_binding_constraints.cpp
+     LIBS
+     Boost::unit_test_framework
+     model_antares
+     antares-solver-simulation
+     antares-solver-hydro
+     antares-solver-ts-generator
+     Antares::tests::in-memory-study)

--- a/src/tests/end-to-end/simple_study/CMakeLists.txt
+++ b/src/tests/end-to-end/simple_study/CMakeLists.txt
@@ -8,5 +8,4 @@ add_boost_test(tests-simple-study
       antares-solver-simulation
       antares-solver-ts-generator
       model_antares
-      ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
       Antares::tests::in-memory-study)

--- a/src/tests/end-to-end/simple_study/CMakeLists.txt
+++ b/src/tests/end-to-end/simple_study/CMakeLists.txt
@@ -1,35 +1,12 @@
-find_package(Boost COMPONENTS unit_test_framework REQUIRED)
-enable_testing()
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-#bigobj support needed for windows compilation
-if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-endif(MSVC)
-
-add_executable(tests-simple-study
-        simple-study.cpp
-)
-
-target_link_libraries(tests-simple-study
-        PRIVATE
-        antares-solver-hydro
-        antares-solver-variable
-        antares-solver-simulation
-        antares-solver-ts-generator
-        model_antares
-        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-        Antares::tests::in-memory-study
-)
-
-target_include_directories(tests-simple-study
-        PRIVATE
-        ${CMAKE_SOURCE_DIR}/solver
-)
-
-add_test(NAME end-to-end-simple-study COMMAND tests-simple-study)
-set_property(TEST end-to-end-simple-study PROPERTY LABELS end-to-end)
-set_target_properties(tests-simple-study PROPERTIES FOLDER Unit-tests/end_to_end)
-
-# Storing tests-simple-study under the folder Unit-tests in the IDE
-
-#----------------------------------------------------------
+add_boost_test(tests-simple-study
+      SRC simple-study.cpp
+      LIBS
+      antares-solver-hydro
+      antares-solver-variable
+      antares-solver-simulation
+      antares-solver-ts-generator
+      model_antares
+      ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+      Antares::tests::in-memory-study)

--- a/src/tests/macros.cmake
+++ b/src/tests/macros.cmake
@@ -29,4 +29,10 @@ function(add_boost_test)
 
     # Give the IDE some directions to display tests in a "Unit-tests" folder
     set_target_properties(${TEST_NAME} PROPERTIES FOLDER Unit-tests)
+
+    # Linux only. TODO remove ?
+    if(UNIX AND NOT APPLE)
+      target_link_libraries(${TEST_NAME} PRIVATE stdc++fs)
+    endif()
+
 endfunction()

--- a/src/tests/macros.cmake
+++ b/src/tests/macros.cmake
@@ -1,0 +1,14 @@
+function(add_boost_test)
+    set(options "")
+    set(oneValueArgs)
+    set(multiValueArgs SRC LIBS)
+    cmake_parse_arguments(PARSE_ARGV 0 arg
+        "${options}" "${oneValueArgs}" "${multiValueArgs}")
+    # Bypass cmake_parse_arguments for the 1st argument
+    set(TEST_NAME ${ARGV0})
+    add_executable(${TEST_NAME} ${arg_SRC})
+    # All tests use boost
+    target_link_libraries(${TEST_NAME} PRIVATE ${arg_LIBS} Boost::unit_test_framework)
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+    set_property(TEST ${TEST_NAME} PROPERTY LABELS unit)
+endfunction()

--- a/src/tests/macros.cmake
+++ b/src/tests/macros.cmake
@@ -1,7 +1,14 @@
+# The following function allows to add a test in a single line
+# Arguments
+# SRC path to the sources
+# (optional) LIBS path to the libs to link
+# (optional) INCLUDE include paths
+# NOTE it's not necessary to add Boost::unit_test_framework
+
 function(add_boost_test)
     set(options "")
     set(oneValueArgs)
-    set(multiValueArgs SRC LIBS)
+    set(multiValueArgs SRC LIBS INCLUDE)
     cmake_parse_arguments(PARSE_ARGV 0 arg
         "${options}" "${oneValueArgs}" "${multiValueArgs}")
     # Bypass cmake_parse_arguments for the 1st argument
@@ -9,6 +16,17 @@ function(add_boost_test)
     add_executable(${TEST_NAME} ${arg_SRC})
     # All tests use boost
     target_link_libraries(${TEST_NAME} PRIVATE ${arg_LIBS} Boost::unit_test_framework)
+
+    # Optional: add private include directories
+    if (NOT "${arg_INCLUDE}" STREQUAL "")
+      target_include_directories(${TEST_NAME} PRIVATE ${arg_INCLUDE})
+    endif()
+
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+
+    # Adding labels allows ctest filter what tests to run
     set_property(TEST ${TEST_NAME} PROPERTY LABELS unit)
+
+    # Give the IDE some directions to display tests in a "Unit-tests" folder
+    set_target_properties(${TEST_NAME} PROPERTIES FOLDER Unit-tests)
 endfunction()

--- a/src/tests/src/api_internal/CMakeLists.txt
+++ b/src/tests/src/api_internal/CMakeLists.txt
@@ -1,28 +1,14 @@
-set(EXECUTABLE_NAME test-api)
-add_executable(${EXECUTABLE_NAME})
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_sources(${EXECUTABLE_NAME}
-    PRIVATE
-    test_api.cpp
-)
+add_boost_test(test-api
+  SRC test_api.cpp
+  LIBS
+  Boost::unit_test_framework
+  Antares::solver_api
+  Antares::tests::in-memory-study
+  test_utils_unit)
 
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        Antares::solver_api
-        Antares::tests::in-memory-study
-	test_utils_unit
-)
-
-target_include_directories(${EXECUTABLE_NAME}
+target_include_directories(test-api
         PRIVATE
         #Allow to use the private headers
-        $<TARGET_PROPERTY:Antares::solver_api,INCLUDE_DIRECTORIES>
-)
-
-# Storing tests-ts-numbers under the folder Unit-tests in the IDE
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME test-api COMMAND ${EXECUTABLE_NAME})
-
-set_property(TEST test-api PROPERTY LABELS unit)
+        $<TARGET_PROPERTY:Antares::solver_api,INCLUDE_DIRECTORIES>)

--- a/src/tests/src/api_internal/CMakeLists.txt
+++ b/src/tests/src/api_internal/CMakeLists.txt
@@ -3,7 +3,6 @@ include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 add_boost_test(test-api
   SRC test_api.cpp
   LIBS
-  Boost::unit_test_framework
   Antares::solver_api
   Antares::tests::in-memory-study
   test_utils_unit)

--- a/src/tests/src/api_internal/CMakeLists.txt
+++ b/src/tests/src/api_internal/CMakeLists.txt
@@ -5,9 +5,7 @@ add_boost_test(test-api
   LIBS
   Antares::solver_api
   Antares::tests::in-memory-study
-  test_utils_unit)
-
-target_include_directories(test-api
-        PRIVATE
-        #Allow to use the private headers
-        $<TARGET_PROPERTY:Antares::solver_api,INCLUDE_DIRECTORIES>)
+  test_utils_unit
+  #Allow to use the private headers
+  INCLUDE
+  $<TARGET_PROPERTY:Antares::solver_api,INCLUDE_DIRECTORIES>)

--- a/src/tests/src/api_lib/CMakeLists.txt
+++ b/src/tests/src/api_lib/CMakeLists.txt
@@ -1,20 +1,5 @@
-set(EXECUTABLE_NAME test-client-api)
-add_executable(${EXECUTABLE_NAME})
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_sources(${EXECUTABLE_NAME}
-        PRIVATE
-        test_api.cpp
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        Antares::solver_api
-)
-
-# Storing tests-ts-numbers under the folder Unit-tests in the IDE
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME test-client-api COMMAND ${EXECUTABLE_NAME})
-
-set_property(TEST test-client-api PROPERTY LABELS unit)
+add_boost_test(test-client-api
+  SRC test_api.cpp
+  LIBS Antares::solver_api)

--- a/src/tests/src/libs/antares/CMakeLists.txt
+++ b/src/tests/src/libs/antares/CMakeLists.txt
@@ -18,108 +18,63 @@ set(SRC_MATRIX_LIB
 	
 	# Necessary cpp files
 	${src_libs_antares}/jit/jit.cpp
-	logs/logs.cpp
-	)
+	logs/logs.cpp)
 
 add_library(matrix ${SRC_MATRIX_LIB})
 
 target_link_libraries(matrix
 		PUBLIC
-		yuni-static-core
-)
+		yuni-static-core)
 
 target_include_directories(matrix
-								PRIVATE
-									"${CMAKE_CURRENT_SOURCE_DIR}/logs"
-									"${src_libs_antares}/jit/include"
-		)
-
-# Storing lib-matrix under the folder Unit-tests in the IDE
-set_target_properties(matrix PROPERTIES FOLDER Unit-tests)
+  PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/logs"
+  "${src_libs_antares}/jit/include")
 
 # Building tests on Matrix save operations
-set(SRC_TEST_MATRIX_SAVE
-	logs/antares/logs/logs.h
-	array/fill-matrix.h
-	array/matrix-bypass-load.h
-	array/tests-matrix-save.h
-	array/tests-matrix-save.cpp
-	)
-
-add_executable(tests-matrix-save ${SRC_TEST_MATRIX_SAVE})
-
-target_include_directories(tests-matrix-save
-								PRIVATE
-									"${src_libs_antares}/array/include"
-									"${src_libs_antares}/io/include"
-									"${src_libs_antares}/jit/include"
-									"${src_libs_antares}/memory/include"
-									"${CMAKE_CURRENT_SOURCE_DIR}/logs"
-									"${CMAKE_CURRENT_SOURCE_DIR}/jit"
-									"${CMAKE_SOURCE_DIR}/tests/src/libs"
-
-		)
-
-target_link_libraries(tests-matrix-save
-						PRIVATE
-							matrix
-							yuni-static-core
-							Boost::unit_test_framework
-							antares-core
-)
-
-# Storing tests-matrix-save under the folder Unit-tests in the IDE
-set_target_properties(tests-matrix-save PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME save-matrix COMMAND tests-matrix-save)
-
-set_property(TEST save-matrix PROPERTY LABELS unit)
+add_boost_test(tests-matrix-save
+  SRC
+  logs/antares/logs/logs.h
+  array/fill-matrix.h
+  array/matrix-bypass-load.h
+  array/tests-matrix-save.h
+  array/tests-matrix-save.cpp
+  INCLUDE
+  "${src_libs_antares}/array/include"
+  "${src_libs_antares}/io/include"
+  "${src_libs_antares}/jit/include"
+  "${src_libs_antares}/memory/include"
+  "${CMAKE_CURRENT_SOURCE_DIR}/logs"
+  "${CMAKE_CURRENT_SOURCE_DIR}/jit"
+  "${CMAKE_SOURCE_DIR}/tests/src/libs"
+  LIBS
+  matrix
+  yuni-static-core
+  antares-core)
 
 # Building tests on Matrix load operations
-set(SRC_TEST_MATRIX_LOAD
-	array/fill-matrix.h
-	array/matrix-bypass-load.h
-	array/tests-matrix-load.h
-	array/tests-matrix-load.cpp
-	)
+add_boost_test(tests-matrix-load
+  SRC
+  array/fill-matrix.h
+  array/matrix-bypass-load.h
+  array/tests-matrix-load.h
+  array/tests-matrix-load.cpp
+  INCLUDE
+  "${src_libs_antares}/array/include"
+  "${src_libs_antares}/io/include"
+  "${src_libs_antares}/jit/include"
+  "${src_libs_antares}/memory/include"
+  "${CMAKE_CURRENT_SOURCE_DIR}/logs"
+  "${CMAKE_CURRENT_SOURCE_DIR}/jit"
+  "${CMAKE_SOURCE_DIR}/tests/src/libs"
+  LIBS
+  matrix
+  yuni-static-core
+  antares-core)
 
-add_executable(tests-matrix-load ${SRC_TEST_MATRIX_LOAD})
-target_include_directories(tests-matrix-load
-								PRIVATE
-									"${src_libs_antares}/array/include"
-									"${src_libs_antares}/io/include"
-									"${src_libs_antares}/jit/include"
-									"${src_libs_antares}/memory/include"
-									"${CMAKE_CURRENT_SOURCE_DIR}/logs"
-									"${CMAKE_CURRENT_SOURCE_DIR}/jit"
-									"${CMAKE_SOURCE_DIR}/tests/src/libs"
-)
-
-
-target_link_libraries(tests-matrix-load
-						PRIVATE
-							matrix
-							yuni-static-core
-							Boost::unit_test_framework
-							antares-core
-)
-
-# Storing tests-matrix-load under the folder Unit-tests in the IDE
-set_target_properties(tests-matrix-load PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME load-matrix COMMAND tests-matrix-load)
-
-set_property(TEST load-matrix PROPERTY LABELS unit)
-
-
-add_executable(test-utils test_utils.cpp)
-target_link_libraries(test-utils
-		PRIVATE
-		Boost::unit_test_framework
-		Antares::utils
-		yuni-static-core
-)
-set_target_properties(test-utils PROPERTIES FOLDER Unit-tests/test-utils)
-
-add_test(NAME test-utils COMMAND test-utils)
-set_property(TEST test-utils PROPERTY LABELS unit)
+# Test utilities
+add_boost_test(test-utils
+               SRC test_utils.cpp
+	       LIBS
+	       Antares::utils
+	       yuni-static-core)

--- a/src/tests/src/libs/antares/antlr4-interface/CMakeLists.txt
+++ b/src/tests/src/libs/antares/antlr4-interface/CMakeLists.txt
@@ -1,20 +1,11 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
 find_package(antlr4-runtime CONFIG REQUIRED)
-Set(SRCS test_antlr_interface.cpp
-)
+add_boost_test(antlr-interface-test
+  SRC test_antlr_interface.cpp
+  LIBS
+  antlr-interface)
 
-set(execname "antlr-interface-test")
-add_executable(${execname}  ${SRCS})
-target_link_libraries(${execname}
-                       PRIVATE
-                       antlr-interface
-		               Boost::unit_test_framework
-                     )  
-
-
-target_include_directories(${execname} 
+target_include_directories(antlr-interface-test
         PRIVATE
-         ${ANTLR4_INCLUDE_DIR})
-add_test(NAME antlr-interface COMMAND ${execname})
-
-set_tests_properties(antlr-interface PROPERTIES LABELS unit)
+        ${ANTLR4_INCLUDE_DIR})

--- a/src/tests/src/libs/antares/antlr4-interface/CMakeLists.txt
+++ b/src/tests/src/libs/antares/antlr4-interface/CMakeLists.txt
@@ -4,8 +4,6 @@ find_package(antlr4-runtime CONFIG REQUIRED)
 add_boost_test(antlr-interface-test
   SRC test_antlr_interface.cpp
   LIBS
-  antlr-interface)
-
-target_include_directories(antlr-interface-test
-        PRIVATE
-        ${ANTLR4_INCLUDE_DIR})
+  antlr-interface
+  INCLUDE
+  ${ANTLR4_INCLUDE_DIR})

--- a/src/tests/src/libs/antares/benchmarking/CMakeLists.txt
+++ b/src/tests/src/libs/antares/benchmarking/CMakeLists.txt
@@ -1,15 +1,5 @@
-set(PROJ test-duration-collector)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-add_executable(${PROJ})
-target_sources(${PROJ} PRIVATE test_duration_collector.cpp)
-target_link_libraries(${PROJ}
-        PRIVATE
-        Antares::benchmarking
-        Boost::unit_test_framework
-)
-
-set_target_properties(${PROJ} PROPERTIES FOLDER Unit-tests/${PROJ})
-
-add_test(NAME ${PROJ} COMMAND ${PROJ})
-
-set_property(TEST ${PROJ} PROPERTY LABELS unit)
+add_boost_test(test-duration-collector
+               SRC test_duration_collector.cpp
+               LIBS Antares::benchmarking)

--- a/src/tests/src/libs/antares/concurrency/CMakeLists.txt
+++ b/src/tests/src/libs/antares/concurrency/CMakeLists.txt
@@ -1,14 +1,5 @@
-add_executable(test-concurrency)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_sources(test-concurrency PRIVATE test_concurrency.cpp)
-
-target_link_libraries(test-concurrency
-						PRIVATE
-							Boost::unit_test_framework
-							Antares::concurrency
-)
-
-set_target_properties(test-concurrency PROPERTIES FOLDER Unit-tests/test-concurrency)
-
-add_test(NAME concurrency COMMAND test-concurrency)
-set_property(TEST concurrency PROPERTY LABELS unit)
+add_boost_test(test-concurrency
+               SRC test_concurrency.cpp
+               LIBS Antares::concurrency)

--- a/src/tests/src/libs/antares/inifile/CMakeLists.txt
+++ b/src/tests/src/libs/antares/inifile/CMakeLists.txt
@@ -1,15 +1,5 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-add_executable(test_inifile_io	test_inifile_io.cpp)
-
-target_link_libraries(test_inifile_io
-						PRIVATE
-							inifile
-							Boost::unit_test_framework
-)
-
-# Storing executable under the folder Unit-tests in the IDE
-set_target_properties(test_inifile_io PROPERTIES FOLDER Unit-tests/test_inifile_io)
-
-add_test(NAME test_inifile_io COMMAND test_inifile_io)
-
-set_property(TEST test_inifile_io PROPERTY LABELS unit)
+add_boost_test(test_inifile_io
+  SRC test_inifile_io.cpp
+  LIBS inifile)

--- a/src/tests/src/libs/antares/study/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 set(src_tests_src_libs_antares_study "${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_subdirectory(area)
@@ -10,14 +12,6 @@ add_subdirectory(parts)
 add_subdirectory(series)
 add_subdirectory(parameters)
 
-add_executable(test-study)
-target_sources(test-study PRIVATE test_study.cpp)
-target_link_libraries(test-study
-        PRIVATE
-        Antares::study
-        Boost::unit_test_framework
-)
-
-add_test(NAME test-study COMMAND test-study)
-
-set_property(TEST test-study PROPERTY LABELS unit)
+add_boost_test(test-study
+  SRC test_study.cpp
+  LIBS Antares::study)

--- a/src/tests/src/libs/antares/study/area/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/area/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # Useful variables definitions
 set(src_libs_antares_study "${CMAKE_SOURCE_DIR}/libs/antares/study")
 
@@ -9,29 +11,15 @@ set(SRC_LINK_PROPERTIES
 	files-helper.cpp
 	test-save-link-properties.cpp
 )
-add_executable(test-save-link-properties ${SRC_LINK_PROPERTIES})
+add_boost_test(test-save-link-properties
+  SRC ${SRC_LINK_PROPERTIES}
+  INCLUDE "${src_libs_antares_study}/include"
+  LIBS model_antares)
 
-target_include_directories(test-save-link-properties
-								PRIVATE
-									"${src_libs_antares_study}/include"
-)
-target_link_libraries(test-save-link-properties
-						PRIVATE
-							Boost::unit_test_framework
-							model_antares
-)
 # Linux
 if(UNIX AND NOT APPLE)
-target_link_libraries(test-save-link-properties PRIVATE stdc++fs)
+  target_link_libraries(test-save-link-properties PRIVATE stdc++fs)
 endif()
-
-
-# Storing test-save-link-properties under the folder Unit-tests in the IDE
-set_target_properties(test-save-link-properties PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME save-link-properties COMMAND test-save-link-properties)
-
-set_property(TEST save-link-properties PROPERTY LABELS unit)
 
 # ===================================
 # Tests on area's optimization.ini
@@ -39,30 +27,15 @@ set_property(TEST save-link-properties PROPERTY LABELS unit)
 set(SRC_AREA_OPTIMIZATION
 	files-helper.h
 	files-helper.cpp
-	test-save-area-optimization-ini.cpp
-)
-add_executable(test-save-area-optimization-ini ${SRC_AREA_OPTIMIZATION})
+	test-save-area-optimization-ini.cpp)
 
-target_include_directories(test-save-area-optimization-ini
-								PRIVATE
-									"${src_libs_antares_study}/include"
-)
-target_link_libraries(test-save-area-optimization-ini
-						PRIVATE
-							Boost::unit_test_framework
-							model_antares
-)
+add_boost_test(test-save-area-optimization-ini
+  SRC ${SRC_AREA_OPTIMIZATION}
+  INCLUDE "${src_libs_antares_study}/include"
+  LIBS model_antares)
 
 # Linux
 if(UNIX AND NOT APPLE)
-target_link_libraries(test-save-area-optimization-ini PRIVATE stdc++fs)
+  target_link_libraries(test-save-area-optimization-ini PRIVATE stdc++fs)
 endif()
-
-
-# Storing test-save-area-optimization-ini under the folder Unit-tests in the IDE
-set_target_properties(test-save-area-optimization-ini PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME save-area-optimization COMMAND test-save-area-optimization-ini)
-
-set_property(TEST save-area-optimization PROPERTY LABELS unit)
 

--- a/src/tests/src/libs/antares/study/area/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/area/CMakeLists.txt
@@ -16,11 +16,6 @@ add_boost_test(test-save-link-properties
   INCLUDE "${src_libs_antares_study}/include"
   LIBS model_antares)
 
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(test-save-link-properties PRIVATE stdc++fs)
-endif()
-
 # ===================================
 # Tests on area's optimization.ini
 # ===================================
@@ -33,9 +28,3 @@ add_boost_test(test-save-area-optimization-ini
   SRC ${SRC_AREA_OPTIMIZATION}
   INCLUDE "${src_libs_antares_study}/include"
   LIBS model_antares)
-
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(test-save-area-optimization-ini PRIVATE stdc++fs)
-endif()
-

--- a/src/tests/src/libs/antares/study/constraint/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/constraint/CMakeLists.txt
@@ -6,16 +6,8 @@ add_boost_test(test_constraint
   test_utils_unit
   Antares::study)
 
-if(UNIX AND NOT APPLE)
-    target_link_libraries(test_constraint PRIVATE stdc++fs)
-endif()
-
 add_boost_test(test_groups
   SRC test_group.cpp
   LIBS
   test_utils_unit
   Antares::study)
-
-if(UNIX AND NOT APPLE)
-    target_link_libraries(test_groups PRIVATE stdc++fs)
-endif()

--- a/src/tests/src/libs/antares/study/constraint/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/constraint/CMakeLists.txt
@@ -1,45 +1,21 @@
-add_executable(test_constraint
-        test_constraint.cpp
-    )
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_link_libraries(test_constraint
-        PRIVATE
-        test_utils_unit
-        Boost::unit_test_framework
-        Antares::study
-        )
-		
-# Storing test_constraint under the folder Unit-tests in the IDE
-set_target_properties(test_constraint PROPERTIES FOLDER Unit-tests)
+add_boost_test(test_constraint
+  SRC test_constraint.cpp
+  LIBS
+  test_utils_unit
+  Antares::study)
 
 if(UNIX AND NOT APPLE)
     target_link_libraries(test_constraint PRIVATE stdc++fs)
 endif()
 
-add_test(NAME test_constraint COMMAND test_constraint)
-
-set_property(TEST test_constraint PROPERTY LABELS unit)
-
-################
-
-add_executable(test_groups
-        test_group.cpp
-        )
-
-target_link_libraries(test_groups
-        PRIVATE
-        test_utils_unit
-        Boost::unit_test_framework
-        Antares::study
-        )
-
-# Storing test_constraint under the folder Unit-tests in the IDE
-set_target_properties(test_groups PROPERTIES FOLDER Unit-tests)
+add_boost_test(test_groups
+  SRC test_group.cpp
+  LIBS
+  test_utils_unit
+  Antares::study)
 
 if(UNIX AND NOT APPLE)
     target_link_libraries(test_groups PRIVATE stdc++fs)
 endif()
-
-add_test(NAME test_groups COMMAND test_groups)
-
-set_property(TEST test_groups PROPERTY LABELS unit)

--- a/src/tests/src/libs/antares/study/output-folder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/output-folder/CMakeLists.txt
@@ -7,8 +7,3 @@ add_boost_test(test-folder-output
   SRC study.cpp
   INCLUDE "${src_libs_antares_study}"
   LIBS Antares::study)
-
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(test-folder-output PRIVATE stdc++fs)
-endif()

--- a/src/tests/src/libs/antares/study/output-folder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/output-folder/CMakeLists.txt
@@ -1,31 +1,14 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # Useful variables definitions
 set(src_libs_antares_study "${CMAKE_SOURCE_DIR}/libs/antares/study")
 
-add_executable(test-folder-output study.cpp)
-
-target_include_directories(test-folder-output
-   						   PRIVATE
-						   "${src_libs_antares_study}"
-)
-
-target_link_libraries(test-folder-output
-    				  PRIVATE
-					  Boost::unit_test_framework
-				      Antares::study
-)
+add_boost_test(test-folder-output
+  SRC study.cpp
+  INCLUDE "${src_libs_antares_study}"
+  LIBS Antares::study)
 
 # Linux
 if(UNIX AND NOT APPLE)
-target_link_libraries(test-folder-output PRIVATE stdc++fs)
+  target_link_libraries(test-folder-output PRIVATE stdc++fs)
 endif()
-
-
-# Storing test-save-link-properties under the folder Unit-tests in the IDE
-set_target_properties(test-folder-output PROPERTIES FOLDER Unit-tests)
-
-import_std_libs(test-folder-output)
-
-add_test(NAME folder-output COMMAND test-folder-output)
-set_property(TEST folder-output PROPERTY LABELS unit)
-
-

--- a/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
@@ -1,20 +1,8 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # ====================================
 # Tests on Parameters class
 # ====================================
-set(SRC_PARAMETERS_TESTS
-	parameters-tests.cpp
-)
-add_executable(parameters-tests ${SRC_PARAMETERS_TESTS})
-
-target_link_libraries(parameters-tests
-                      PRIVATE
-                      Boost::unit_test_framework
-                      Antares::study
-)
-
-# Storing parameters-tests under the folder Unit-tests in the IDE
-set_target_properties(parameters-tests PROPERTIES FOLDER Unit-tests/parameters-tests)
-
-add_test(NAME parameters-tests COMMAND parameters-tests)
-
-set_property(TEST parameters-tests PROPERTY LABELS unit)
+add_boost_test(parameters-tests
+  SRC parameters-tests.cpp
+  LIBS Antares::study)

--- a/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
@@ -7,18 +7,9 @@ add_boost_test(test-hydro-reader
   Antares::study
   test_utils_unit)
 
-if(UNIX AND NOT APPLE)
-	target_link_libraries(test-hydro-reader PRIVATE stdc++fs)
-endif()
-
 # Hydro series
 add_boost_test(test-hydro-series
   SRC test-hydro-series.cpp
   LIBS
   Antares::study
   test_utils_unit)
-
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(test-hydro-series PRIVATE stdc++fs)
-endif()

--- a/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parts/hydro/CMakeLists.txt
@@ -1,44 +1,24 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # Hydro data reader
-set(SRC_HYDRO_READER
-	test-hydroreader-class.cpp)
+add_boost_test(test-hydro-reader
+  SRC test-hydroreader-class.cpp
+  LIBS
+  Antares::study
+  test_utils_unit)
 
-add_executable(test-hydro-reader ${SRC_HYDRO_READER})
-
-target_link_libraries(test-hydro-reader
-	PRIVATE
-	Boost::unit_test_framework
-	Antares::study
-	test_utils_unit
-)
-
-# Linux
 if(UNIX AND NOT APPLE)
 	target_link_libraries(test-hydro-reader PRIVATE stdc++fs)
 endif()
 
-set_target_properties(test-hydro-reader PROPERTIES FOLDER Unit-tests/hydro)
-add_test(NAME hydro-reader COMMAND test-hydro-reader)
-set_property(TEST hydro-reader PROPERTY LABELS unit)
-
-
 # Hydro series
-set(SRC_HYDRO_SERIES
-	test-hydro-series.cpp)
-
-add_executable(test-hydro-series ${SRC_HYDRO_SERIES})
-
-target_link_libraries(test-hydro-series
-	PRIVATE
-	Boost::unit_test_framework
-	Antares::study
-	test_utils_unit
-)
+add_boost_test(test-hydro-series
+  SRC test-hydro-series.cpp
+  LIBS
+  Antares::study
+  test_utils_unit)
 
 # Linux
 if(UNIX AND NOT APPLE)
-	target_link_libraries(test-hydro-series PRIVATE stdc++fs)
+  target_link_libraries(test-hydro-series PRIVATE stdc++fs)
 endif()
-
-set_target_properties(test-hydro-series PROPERTIES FOLDER Unit-tests/hydro)
-add_test(NAME hydro-series COMMAND test-hydro-series)
-set_property(TEST hydro-series PROPERTY LABELS unit)

--- a/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
@@ -1,62 +1,31 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # Useful variables definitions
 set(src_libs_antares_study "${CMAKE_SOURCE_DIR}/libs/antares/study")
 
 # ====================================
 # Tests on reading scenario-builder
 # ====================================
-set(SRC_SC_BUILDER_READ
-	test-sc-builder-file-read-line.cpp
-)
-add_executable(test-sc-builder-file-read-line ${SRC_SC_BUILDER_READ})
+add_boost_test(test-sc-builder-file-read-line
+  SRC test-sc-builder-file-read-line.cpp
+  INCLUDE "${src_libs_antares_study}/include"
+  LIBS model_antares)
 
-target_include_directories(test-sc-builder-file-read-line
-								PRIVATE
-									"${src_libs_antares_study}/include"
-)
-
-target_link_libraries(test-sc-builder-file-read-line
-						PRIVATE
-							Boost::unit_test_framework
-							model_antares
-)
 # Linux
 if(UNIX AND NOT APPLE)
-target_link_libraries(test-sc-builder-file-read-line PRIVATE stdc++fs)
+  target_link_libraries(test-sc-builder-file-read-line PRIVATE stdc++fs)
 endif()
-
-
-# Storing test-sc-builder-file-read-line under the folder Unit-tests in the IDE
-add_test(NAME sc-builder-file-read-line COMMAND test-sc-builder-file-read-line)
-set_property(TEST sc-builder-file-read-line PROPERTY LABELS unit)
-set_target_properties(test-sc-builder-file-read-line PROPERTIES FOLDER Unit-tests/sc-builder)
-
-
 
 # ====================================
 # Tests on saving scenario-builder
 # ====================================
-set(SRC_SC_BUILDER_SAVE
-	test-sc-builder-file-save.cpp
-	"${src_tests_src_libs_antares_study}/area/files-helper.cpp"
-)
-add_executable(test-sc-builder-file-save ${SRC_SC_BUILDER_SAVE})
-
-target_include_directories(test-sc-builder-file-save
-								PRIVATE
-									"${src_libs_antares_study}"
-									"${src_libs_antares_study}/scenario-builder"
-									"${src_tests_src_libs_antares_study}"
-)
-
-target_link_libraries(test-sc-builder-file-save
-  PRIVATE
-						Boost::unit_test_framework
-						model_antares
-)
-
-# Storing test-sc-builder-file-savee under the folder Unit-tests in the IDE
-set_target_properties(test-sc-builder-file-save PROPERTIES FOLDER Unit-tests/sc-builder)
-
-add_test(NAME sc-builder-file-save COMMAND test-sc-builder-file-save)
-
-set_property(TEST sc-builder-file-save PROPERTY LABELS unit)
+add_boost_test(test-sc-builder-file-save
+  SRC
+  test-sc-builder-file-save.cpp
+  "${src_tests_src_libs_antares_study}/area/files-helper.cpp"
+  INCLUDE
+  "${src_libs_antares_study}"
+  "${src_libs_antares_study}/scenario-builder"
+  "${src_tests_src_libs_antares_study}"
+  LIBS
+  model_antares)

--- a/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
@@ -11,11 +11,6 @@ add_boost_test(test-sc-builder-file-read-line
   INCLUDE "${src_libs_antares_study}/include"
   LIBS model_antares)
 
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(test-sc-builder-file-read-line PRIVATE stdc++fs)
-endif()
-
 # ====================================
 # Tests on saving scenario-builder
 # ====================================

--- a/src/tests/src/libs/antares/study/series/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/series/CMakeLists.txt
@@ -1,22 +1,11 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # ====================================
 # Tests on TimeSeries class
 # ====================================
-set(SRC_TIMESERIES_TESTS
-	timeseries-tests.cpp
-)
-add_executable(timeseries-tests ${SRC_TIMESERIES_TESTS})
-
-target_link_libraries(timeseries-tests
-                      PRIVATE
-                      Antares::array
-                      Boost::unit_test_framework
-                      Antares::series
-                      antares-solver-simulation
-)
-
-# Storing timeseries-tests under the folder Unit-tests in the IDE
-set_target_properties(timeseries-tests PROPERTIES FOLDER Unit-tests/timeseries-tests)
-
-add_test(NAME timeseries-tests COMMAND timeseries-tests)
-
-set_property(TEST timeseries-tests PROPERTY LABELS unit)
+add_boost_test(timeseries-tests
+  SRC timeseries-tests.cpp
+  LIBS
+  Antares::array
+  Antares::series
+  antares-solver-simulation)

--- a/src/tests/src/libs/antares/study/short-term-storage-input/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/CMakeLists.txt
@@ -1,33 +1,11 @@
-# Useful variables definitions
-set(src_libs_antares_study "${CMAKE_SOURCE_DIR}/libs/antares/study")
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-# ====================================
-# Tests on reading scenario-builder
-# ====================================
-set(SRC_SC_BUILDER_READ
-	short-term-storage-input-output.cpp
-)
-add_executable(short-term-storage-input ${SRC_SC_BUILDER_READ})
+add_boost_test(short-term-storage-input
+  SRC short-term-storage-input-output.cpp
+  LIBS model_antares
+  INCLUDE "${src_libs_antares_study}/parts/short-term-storage")
 
-target_include_directories(short-term-storage-input
-								PRIVATE
-									"${src_libs_antares_study}/parts/short-term-storage"
-)
-
-target_link_libraries(short-term-storage-input
-						PRIVATE
-							Boost::unit_test_framework
-							model_antares
-)
 # Linux
 if(UNIX AND NOT APPLE)
-target_link_libraries(short-term-storage-input PRIVATE stdc++fs)
+  target_link_libraries(short-term-storage-input PRIVATE stdc++fs)
 endif()
-
-
-# Storing short-term-storage-input under the folder Unit-tests in the IDE
-set_target_properties(short-term-storage-input PROPERTIES FOLDER Unit-tests/short-term-storage-input)
-
-add_test(NAME short-term-storage-input COMMAND short-term-storage-input)
-
-set_property(TEST short-term-storage-input PROPERTY LABELS unit)

--- a/src/tests/src/libs/antares/study/short-term-storage-input/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/CMakeLists.txt
@@ -4,8 +4,3 @@ add_boost_test(short-term-storage-input
   SRC short-term-storage-input-output.cpp
   LIBS model_antares
   INCLUDE "${src_libs_antares_study}/parts/short-term-storage")
-
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(short-term-storage-input PRIVATE stdc++fs)
-endif()

--- a/src/tests/src/libs/antares/study/thermal-price-definition/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # Useful variables definitions
 set(src_libs_antares_study "${CMAKE_SOURCE_DIR}/libs/antares/study")
 set(src_libs_antares_checks "${CMAKE_SOURCE_DIR}/libs/antares/checks")
@@ -5,36 +7,20 @@ set(src_libs_antares_checks "${CMAKE_SOURCE_DIR}/libs/antares/checks")
 # ====================================
 # Tests on thermal price definition
 # ====================================
-set(SRC_THERM_PRICE_DEF
-	thermal-price-definition.cpp
-)
-add_executable(thermal-price-definition ${SRC_THERM_PRICE_DEF})
+add_boost_test(thermal-price-definition
+  SRC thermal-price-definition.cpp
+  LIBS
+  checks
+  Antares::study
+  Antares::exception
+  Antares::checks
+  INCLUDE
+  "${src_libs_antares_study}/parts/thermal"
+  "${src_libs_antares_study}/area"
+  "${src_libs_antares_study}"
+  "${src_libs_antares_checks}")
 
-target_include_directories(thermal-price-definition
-								PRIVATE
-									"${src_libs_antares_study}/parts/thermal"
-									"${src_libs_antares_study}/area"
-									"${src_libs_antares_study}"
-									"${src_libs_antares_checks}"
-)
-
-target_link_libraries(thermal-price-definition
-						PRIVATE
-							Boost::unit_test_framework
-							checks
-							Antares::study
-							Antares::exception
-							Antares::checks
-)
 # Linux
 if(UNIX AND NOT APPLE)
 target_link_libraries(thermal-price-definition PRIVATE stdc++fs)
 endif()
-
-
-# Storing thermal-price-definition under the folder Unit-tests in the IDE
-set_target_properties(thermal-price-definition PROPERTIES FOLDER Unit-tests/thermal-price-definition)
-
-add_test(NAME thermal-price-definition COMMAND thermal-price-definition)
-
-set_property(TEST thermal-price-definition PROPERTY LABELS unit)

--- a/src/tests/src/libs/antares/study/thermal-price-definition/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/CMakeLists.txt
@@ -19,8 +19,3 @@ add_boost_test(thermal-price-definition
   "${src_libs_antares_study}/area"
   "${src_libs_antares_study}"
   "${src_libs_antares_checks}")
-
-# Linux
-if(UNIX AND NOT APPLE)
-target_link_libraries(thermal-price-definition PRIVATE stdc++fs)
-endif()

--- a/src/tests/src/libs/antares/writer/CMakeLists.txt
+++ b/src/tests/src/libs/antares/writer/CMakeLists.txt
@@ -1,15 +1,10 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # Zip writer
-add_executable(test-writer test_writer.cpp)
+add_boost_test(test-writer
+  SRC test_writer.cpp
+  LIBS
+  Antares::result_writer
+  test_utils_unit
+  MINIZIP::minizip)
 
-target_link_libraries(test-writer
-        PRIVATE
-        Boost::unit_test_framework
-        Antares::result_writer
-        test_utils_unit
-        MINIZIP::minizip
-)
-
-set_target_properties(test-writer PROPERTIES FOLDER Unit-tests/test-writer)
-
-add_test(NAME writer COMMAND test-writer)
-set_tests_properties(writer PROPERTIES LABELS unit)

--- a/src/tests/src/libs/antares/yaml-parser/CMakeLists.txt
+++ b/src/tests/src/libs/antares/yaml-parser/CMakeLists.txt
@@ -1,14 +1,5 @@
-set(SRCS test_yaml_parser.cpp
-)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-set(execname "yaml-parser-test")
-add_executable(${execname}  ${SRCS})
-target_link_libraries(${execname}
-                       PRIVATE
-                       yaml-cpp
-		       Boost::unit_test_framework)
-
-
-add_test(NAME yaml-parser COMMAND ${execname})
-
-set_tests_properties(yaml-parser PROPERTIES LABELS unit)
+add_boost_test(yaml-parser-test
+  SRC test_yaml_parser.cpp
+  LIBS yaml-cpp)

--- a/src/tests/src/solver/expressions/CMakeLists.txt
+++ b/src/tests/src/solver/expressions/CMakeLists.txt
@@ -1,31 +1,17 @@
-set(EXECUTABLE_NAME test-expressions)
-add_executable(${EXECUTABLE_NAME})
-
-target_sources(${EXECUTABLE_NAME}
-        PRIVATE
-        test_main.cpp
-        test_nodes.cpp
-        test_PrintAndEvalNodes.cpp
-        test_TimeIndexVisitor.cpp
-        test_SubstitutionVisitor.cpp
-        test_LinearVisitor.cpp
-        test_CompareVisitor.cpp
-        test_CloneVisitor.cpp
-        test_DeepWideTrees.cpp
-        test_Iterators.cpp
-        test_AstDOTStyleVisitor.cpp
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        solver-expressions
-        solver-expressions-iterators
-)
-
-# Storing tests-ts-numbers under the folder Unit-tests in the IDE
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME test-expressions COMMAND ${EXECUTABLE_NAME})
-
-set_property(TEST test-expressions PROPERTY LABELS unit)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+add_boost_test(test-expressions
+  SRC
+  test_main.cpp
+  test_nodes.cpp
+  test_PrintAndEvalNodes.cpp
+  test_TimeIndexVisitor.cpp
+  test_SubstitutionVisitor.cpp
+  test_LinearVisitor.cpp
+  test_CompareVisitor.cpp
+  test_CloneVisitor.cpp
+  test_DeepWideTrees.cpp
+  test_Iterators.cpp
+  test_AstDOTStyleVisitor.cpp
+  LIBS
+  solver-expressions
+  solver-expressions-iterators)

--- a/src/tests/src/solver/infeasible-problem-analysis/CMakeLists.txt
+++ b/src/tests/src/solver/infeasible-problem-analysis/CMakeLists.txt
@@ -1,16 +1,7 @@
-add_executable(test-unfeasible-problem-analyzer)
-target_sources(test-unfeasible-problem-analyzer
-		PRIVATE
-		test-unfeasible-problem-analyzer.cpp)
-target_link_libraries(test-unfeasible-problem-analyzer
-		PRIVATE
-		Boost::unit_test_framework
-		infeasible_problem_analysis
-		ortools::ortools
-)
-
-add_test(NAME test-unfeasible-problem-analyzer COMMAND test-unfeasible-problem-analyzer)
-
-# Storing the executable under the folder Unit-tests in Visual Studio
-set_target_properties(test-unfeasible-problem-analyzer PROPERTIES FOLDER Unit-tests)
-set_property(TEST test-unfeasible-problem-analyzer PROPERTY LABELS unit)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+add_boost_test(test-unfeasible-problem-analyzer
+  SRC
+  test-unfeasible-problem-analyzer.cpp
+  LIBS
+  infeasible_problem_analysis
+  ortools::ortools)

--- a/src/tests/src/solver/lps/CMakeLists.txt
+++ b/src/tests/src/solver/lps/CMakeLists.txt
@@ -1,20 +1,5 @@
-set(EXECUTABLE_NAME test-lps)
-add_executable(${EXECUTABLE_NAME})
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_sources(${EXECUTABLE_NAME}
-        PRIVATE
-        test_lps.cpp
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        antares-solver-simulation
-)
-
-# Storing tests-ts-numbers under the folder Unit-tests in the IDE
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME test-lps COMMAND ${EXECUTABLE_NAME})
-
-set_property(TEST test-lps PROPERTY LABELS unit)
+add_boost_test(test-lps
+  SRC test_lps.cpp
+  LIBS antares-solver-simulation)

--- a/src/tests/src/solver/modelParser/CMakeLists.txt
+++ b/src/tests/src/solver/modelParser/CMakeLists.txt
@@ -1,34 +1,18 @@
-# Add source files
-set(SOURCE_FILES
-        testModelParser.cpp
-        testModelTranslator.cpp
-        testConvertorVisitor.cpp
-        test_full.cpp
-        enum_operators.h
-        testSystemParser.cpp
-        testSystemConverter.cpp
-)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-# Add executable
-add_executable(TestModelParser ${SOURCE_FILES})
-
-# Link libraries
-target_link_libraries(TestModelParser
-        PRIVATE
-        Boost::unit_test_framework
-        Antares::solver-expressions
-        Antares::modelConverter
-        Antares::modelParser
-        Antares::systemParser
-        Antares::antares-study-system-model
-        Antares::antlr-interface
-)
-
-# Storing test-toybox under the folder Unit-tests in the IDE
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-
-# Add the test
-add_test(NAME TestModelParser COMMAND TestModelParser)
-
-# Set test properties
-set_property(TEST TestModelParser PROPERTY LABELS unit)
+add_boost_test(TestModelParser
+  SRC
+  testModelParser.cpp
+  testModelTranslator.cpp
+  testConvertorVisitor.cpp
+  test_full.cpp
+  enum_operators.h
+  testSystemParser.cpp
+  testSystemConverter.cpp
+  LIBS
+  Antares::solver-expressions
+  Antares::modelConverter
+  Antares::modelParser
+  Antares::systemParser
+  Antares::antares-study-system-model
+  Antares::antlr-interface)

--- a/src/tests/src/solver/modeler/api/CMakeLists.txt
+++ b/src/tests/src/solver/modeler/api/CMakeLists.txt
@@ -1,24 +1,12 @@
-set(EXECUTABLE_NAME unit-tests-for-modeler-api)
-add_executable(${EXECUTABLE_NAME})
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_sources(${EXECUTABLE_NAME}
-        PRIVATE
-        test_main.cpp
-        testModelerLinearProblemWithOrtools.cpp
-        testModelerLPbuilder.cpp
-)
-target_include_directories(${EXECUTABLE_NAME}
-        PRIVATE
-        "${src_solver_optimisation}"
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        Antares::modeler-ortools-impl
-)
-
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-add_test(NAME ${EXECUTABLE_NAME} COMMAND ${EXECUTABLE_NAME})
-set_property(TEST ${EXECUTABLE_NAME} PROPERTY LABELS unit)
+add_boost_test(unit-tests-for-modeler-api
+  SRC
+  test_main.cpp
+  testModelerLinearProblemWithOrtools.cpp
+  testModelerLPbuilder.cpp
+  INCLUDE
+  "${src_solver_optimisation}"
+  LIBS
+  Antares::modeler-ortools-impl)
 

--- a/src/tests/src/solver/modeler/parameters/CMakeLists.txt
+++ b/src/tests/src/solver/modeler/parameters/CMakeLists.txt
@@ -1,14 +1,7 @@
-# Zip writer
-add_executable(parse-parameters testParametersParsing.cpp)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_link_libraries(parse-parameters
-        PRIVATE
-        Boost::unit_test_framework
-        modeler-parameters
-        test_utils_unit
-)
-
-set_target_properties(parse-parameters PROPERTIES FOLDER Unit-tests/test-writer)
-
-add_test(NAME parse-parameters COMMAND parse-parameters)
-set_tests_properties(parse-parameters PROPERTIES LABELS unit)
+add_boost_test(parse-parameters
+  SRC testParametersParsing.cpp
+  LIBS
+  modeler-parameters
+  test_utils_unit)

--- a/src/tests/src/solver/optim-model-filler/CMakeLists.txt
+++ b/src/tests/src/solver/optim-model-filler/CMakeLists.txt
@@ -1,29 +1,16 @@
-set(EXECUTABLE_NAME unit-tests-for-component-filler)
-add_executable(${EXECUTABLE_NAME})
-
-target_sources(${EXECUTABLE_NAME}
-        PRIVATE
-        test_main.cpp
-        test_componentFiller.cpp
-        test_linearExpression.cpp
-        test_readLinearExpressionVisitor.cpp
-        test_readLinearConstraintVisitor.cpp
-)
-target_include_directories(${EXECUTABLE_NAME}
-        PRIVATE
-        "${src_solver_optimisation}"
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        antares-study-system-model
-        Antares::modeler-ortools-impl
-        Antares::optim-model-filler
-        test_utils_unit
-)
-
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-add_test(NAME ${EXECUTABLE_NAME} COMMAND ${EXECUTABLE_NAME})
-set_property(TEST ${EXECUTABLE_NAME} PROPERTY LABELS unit)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+add_boost_test(unit-tests-for-component-filler
+  SRC
+  test_main.cpp
+  test_componentFiller.cpp
+  test_linearExpression.cpp
+  test_readLinearExpressionVisitor.cpp
+  test_readLinearConstraintVisitor.cpp
+  INCLUDE
+  "${src_solver_optimisation}"
+  LIBS
+  antares-study-system-model
+  Antares::modeler-ortools-impl
+  Antares::optim-model-filler
+  test_utils_unit)
 

--- a/src/tests/src/solver/optimisation/adequacy_patch/CMakeLists.txt
+++ b/src/tests/src/solver/optimisation/adequacy_patch/CMakeLists.txt
@@ -1,24 +1,11 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # Useful variables definitions
 set(src_solver_optimisation "${CMAKE_SOURCE_DIR}/solver/optimisation")
 
-set(EXECUTABLE_NAME tests-adq-patch)
-add_executable(${EXECUTABLE_NAME} adequacy_patch.cpp)
-
-target_include_directories(${EXECUTABLE_NAME}
-        PRIVATE
-        "${src_solver_optimisation}"
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        model_antares
-        array
-)
-
-# Storing tests-ts-numbers under the folder Unit-tests in the IDE
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME test-adq-patch COMMAND ${EXECUTABLE_NAME})
-
-set_property(TEST test-adq-patch PROPERTY LABELS unit)
+add_boost_test(tests-adq-patch
+  SRC adequacy_patch.cpp
+  INCLUDE "${src_solver_optimisation}"
+  LIBS
+  model_antares
+  array)

--- a/src/tests/src/solver/optimisation/name-translator/CMakeLists.txt
+++ b/src/tests/src/solver/optimisation/name-translator/CMakeLists.txt
@@ -1,20 +1,5 @@
-set(EXECUTABLE_NAME test-name-translator)
-add_executable(${EXECUTABLE_NAME})
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_sources(${EXECUTABLE_NAME}
-        PRIVATE
-        test_name_translator.cpp
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        model_antares
-)
-
-# Storing tests-ts-numbers under the folder Unit-tests in the IDE
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME test-name-translator COMMAND ${EXECUTABLE_NAME})
-
-set_property(TEST test-name-translator PROPERTY LABELS unit)
+add_boost_test(test-name-translator
+  SRC test_name_translator.cpp
+  LIBS model_antares)

--- a/src/tests/src/solver/optimisation/translator/CMakeLists.txt
+++ b/src/tests/src/solver/optimisation/translator/CMakeLists.txt
@@ -1,20 +1,5 @@
-set(EXECUTABLE_NAME test-translator)
-add_executable(${EXECUTABLE_NAME})
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-target_sources(${EXECUTABLE_NAME}
-        PRIVATE
-        test_translator.cpp
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        model_antares
-)
-
-# Storing tests-ts-numbers under the folder Unit-tests in the IDE
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME test-translator COMMAND ${EXECUTABLE_NAME})
-
-set_property(TEST test-translator PROPERTY LABELS unit)
+add_boost_test(test-translator
+  SRC test_translator.cpp
+  LIBS model_antares)

--- a/src/tests/src/solver/simulation/CMakeLists.txt
+++ b/src/tests/src/solver/simulation/CMakeLists.txt
@@ -35,10 +35,6 @@ add_boost_test(test-store-timeseries-number
   antares-solver-simulation
   Antares::study
   Antares::result_writer)
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(test-store-timeseries-number PRIVATE stdc++fs)
-endif()
 
 # ===================================
 # Tests on time series
@@ -49,11 +45,6 @@ add_boost_test(test-time_series
   test_utils_unit
   antares-solver-simulation
   Antares::study)
-
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(test-time_series PRIVATE stdc++fs)
-endif()
 
 # ===================================
 # Tests on hydro final reservoir level functions
@@ -69,8 +60,3 @@ add_boost_test(test-hydro_final
   Antares::study
   antares-solver-simulation
   Antares::array)
-
-# Linux
-if(UNIX AND NOT APPLE)
-  target_link_libraries(test-hydro_final PRIVATE stdc++fs)
-endif()

--- a/src/tests/src/solver/simulation/CMakeLists.txt
+++ b/src/tests/src/solver/simulation/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+
 # Useful variables definitions
 set(src_solver_simulation "${CMAKE_SOURCE_DIR}/solver/simulation")
 set(src_solver_hydro "${CMAKE_SOURCE_DIR}/solver/hydro")
@@ -11,112 +13,64 @@ set(SRC_TS_NUMBERS
 	${src_solver_simulation}/timeseries-numbers.cpp
 	${src_solver_simulation}/include/antares/solver/simulation/ITimeSeriesNumbersWriter.h)
 
-add_executable(tests-ts-numbers tests-ts-numbers.cpp ${SRC_TS_NUMBERS})
+add_boost_test(tests-ts-numbers
+  SRC tests-ts-numbers.cpp ${SRC_TS_NUMBERS}
+  INCLUDE
+  "${src_solver_simulation}"
+  "${src_libs_antares_study}"
+  LIBS
+  Antares::utils
+  model_antares
+  antares-solver-simulation
+  antares-solver-ts-generator)
 
-target_include_directories(tests-ts-numbers
-								PRIVATE
-									"${src_solver_simulation}"
-									"${src_libs_antares_study}"
-)
-target_link_libraries(tests-ts-numbers
-						PRIVATE
-                            Antares::utils
-							Boost::unit_test_framework
-							model_antares
-							antares-solver-simulation
-							antares-solver-ts-generator
-)
-
-# Storing tests-ts-numbers under the folder Unit-tests in the IDE
-set_target_properties(tests-ts-numbers PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME ts-numbers COMMAND tests-ts-numbers)
-
-set_property(TEST ts-numbers PROPERTY LABELS unit)
 
 # ===================================
 # Tests on area's store-timeseries-number
 # ===================================
-set(SRC_STORE_TS
-		test-store-timeseries-number.cpp
-		)
-add_executable(test-store-timeseries-number ${SRC_STORE_TS})
-
-target_link_libraries(test-store-timeseries-number
-		PRIVATE
-		Boost::unit_test_framework
-        test_utils_unit
-		antares-solver-simulation
-		Antares::study
-		Antares::result_writer
-		)
-
+add_boost_test(test-store-timeseries-number
+  SRC test-store-timeseries-number.cpp
+  LIBS
+  test_utils_unit
+  antares-solver-simulation
+  Antares::study
+  Antares::result_writer)
 # Linux
 if(UNIX AND NOT APPLE)
-	target_link_libraries(test-store-timeseries-number PRIVATE stdc++fs)
+  target_link_libraries(test-store-timeseries-number PRIVATE stdc++fs)
 endif()
-
-set_target_properties(test-store-timeseries-number PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME store-timeseries-number COMMAND test-store-timeseries-number)
-
-set_property(TEST store-timeseries-number PROPERTY LABELS unit)
 
 # ===================================
 # Tests on time series
 # ===================================
-set(SRC_STORE_TS
-		test-time_series.cpp
-		)
-add_executable(test-time_series ${SRC_STORE_TS})
-
-target_link_libraries(test-time_series
-		PRIVATE
-		Boost::unit_test_framework
-        test_utils_unit
-		antares-solver-simulation
-		Antares::study
-		)
+add_boost_test(test-time_series
+  SRC test-time_series.cpp
+  LIBS
+  test_utils_unit
+  antares-solver-simulation
+  Antares::study)
 
 # Linux
 if(UNIX AND NOT APPLE)
-	target_link_libraries(test-time_series PRIVATE stdc++fs)
+  target_link_libraries(test-time_series PRIVATE stdc++fs)
 endif()
-
-
-set_target_properties(test-time_series PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME time_series COMMAND test-time_series)
-
-set_property(TEST time_series PROPERTY LABELS unit)
 
 # ===================================
 # Tests on hydro final reservoir level functions
 # ===================================
-
-add_executable(test-hydro_final test-hydro-final-reservoir-level-functions.cpp)
-
-target_include_directories(test-hydro_final
-	PRIVATE
-	"${src_solver_simulation}"
-	"${src_libs_antares_study}"
-	"${src_solver_hydro}"
-)
-target_link_libraries(test-hydro_final
-	PRIVATE
-	Boost::unit_test_framework
-	Antares::study
-	antares-solver-simulation
-	Antares::array
-)
+add_boost_test(test-hydro_final
+  SRC
+  test-hydro-final-reservoir-level-functions.cpp
+  INCLUDE
+  "${src_solver_simulation}"
+  "${src_libs_antares_study}"
+  "${src_solver_hydro}"
+  LIBS
+  Antares::study
+  antares-solver-simulation
+  Antares::array)
 
 # Linux
 if(UNIX AND NOT APPLE)
-	target_link_libraries(test-hydro_final PRIVATE stdc++fs)
+  target_link_libraries(test-hydro_final PRIVATE stdc++fs)
 endif()
-
-set_target_properties(test-hydro_final PROPERTIES FOLDER Unit-tests)
-
-add_test(NAME hydro_final COMMAND test-hydro_final)
-
-set_property(TEST hydro_final PROPERTY LABELS unit)

--- a/src/tests/src/solver/utils/CMakeLists.txt
+++ b/src/tests/src/solver/utils/CMakeLists.txt
@@ -1,20 +1,10 @@
-set(src_utils "${CMAKE_SOURCE_DIR}/solver/utils")
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 
-set(EXECUTABLE_NAME tests-basis-status)
-add_executable(${EXECUTABLE_NAME} basis_status.cpp)
-
-
-target_include_directories(${EXECUTABLE_NAME}
-							PRIVATE
-						    "${src_utils}" # basis_status_impl.h is private
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-                      PRIVATE
-                      Boost::unit_test_framework
-                      ortools::ortools
-                      Antares::solverUtils
-)
-
-add_test(NAME test-basis-status COMMAND ${EXECUTABLE_NAME})
-set_property(TEST test-basis-status PROPERTY LABELS unit)
+add_boost_test(tests-basis-status
+  SRC
+  basis_status.cpp
+  INCLUDE
+  "${CMAKE_SOURCE_DIR}/solver/utils"
+  LIBS
+  ortools::ortools
+  Antares::solverUtils)

--- a/src/tests/src/study/system-model/CMakeLists.txt
+++ b/src/tests/src/study/system-model/CMakeLists.txt
@@ -1,20 +1,10 @@
-set(EXECUTABLE_NAME test-system-model)
-add_executable(${EXECUTABLE_NAME})
-
-target_sources(${EXECUTABLE_NAME}
-        PRIVATE
-        test_main.cpp
-        test_component.cpp
-        test_system.cpp
-)
-
-target_link_libraries(${EXECUTABLE_NAME}
-        PRIVATE
-        Boost::unit_test_framework
-        antares-study-system-model
-        test_utils_unit
-)
-
-set_target_properties(${EXECUTABLE_NAME} PROPERTIES FOLDER Unit-tests)
-add_test(NAME test-system-model COMMAND ${EXECUTABLE_NAME})
-set_property(TEST test-system-model PROPERTY LABELS unit)
+include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
+add_boost_test(test-system-model
+  SRC
+  test_main.cpp
+  test_component.cpp
+  test_system.cpp
+  LIBS
+  Boost::unit_test_framework
+  antares-study-system-model
+  test_utils_unit)


### PR DESCRIPTION
Allow adding unit test in a single line, avoiding repetition of CMake targets.

TODO 
- [x] Add optional argument for `target_include_directories`
- [ ] Allow more labels / directories (IDE specific) ?
- [x] Use `add_boost_test` in place of `add_executable` where needed
This pull request includes significant changes to the CMake build system for various tests, primarily focusing on simplifying and standardizing the test definitions by introducing a new macro. The main changes involve replacing existing test setup code with a new `add_boost_test` function, which consolidates the test setup into a single line.