### PR TITLE
Use MPSolver* instead of void*, remove static_casts

### DIFF
--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_structure_probleme_a_resoudre.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_structure_probleme_a_resoudre.h
@@ -30,6 +30,11 @@
 #include "SparseVector.hxx"
 #include "opt_constants.h"
 
+namespace operations_research
+{
+class MPSolver;
+}
+
 /*--------------------------------------------------------------------------------------*/
 
 /* Le probleme a resoudre */
@@ -90,7 +95,7 @@ struct PROBLEME_ANTARES_A_RESOUDRE
                                   matrice de base reguliere, et dans ce cas il n'y a pas de solution
                                 */
 
-    std::vector<void*> ProblemesSpx;
+    std::vector<operations_research::MPSolver*> ProblemesSpx;
 
     std::vector<int>
       PositionDeLaVariable; /* Vecteur a passer au Simplexe pour recuperer la base optimale */

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -92,7 +92,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
                                           IResultWriter& writer)
 {
     const auto& ProblemeAResoudre = problemeHebdo->ProblemeAResoudre;
-    auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[NumIntervalle]);
+    auto* solver = ProblemeAResoudre->ProblemesSpx[NumIntervalle];
 
     const int opt = optimizationNumber - 1;
     assert(opt >= 0 && opt < 2);
@@ -220,7 +220,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
     solver = ORTOOLS_Simplexe(&Probleme, solver, keepBasis, options);
     if (solver != nullptr)
     {
-        ProblemeAResoudre->ProblemesSpx[NumIntervalle] = (void*)solver;
+        ProblemeAResoudre->ProblemesSpx[NumIntervalle] = solver;
     }
 
     measure.tick();

--- a/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
+++ b/src/solver/optimisation/opt_liberation_problemes_simplexe.cpp
@@ -50,7 +50,7 @@ void OPT_LiberationProblemesSimplexe(const PROBLEME_HEBDO* problemeHebdo)
     {
         for (int numIntervalle = 0; numIntervalle < nbIntervalles; numIntervalle++)
         {
-            auto solver = (MPSolver*)(ProblemeAResoudre->ProblemesSpx[numIntervalle]);
+            auto* solver = ProblemeAResoudre->ProblemesSpx[numIntervalle];
 
             if (solver)
             {


### PR DESCRIPTION
The `void*` was necessary previously because it could store an `MPSolver*` or a `PROBLEME_SIMPLEXE*`, but now it's only `MPSolver*`.