### PR TITLE
Small refactor around `PROBLEME_SIMPLEXE_NOMME -> MPSolver` conversion

### DIFF
--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -82,6 +82,20 @@ struct SimplexResult
     mpsWriterFactory mps_writer_factory;
 };
 
+// Returns a non-owning pointer
+MPSolver* convertToMPSolver(const Optimization::PROBLEME_SIMPLEXE_NOMME& pb,
+                            const OptimizationOptions& options)
+{
+    LegacyOrtoolsLinearProblem ortoolsProblem(pb.isMIP(), options.ortoolsSolver);
+    LegacyFiller legacyOrtoolsFiller(&pb);
+    std::vector<LinearProblemFiller*> fillersCollection = {&legacyOrtoolsFiller};
+    LinearProblemData LP_Data;
+    FillContext fillCtx(0, 167);
+    LinearProblemBuilder linearProblemBuilder(fillersCollection);
+    linearProblemBuilder.build(ortoolsProblem, LP_Data, fillCtx);
+    return ortoolsProblem.getMpSolver();
+}
+
 static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
                                           PROBLEME_HEBDO* problemeHebdo,
                                           Optimization::PROBLEME_SIMPLEXE_NOMME& Probleme,
@@ -193,15 +207,7 @@ static SimplexResult OPT_TryToCallSimplex(const OptimizationOptions& options,
 
     if (solver == nullptr)
     {
-        auto ortoolsProblem = std::make_unique<LegacyOrtoolsLinearProblem>(Probleme.isMIP(),
-                                                                           options.ortoolsSolver);
-        auto legacyOrtoolsFiller = std::make_unique<LegacyFiller>(&Probleme);
-        std::vector<LinearProblemFiller*> fillersCollection = {legacyOrtoolsFiller.get()};
-        LinearProblemData LP_Data;
-        FillContext fillCtx(0, 167);
-        LinearProblemBuilder linearProblemBuilder(fillersCollection);
-        linearProblemBuilder.build(*ortoolsProblem, LP_Data, fillCtx);
-        solver = ortoolsProblem->getMpSolver();
+        solver = convertToMPSolver(Probleme, options);
     }
     const std::string filename = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
 
@@ -353,19 +359,10 @@ bool OPT_AppelDuSimplexe(const OptimizationOptions& options,
 
         Probleme.SetUseNamedProblems(true);
 
-        auto ortoolsProblem = std::make_unique<LegacyOrtoolsLinearProblem>(Probleme.isMIP(),
-                                                                           options.ortoolsSolver);
-        auto legacyOrtoolsFiller = std::make_unique<LegacyFiller>(&Probleme);
-        std::vector<LinearProblemFiller*> fillersCollection = {legacyOrtoolsFiller.get()};
-        LinearProblemData LP_Data;
-        FillContext fillCtx(0, 167);
-        LinearProblemBuilder linearProblemBuilder(fillersCollection);
-
-        linearProblemBuilder.build(*ortoolsProblem, LP_Data, fillCtx);
-        auto* MPproblem = ortoolsProblem->getMpSolver();
+        std::unique_ptr<MPSolver> MPproblem(convertToMPSolver(Probleme, options));
 
         auto analyzer = makeUnfeasiblePbAnalyzer();
-        analyzer->run(MPproblem);
+        analyzer->run(MPproblem.get());
         analyzer->printReport();
 
         auto mps_writer_on_error = simplexResult.mps_writer_factory.createOnOptimizationError();


### PR DESCRIPTION
- Don't use `std::make_unique` if it's not needed
- Add a function to avoid code duplication
- Avoid a memory leak in the "unfeasibility analyzer" part