### PR TITLE
Fix std::bad_array_new_length exception in SurveyResults::SurveyResults

### DIFF
--- a/src/solver/variable/surveyresults/surveyresults.cpp
+++ b/src/solver/variable/surveyresults/surveyresults.cpp
@@ -558,7 +558,11 @@ SurveyResults::SurveyResults(const Data::Study& s, const Yuni::String& o, IResul
     digestNonApplicableStatus = new bool*[digestSize];
     for (uint i = 0; i < digestSize; i++)
     {
-        digestNonApplicableStatus[i] = new bool[maxVariables]{false};
+        digestNonApplicableStatus[i] = new bool[maxVariables];
+        for (uint var = 0; var != maxVariables; ++var)
+        {
+            digestNonApplicableStatus[i][var] = false;
+        }
     }
 }
 

--- a/src/tests/src/solver/variable/CMakeLists.txt
+++ b/src/tests/src/solver/variable/CMakeLists.txt
@@ -3,3 +3,9 @@ include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 add_boost_test(test-intermediate
   SRC test_intermediate.cpp
   LIBS antares-solver-variable)
+
+add_boost_test(test-surveyresults
+  SRC test_surveyresults.cpp
+  LIBS
+  antares-solver-variable
+  result_writer)

--- a/src/tests/src/solver/variable/test_surveyresults.cpp
+++ b/src/tests/src/solver/variable/test_surveyresults.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2007-2024, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
+#define BOOST_TEST_MODULE "test time series"
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <boost/test/unit_test.hpp>
+
+#include "antares/antares/constants.h"
+#include "antares/solver/variable/surveyresults.h"
+#include "antares/writer/in_memory_writer.h"
+
+using namespace Antares::Solver::Variable;
+
+struct StudyFixture
+{
+    StudyFixture():
+        study(std::make_unique<Antares::Data::Study>())
+    {
+        study->parameters.simulationDays.first = 0;
+        study->parameters.simulationDays.end = 7;
+        study->initializeRuntimeInfos();
+    }
+
+    std::unique_ptr<Antares::Data::Study> study;
+};
+
+BOOST_AUTO_TEST_SUITE(surveyresults)
+
+BOOST_FIXTURE_TEST_CASE(no_variable_constructor_does_not_throw, StudyFixture)
+{
+    Benchmarking::DurationCollector durationCollector;
+    Antares::Solver::InMemoryWriter writer(durationCollector);
+    // At least one area was required to trigger a std::bad_alloc throw
+    Antares::Data::addAreaToListOfAreas(study->areas, "dummyArea");
+    BOOST_CHECK_NO_THROW(SurveyResults survey(*study, "out", writer););
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/variable/test_surveyresults.cpp
+++ b/src/tests/src/solver/variable/test_surveyresults.cpp
@@ -24,7 +24,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "antares/antares/constants.h"
 #include "antares/solver/variable/surveyresults.h"
 #include "antares/writer/in_memory_writer.h"
 


### PR DESCRIPTION
This happens only if there is at least one area and no output variables (example study valid-filter-outputs/no-geo-trim--noVar)

The original code is equivalent to 
```cpp
bool* x = new bool[0]{false};
```
which throws a `std::bad_array_new_length` exception as shown [here](https://en.cppreference.com/w/cpp/memory/new/bad_array_new_length).