### PR TITLE
Update vcpkg@2023.07.21 -> vcpkg@2024.12.16, Boost@1.81.0 -> Boost@1.86.0

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(unit_tests_antares VERSION 1.0)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.29")
+  # FindBoost.cmake was removed with recent versions of CMake
+  cmake_policy(SET CMP0167 NEW)
+endif()
+
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 # Make found targets globally available.

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,11 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 project(unit_tests_antares VERSION 1.0)
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.29")
-  # FindBoost.cmake was removed with recent versions of CMake
-  cmake_policy(SET CMP0167 NEW)
-endif()
-
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 # Make found targets globally available.

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "antares-simulator",
   "version-string": "9.2.0",
-  "builtin-baseline": "9484a57dd560b89f0a583be08af6753611c57fd5",
+  "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
   "vcpkg-configuration": {
     "overlay-ports": [
       "./ports"
@@ -21,11 +21,11 @@
     },
     {
       "name": "boost-test",
-      "version>=": "1.81.0"
+      "version>=": "1.86.0"
     },
     {
       "name": "boost-core",
-      "version>=": "1.81.0"
+      "version>=": "1.86.0"
     },
     {
       "name": "minizip-ng",

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -21,11 +21,11 @@
     },
     {
       "name": "boost-test",
-      "version>=": "1.86.0"
+      "version>=": "1.81.0"
     },
     {
       "name": "boost-core",
-      "version>=": "1.86.0"
+      "version>=": "1.81.0"
     },
     {
       "name": "minizip-ng",

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -21,11 +21,11 @@
     },
     {
       "name": "boost-test",
-      "version>=": "1.81.0"
+      "version>=": "1.86.0"
     },
     {
       "name": "boost-core",
-      "version>=": "1.81.0"
+      "version>=": "1.86.0"
     },
     {
       "name": "minizip-ng",


### PR DESCRIPTION
The old tag seems to reference invalid URLs on Windows, e.g

```
 Downloading https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst
Downloading https://repo.msys2.org/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst
Downloading https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst
Downloading https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst
Downloading https://mirrors.ustc.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst
Downloading https://mirror.selfnet.de/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst
error: Failed to download from mirror set
error: https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst: failed: status code 404
error: https://repo.msys2.org/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst: failed: status code 404
error: https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst: failed: status code 404
error: https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst: failed: status code 404
error: https://mirrors.ustc.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst: failed: status code 404
error: https://mirror.selfnet.de/msys2/msys/x86_64/msys2-runtime-3.4.6-1-x86_64.pkg.tar.zst: failed: status code 404
```
[source](https://github.com/AntaresSimulatorTeam/Antares_Simulator/actions/runs/12580772537/job/35063320582?pr=2552)