### PR TITLE
Fix function `ThermalCluster::getMarketBidCost` [ANT-2527] (backport)

### DIFF
--- a/src/libs/antares/study/parts/thermal/cluster.cpp
+++ b/src/libs/antares/study/parts/thermal/cluster.cpp
@@ -765,16 +765,14 @@ double ThermalCluster::getMarginalCost(uint serieIndex, uint hourInTheYear) cons
 
 double ThermalCluster::getMarketBidCost(uint hourInTheYear, uint year) const
 {
-    uint serieIndex = series.getSeriesIndex(year);
-
-    double mod = modulation[thermalModulationMarketBid][serieIndex];
-
+    double mod = modulation[thermalModulationMarketBid][hourInTheYear];
     if (costgeneration == Data::setManually)
     {
         return marketBidCost * mod;
     }
     else
     {
+        uint serieIndex = series.getSeriesIndex(year);
         const uint tsIndex = Math::Min(serieIndex, costsTimeSeries.size() - 1);
         return costsTimeSeries[tsIndex].marketBidCostTS[hourInTheYear] * mod;
     }


### PR DESCRIPTION
Partial backport of #2525 on branch 8.8.x