### PR TITLE
Simplify ComponentFiller::addVariables

### DIFF
--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ComponentFiller.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ComponentFiller.h
@@ -53,10 +53,6 @@ public:
     /// Create a ComponentFiller for a Component
     explicit ComponentFiller(const Study::SystemModel::Component& component);
 
-    void addVariables_(Solver::Modeler::Api::ILinearProblem& pb,
-                       const std::unique_ptr<Solver::Visitors::EvalVisitor>& evaluator,
-                       unsigned int nb_vars) const;
-
     void addVariables(Solver::Modeler::Api::ILinearProblem& pb,
                       Solver::Modeler::Api::LinearProblemData& data,
                       Solver::Modeler::Api::FillContext& ctx) override;


### PR DESCRIPTION
Remove `addVariables_`, `std::make_unique`, etc. Keep the same overall behavior.