### PR TITLE
High-level API: provide output path instead of returning it [ANT-2561]

### DIFF
--- a/src/api/API.cpp
+++ b/src/api/API.cpp
@@ -83,7 +83,12 @@ SimulationResults APIInternal::execute(
                                                     study_->folderOutput,
                                                     ioQueueService,
                                                     durationCollector);
-    study_->saveAboutTheStudy(*resultWriter);
+
+    // In some cases (e.g tests) we don't want to write anything
+    if (!output.empty())
+    {
+        study_->saveAboutTheStudy(*resultWriter);
+    }
 
     SimulationObserver simulationObserver;
 

--- a/src/api/API.cpp
+++ b/src/api/API.cpp
@@ -72,17 +72,19 @@ SimulationResults APIInternal::execute(
     auto& parameters = study_->parameters;
     parameters.optOptions = optOptions;
 
-    study_->folderOutput = output;
-
     Benchmarking::DurationCollector durationCollector;
     Benchmarking::OptimizationInfo optimizationInfo;
     auto ioQueueService = std::make_shared<Yuni::Job::QueueService>();
     ioQueueService->maximumThreadCount(1);
     ioQueueService->start();
+
+    study_->folderOutput = output;
     auto resultWriter = Solver::resultWriterFactory(parameters.resultFormat,
                                                     study_->folderOutput,
                                                     ioQueueService,
                                                     durationCollector);
+    study_->saveAboutTheStudy(*resultWriter);
+
     SimulationObserver simulationObserver;
 
     optimizationInfo = simulationRun(*study_,

--- a/src/api/include/antares/api/SimulationResults.h
+++ b/src/api/include/antares/api/SimulationResults.h
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+
 #include "antares/solver/lps/LpsFromAntares.h"
 
 namespace Antares::API
@@ -31,7 +32,8 @@ namespace Antares::API
  * @struct Error
  * @brief The Error structure is used to represent an error that occurred during the simulation.
  */
-struct Error {
+struct Error
+{
     /**
      * @brief The reason for the error.
      */
@@ -46,10 +48,6 @@ struct Error {
 struct [[nodiscard("Contains results and potential error")]] SimulationResults
 {
     /**
-     * @brief The path to the simulation (output).
-     */
-    std::filesystem::path simulationPath;
-    /**
      * @brief weekly problems
      */
     Antares::Solver::LpsFromAntares antares_problems;
@@ -59,4 +57,4 @@ struct [[nodiscard("Contains results and potential error")]] SimulationResults
     std::optional<Error> error;
 };
 
-}
+} // namespace Antares::API

--- a/src/api/include/antares/api/solver.h
+++ b/src/api/include/antares/api/solver.h
@@ -36,5 +36,6 @@ namespace Antares::API
  */
 SimulationResults PerformSimulation(
   const std::filesystem::path& study_path,
+  const std::filesystem::path& output,
   const Antares::Solver::Optimization::OptimizationOptions& optOptions) noexcept;
 } // namespace Antares::API

--- a/src/api/private/API.h
+++ b/src/api/private/API.h
@@ -48,11 +48,13 @@ public:
      * @return SimulationResults object which contains the results of the simulation.
      */
     SimulationResults run(const IStudyLoader& study_loader,
+                          const std::filesystem::path& output,
                           const Antares::Solver::Optimization::OptimizationOptions& optOptions);
 
 private:
     std::shared_ptr<Antares::Data::Study> study_;
     SimulationResults execute(
+      const std::filesystem::path& output,
       const Antares::Solver::Optimization::OptimizationOptions& optOptions) const;
 };
 

--- a/src/api/solver.cpp
+++ b/src/api/solver.cpp
@@ -30,18 +30,19 @@ namespace Antares::API
 
 SimulationResults PerformSimulation(
   const std::filesystem::path& study_path,
+  const std::filesystem::path& output,
   const Antares::Solver::Optimization::OptimizationOptions& optOptions) noexcept
 {
     try
     {
         APIInternal api;
         FileTreeStudyLoader study_loader(study_path);
-        return api.run(study_loader, optOptions);
+        return api.run(study_loader, output, optOptions);
     }
     catch (const std::exception& e)
     {
         Antares::API::Error err{.reason = e.what()};
-        return SimulationResults{.simulationPath = study_path, .antares_problems{}, .error = err};
+        return SimulationResults{.antares_problems{}, .error = err};
     }
 }
 

--- a/src/api_client_example/src/API_client.cpp
+++ b/src/api_client_example/src/API_client.cpp
@@ -23,7 +23,8 @@
 
 #include <utility>
 
-Antares::API::SimulationResults solve(std::filesystem::path study_path)
+Antares::API::SimulationResults solve(std::filesystem::path study_path,
+                                      std::filesystem::path output)
 {
-    return Antares::API::PerformSimulation(std::move(study_path), {});
+    return Antares::API::PerformSimulation(std::move(study_path), std::move(output), {});
 }

--- a/src/api_client_example/src/API_client.h
+++ b/src/api_client_example/src/API_client.h
@@ -22,7 +22,8 @@
 
 #pragma once
 
-#include <antares/api/solver.h>
 #include <antares/api/SimulationResults.h>
+#include <antares/api/solver.h>
 
-Antares::API::SimulationResults solve(std::filesystem::path study_path);
+Antares::API::SimulationResults solve(std::filesystem::path study_path,
+                                      std::filesystem::path output);

--- a/src/api_client_example/tests/test.cpp
+++ b/src/api_client_example/tests/test.cpp
@@ -22,10 +22,12 @@
 #define BOOST_TEST_MODULE test_client_api
 
 #include <boost/test/unit_test.hpp>
+
 #include "API_client.h"
 
-BOOST_AUTO_TEST_CASE(test_run) {
-    auto results = solve("dummy_study_test_client_api");
+BOOST_AUTO_TEST_CASE(test_run)
+{
+    auto results = solve("dummy_study_test_client_api", {});
     BOOST_CHECK(results.error);
     BOOST_CHECK(!results.error->reason.empty());
     auto c = results.error->reason;

--- a/src/format-code.sh
+++ b/src/format-code.sh
@@ -3,7 +3,7 @@
 if [ $# -eq 0 ]
 then
     # No arguments: format all
-    SOURCE_DIRS="analyzer/ libs/ solver/ tools/ config/ tests/ packaging/"
+    SOURCE_DIRS="analyzer/ libs/ solver/ tools/ config/ tests/ packaging/ api/"
     SOURCE_FILES=$(find $SOURCE_DIRS -regextype egrep -regex ".*/*\.(c|cxx|cpp|cc|h|hxx|hpp)$" ! -path '*/antlr-interface/*')
 else
     # Format files provided as arguments

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -161,9 +161,6 @@ void Application::readDataForTheStudy(Data::StudyLoadOptions& options)
 
     Antares::Solver::initializeSignalHandlers(resultWriter);
 
-    // Save about-the-study files (comments, notes, etc.)
-    study.saveAboutTheStudy(*resultWriter);
-
     // Name of the simulation (again, if the value has been overwritten)
     if (!pSettings.simulationName.empty())
     {
@@ -374,6 +371,9 @@ void Application::execute()
     {
         return;
     }
+
+    // Save about-the-study files (comments, notes, etc.)
+    pStudy->saveAboutTheStudy(*resultWriter);
 
     SystemMemoryLogger memoryReport;
     memoryReport.interval(1000 * 60 * 5); // 5 minutes

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -52,28 +52,17 @@ public:
         builder.study->initializeRuntimeInfos();
         builder.setNumberMCyears(1);
         builder.study->parameters.resultFormat = ResultFormat::inMemory;
-        builder.study->prepareOutput();
         return std::move(builder.study);
     }
 
     bool success_ = true;
 };
 
-BOOST_AUTO_TEST_CASE(simulation_path_points_to_results)
-{
-    Antares::API::APIInternal api;
-    auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    auto results = api.run(*study_loader.get(), {});
-    BOOST_CHECK_EQUAL(results.simulationPath, std::filesystem::path{"no_output"});
-    // Testing for "no_output" is a bit weird, but it's the only way to test this without actually
-    // running the simulation
-}
-
 BOOST_AUTO_TEST_CASE(api_run_contains_antares_problem)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    auto results = api.run(*study_loader.get(), {});
+    auto results = api.run(*study_loader.get(), {}, {});
 
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);
@@ -83,7 +72,7 @@ BOOST_AUTO_TEST_CASE(result_failure_when_study_is_null)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>(false);
-    auto results = api.run(*study_loader.get(), {});
+    auto results = api.run(*study_loader.get(), {}, {});
 
     BOOST_CHECK(results.error);
 }
@@ -93,7 +82,7 @@ BOOST_AUTO_TEST_CASE(result_contains_problems)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    auto results = api.run(*study_loader.get(), {});
+    auto results = api.run(*study_loader.get(), {}, {});
 
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);
@@ -109,7 +98,7 @@ BOOST_AUTO_TEST_CASE(result_with_ortools_coin)
                                                                  .solverLogs = false,
                                                                  .solverParameters = ""};
 
-    auto results = api.run(*study_loader.get(), opt);
+    auto results = api.run(*study_loader.get(), {}, opt);
 
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);
@@ -126,7 +115,8 @@ BOOST_AUTO_TEST_CASE(invalid_ortools_solver)
       .solverLogs = true,
       .solverParameters = ""};
 
-    auto shouldThrow = [&api, &study_loader, &opt] { return api.run(*study_loader.get(), opt); };
+    auto shouldThrow = [&api, &study_loader, &opt]
+    { return api.run(*study_loader.get(), {}, opt); };
     BOOST_CHECK_EXCEPTION(shouldThrow(),
                           std::invalid_argument,
                           checkMessage("Solver this-solver-does-not-exist not found"));

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(api_run_contains_antares_problem)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    auto results = api.run(*study_loader.get(), {}, {});
+    auto results = api.run(*study_loader, {}, {});
 
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(result_failure_when_study_is_null)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>(false);
-    auto results = api.run(*study_loader.get(), {}, {});
+    auto results = api.run(*study_loader, {}, {});
 
     BOOST_CHECK(results.error);
 }
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(result_contains_problems)
 {
     Antares::API::APIInternal api;
     auto study_loader = std::make_unique<InMemoryStudyLoader>();
-    auto results = api.run(*study_loader.get(), {}, {});
+    auto results = api.run(*study_loader, {}, {});
 
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(result_with_ortools_coin)
                                                                  .solverLogs = false,
                                                                  .solverParameters = ""};
 
-    auto results = api.run(*study_loader.get(), {}, opt);
+    auto results = api.run(*study_loader, {}, opt);
 
     BOOST_CHECK(!results.antares_problems.empty());
     BOOST_CHECK(!results.error);
@@ -115,8 +115,7 @@ BOOST_AUTO_TEST_CASE(invalid_ortools_solver)
       .solverLogs = true,
       .solverParameters = ""};
 
-    auto shouldThrow = [&api, &study_loader, &opt]
-    { return api.run(*study_loader.get(), {}, opt); };
+    auto shouldThrow = [&api, &study_loader, &opt] { return api.run(*study_loader, {}, opt); };
     BOOST_CHECK_EXCEPTION(shouldThrow(),
                           std::invalid_argument,
                           checkMessage("Solver this-solver-does-not-exist not found"));

--- a/src/tests/src/api_lib/test_api.cpp
+++ b/src/tests/src/api_lib/test_api.cpp
@@ -29,7 +29,7 @@
 BOOST_AUTO_TEST_CASE(result_failure_when_study_path_invalid)
 {
     using namespace std::string_literals;
-    auto results = Antares::API::PerformSimulation("dummy"s, {});
+    auto results = Antares::API::PerformSimulation("dummy"s, {}, {});
     BOOST_CHECK(results.error);
     BOOST_CHECK(!results.error->reason.empty());
 }


### PR DESCRIPTION
TODO
- [x] Fix build for api_client_test (missing argument)
- [x] Fix extra output directory created by Simulator, for example 20241204-1554eco and 20241204-1554eco-2