### PR TITLE
Features/scalian warning doubles clean

### DIFF
--- a/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
@@ -269,7 +269,10 @@ void BindingConstraintsRepository::checkDouble() const
             }
             if (id == constraints_.at(indexCstSearch).get()->id())
             {
-                logs.warning() << "Two binding constraints with id " << id;
+                if (!(name.endsWith("_sup") || name.endsWith("_inf")))
+                {
+                    logs.warning() << "Two binding constraints with id " << id;
+                }
             }
         }
     }

--- a/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
@@ -221,6 +221,7 @@ bool BindingConstraintsRepository::loadFromFolder(Study& study,
                 std::copy(new_bc.begin(), new_bc.end(), std::back_inserter(constraints_));
             }
         }
+        this->checkDouble();
     }
 
     // Logs
@@ -250,6 +251,28 @@ bool BindingConstraintsRepository::loadFromFolder(Study& study,
     }
 
     return true;
+}
+
+void BindingConstraintsRepository::checkDouble() const
+{
+    for (int indexCst = 0; indexCst < constraints_.size() - 1; indexCst++)
+    {
+        Antares::Data::ConstraintName name = constraints_.at(indexCst).get()->name();
+        Antares::Data::ConstraintName id = constraints_.at(indexCst).get()->id();
+
+        for (int indexCstSearch = indexCst + 1; indexCstSearch < constraints_.size();
+             indexCstSearch++)
+        {
+            if (name == constraints_.at(indexCstSearch).get()->name())
+            {
+                logs.warning() << "Two binding constraints named " << name;
+            }
+            if (id == constraints_.at(indexCstSearch).get()->id())
+            {
+                logs.warning() << "Two binding constraints with id " << id;
+            }
+        }
+    }
 }
 
 void BindingConstraintsRepository::changeConstraintsWeeklyToDaily()

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintsRepository.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintsRepository.h
@@ -81,6 +81,11 @@ public:
     //@}
 
     /*!
+    ** \brief Checks for doubles of name or ID inside the vector
+    */
+    void checkDouble() const;
+
+    /*!
     ** \brief Add a new binding constraint
     */
     std::shared_ptr<BindingConstraint> add(const AnyString& name);

--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/container.h
@@ -52,6 +52,8 @@ public:
 
     bool saveDataSeriesToFolder(const std::string& folder) const;
 
+    void checkForDoubles(std::string clusterID) const;
+
     std::vector<STStorageCluster> storagesByIndex;
 
     /// Number cumulative - constraint

--- a/src/libs/antares/study/parts/common/cluster_list.cpp
+++ b/src/libs/antares/study/parts/common/cluster_list.cpp
@@ -117,6 +117,7 @@ void ClusterList<ClusterT>::addToCompleteList(std::shared_ptr<ClusterT> cluster)
 {
     if (alreadyInAllClusters(cluster->id()))
     {
+        logs.warning() << "Two cluster with id " << cluster->id();
         return;
     }
     allClusters_.push_back(cluster);

--- a/src/libs/antares/study/parts/short-term-storage/container.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/container.cpp
@@ -67,7 +67,7 @@ bool STStorageInput::createSTStorageClustersFromIniFile(const fs::path& path)
         {
             return false;
         }
-
+        this->checkForDoubles(cluster.id);
         storagesByIndex.push_back(cluster);
     }
 
@@ -76,6 +76,17 @@ bool STStorageInput::createSTStorageClustersFromIniFile(const fs::path& path)
                       { return a.properties.name < b.properties.name; });
 
     return true;
+}
+
+void STStorageInput::checkForDoubles(std::string clusterID) const
+{
+    for (int index = 0; index < storagesByIndex.size(); index++)
+    {
+        if (clusterID == storagesByIndex.at(index).id)
+        {
+            logs.warning() << "Two STS with id " << clusterID;
+        }
+    }
 }
 
 static bool loadHours(std::string hoursStr, AdditionalConstraints& additionalConstraints)


### PR DESCRIPTION
Removes doubles from clusters, areas and binding contraints, and handles memory errors when binding constraints timeseries have the same id.
References gopro 2127

Is a cleanup of https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/2714