### PR TITLE
Set modeler name for logs (instead of [noname])

### DIFF
--- a/src/solver/modeler/main.cpp
+++ b/src/solver/modeler/main.cpp
@@ -28,6 +28,8 @@ using namespace Antares::Solver;
 
 int main(int argc, const char** argv)
 {
+    logs.applicationName("modeler");
+
     if (argc < 1)
     {
         logs.error() << "No study path provided, exiting.";


### PR DESCRIPTION
Before
```
omnesflo@gm0winl772:~/Antares_Simulator_Tests_NR/modeler$ ~/Antares_Simulator/build-debug/solver/modeler/antares-modeler example3
[2025-01-07 15:02:42][noname][infos] Study path: example3
[2025-01-07 15:02:42][noname][infos] Parameters loaded
[2025-01-07 15:02:42][noname][infos] Library loaded: lib_example1
[2025-01-07 15:02:42][noname][infos] Library loaded: lib_example2
[2025-01-07 15:02:42][noname][infos] Libraries loaded
[2025-01-07 15:02:42][noname][infos] System loaded
[2025-01-07 15:02:42][noname][infos] Number of variables: 6
[2025-01-07 15:02:42][noname][infos] Number of constraints: 6
```
After
```
omnesflo@gm0winl772:~/Antares_Simulator_Tests_NR/modeler$ ~/Antares_Simulator/build-debug/solver/modeler/antares-modeler example3
[2025-01-07 15:03:41][modeler][infos] Study path: example3
[2025-01-07 15:03:41][modeler][infos] Parameters loaded
[2025-01-07 15:03:41][modeler][infos] Library loaded: lib_example1
[2025-01-07 15:03:41][modeler][infos] Library loaded: lib_example2
[2025-01-07 15:03:41][modeler][infos] Libraries loaded
[2025-01-07 15:03:41][modeler][infos] System loaded
[2025-01-07 15:03:41][modeler][infos] Number of variables: 6
[2025-01-07 15:03:41][modeler][infos] Number of constraints: 6
```