### PR TITLE
Place all unit test executables in the same build subdirectory

### DIFF
--- a/src/tests/macros.cmake
+++ b/src/tests/macros.cmake
@@ -17,6 +17,11 @@ function(add_boost_test)
     # All tests use boost
     target_link_libraries(${TEST_NAME} PRIVATE ${arg_LIBS} Boost::unit_test_framework)
 
+    # All executables in <build>/tests
+    set_target_properties(${TEST_NAME} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
+
     # Optional: add private include directories
     if (NOT "${arg_INCLUDE}" STREQUAL "")
       target_include_directories(${TEST_NAME} PRIVATE ${arg_INCLUDE})


### PR DESCRIPTION
Use existing CMake function `add_boost_test` to instruct CMake to place all executables in build/tests. This should help developers easily locate tests to run them individually for debugging purposes.

## Before
```
cd build-debug
ctest .
test_feature1...OK
test_feature2...OK
test_feature3...FAILED
find -name test_feature3
# Developer copies the path
# Developer pastes the path
[gdb|valgrind] extremely/long/path/to/test_feature3
```

## After
```
cd build-debug
ctest .
test_feature1...OK
test_feature2...OK
test_feature3...FAILED
# Developer pushes tab a few times
[gdb|valgrind] tests/test_feature3
```

## Collisions
Two tests should never have the same name, or else the executable might be overwritten. Since the executable name is the same as the target name, there should be no collision. If there was any collision CMake would tell us something along the lines of "target XX already defined in YYY".