### PR TITLE
[ANT-2890] Fix segfault loading scenario

### DIFF
--- a/src/ext/yuni/src/yuni/core/string/traits/traits.hxx
+++ b/src/ext/yuni/src/yuni/core/string/traits/traits.hxx
@@ -65,7 +65,10 @@ inline Data<ChunkSizeT, ExpandableT>::~Data()
     // The string is a string adapter only if the chunk size if null
     // When the string is an adapter, the variable is const
     if (chunkSize != 0)
+    {
         ::free(const_cast<void*>(static_cast<const void*>(data)));
+        data = nullptr;
+    }
 }
 
 #ifdef YUNI_HAS_CPP_MOVE

--- a/src/libs/antares/array/include/antares/array/matrix.hxx
+++ b/src/libs/antares/array/include/antares/array/matrix.hxx
@@ -577,12 +577,6 @@ void Matrix<T, ReadWriteT>::resize(uint w, uint h, bool fixedSize)
                 }
                 delete[] entry;
             }
-            if (!w and !h)
-            {
-                entry = nullptr;
-                width = 0;
-                height = 0;
-            }
             else
             {
                 // Assigning the new size
@@ -621,7 +615,7 @@ void Matrix<T, ReadWriteT>::resize(uint w, uint h, bool fixedSize)
 
 namespace // anonymous
 {
-static inline bool DetectEncoding(const AnyString& filename, const AnyString& data, size_t& offset)
+bool DetectEncoding(const AnyString& filename, const AnyString& data, size_t& offset)
 {
     if (data.size() > 1)
     {

--- a/src/libs/antares/array/include/antares/array/matrix.hxx
+++ b/src/libs/antares/array/include/antares/array/matrix.hxx
@@ -577,20 +577,18 @@ void Matrix<T, ReadWriteT>::resize(uint w, uint h, bool fixedSize)
                 }
                 delete[] entry;
             }
-            else
+
+            // Assigning the new size
+            width = w;
+            height = h;
+
+            // Allocating the entry for the matrix
+            entry = new typename Antares::Memory::Stored<T>::Type[width + 1];
+            entry[width] = nullptr;
+
+            for (uint i = 0; i != w; ++i)
             {
-                // Assigning the new size
-                width = w;
-                height = h;
-
-                // Allocating the entry for the matrix
-                entry = new typename Antares::Memory::Stored<T>::Type[width + 1];
-                entry[width] = nullptr;
-
-                for (uint i = 0; i != w; ++i)
-                {
-                    Antares::Memory::Allocate<T>(entry[i], height);
-                }
+                Antares::Memory::Allocate<T>(entry[i], height);
             }
         }
     }

--- a/src/libs/antares/study/binding_constraint/BindingConstraintGroupRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintGroupRepository.cpp
@@ -40,9 +40,11 @@ unsigned BindingConstraintGroupRepository::size() const
     return groups_.size();
 }
 
-    bool BindingConstraintGroupRepository::buildFrom(const BindingConstraintsRepository &repository) {
-        groupsByName_.clear();
-        for (const auto& constraint: repository) {
+bool BindingConstraintGroupRepository::buildFrom(const BindingConstraintsRepository& repository)
+{
+    groupsByName_.clear();
+    for (const auto& constraint: repository)
+    {
         const auto group_found = operator[](constraint->group());
         BindingConstraintGroup* group;
         if (group_found)
@@ -88,18 +90,19 @@ void BindingConstraintGroupRepository::resizeAllTimeseriesNumbers(unsigned int n
                           [&nb_years](auto& group) { group->timeseriesNumbers.reset(nb_years); });
 }
 
-    BindingConstraintGroup* BindingConstraintGroupRepository::operator[](const std::string& name) const {
-        if (auto it = groupsByName_.find(name); it != groupsByName_.end())
-        {
-            return it->second;
-        }
-        auto group = std::ranges::find_if(groups_, [&name](auto group_of_constraint) {
-                                        return group_of_constraint->name() == name;
-                                    });
-        if (group != groups_.end())
+BindingConstraintGroup* BindingConstraintGroupRepository::operator[](const std::string& name) const
+{
+    if (auto it = groupsByName_.find(name); it != groupsByName_.end())
     {
-            groupsByName_[name] = *group;
-            return *group;
+        return it->second;
+    }
+    auto group = std::ranges::find_if(groups_,
+                                      [&name](auto group_of_constraint)
+                                      { return group_of_constraint->name() == name; });
+    if (group != groups_.end())
+    {
+        groupsByName_[name] = *group;
+        return *group;
     }
     return nullptr;
 }
@@ -124,14 +127,16 @@ BindingConstraintGroupRepository::const_iterator BindingConstraintGroupRepositor
     return groups_.end();
 }
 
-    BindingConstraintGroup* BindingConstraintGroupRepository::add(const std::string& name) {
-        auto& new_group = owning_groups_.emplace_back(std::make_unique<BindingConstraintGroup>(name));
-        return new_group.get();
+BindingConstraintGroup* BindingConstraintGroupRepository::add(const std::string& name)
+{
+    auto& new_group = owning_groups_.emplace_back(std::make_unique<BindingConstraintGroup>(name));
+    return new_group.get();
 }
 
-    void BindingConstraintGroupRepository::clear() {
-        groupsByName_.clear();
+void BindingConstraintGroupRepository::clear()
+{
+    groupsByName_.clear();
     groups_.clear();
-        owning_groups_.clear();
+    owning_groups_.clear();
 }
 } // namespace Antares::Data

--- a/src/libs/antares/study/binding_constraint/BindingConstraintGroupRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintGroupRepository.cpp
@@ -40,10 +40,9 @@ unsigned BindingConstraintGroupRepository::size() const
     return groups_.size();
 }
 
-bool BindingConstraintGroupRepository::buildFrom(const BindingConstraintsRepository& repository)
-{
-    for (const auto& constraint: repository)
-    {
+    bool BindingConstraintGroupRepository::buildFrom(const BindingConstraintsRepository &repository) {
+        groupsByName_.clear();
+        for (const auto& constraint: repository) {
         const auto group_found = operator[](constraint->group());
         BindingConstraintGroup* group;
         if (group_found)
@@ -89,14 +88,18 @@ void BindingConstraintGroupRepository::resizeAllTimeseriesNumbers(unsigned int n
                           [&nb_years](auto& group) { group->timeseriesNumbers.reset(nb_years); });
 }
 
-BindingConstraintGroup* BindingConstraintGroupRepository::operator[](const std::string& name) const
-{
-    if (auto group = std::ranges::find_if(groups_,
-                                          [&name](auto& group_of_constraint)
-                                          { return group_of_constraint->name() == name; });
-        group != groups_.end())
+    BindingConstraintGroup* BindingConstraintGroupRepository::operator[](const std::string& name) const {
+        if (auto it = groupsByName_.find(name); it != groupsByName_.end())
+        {
+            return it->second;
+        }
+        auto group = std::ranges::find_if(groups_, [&name](auto group_of_constraint) {
+                                        return group_of_constraint->name() == name;
+                                    });
+        if (group != groups_.end())
     {
-        return group->get();
+            groupsByName_[name] = *group;
+            return *group;
     }
     return nullptr;
 }
@@ -121,13 +124,14 @@ BindingConstraintGroupRepository::const_iterator BindingConstraintGroupRepositor
     return groups_.end();
 }
 
-BindingConstraintGroup* BindingConstraintGroupRepository::add(const std::string& name)
-{
-    return groups_.emplace_back(std::make_unique<BindingConstraintGroup>(name)).get();
+    BindingConstraintGroup* BindingConstraintGroupRepository::add(const std::string& name) {
+        auto& new_group = owning_groups_.emplace_back(std::make_unique<BindingConstraintGroup>(name));
+        return new_group.get();
 }
 
-void BindingConstraintGroupRepository::clear()
-{
+    void BindingConstraintGroupRepository::clear() {
+        groupsByName_.clear();
     groups_.clear();
+        owning_groups_.clear();
 }
 } // namespace Antares::Data

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintGroupRepository.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintGroupRepository.h
@@ -48,8 +48,8 @@ public:
 
     BindingConstraintGroup* operator[](const std::string& name) const;
 
-    using iterator = std::vector<std::unique_ptr<BindingConstraintGroup>>::iterator;
-    using const_iterator = std::vector<std::unique_ptr<BindingConstraintGroup>>::const_iterator;
+    using iterator = std::vector<BindingConstraintGroup*>::iterator;
+    using const_iterator = std::vector<BindingConstraintGroup*>::const_iterator;
 
     [[nodiscard]] iterator begin();
     [[nodiscard]] const_iterator begin() const;
@@ -63,7 +63,20 @@ public:
 private:
     [[nodiscard]] bool timeSeriesWidthConsistentInGroups() const;
 
-    std::vector<std::unique_ptr<BindingConstraintGroup>> groups_;
+    /**
+     * Owning vector of groups
+     */
+    std::vector<std::unique_ptr<BindingConstraintGroup>> owning_groups_;
+    /**
+     * Non-owning vector of groups. Used for accessing data
+     */
+    std::vector<BindingConstraintGroup*> groups_;
+    /**
+     * Used to speed up the search for a group by name
+     * Debatable: we could use a map and discard "groups_" vector
+     * Would require performance analysis
+     */
+    mutable std::unordered_map<std::string, BindingConstraintGroup*> groupsByName_;
 };
 
 } // namespace Antares::Data

--- a/src/libs/antares/study/include/antares/study/scenario-builder/rules.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/rules.h
@@ -132,20 +132,26 @@ public:
 private:
     // Member methods
     bool readThermalCluster(const AreaName::Vector& instrs, const String& value, bool updaterMode);
-    bool readRenewableCluster(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readRenewableCluster(const AreaName::Vector& instrs,
+                              const String& value,
+                              bool updaterMode);
     bool readLoad(const AreaName::Vector& instrs, const String& value, bool updaterMode);
     bool readWind(const AreaName::Vector& instrs, const String& value, bool updaterMode);
     bool readHydro(const AreaName::Vector& instrs, const String& value, bool updaterMode);
     bool readSolar(const AreaName::Vector& instrs, const String& value, bool updaterMode);
-    bool readInitialHydroLevels(const AreaName::Vector& instrs, const String& value, bool updaterMode);
-    bool readFinalHydroLevels(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readInitialHydroLevels(const AreaName::Vector& instrs,
+                                const String& value,
+                                bool updaterMode);
+    bool readFinalHydroLevels(const AreaName::Vector& instrs,
+                              const String& value,
+                              bool updaterMode);
     bool readLink(const AreaName::Vector& instrs, const String& value, bool updaterMode);
     bool readBindingConstraints(const AreaName::Vector& splitKey, const String& value);
 
-    const Data::Area *getArea(const AreaName &areaname, bool updaterMode);
+    const Data::Area* getArea(const AreaName& areaname, bool updaterMode);
 
-    const Data::AreaLink *getLink(const AreaName &fromAreaName,
-                                  const AreaName &toAreaName,
+    const Data::AreaLink* getLink(const AreaName& fromAreaName,
+                                  const AreaName& toAreaName,
                                   bool updaterMode);
     bool checkGroupExists(const std::string& groupName) const;
 

--- a/src/libs/antares/study/include/antares/study/scenario-builder/rules.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/rules.h
@@ -80,7 +80,7 @@ public:
     /*!
     ** \brief Load information from a single line (extracted from an INI file)
     */
-    bool readLine(const AreaName::Vector& splitKey, String value, bool updaterMode = false);
+    bool readLine(const AreaName::Vector& splitKey, const String& value, bool updaterMode = false);
 
     /*!
     ** \brief Export the data into a mere INI file
@@ -131,16 +131,16 @@ public:
 
 private:
     // Member methods
-    bool readThermalCluster(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readRenewableCluster(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readLoad(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readWind(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readHydro(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readSolar(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readInitialHydroLevels(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readFinalHydroLevels(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readLink(const AreaName::Vector& instrs, String value, bool updaterMode);
-    bool readBindingConstraints(const AreaName::Vector& splitKey, String value);
+    bool readThermalCluster(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readRenewableCluster(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readLoad(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readWind(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readHydro(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readSolar(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readInitialHydroLevels(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readFinalHydroLevels(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readLink(const AreaName::Vector& instrs, const String& value, bool updaterMode);
+    bool readBindingConstraints(const AreaName::Vector& splitKey, const String& value);
 
     Data::Area* getArea(const AreaName& areaname, bool updaterMode);
     Data::AreaLink* getLink(const AreaName& fromAreaName,

--- a/src/libs/antares/study/include/antares/study/scenario-builder/rules.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/rules.h
@@ -142,10 +142,11 @@ private:
     bool readLink(const AreaName::Vector& instrs, const String& value, bool updaterMode);
     bool readBindingConstraints(const AreaName::Vector& splitKey, const String& value);
 
-    Data::Area* getArea(const AreaName& areaname, bool updaterMode);
-    Data::AreaLink* getLink(const AreaName& fromAreaName,
-                            const AreaName& toAreaName,
-                            bool updaterMode);
+    const Data::Area *getArea(const AreaName &areaname, bool updaterMode);
+
+    const Data::AreaLink *getLink(const AreaName &fromAreaName,
+                                  const AreaName &toAreaName,
+                                  bool updaterMode);
     bool checkGroupExists(const std::string& groupName) const;
 
     // Member data

--- a/src/libs/antares/study/scenario-builder/rules.cpp
+++ b/src/libs/antares/study/scenario-builder/rules.cpp
@@ -124,7 +124,9 @@ Data::Area* Rules::getArea(const AreaName& areaname, bool updaterMode)
     return area;
 }
 
-bool Rules::readThermalCluster(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readThermalCluster(const AreaName::Vector& splitKey,
+                               const String& value,
+                               bool updaterMode)
 {
     const AreaName& areaname = splitKey[1];
     const uint year = splitKey[2].to<uint>();
@@ -159,7 +161,9 @@ bool Rules::readThermalCluster(const AreaName::Vector& splitKey, String value, b
     return true;
 }
 
-bool Rules::readRenewableCluster(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readRenewableCluster(const AreaName::Vector& splitKey,
+                                 const String& value,
+                                 bool updaterMode)
 {
     const AreaName& areaname = splitKey[1];
     const uint year = splitKey[2].to<uint>();
@@ -201,7 +205,7 @@ bool Rules::readRenewableCluster(const AreaName::Vector& splitKey, String value,
     return true;
 }
 
-bool Rules::readLoad(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readLoad(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
 {
     const AreaName& areaname = splitKey[1];
     const uint year = splitKey[2].to<uint>();
@@ -217,7 +221,7 @@ bool Rules::readLoad(const AreaName::Vector& splitKey, String value, bool update
     return true;
 }
 
-bool Rules::readWind(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readWind(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
 {
     const uint year = splitKey[2].to<uint>();
     const AreaName& areaname = splitKey[1];
@@ -233,7 +237,7 @@ bool Rules::readWind(const AreaName::Vector& splitKey, String value, bool update
     return true;
 }
 
-bool Rules::readHydro(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readHydro(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
 {
     const uint year = splitKey[2].to<uint>();
     const AreaName& areaname = splitKey[1];
@@ -249,7 +253,7 @@ bool Rules::readHydro(const AreaName::Vector& splitKey, String value, bool updat
     return true;
 }
 
-bool Rules::readSolar(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readSolar(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
 {
     const uint year = splitKey[2].to<uint>();
     const AreaName& areaname = splitKey[1];
@@ -265,7 +269,7 @@ bool Rules::readSolar(const AreaName::Vector& splitKey, String value, bool updat
     return true;
 }
 
-bool Rules::readInitialHydroLevels(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readInitialHydroLevels(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
 {
     const uint year = splitKey[2].to<uint>();
     const AreaName& areaname = splitKey[1];
@@ -281,7 +285,7 @@ bool Rules::readInitialHydroLevels(const AreaName::Vector& splitKey, String valu
     return true;
 }
 
-bool Rules::readFinalHydroLevels(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readFinalHydroLevels(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
 {
     const uint year = splitKey[2].to<uint>();
     const AreaName& areaname = splitKey[1];
@@ -311,7 +315,7 @@ Data::AreaLink* Rules::getLink(const AreaName& fromAreaName,
     return link;
 }
 
-bool Rules::readLink(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readLink(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
 {
     const AreaName& fromAreaName = splitKey[1];
     const AreaName& toAreaName = splitKey[2];
@@ -353,7 +357,7 @@ bool Rules::checkGroupExists(const std::string& groupName) const
     return true;
 }
 
-bool Rules::readBindingConstraints(const AreaName::Vector& splitKey, String value)
+bool Rules::readBindingConstraints(const AreaName::Vector& splitKey, const String& value)
 {
     std::string group_name = splitKey[1].c_str();
     auto year = std::stoi(splitKey[2].c_str());
@@ -368,7 +372,7 @@ bool Rules::readBindingConstraints(const AreaName::Vector& splitKey, String valu
     return true;
 }
 
-bool Rules::readLine(const AreaName::Vector& splitKey, String value, bool updaterMode)
+bool Rules::readLine(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
 {
     if (splitKey.size() <= 2)
     {

--- a/src/libs/antares/study/scenario-builder/rules.cpp
+++ b/src/libs/antares/study/scenario-builder/rules.cpp
@@ -113,9 +113,9 @@ bool Rules::reset()
     return true;
 }
 
-Data::Area* Rules::getArea(const AreaName& areaname, bool updaterMode)
+const Data::Area *Rules::getArea(const AreaName &areaname, bool updaterMode)
 {
-    Data::Area* area = study_.areas.find(areaname);
+    const Data::Area* area = study_.areas.find(areaname);
     if (!area && !updaterMode)
     {
         // silently ignore the error
@@ -137,7 +137,7 @@ bool Rules::readThermalCluster(const AreaName::Vector& splitKey,
         return false;
     }
 
-    Data::Area* area = getArea(areaname, updaterMode);
+    const Data::Area* area = getArea(areaname, updaterMode);
     if (!area)
     {
         return false;
@@ -150,7 +150,8 @@ bool Rules::readThermalCluster(const AreaName::Vector& splitKey,
     }
     else
     {
-        bool isTheActiveRule = (pName.toLower() == study_.parameters.activeRulesScenario.toLower());
+        auto rule = study_.parameters.activeRulesScenario;
+        bool isTheActiveRule = (pName.toLower() == rule.toLower());
         if (!updaterMode and isTheActiveRule)
         {
             std::string clusterId = (area->id).to<std::string>() + "." + clustername;
@@ -179,7 +180,7 @@ bool Rules::readRenewableCluster(const AreaName::Vector& splitKey,
         return false;
     }
 
-    Data::Area* area = getArea(areaname, updaterMode);
+    const Data::Area* area = getArea(areaname, updaterMode);
     if (!area)
     {
         return false;
@@ -194,7 +195,9 @@ bool Rules::readRenewableCluster(const AreaName::Vector& splitKey,
     }
     else
     {
-        bool isTheActiveRule = (pName.toLower() == study_.parameters.activeRulesScenario.toLower());
+        // Use temporary to create a copy because toLower is not const
+        auto rule = study_.parameters.activeRulesScenario;
+        bool isTheActiveRule = (pName.toLower() == rule.toLower());
         if (!updaterMode and isTheActiveRule)
         {
             std::string clusterId = (area->id).to<std::string>() + "." + clustername;
@@ -301,11 +304,11 @@ bool Rules::readFinalHydroLevels(const AreaName::Vector& splitKey, const String&
     return true;
 }
 
-Data::AreaLink* Rules::getLink(const AreaName& fromAreaName,
-                               const AreaName& toAreaName,
-                               bool updaterMode)
+const Data::AreaLink *Rules::getLink(const AreaName &fromAreaName,
+                                     const AreaName &toAreaName,
+                                     bool updaterMode)
 {
-    Data::AreaLink* link = study_.areas.findLink(fromAreaName, toAreaName);
+    const Data::AreaLink* link = study_.areas.findLink(fromAreaName, toAreaName);
     if (!link && !updaterMode)
     {
         // silently ignore the error
@@ -321,7 +324,7 @@ bool Rules::readLink(const AreaName::Vector& splitKey, const String& value, bool
     const AreaName& toAreaName = splitKey[2];
     const uint year = splitKey[3].to<uint>();
 
-    Data::Area* fromArea = getArea(fromAreaName, updaterMode);
+    const Data::Area* fromArea = getArea(fromAreaName, updaterMode);
     if (!fromArea)
     {
         return false;
@@ -333,7 +336,7 @@ bool Rules::readLink(const AreaName::Vector& splitKey, const String& value, bool
         return false;
     }
 
-    AreaLink* link = getLink(fromAreaName, toAreaName, updaterMode);
+    const AreaLink* link = getLink(fromAreaName, toAreaName, updaterMode);
     if (!link)
     {
         return false;

--- a/src/libs/antares/study/scenario-builder/rules.cpp
+++ b/src/libs/antares/study/scenario-builder/rules.cpp
@@ -113,7 +113,7 @@ bool Rules::reset()
     return true;
 }
 
-const Data::Area *Rules::getArea(const AreaName &areaname, bool updaterMode)
+const Data::Area* Rules::getArea(const AreaName& areaname, bool updaterMode)
 {
     const Data::Area* area = study_.areas.find(areaname);
     if (!area && !updaterMode)
@@ -272,7 +272,9 @@ bool Rules::readSolar(const AreaName::Vector& splitKey, const String& value, boo
     return true;
 }
 
-bool Rules::readInitialHydroLevels(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
+bool Rules::readInitialHydroLevels(const AreaName::Vector& splitKey,
+                                   const String& value,
+                                   bool updaterMode)
 {
     const uint year = splitKey[2].to<uint>();
     const AreaName& areaname = splitKey[1];
@@ -288,7 +290,9 @@ bool Rules::readInitialHydroLevels(const AreaName::Vector& splitKey, const Strin
     return true;
 }
 
-bool Rules::readFinalHydroLevels(const AreaName::Vector& splitKey, const String& value, bool updaterMode)
+bool Rules::readFinalHydroLevels(const AreaName::Vector& splitKey,
+                                 const String& value,
+                                 bool updaterMode)
 {
     const uint year = splitKey[2].to<uint>();
     const AreaName& areaname = splitKey[1];
@@ -304,8 +308,8 @@ bool Rules::readFinalHydroLevels(const AreaName::Vector& splitKey, const String&
     return true;
 }
 
-const Data::AreaLink *Rules::getLink(const AreaName &fromAreaName,
-                                     const AreaName &toAreaName,
+const Data::AreaLink* Rules::getLink(const AreaName& fromAreaName,
+                                     const AreaName& toAreaName,
                                      bool updaterMode)
 {
     const Data::AreaLink* link = study_.areas.findLink(fromAreaName, toAreaName);

--- a/src/libs/antares/study/scenario-builder/sets.cpp
+++ b/src/libs/antares/study/scenario-builder/sets.cpp
@@ -34,9 +34,7 @@ Sets::Sets():
     inUpdaterMode = false;
 }
 
-Sets::~Sets()
-{
-}
+Sets::~Sets() = default;
 
 void Sets::setStudy(Study& study)
 {


### PR DESCRIPTION
The exact cause has not been exactly found but we found what could cause it and how to fix it.

The error happened in destructor of yuni strings in rules. By preventing string copy we "moved" the issue in BindingConstraintGroupRepository::operator[].

Valgrind reported invalid write in _BindingConstraintGroupRepository::operator[]_ and _Antares::Data::ScenarioBuilder::BindingConstraintsTSNumberData::reset_

The suspicion is an invalid usage of unique_ptr in lambdas.

## Fix
Instead of exposing the container of unique_ptr to consultation through iterators, we maintain a second vector of raw pointers. One vector is for ownership, one for data consultation.

## Improvement
### Group caching
Add a map to cache group when searching by name. This map may be redundant with the new vector of raw pointer. We could find some time to analyze performance (time and memory) difference between using the two structures or only one map.
### Pass by reference in Rules.cpp
A lot of strings were passed by copy. They are now passed by reference. Ideally with std::string instead of Yuni::string we could passe std::string_view if applicable.
### Add constness
Improve constness locally

### VCPKG management

Update vcpkg configuration to properly use manifest and configuration

Note: Frontport of https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/2666