### PR TITLE
Throw exception instead of pointer to exception

### DIFF
--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -336,7 +336,7 @@ void RemixHydroForAllAreas(const Data::AreaList& areas,
 
         if (!result)
         {
-            throw new Data::AssertionError(
+            throw Data::AssertionError(
               "Error in simplex optimisation. Check logs for more details.");
         }
     }


### PR DESCRIPTION
## Explanation
We don't catch `AssertionError*`, only `AssertionError` or references to `AssertionError`.

### Code
```cpp
#include <iostream>
#include <stdexcept>

int main()
{
    try
    {
        throw new std::runtime_error("nope");
    }
    catch (const std::runtime_error& re)
    {
        std::cout << "A " << re.what() << std::endl;
    }
    catch (std::runtime_error* re)
    {
        std::cout << "B " << re->what() << std::endl;
    }
}
```
### Output
```
B nope
```