### PR TITLE
Derive ElemAlreadyExists from std::runtime_error

### DIFF
--- a/src/solver/modeler/ortoolsImpl/linearProblem.cpp
+++ b/src/solver/modeler/ortoolsImpl/linearProblem.cpp
@@ -37,12 +37,12 @@ OrtoolsLinearProblem::OrtoolsLinearProblem(bool isMip, const std::string& solver
     objective_ = mpSolver_->MutableObjective();
 }
 
-class ElemAlreadyExists: public std::exception
+class ElemAlreadyExists: public std::runtime_error
 {
 public:
-    const char* what() const noexcept override
+    explicit ElemAlreadyExists():
+        std::runtime_error("Element name already exists in linear problem")
     {
-        return "Element name already exists in linear problem";
     }
 };
 


### PR DESCRIPTION
`std::exception`'s constructors don't accept `std::strings`, so it's a bit strange to override method `what`

https://en.cppreference.com/w/cpp/error/exception/exception