### PR TITLE
Add tests for TSData getters & setters

### DIFF
--- a/src/libs/antares/study/include/antares/study/scenario-builder/NTCTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/NTCTSNumberData.h
@@ -41,7 +41,7 @@ public:
         pArea = area;
     }
 
-    void setDataForLink(const Antares::Data::AreaLink* link, const uint year, uint value);
+    void setTSnumber(const Antares::Data::AreaLink* link, const uint year, uint value);
     uint get(const Antares::Data::AreaLink* link, const uint year) const;
     bool apply(Study& study) override;
     CString<512, false> get_prefix() const override;

--- a/src/libs/antares/study/scenario-builder/NTCTSNumberData.cpp
+++ b/src/libs/antares/study/scenario-builder/NTCTSNumberData.cpp
@@ -80,9 +80,7 @@ void ntcTSNumberData::saveToINIFile(const Study& /* study */, Yuni::IO::File::St
     }
 }
 
-void ntcTSNumberData::setDataForLink(const Antares::Data::AreaLink* link,
-                                     const uint year,
-                                     uint value)
+void ntcTSNumberData::setTSnumber(const Antares::Data::AreaLink* link, const uint year, uint value)
 {
     assert(link != nullptr);
     if (year < pTSNumberRules.height && link->indexForArea < pTSNumberRules.width)

--- a/src/libs/antares/study/scenario-builder/rules.cpp
+++ b/src/libs/antares/study/scenario-builder/rules.cpp
@@ -337,7 +337,7 @@ bool Rules::readLink(const AreaName::Vector& splitKey, String value, bool update
 
     uint val = fromStringToTSnumber(value);
     fromArea = link->from;
-    linksNTC[fromArea->index].setDataForLink(link, year, val);
+    linksNTC[fromArea->index].setTSnumber(link, year, val);
     return true;
 }
 

--- a/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/scenario-builder/CMakeLists.txt
@@ -24,3 +24,12 @@ add_boost_test(test-sc-builder-file-save
   "${src_tests_src_libs_antares_study}"
   LIBS
   model_antares)
+
+add_boost_test(test-sc-builder-get-set
+  SRC test-sc-builder-get-set.cpp
+  INCLUDE
+  "${src_libs_antares_study}"
+  "${src_libs_antares_study}/scenario-builder"
+  "${src_tests_src_libs_antares_study}"
+  LIBS
+  model_antares)

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -463,9 +463,9 @@ BOOST_FIXTURE_TEST_CASE(
   LINKS_NTC__TS_number_for_many_areas_and_years__generated_and_ref_sc_buider_files_are_identical,
   saveFixture)
 {
-    my_rule->linksNTC[area_1->index].setDataForLink(link_12, 5, 13);
-    my_rule->linksNTC[area_1->index].setDataForLink(link_13, 19, 8);
-    my_rule->linksNTC[area_2->index].setDataForLink(link_23, 2, 4);
+    my_rule->linksNTC[area_1->index].setTSnumber(link_12, 5, 13);
+    my_rule->linksNTC[area_1->index].setTSnumber(link_13, 19, 8);
+    my_rule->linksNTC[area_2->index].setTSnumber(link_23, 2, 4);
 
     saveScenarioBuilder();
 
@@ -517,8 +517,8 @@ BOOST_FIXTURE_TEST_CASE(
     my_rule->thermal[area_3->index].setTSnumber(thCluster_31.get(), 5, 13);
     my_rule->thermal[area_1->index].setTSnumber(thCluster_11.get(), 19, 8);
     my_rule->renewable[area_3->index].setTSnumber(rnCluster_32.get(), 5, 13);
-    my_rule->linksNTC[area_1->index].setDataForLink(link_13, 19, 8);
-    my_rule->linksNTC[area_2->index].setDataForLink(link_23, 2, 4);
+    my_rule->linksNTC[area_1->index].setTSnumber(link_13, 19, 8);
+    my_rule->linksNTC[area_2->index].setTSnumber(link_23, 2, 4);
     my_rule->hydroInitialLevels.setTSnumber(area_1->index, 5, 8);
     my_rule->binding_constraints.setTSnumber("group3", 10, 6);
 

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
@@ -38,8 +38,6 @@
 #include <antares/study/scenario-builder/rules.h>
 #include <antares/study/study.h>
 
-BOOST_AUTO_TEST_SUITE(sc_builder)
-
 using namespace Antares::Data;
 using namespace Antares::Data::ScenarioBuilder;
 
@@ -51,9 +49,17 @@ public:
         study(std::make_unique<Study>()),
         area(study->areaAdd("area 1"))
     {
-        study->parameters.nbYears = 5;
+    }
+
+    void setNumberOfYears(uint nbYears)
+    {
+        study->parameters.nbYears = nbYears;
+    }
+
+    void initializeTSNumbers(uint nbYears)
+    {
         tsdata.reset(*study);
-        for (unsigned int year = 0; year < study->parameters.nbYears; ++year)
+        for (unsigned int year = 0; year < nbYears; ++year)
         {
             tsdata.setTSnumber(area->index, year, 12);
         }
@@ -89,20 +95,23 @@ public:
         rencluster(std::make_shared<RenewableCluster>(area1)),
         bc(study->bindingConstraints.add("my-bc"))
     {
-        study->parameters.nbYears = 5;
-
         area1->thermal.list.addToCompleteList(thcluster);
         area1->renewable.list.addToCompleteList(rencluster);
 
         bc->group("my-group");
     }
 
+    void setNumberOfYears(uint nbYears)
+    {
+        study->parameters.nbYears = nbYears;
+    }
+
     // virtual function calls not allowed in constructors (UB)
-    void initialize()
+    void initializeTSNumbers(uint nbYears)
     {
         attachArea();
         tsdata.reset(*study);
-        for (unsigned int year = 0; year < study->parameters.nbYears; ++year)
+        for (unsigned int year = 0; year < nbYears; ++year)
         {
             tsdata.setTSnumber(getObject(), year, 12);
         }
@@ -193,48 +202,132 @@ struct BindingConstraint: public StructureIndex<BindingConstraintsTSNumberData, 
 
 } // namespace Fixture
 
+BOOST_AUTO_TEST_SUITE(sc_nominal)
+
 BOOST_FIXTURE_TEST_CASE(load, Fixture::Load)
 
 {
+    setNumberOfYears(5);
+    initializeTSNumbers(5);
     check();
 }
 
 BOOST_FIXTURE_TEST_CASE(wind, Fixture::Wind)
 {
+    setNumberOfYears(5);
+    initializeTSNumbers(5);
+
     check();
 }
 
 BOOST_FIXTURE_TEST_CASE(solar, Fixture::Solar)
 {
+    setNumberOfYears(5);
+    initializeTSNumbers(5);
+
     check();
 }
 
 BOOST_FIXTURE_TEST_CASE(hydro, Fixture::Hydro)
 {
+    setNumberOfYears(5);
+    initializeTSNumbers(5);
+
     check();
 }
 
 BOOST_FIXTURE_TEST_CASE(thermal, Fixture::Thermal)
 {
-    initialize();
+    setNumberOfYears(5);
+    initializeTSNumbers(5);
+
     check();
 }
 
 BOOST_FIXTURE_TEST_CASE(renewable, Fixture::Renewable)
 {
-    initialize();
+    setNumberOfYears(5);
+    initializeTSNumbers(5);
     check();
 }
 
 BOOST_FIXTURE_TEST_CASE(link, Fixture::Link)
 {
-    initialize();
+    setNumberOfYears(5);
+    initializeTSNumbers(5);
     check();
 }
 
 BOOST_FIXTURE_TEST_CASE(binding_constraint, Fixture::BindingConstraint)
 {
-    initialize();
+    setNumberOfYears(5);
+    initializeTSNumbers(5);
+
+    check();
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(sc_too_many_years)
+
+BOOST_FIXTURE_TEST_CASE(load, Fixture::Load)
+
+{
+    setNumberOfYears(5);
+    initializeTSNumbers(10);
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(wind, Fixture::Wind)
+{
+    setNumberOfYears(5);
+    initializeTSNumbers(10);
+
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(solar, Fixture::Solar)
+{
+    setNumberOfYears(5);
+    initializeTSNumbers(10);
+
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(hydro, Fixture::Hydro)
+{
+    setNumberOfYears(5);
+    initializeTSNumbers(10);
+
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(thermal, Fixture::Thermal)
+{
+    setNumberOfYears(5);
+    initializeTSNumbers(10);
+
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(renewable, Fixture::Renewable)
+{
+    setNumberOfYears(5);
+    initializeTSNumbers(10);
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(link, Fixture::Link)
+{
+    setNumberOfYears(5);
+    initializeTSNumbers(10);
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(binding_constraint, Fixture::BindingConstraint)
+{
+    setNumberOfYears(5);
+    initializeTSNumbers(10);
+
     check();
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
@@ -47,6 +47,8 @@ study->parameters.nbYears). In this case, calls to setTSnumber should have no ef
 using namespace Antares::Data;
 using namespace Antares::Data::ScenarioBuilder;
 
+// We need a distinct TS number for each year
+// in order for tests to be more specific
 uint dummyTSNumber(uint y)
 {
     return y * y * y + 1;

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
@@ -47,6 +47,11 @@ study->parameters.nbYears). In this case, calls to setTSnumber should have no ef
 using namespace Antares::Data;
 using namespace Antares::Data::ScenarioBuilder;
 
+uint dummyTSNumber(uint y)
+{
+    return y * y * y + 1;
+}
+
 template<class TSData>
 class IntegerIndex
 {
@@ -67,7 +72,7 @@ public:
         tsdata.reset(*study);
         for (unsigned int year = 0; year < nbYears; ++year)
         {
-            tsdata.setTSnumber(area->index, year, 12);
+            tsdata.setTSnumber(area->index, year, dummyTSNumber(year));
         }
     }
 
@@ -75,7 +80,7 @@ public:
     {
         for (unsigned int year = 0; year < study->parameters.nbYears; ++year)
         {
-            BOOST_CHECK_EQUAL(tsdata.get_value(year, area->index), 12);
+            BOOST_CHECK_EQUAL(tsdata.get_value(year, area->index), dummyTSNumber(year));
         }
     }
 
@@ -119,7 +124,7 @@ public:
         tsdata.reset(*study);
         for (unsigned int year = 0; year < nbYears; ++year)
         {
-            tsdata.setTSnumber(getObject(), year, 12);
+            tsdata.setTSnumber(getObject(), year, dummyTSNumber(year));
         }
     }
 
@@ -127,7 +132,7 @@ public:
     {
         for (unsigned int year = 0; year < study->parameters.nbYears; ++year)
         {
-            BOOST_CHECK_EQUAL(tsdata.get(getObject(), year), 12);
+            BOOST_CHECK_EQUAL(tsdata.get(getObject(), year), dummyTSNumber(year));
         }
     }
 
@@ -332,7 +337,10 @@ BOOST_FIXTURE_TEST_CASE(link, Fixture::Link)
     check();
 }
 
-BOOST_FIXTURE_TEST_CASE(binding_constraint, Fixture::BindingConstraint)
+// This test is disabled for now because is causes a crash, wait for fix to be published
+BOOST_FIXTURE_TEST_CASE(binding_constraint,
+                        Fixture::BindingConstraint,
+                        *boost::unit_test::disabled())
 {
     setNumberOfYears(5);
     initializeTSNumbers(10);

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
@@ -340,9 +340,7 @@ BOOST_FIXTURE_TEST_CASE(link, Fixture::Link)
 }
 
 // This test is disabled for now because is causes a crash, wait for fix to be published
-BOOST_FIXTURE_TEST_CASE(binding_constraint,
-                        Fixture::BindingConstraint,
-                        *boost::unit_test::disabled())
+BOOST_FIXTURE_TEST_CASE(binding_constraint, Fixture::BindingConstraint)
 {
     setNumberOfYears(5);
     initializeTSNumbers(10);

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2007-2024, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
+#define BOOST_TEST_MODULE sc_builder_get_set
+
+/* The goal of this suite is to test the setTSnumber and get method for the following classes
+- loadTSNumberData
+- windTSNumberData
+- solarTSNumberData
+- hydroTSNumberData
+- thermalTSNumberData
+- renewableTSNumberData
+- ntcTSNumberData
+- BindingConstraintsTSNumberData
+*/
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <boost/test/unit_test.hpp>
+
+#include <antares/study/scenario-builder/rules.h>
+#include <antares/study/study.h>
+
+BOOST_AUTO_TEST_SUITE(sc_builder)
+
+using namespace Antares::Data;
+using namespace Antares::Data::ScenarioBuilder;
+
+template<class TSData>
+class IntegerIndex
+{
+public:
+    IntegerIndex():
+        study(std::make_unique<Study>()),
+        area(study->areaAdd("area 1"))
+    {
+        study->parameters.nbYears = 5;
+        tsdata.reset(*study);
+        for (unsigned int year = 0; year < study->parameters.nbYears; ++year)
+        {
+            tsdata.setTSnumber(area->index, year, 12);
+        }
+    }
+
+    void check() const
+    {
+        for (unsigned int year = 0; year < study->parameters.nbYears; ++year)
+        {
+            BOOST_CHECK_EQUAL(tsdata.get_value(year, area->index), 12);
+        }
+    }
+
+private:
+    TSData tsdata;
+    std::unique_ptr<Study> study;
+    Area* area;
+};
+
+template<class TSData, class ObjectT>
+class StructureIndex
+{
+public:
+    virtual ObjectT getObject() const = 0;
+    virtual void attachArea() = 0;
+
+    explicit StructureIndex():
+        study(std::make_unique<Study>()),
+        area1(study->areaAdd("area 1")),
+        area2(study->areaAdd("area 2")),
+        link(AreaAddLinkBetweenAreas(area1, area2, false)),
+        thcluster(std::make_shared<ThermalCluster>(area1)),
+        rencluster(std::make_shared<RenewableCluster>(area1)),
+        bc(study->bindingConstraints.add("my-bc"))
+    {
+        study->parameters.nbYears = 5;
+
+        area1->thermal.list.addToCompleteList(thcluster);
+        area1->renewable.list.addToCompleteList(rencluster);
+
+        bc->group("my-group");
+    }
+
+    // virtual function calls not allowed in constructors (UB)
+    void initialize()
+    {
+        attachArea();
+        tsdata.reset(*study);
+        for (unsigned int year = 0; year < study->parameters.nbYears; ++year)
+        {
+            tsdata.setTSnumber(getObject(), year, 12);
+        }
+    }
+
+    void check() const
+    {
+        for (unsigned int year = 0; year < study->parameters.nbYears; ++year)
+        {
+            BOOST_CHECK_EQUAL(tsdata.get(getObject(), year), 12);
+        }
+    }
+
+protected:
+    std::unique_ptr<Study> study;
+    TSData tsdata;
+    Area *area1, *area2;
+    AreaLink* link;
+    std::shared_ptr<ThermalCluster> thcluster;
+    std::shared_ptr<RenewableCluster> rencluster;
+    std::shared_ptr<BindingConstraint> bc;
+};
+
+namespace Fixture
+{
+// BOOST_FIXTURE_TEST_CASE doesn't support templates
+using Load = IntegerIndex<loadTSNumberData>;
+using Wind = IntegerIndex<windTSNumberData>;
+using Solar = IntegerIndex<solarTSNumberData>;
+using Hydro = IntegerIndex<hydroTSNumberData>;
+
+struct Thermal: public StructureIndex<thermalTSNumberData, const ThermalCluster*>
+{
+    const ThermalCluster* getObject() const override
+    {
+        return thcluster.get();
+    }
+
+    void attachArea() override
+    {
+        tsdata.attachArea(area1);
+    }
+};
+
+struct Renewable: public StructureIndex<renewableTSNumberData, const RenewableCluster*>
+{
+    const RenewableCluster* getObject() const override
+    {
+        return rencluster.get();
+    }
+
+    void attachArea() override
+    {
+        tsdata.attachArea(area1);
+    }
+};
+
+struct Link: public StructureIndex<ntcTSNumberData, const AreaLink*>
+{
+    const AreaLink* getObject() const override
+    {
+        return link;
+    }
+
+    void attachArea() override
+    {
+        tsdata.attachArea(area1);
+    }
+};
+
+struct BindingConstraint: public StructureIndex<BindingConstraintsTSNumberData, std::string>
+{
+    BindingConstraint()
+    {
+        BOOST_REQUIRE(study->bindingConstraintsGroups.buildFrom(study->bindingConstraints));
+    }
+
+    std::string getObject() const override
+    {
+        return bc->group();
+    }
+
+    void attachArea() override
+    {
+        // No area is attached to a binding constraint
+    }
+};
+
+} // namespace Fixture
+
+BOOST_FIXTURE_TEST_CASE(load, Fixture::Load)
+
+{
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(wind, Fixture::Wind)
+{
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(solar, Fixture::Solar)
+{
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(hydro, Fixture::Hydro)
+{
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(thermal, Fixture::Thermal)
+{
+    initialize();
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(renewable, Fixture::Renewable)
+{
+    initialize();
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(link, Fixture::Link)
+{
+    initialize();
+    check();
+}
+
+BOOST_FIXTURE_TEST_CASE(binding_constraint, Fixture::BindingConstraint)
+{
+    initialize();
+    check();
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
@@ -20,7 +20,7 @@
  */
 #define BOOST_TEST_MODULE sc_builder_get_set
 
-/* The goal of this suite is to test the setTSnumber and get method for the following classes
+/* The goal of this file is to test the setTSnumber and get method for the following classes
 - loadTSNumberData
 - windTSNumberData
 - solarTSNumberData
@@ -29,6 +29,12 @@
 - renewableTSNumberData
 - ntcTSNumberData
 - BindingConstraintsTSNumberData
+
+There are two test suites
+- sc_nominal tests the nominal cases, when all year indices are within bounds (0 <= index
+<study->parameters.nbYears)
+- sc_too_many_years tests the error cases, when some indices are out of bounds (index >=
+study->parameters.nbYears). In this case, calls to setTSnumber should have no effect.
 */
 
 #define WIN32_LEAN_AND_MEAN
@@ -209,6 +215,7 @@ BOOST_FIXTURE_TEST_CASE(load, Fixture::Load)
 {
     setNumberOfYears(5);
     initializeTSNumbers(5);
+
     check();
 }
 
@@ -248,6 +255,7 @@ BOOST_FIXTURE_TEST_CASE(renewable, Fixture::Renewable)
 {
     setNumberOfYears(5);
     initializeTSNumbers(5);
+
     check();
 }
 
@@ -274,6 +282,7 @@ BOOST_FIXTURE_TEST_CASE(load, Fixture::Load)
 {
     setNumberOfYears(5);
     initializeTSNumbers(10);
+
     check();
 }
 

--- a/src/ui/simulator/toolbox/components/datagrid/renderer/scenario-builder-ntc-renderer.cpp
+++ b/src/ui/simulator/toolbox/components/datagrid/renderer/scenario-builder-ntc-renderer.cpp
@@ -83,7 +83,7 @@ bool ntcScBuilderRenderer::cellValue(int x, int y, const String& value)
     const Data::AreaLink* link = (*pListOfLinks)[y];
     const uint areaIndex = link->from->index;
     uint val = fromStringToTSnumber(value);
-    pRules->linksNTC[areaIndex].setDataForLink(link, x, val);
+    pRules->linksNTC[areaIndex].setTSnumber(link, x, val);
     return true;
 }
 


### PR DESCRIPTION
Following #2674, I realized that there are no tests on classes
- `loadTSNumberData`
- `windTSNumberData`
- `solarTSNumberData`
- `hydroTSNumberData`
- `thermalTSNumberData`
- `renewableTSNumberData`
- `ntcTSNumberData`
- `BindingConstraintsTSNumberData`

so I added them for methods `setTSnumber` and `get`. 

There are two test suites
- `sc_nominal` tests the nominal cases, when all year indices are within bounds (0 <= index
<study->parameters.nbYears)
- `sc_too_many_years` tests the error cases, when some indices are out of bounds (index >=
study->parameters.nbYears). In this case, calls to setTSnumber should have no effect.

In passing, I renamed `setDataForLink` -> `setTSnumber` for homogeneity.