### PR TITLE
Fix the upgrade from v8.8 to 9.2 of hydro power matrices [ANT-2742]

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -774,7 +774,7 @@ bool AreaList::saveToFolder(const AnyString& folder) const
     // Hydro
     // The hydro files must be saved after the area has been invalidated
     buffer.clear() << folder << SEP << "input" << SEP << "hydro";
-    ret = PartHydro::SaveToFolder(*this, buffer) && ret;
+    ret = PartHydro::SaveToFolder(*this, buffer, pStudy.parameters.compatibility.hydroPmax) && ret;
 
     // update nameid set
     updateNameIDSet();

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -194,7 +194,7 @@ static bool AreaListSaveThermalDataToFile(const AreaList& list, const AnyString&
 
 static bool AreaListSaveToFolderSingleArea(const Area& area,
                                            const AnyString& folder,
-                                           Parameters::Compatibility::HydroPmax hydroPmax)
+                                           const Parameters::Compatibility::HydroPmax hydroPmax)
 {
     bool ret = true;
     Clob buffer;

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -192,9 +192,10 @@ static bool AreaListSaveThermalDataToFile(const AreaList& list, const AnyString&
     return ini.save(filename);
 }
 
-static bool AreaListSaveToFolderSingleArea(const Area& area, Clob& buffer, const AnyString& folder)
+static bool AreaListSaveToFolderSingleArea(const Area& area, const AnyString& folder)
 {
     bool ret = true;
+    Clob buffer;
 
     // A specific folder for general data
     buffer.clear() << folder << SEP << "input" << SEP << "areas" << SEP << area.id;
@@ -762,7 +763,7 @@ bool AreaList::saveToFolder(const AnyString& folder) const
       {
           logs.info() << "Exporting the area " << (area.index + 1) << '/' << areas.size() << ": "
                       << area.name;
-          ret = AreaListSaveToFolderSingleArea(area, buffer, folder) && ret;
+          ret = AreaListSaveToFolderSingleArea(area, folder) && ret;
       });
 
     // Hydro

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -194,7 +194,7 @@ static bool AreaListSaveThermalDataToFile(const AreaList& list, const AnyString&
 
 static bool AreaListSaveToFolderSingleArea(const Area& area,
                                            const AnyString& folder,
-                                           Parameters::Compatibility::HydroPmax& hydroPmax)
+                                           Parameters::Compatibility::HydroPmax hydroPmax)
 {
     bool ret = true;
     Clob buffer;

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -192,7 +192,9 @@ static bool AreaListSaveThermalDataToFile(const AreaList& list, const AnyString&
     return ini.save(filename);
 }
 
-static bool AreaListSaveToFolderSingleArea(const Area& area, const AnyString& folder)
+static bool AreaListSaveToFolderSingleArea(const Area& area,
+                                           const AnyString& folder,
+                                           Parameters::Compatibility::HydroPmax& hydroPmax)
 {
     bool ret = true;
     Clob buffer;
@@ -274,7 +276,7 @@ static bool AreaListSaveToFolderSingleArea(const Area& area, const AnyString& fo
         if (area.hydro.series) // Series
         {
             buffer.clear() << folder << SEP << "input" << SEP << "hydro" << SEP << "series";
-            ret = area.hydro.series->saveToFolder(area.id, buffer) && ret;
+            ret = area.hydro.series->saveToFolder(area.id, buffer, hydroPmax) && ret;
         }
     }
 
@@ -763,7 +765,10 @@ bool AreaList::saveToFolder(const AnyString& folder) const
       {
           logs.info() << "Exporting the area " << (area.index + 1) << '/' << areas.size() << ": "
                       << area.name;
-          ret = AreaListSaveToFolderSingleArea(area, folder) && ret;
+          ret = AreaListSaveToFolderSingleArea(area,
+                                               folder,
+                                               pStudy.parameters.compatibility.hydroPmax)
+                && ret;
       });
 
     // Hydro

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -531,8 +531,8 @@ const char* SimulationModeToCString(SimulationMode mode);
 */
 bool StringToSimulationMode(SimulationMode& mode, Yuni::CString<20, false> text);
 
-const char* CompatibilityHydroPmaxToCString(Parameters::Compatibility::HydroPmax);
-bool StringToCompatibilityHydroPmax(Parameters::Compatibility::HydroPmax, const std::string& text);
+const char* CompatibilityHydroPmaxToCString(const Parameters::Compatibility::HydroPmax);
+bool StringToCompatibilityHydroPmax(Parameters::Compatibility::HydroPmax&, const std::string& text);
 
 } // namespace Antares::Data
 

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -532,7 +532,7 @@ const char* SimulationModeToCString(SimulationMode mode);
 bool StringToSimulationMode(SimulationMode& mode, Yuni::CString<20, false> text);
 
 const char* CompatibilityHydroPmaxToCString(Parameters::Compatibility::HydroPmax);
-bool StringToCompatibilityHydroPmax(Parameters::Compatibility::HydroPmax&, const std::string& text);
+bool StringToCompatibilityHydroPmax(Parameters::Compatibility::HydroPmax, const std::string& text);
 
 } // namespace Antares::Data
 

--- a/src/libs/antares/study/include/antares/study/parts/hydro/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/container.h
@@ -131,7 +131,9 @@ public:
     ** \param folder The targer folder
     ** \return A non-zero value if the operation succeeded, 0 otherwise
     */
-    static bool SaveToFolder(const AreaList& areas, const AnyString& folder);
+    static bool SaveToFolder(const AreaList& areas,
+                             const AnyString& folder,
+                             const Parameters::Compatibility::HydroPmax& hydroPmax);
 
     /*!
     ** \brief Default Constructor
@@ -195,6 +197,9 @@ public:
     double leewayUpperBound;
     //! Puming efficiency
     double pumpingEfficiency;
+    //! Daily max power ({generating max Power, generating max energy, pumping max power, pumping
+    //! max energy}x365)
+    Matrix<double, double> dailyMaxPumpAndGen;
     //! Credit Modulation (default 0, 101 * 2)
     Matrix<double, double> creditModulation;
 

--- a/src/libs/antares/study/include/antares/study/parts/hydro/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/container.h
@@ -133,7 +133,7 @@ public:
     */
     static bool SaveToFolder(const AreaList& areas,
                              const AnyString& folder,
-                             const Parameters::Compatibility::HydroPmax& hydroPmax);
+                             const Parameters::Compatibility::HydroPmax hydroPmax);
 
     /*!
     ** \brief Default Constructor

--- a/src/libs/antares/study/include/antares/study/parts/hydro/hydromaxtimeseriesreader.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/hydromaxtimeseriesreader.h
@@ -58,8 +58,6 @@ public:
     };
 
 private:
-    Matrix<double, double> dailyMaxPumpAndGen;
-
     PartHydro& hydro_;
     std::string areaID_;
     std::string areaName_;

--- a/src/libs/antares/study/include/antares/study/parts/hydro/series.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/series.h
@@ -93,7 +93,7 @@ public:
     */
     bool saveToFolder(const AreaName& areaID,
                       const AnyString& folder,
-                      Parameters::Compatibility::HydroPmax& hydroPmax) const;
+                      Parameters::Compatibility::HydroPmax hydroPmax) const;
     //@}
 
     TimeSeriesNumbers timeseriesNumbers;

--- a/src/libs/antares/study/include/antares/study/parts/hydro/series.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/series.h
@@ -91,7 +91,9 @@ public:
     ** \param folder The target folder
     ** \return A non-zero value if the operation succeeded, 0 otherwise
     */
-    bool saveToFolder(const AreaName& areaID, const AnyString& folder) const;
+    bool saveToFolder(const AreaName& areaID,
+                      const AnyString& folder,
+                      Parameters::Compatibility::HydroPmax& hydroPmax) const;
     //@}
 
     TimeSeriesNumbers timeseriesNumbers;

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -221,7 +221,7 @@ const char* CompatibilityHydroPmaxToCString(Parameters::Compatibility::HydroPmax
     }
 }
 
-bool StringToCompatibilityHydroPmax(Parameters::Compatibility::HydroPmax& mode,
+bool StringToCompatibilityHydroPmax(Parameters::Compatibility::HydroPmax mode,
                                     const std::string& text)
 {
     if (text.empty())

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -208,7 +208,7 @@ const char* SimulationModeToCString(SimulationMode mode)
     }
 }
 
-const char* CompatibilityHydroPmaxToCString(Parameters::Compatibility::HydroPmax mode)
+const char* CompatibilityHydroPmaxToCString(const Parameters::Compatibility::HydroPmax mode)
 {
     switch (mode)
     {
@@ -221,7 +221,7 @@ const char* CompatibilityHydroPmaxToCString(Parameters::Compatibility::HydroPmax
     }
 }
 
-bool StringToCompatibilityHydroPmax(Parameters::Compatibility::HydroPmax mode,
+bool StringToCompatibilityHydroPmax(Parameters::Compatibility::HydroPmax& mode,
                                     const std::string& text)
 {
     if (text.empty())

--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -467,7 +467,7 @@ bool PartHydro::validate(Study& study)
 
 bool PartHydro::SaveToFolder(const AreaList& areas,
                              const AnyString& folder,
-                             const Parameters::Compatibility::HydroPmax& hydroPmax)
+                             const Parameters::Compatibility::HydroPmax hydroPmax)
 {
     if (!folder)
     {
@@ -575,7 +575,7 @@ bool PartHydro::SaveToFolder(const AreaList& areas,
               buffer.clear() << folder << SEP << "common" << SEP << "capacity" << SEP
                              << "maxDailyGenEnergy_" << area.id << ".txt";
               ret = area.hydro.dailyNbHoursAtGenPmax.saveToCSVFile(buffer, /*decimal*/ 2) && ret;
-              
+
               buffer.clear() << folder << SEP << "common" << SEP << "capacity" << SEP
                              << "maxDailyPumpEnergy_" << area.id << ".txt";
               ret = area.hydro.dailyNbHoursAtPumpPmax.saveToCSVFile(buffer, /*decimal*/ 2) && ret;

--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -465,7 +465,9 @@ bool PartHydro::validate(Study& study)
     return checkProperties(study) && ret;
 }
 
-bool PartHydro::SaveToFolder(const AreaList& areas, const AnyString& folder)
+bool PartHydro::SaveToFolder(const AreaList& areas,
+                             const AnyString& folder,
+                             const Parameters::Compatibility::HydroPmax& hydroPmax)
 {
     if (!folder)
     {
@@ -524,7 +526,7 @@ bool PartHydro::SaveToFolder(const AreaList& areas, const AnyString& folder)
 
     // Add all alpha values for each area
     areas.each(
-      [&allSections, &buffer, &folder, &ret](const Data::Area& area)
+      [&allSections, &buffer, &folder, &hydroPmax, &ret](const Data::Area& area)
       {
           allSections.s->add(area.id, area.hydro.interDailyBreakdown);
           allSections.smod->add(area.id, area.hydro.intraDailyModulation);
@@ -568,13 +570,23 @@ bool PartHydro::SaveToFolder(const AreaList& areas, const AnyString& folder)
           }
 
           // max hours gen
-          buffer.clear() << folder << SEP << "common" << SEP << "capacity" << SEP
-                         << "maxDailyGenEnergy_" << area.id << ".txt";
-          ret = area.hydro.dailyNbHoursAtGenPmax.saveToCSVFile(buffer, /*decimal*/ 2) && ret;
-          // max hours pump
-          buffer.clear() << folder << SEP << "common" << SEP << "capacity" << SEP
-                         << "maxDailyPumpEnergy_" << area.id << ".txt";
-          ret = area.hydro.dailyNbHoursAtPumpPmax.saveToCSVFile(buffer, /*decimal*/ 2) && ret;
+          if (hydroPmax == Parameters::Compatibility::HydroPmax::Hourly)
+          {
+              buffer.clear() << folder << SEP << "common" << SEP << "capacity" << SEP
+                             << "maxDailyGenEnergy_" << area.id << ".txt";
+              ret = area.hydro.dailyNbHoursAtGenPmax.saveToCSVFile(buffer, /*decimal*/ 2) && ret;
+              
+              buffer.clear() << folder << SEP << "common" << SEP << "capacity" << SEP
+                             << "maxDailyPumpEnergy_" << area.id << ".txt";
+              ret = area.hydro.dailyNbHoursAtPumpPmax.saveToCSVFile(buffer, /*decimal*/ 2) && ret;
+          }
+          else
+          {
+              buffer.clear() << folder << SEP << "common" << SEP << "capacity" << SEP << "maxpower_"
+                             << area.id << ".txt";
+              ret = area.hydro.dailyMaxPumpAndGen.saveToCSVFile(buffer, /*decimal*/ 2) && ret;
+          }
+
           // credit modulations
           buffer.clear() << folder << SEP << "common" << SEP << "capacity" << SEP
                          << "creditmodulations_" << area.id << ".txt";

--- a/src/libs/antares/study/parts/hydro/series.cpp
+++ b/src/libs/antares/study/parts/hydro/series.cpp
@@ -191,7 +191,9 @@ void DataSeriesHydro::buildHourlyMaxPowerFromDailyTS(
     ConvertDailyTSintoHourlyTS(DailyMaxPumpPower, maxHourlyPumpPower.timeSeries[0]);
 }
 
-bool DataSeriesHydro::saveToFolder(const AreaName& areaID, const AnyString& folder) const
+bool DataSeriesHydro::saveToFolder(const AreaName& areaID,
+                                   const AnyString& folder,
+                                   Parameters::Compatibility::HydroPmax& hydroPmax) const
 {
     String buffer;
     buffer.clear() << folder << SEP << areaID;
@@ -207,10 +209,14 @@ bool DataSeriesHydro::saveToFolder(const AreaName& areaID, const AnyString& fold
         ret = storage.timeSeries.saveToCSVFile(buffer, 0) && ret;
         buffer.clear() << folder << SEP << areaID << SEP << "mingen.txt";
         ret = mingen.timeSeries.saveToCSVFile(buffer, 0) && ret;
-        buffer.clear() << folder << SEP << areaID << SEP << "maxHourlyGenPower.txt";
-        ret = maxHourlyGenPower.timeSeries.saveToCSVFile(buffer, 0) && ret;
-        buffer.clear() << folder << SEP << areaID << SEP << "maxHourlyPumpPower.txt";
-        ret = maxHourlyPumpPower.timeSeries.saveToCSVFile(buffer, 0) && ret;
+
+        if (hydroPmax == Parameters::Compatibility::HydroPmax::Hourly)
+        {
+            buffer.clear() << folder << SEP << areaID << SEP << "maxHourlyGenPower.txt";
+            ret = maxHourlyGenPower.timeSeries.saveToCSVFile(buffer, 0) && ret;
+            buffer.clear() << folder << SEP << areaID << SEP << "maxHourlyPumpPower.txt";
+            ret = maxHourlyPumpPower.timeSeries.saveToCSVFile(buffer, 0) && ret;
+        }
 
         return ret;
     }

--- a/src/libs/antares/study/parts/hydro/series.cpp
+++ b/src/libs/antares/study/parts/hydro/series.cpp
@@ -193,7 +193,7 @@ void DataSeriesHydro::buildHourlyMaxPowerFromDailyTS(
 
 bool DataSeriesHydro::saveToFolder(const AreaName& areaID,
                                    const AnyString& folder,
-                                   Parameters::Compatibility::HydroPmax& hydroPmax) const
+                                   Parameters::Compatibility::HydroPmax hydroPmax) const
 {
     String buffer;
     buffer.clear() << folder << SEP << areaID;

--- a/src/libs/antares/study/study.importprepro.cpp
+++ b/src/libs/antares/study/study.importprepro.cpp
@@ -82,7 +82,10 @@ bool Study::importTimeseriesIntoInput()
             {
                 logs.info() << "Importing hydro timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "hydro" << SEP << "series";
-                ret = area->hydro.series->saveToFolder(area->id, buffer, parameters.compatibility.hydroPmax) && ret;
+                ret = area->hydro.series->saveToFolder(area->id,
+                                                       buffer,
+                                                       parameters.compatibility.hydroPmax)
+                      && ret;
                 ++progression;
             }
         }

--- a/src/libs/antares/study/study.importprepro.cpp
+++ b/src/libs/antares/study/study.importprepro.cpp
@@ -82,7 +82,7 @@ bool Study::importTimeseriesIntoInput()
             {
                 logs.info() << "Importing hydro timeseries : " << areaName;
                 buffer.clear() << folderInput << SEP << "hydro" << SEP << "series";
-                ret = area->hydro.series->saveToFolder(area->id, buffer) && ret;
+                ret = area->hydro.series->saveToFolder(area->id, buffer, parameters.compatibility.hydroPmax) && ret;
                 ++progression;
             }
         }


### PR DESCRIPTION
Fixes problem described in issue [ANT-2742](https://gopro-tickets.rte-france.com/browse/ANT-2742)

This fix is a quick fix : code could be cleaner. 
Some refactoring could make code more readable when reading it again in a few months / years.
In particular, we could create an interface for reading and saving this data (hydro power) and create 2 classes implementing this interface and encapsulating each case (read/write daily or hourly)  