### PR TITLE
Use indices for getVariable & getConstraint, don't reconstruct name

### DIFF
--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/linearProblem.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/linearProblem.h
@@ -52,13 +52,17 @@ public:
     virtual IMipVariable* addVariable(double lb, double ub, bool integer, const std::string& name)
       = 0;
 
+    // Variables observers
     virtual IMipVariable* getVariable(std::size_t index) const = 0;
+    virtual IMipVariable* lookupVariable(const std::string& name) const = 0;
     virtual int variableCount() const = 0;
 
     /// Add a bounded constraint to the problem
     virtual IMipConstraint* addConstraint(double lb, double ub, const std::string& name) = 0;
 
+    // Constraints observers
     virtual IMipConstraint* getConstraint(std::size_t index) const = 0;
+    virtual IMipConstraint* lookupConstraint(const std::string& name) const = 0;
     virtual int constraintCount() const = 0;
 
     /// Set the objective coefficient for a given variable

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/linearProblem.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/linearProblem.h
@@ -52,13 +52,13 @@ public:
     virtual IMipVariable* addVariable(double lb, double ub, bool integer, const std::string& name)
       = 0;
 
-    virtual IMipVariable* getVariable(const std::string& name) const = 0;
+    virtual IMipVariable* getVariable(std::size_t index) const = 0;
     virtual int variableCount() const = 0;
 
     /// Add a bounded constraint to the problem
     virtual IMipConstraint* addConstraint(double lb, double ub, const std::string& name) = 0;
 
-    virtual IMipConstraint* getConstraint(const std::string& name) const = 0;
+    virtual IMipConstraint* getConstraint(std::size_t index) const = 0;
     virtual int constraintCount() const = 0;
 
     /// Set the objective coefficient for a given variable

--- a/src/optimisation/linear-problem-api/linearProblemBuilder.cpp
+++ b/src/optimisation/linear-problem-api/linearProblemBuilder.cpp
@@ -33,7 +33,6 @@ LinearProblemBuilder::LinearProblemBuilder(const std::vector<LinearProblemFiller
 
 void LinearProblemBuilder::build(ILinearProblem& pb, ILinearProblemData& data, FillContext& ctx)
 {
-    // TODO grouper les appels
     std::ranges::for_each(fillers_,
                           [&](const auto& filler) { filler->addVariables(pb, data, ctx); });
     std::ranges::for_each(fillers_,

--- a/src/optimisation/linear-problem-api/linearProblemBuilder.cpp
+++ b/src/optimisation/linear-problem-api/linearProblemBuilder.cpp
@@ -33,6 +33,7 @@ LinearProblemBuilder::LinearProblemBuilder(const std::vector<LinearProblemFiller
 
 void LinearProblemBuilder::build(ILinearProblem& pb, ILinearProblemData& data, FillContext& ctx)
 {
+    // TODO grouper les appels
     std::ranges::for_each(fillers_,
                           [&](const auto& filler) { filler->addVariables(pb, data, ctx); });
     std::ranges::for_each(fillers_,

--- a/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/linearProblem.h
+++ b/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/linearProblem.h
@@ -52,11 +52,14 @@ public:
                                     const std::string& name) override;
 
     OrtoolsMipVariable* getVariable(std::size_t index) const override;
+    OrtoolsMipVariable* lookupVariable(const std::string& name) const override;
+
     int variableCount() const override;
 
     OrtoolsMipConstraint* addConstraint(double lb, double ub, const std::string& name) override;
 
     OrtoolsMipConstraint* getConstraint(std::size_t index) const override;
+    OrtoolsMipConstraint* lookupConstraint(const std::string& name) const override;
     int constraintCount() const override;
 
     void setObjectiveCoefficient(LinearProblemApi::IMipVariable* var, double coefficient) override;

--- a/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/linearProblem.h
+++ b/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/linearProblem.h
@@ -40,7 +40,7 @@ class OrtoolsLinearProblem: public LinearProblemApi::ILinearProblem
 {
 public:
     OrtoolsLinearProblem(bool isMip, const std::string& solverName);
-    virtual ~OrtoolsLinearProblem();
+    ~OrtoolsLinearProblem() override = default;
 
     OrtoolsMipVariable* addNumVariable(double lb, double ub, const std::string& name) override;
 
@@ -84,8 +84,8 @@ private:
     operations_research::MPObjective* objective_;
     operations_research::MPSolverParameters params_;
 
-    std::vector<OrtoolsMipVariable*> variables_;
-    std::vector<OrtoolsMipConstraint*> constraints_;
+    std::vector<std::unique_ptr<OrtoolsMipVariable>> variables_;
+    std::vector<std::unique_ptr<OrtoolsMipConstraint>> constraints_;
 
     std::unique_ptr<OrtoolsMipSolution> solution_;
 };

--- a/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/linearProblem.h
+++ b/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/linearProblem.h
@@ -40,7 +40,7 @@ class OrtoolsLinearProblem: public LinearProblemApi::ILinearProblem
 {
 public:
     OrtoolsLinearProblem(bool isMip, const std::string& solverName);
-    ~OrtoolsLinearProblem() override = default;
+    virtual ~OrtoolsLinearProblem();
 
     OrtoolsMipVariable* addNumVariable(double lb, double ub, const std::string& name) override;
 
@@ -51,12 +51,12 @@ public:
                                     bool integer,
                                     const std::string& name) override;
 
-    OrtoolsMipVariable* getVariable(const std::string& name) const override;
+    OrtoolsMipVariable* getVariable(std::size_t index) const override;
     int variableCount() const override;
 
     OrtoolsMipConstraint* addConstraint(double lb, double ub, const std::string& name) override;
 
-    OrtoolsMipConstraint* getConstraint(const std::string& name) const override;
+    OrtoolsMipConstraint* getConstraint(std::size_t index) const override;
     int constraintCount() const override;
 
     void setObjectiveCoefficient(LinearProblemApi::IMipVariable* var, double coefficient) override;
@@ -81,8 +81,8 @@ private:
     operations_research::MPObjective* objective_;
     operations_research::MPSolverParameters params_;
 
-    std::map<std::string, std::unique_ptr<OrtoolsMipVariable>> variables_;
-    std::map<std::string, std::unique_ptr<OrtoolsMipConstraint>> constraints_;
+    std::vector<OrtoolsMipVariable*> variables_;
+    std::vector<OrtoolsMipConstraint*> constraints_;
 
     std::unique_ptr<OrtoolsMipSolution> solution_;
 };

--- a/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
@@ -43,15 +43,6 @@ OrtoolsLinearProblem::~OrtoolsLinearProblem()
     std::ranges::for_each(constraints_, [](OrtoolsMipConstraint* c) { delete c; });
 }
 
-class ElemAlreadyExists: public std::runtime_error
-{
-public:
-    explicit ElemAlreadyExists():
-        std::runtime_error("Element name already exists in linear problem")
-    {
-    }
-};
-
 OrtoolsMipVariable* OrtoolsLinearProblem::addVariable(double lb,
                                                       double ub,
                                                       bool integer,

--- a/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
@@ -37,12 +37,6 @@ OrtoolsLinearProblem::OrtoolsLinearProblem(bool isMip, const std::string& solver
     objective_ = mpSolver_->MutableObjective();
 }
 
-OrtoolsLinearProblem::~OrtoolsLinearProblem()
-{
-    std::ranges::for_each(variables_, std::default_delete<OrtoolsMipVariable>());
-    std::ranges::for_each(constraints_, std::default_delete<OrtoolsMipConstraint>());
-}
-
 OrtoolsMipVariable* OrtoolsLinearProblem::addVariable(double lb,
                                                       double ub,
                                                       bool integer,
@@ -55,8 +49,8 @@ OrtoolsMipVariable* OrtoolsLinearProblem::addVariable(double lb,
         logs.error() << "Couldn't add variable to Ortools MPSolver: " << name;
     }
 
-    variables_.push_back(new OrtoolsMipVariable(mpVar));
-    return variables_.back();
+    variables_.push_back(std::make_unique<OrtoolsMipVariable>(mpVar));
+    return variables_.back().get();
 }
 
 OrtoolsMipVariable* OrtoolsLinearProblem::addNumVariable(double lb,
@@ -75,16 +69,17 @@ OrtoolsMipVariable* OrtoolsLinearProblem::addIntVariable(double lb,
 
 OrtoolsMipVariable* OrtoolsLinearProblem::getVariable(std::size_t index) const
 {
-    return variables_.at(index);
+    return variables_.at(index).get();
 }
 
 OrtoolsMipVariable* OrtoolsLinearProblem::lookupVariable(const std::string& name) const
 {
     auto it = std::ranges::find_if(variables_,
-                                   [&name](OrtoolsMipVariable* v) { return v->getName() == name; });
+                                   [&name](const std::unique_ptr<OrtoolsMipVariable>& v)
+                                   { return v->getName() == name; });
     if (it != variables_.end())
     {
-        return *it;
+        return it->get();
     }
     return nullptr;
 }
@@ -92,11 +87,11 @@ OrtoolsMipVariable* OrtoolsLinearProblem::lookupVariable(const std::string& name
 OrtoolsMipConstraint* OrtoolsLinearProblem::lookupConstraint(const std::string& name) const
 {
     auto it = std::ranges::find_if(constraints_,
-                                   [&name](OrtoolsMipConstraint* c)
+                                   [&name](const std::unique_ptr<OrtoolsMipConstraint>& c)
                                    { return c->getName() == name; });
     if (it != constraints_.end())
     {
-        return *it;
+        return it->get();
     }
     return nullptr;
 }
@@ -117,13 +112,13 @@ OrtoolsMipConstraint* OrtoolsLinearProblem::addConstraint(double lb,
         logs.error() << "Couldn't add variable to Ortools MPSolver: " << name;
     }
 
-    constraints_.push_back(new OrtoolsMipConstraint(mpConstraint));
-    return constraints_.back();
+    constraints_.push_back(std::make_unique<OrtoolsMipConstraint>(mpConstraint));
+    return constraints_.back().get();
 }
 
 OrtoolsMipConstraint* OrtoolsLinearProblem::getConstraint(std::size_t index) const
 {
-    return constraints_.at(index);
+    return constraints_.at(index).get();
 }
 
 int OrtoolsLinearProblem::constraintCount() const

--- a/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
@@ -78,6 +78,29 @@ OrtoolsMipVariable* OrtoolsLinearProblem::getVariable(std::size_t index) const
     return variables_.at(index);
 }
 
+OrtoolsMipVariable* OrtoolsLinearProblem::lookupVariable(const std::string& name) const
+{
+    auto it = std::ranges::find_if(variables_,
+                                   [&name](OrtoolsMipVariable* v) { return v->getName() == name; });
+    if (it != variables_.end())
+    {
+        return *it;
+    }
+    return nullptr;
+}
+
+OrtoolsMipConstraint* OrtoolsLinearProblem::lookupConstraint(const std::string& name) const
+{
+    auto it = std::ranges::find_if(constraints_,
+                                   [&name](OrtoolsMipConstraint* c)
+                                   { return c->getName() == name; });
+    if (it != constraints_.end())
+    {
+        return *it;
+    }
+    return nullptr;
+}
+
 int OrtoolsLinearProblem::variableCount() const
 {
     return mpSolver_->NumVariables();

--- a/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
@@ -39,8 +39,8 @@ OrtoolsLinearProblem::OrtoolsLinearProblem(bool isMip, const std::string& solver
 
 OrtoolsLinearProblem::~OrtoolsLinearProblem()
 {
-    std::ranges::for_each(variables_, [](OrtoolsMipVariable* v) { delete v; });
-    std::ranges::for_each(constraints_, [](OrtoolsMipConstraint* c) { delete c; });
+    std::ranges::for_each(variables_, std::default_delete<OrtoolsMipVariable>());
+    std::ranges::for_each(constraints_, std::default_delete<OrtoolsMipConstraint>());
 }
 
 OrtoolsMipVariable* OrtoolsLinearProblem::addVariable(double lb,

--- a/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
@@ -37,6 +37,12 @@ OrtoolsLinearProblem::OrtoolsLinearProblem(bool isMip, const std::string& solver
     objective_ = mpSolver_->MutableObjective();
 }
 
+OrtoolsLinearProblem::~OrtoolsLinearProblem()
+{
+    std::ranges::for_each(variables_, [](OrtoolsMipVariable* v) { delete v; });
+    std::ranges::for_each(constraints_, [](OrtoolsMipConstraint* c) { delete c; });
+}
+
 class ElemAlreadyExists: public std::runtime_error
 {
 public:
@@ -51,12 +57,6 @@ OrtoolsMipVariable* OrtoolsLinearProblem::addVariable(double lb,
                                                       bool integer,
                                                       const std::string& name)
 {
-    if (variables_.contains(name))
-    {
-        logs.error() << "This variable already exists: " << name;
-        throw ElemAlreadyExists();
-    }
-
     auto* mpVar = mpSolver_->MakeVar(lb, ub, integer, name);
 
     if (!mpVar)
@@ -64,8 +64,8 @@ OrtoolsMipVariable* OrtoolsLinearProblem::addVariable(double lb,
         logs.error() << "Couldn't add variable to Ortools MPSolver: " << name;
     }
 
-    const auto& pair = variables_.emplace(name, std::make_unique<OrtoolsMipVariable>(mpVar));
-    return pair.first->second.get(); // <<name, var>, bool>
+    variables_.push_back(new OrtoolsMipVariable(mpVar));
+    return variables_.back();
 }
 
 OrtoolsMipVariable* OrtoolsLinearProblem::addNumVariable(double lb,
@@ -82,9 +82,9 @@ OrtoolsMipVariable* OrtoolsLinearProblem::addIntVariable(double lb,
     return addVariable(lb, ub, true, name);
 }
 
-OrtoolsMipVariable* OrtoolsLinearProblem::getVariable(const std::string& name) const
+OrtoolsMipVariable* OrtoolsLinearProblem::getVariable(std::size_t index) const
 {
-    return variables_.at(name).get();
+    return variables_.at(index);
 }
 
 int OrtoolsLinearProblem::variableCount() const
@@ -96,12 +96,6 @@ OrtoolsMipConstraint* OrtoolsLinearProblem::addConstraint(double lb,
                                                           double ub,
                                                           const std::string& name)
 {
-    if (constraints_.contains(name))
-    {
-        logs.error() << "This constraint already exists: " << name;
-        throw ElemAlreadyExists();
-    }
-
     auto* mpConstraint = mpSolver_->MakeRowConstraint(lb, ub, name);
 
     if (!mpConstraint)
@@ -109,14 +103,13 @@ OrtoolsMipConstraint* OrtoolsLinearProblem::addConstraint(double lb,
         logs.error() << "Couldn't add variable to Ortools MPSolver: " << name;
     }
 
-    const auto& pair = constraints_.emplace(name,
-                                            std::make_unique<OrtoolsMipConstraint>(mpConstraint));
-    return pair.first->second.get(); // <<name, constraint>, bool>
+    constraints_.push_back(new OrtoolsMipConstraint(mpConstraint));
+    return constraints_.back();
 }
 
-OrtoolsMipConstraint* OrtoolsLinearProblem::getConstraint(const std::string& name) const
+OrtoolsMipConstraint* OrtoolsLinearProblem::getConstraint(std::size_t index) const
 {
-    return constraints_.at(name).get();
+    return constraints_.at(index);
 }
 
 int OrtoolsLinearProblem::constraintCount() const

--- a/src/solver/optimisation/LegacyFiller.cpp
+++ b/src/solver/optimisation/LegacyFiller.cpp
@@ -32,13 +32,13 @@ void LegacyFiller::CopyMatrix(ILinearProblem& pb) const
 {
     for (int idxRow = 0; idxRow < problemeSimplexe_->NombreDeContraintes; ++idxRow)
     {
-        auto* ct = pb.getConstraint(GetConstraintName(idxRow));
+        auto* ct = pb.getConstraint(idxRow);
         int debutLigne = problemeSimplexe_->IndicesDebutDeLigne[idxRow];
         for (int idxCoef = 0; idxCoef < problemeSimplexe_->NombreDeTermesDesLignes[idxRow];
              ++idxCoef)
         {
             int pos = debutLigne + idxCoef;
-            auto* var = pb.getVariable(GetVariableName(problemeSimplexe_->IndicesColonnes[pos]));
+            auto* var = pb.getVariable(problemeSimplexe_->IndicesColonnes[pos]);
             ct->setCoefficient(var, problemeSimplexe_->CoefficientsDeLaMatriceDesContraintes[pos]);
         }
     }

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/OneVarFiller.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/OneVarFiller.h
@@ -34,7 +34,7 @@ void OneVarFiller::addObjective(ILinearProblem& pb,
                                 [[maybe_unused]] ILinearProblemData& data,
                                 [[maybe_unused]] FillContext& ctx)
 {
-    auto* var = pb.getVariable(added_var_name_);
+    auto* var = pb.lookupVariable(added_var_name_);
     pb.setObjectiveCoefficient(var, 1);
 }
 

--- a/src/tests/src/optimisation/linear-problem/testLinearProblemBuilder.cpp
+++ b/src/tests/src/optimisation/linear-problem/testLinearProblemBuilder.cpp
@@ -69,7 +69,7 @@ BOOST_FIXTURE_TEST_CASE(one_var_filler___the_var_is_built, Fixture)
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 1);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 0);
-    auto* var = pb->getVariable("var-by-OneVarFiller");
+    auto* var = pb->lookupVariable("var-by-OneVarFiller");
     BOOST_CHECK(var);
     BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(var), 1);
 }
@@ -84,7 +84,7 @@ BOOST_FIXTURE_TEST_CASE(one_constraint_filler___the_constraint_is_built, Fixture
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 0);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 1);
-    BOOST_CHECK(pb->getConstraint("constraint-by-OneConstraintFiller"));
+    BOOST_CHECK(pb->lookupConstraint("constraint-by-OneConstraintFiller"));
 }
 
 BOOST_FIXTURE_TEST_CASE(two_fillers_given_to_builder___all_is_built, Fixture)
@@ -98,7 +98,7 @@ BOOST_FIXTURE_TEST_CASE(two_fillers_given_to_builder___all_is_built, Fixture)
     lpBuilder.build(*pb, LP_Data, ctx);
 
     BOOST_CHECK_EQUAL(pb->constraintCount(), 1);
-    BOOST_CHECK(pb->getConstraint("constraint-by-OneConstraintFiller"));
+    BOOST_CHECK(pb->lookupConstraint("constraint-by-OneConstraintFiller"));
     BOOST_CHECK_EQUAL(pb->variableCount(), 1);
 }
 
@@ -131,10 +131,10 @@ BOOST_FIXTURE_TEST_CASE(FillerWithContext, Fixture)
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 10); // 5 timestep * 2 scenario
 
-    auto var1 = pb->getVariable("variable-ts0-sc0");
+    auto var1 = pb->lookupVariable("variable-ts0-sc0");
     BOOST_CHECK_EQUAL(var1->getLb(), varFiller->timeseries[0][0]);
 
-    auto var2 = pb->getVariable("variable-ts3-sc2");
+    auto var2 = pb->lookupVariable("variable-ts3-sc2");
     BOOST_CHECK_EQUAL(var2->getLb(), varFiller->timeseries[3][2]);
 }
 

--- a/src/tests/src/optimisation/linear-problem/testLinearProblemMpsolverImpl.cpp
+++ b/src/tests/src/optimisation/linear-problem/testLinearProblemMpsolverImpl.cpp
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_SUITE(tests_on_OrtoolsLinearProblem)
 BOOST_FIXTURE_TEST_CASE(add_int_variable_to_problem___check_var_exists, FixtureEmptyProblem)
 {
     pb->addIntVariable(5, 15, "var");
-    auto* var = pb->getVariable("var");
+    auto* var = pb->lookupVariable("var");
     BOOST_CHECK(var);
     BOOST_CHECK(var->isInteger());
     BOOST_CHECK_EQUAL(var->getLb(), 5);
@@ -73,7 +73,7 @@ BOOST_FIXTURE_TEST_CASE(add_int_variable_to_problem___check_var_exists, FixtureE
 BOOST_FIXTURE_TEST_CASE(add_num_variable_to_problem___check_var_exists, FixtureEmptyProblem)
 {
     pb->addNumVariable(2., 7., "var");
-    auto* var = pb->getVariable("var");
+    auto* var = pb->lookupVariable("var");
     BOOST_CHECK(var);
     BOOST_CHECK(!var->isInteger());
     BOOST_CHECK_EQUAL(var->getLb(), 2.);
@@ -83,7 +83,7 @@ BOOST_FIXTURE_TEST_CASE(add_num_variable_to_problem___check_var_exists, FixtureE
 BOOST_FIXTURE_TEST_CASE(add_constraint_to_problem___check_constraint_exists, FixtureEmptyProblem)
 {
     pb->addConstraint(3., 8., "constraint");
-    auto* constraint = pb->getConstraint("constraint");
+    auto* constraint = pb->lookupConstraint("constraint");
     BOOST_CHECK(constraint);
     BOOST_CHECK_EQUAL(constraint->getLb(), 3.);
     BOOST_CHECK_EQUAL(constraint->getUb(), 8.);
@@ -114,19 +114,6 @@ bool expectedMessage(const std::exception& ex)
 {
     BOOST_CHECK_EQUAL(ex.what(), std::string("Element name already exists in linear problem"));
     return true;
-}
-
-BOOST_FIXTURE_TEST_CASE(add_already_existing_var_to_problem_leads_to_exception, FixtureEmptyProblem)
-{
-    pb->addNumVariable(0, 1, "var");
-    BOOST_CHECK_EXCEPTION(pb->addNumVariable(0, 1, "var"), std::exception, expectedMessage);
-}
-
-BOOST_FIXTURE_TEST_CASE(add_already_existing_constaint_to_problem_leads_to_exception,
-                        FixtureEmptyProblem)
-{
-    pb->addConstraint(0, 1, "constraint");
-    BOOST_CHECK_EXCEPTION(pb->addConstraint(0, 1, "constraint"), std::exception, expectedMessage);
 }
 
 BOOST_FIXTURE_TEST_CASE(minimize_problem___check_minimize_status, FixtureEmptyProblem)
@@ -204,7 +191,7 @@ BOOST_FIXTURE_TEST_CASE(solve_infeasible_problem___check_any_var_is_zero, Fixtur
 {
     auto* solution = pb->solve(true);
 
-    auto* var = pb->getVariable("var");
+    auto* var = pb->lookupVariable("var");
     BOOST_CHECK(var); // searched variable is known by problem
     BOOST_CHECK_EQUAL(solution->getOptimalValue(var), 0);
 }

--- a/src/tests/src/solver/optim-model-filler/test_componentFiller.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_componentFiller.cpp
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(var_with_literal_bounds_to_filler__problem_contains_one_var
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 1);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 0);
-    auto* var = pb->getVariable("some_component.var1");
+    auto* var = pb->lookupVariable("some_component.var1");
     BOOST_REQUIRE(var);
     BOOST_CHECK_EQUAL(var->getLb(), -5);
     BOOST_CHECK_EQUAL(var->getUb(), 10);
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(ten_timesteps_var_with_literal_bounds_to_filler__problem_co
     BOOST_CHECK_EQUAL(pb->constraintCount(), 0);
     for (unsigned int i = 0; i < nb_var; i++)
     {
-        auto* var = pb->getVariable("some_component.var1_t" + to_string(i));
+        auto* var = pb->lookupVariable("some_component.var1_t" + to_string(i));
         BOOST_REQUIRE(var);
         BOOST_CHECK_EQUAL(var->getLb(), -5);
         BOOST_CHECK_EQUAL(var->getUb(), 10);
@@ -321,13 +321,13 @@ BOOST_AUTO_TEST_CASE(two_variables_given_to_different_fillers__LP_contains_the_t
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 2);
 
-    auto* var1 = pb->getVariable("component_1.var1");
+    auto* var1 = pb->lookupVariable("component_1.var1");
     BOOST_REQUIRE(var1);
     BOOST_CHECK(!var1->isInteger());
     BOOST_CHECK_EQUAL(var1->getLb(), -1.);
     BOOST_CHECK_EQUAL(var1->getUb(), 6.);
 
-    auto* var2 = pb->getVariable("component_2.var2");
+    auto* var2 = pb->lookupVariable("component_2.var2");
     BOOST_REQUIRE(var2);
     BOOST_CHECK(!var2->isInteger());
     BOOST_CHECK_EQUAL(var2->getLb(), -3.);
@@ -349,13 +349,13 @@ BOOST_AUTO_TEST_CASE(
     BOOST_CHECK_EQUAL(pb->variableCount(), 2 * 10);
     for (auto i = 0; i < nb_var; i++)
     {
-        auto* var1 = pb->getVariable("component_1.var1_t" + to_string(i));
+        auto* var1 = pb->lookupVariable("component_1.var1_t" + to_string(i));
         BOOST_REQUIRE(var1);
         BOOST_CHECK(!var1->isInteger());
         BOOST_CHECK_EQUAL(var1->getLb(), -1.);
         BOOST_CHECK_EQUAL(var1->getUb(), 6.);
 
-        auto* var2 = pb->getVariable("component_2.var2_t" + to_string(i));
+        auto* var2 = pb->lookupVariable("component_2.var2_t" + to_string(i));
         BOOST_REQUIRE(var2);
         BOOST_CHECK(!var2->isInteger());
         BOOST_CHECK_EQUAL(var2->getLb(), -3.);
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(var_whose_bounds_are_parameters_given_to_component__problem
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 1);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 0);
-    auto* var = pb->getVariable("componentToto.var1");
+    auto* var = pb->lookupVariable("componentToto.var1");
     BOOST_REQUIRE(var);
     BOOST_CHECK(var->isInteger());
     BOOST_CHECK_EQUAL(var->getLb(), -3.);
@@ -409,17 +409,17 @@ BOOST_AUTO_TEST_CASE(three_different_vars__exist)
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 3);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 0);
-    auto* is_cluster_on = pb->getVariable("thermalCluster1.is_cluster_on");
+    auto* is_cluster_on = pb->lookupVariable("thermalCluster1.is_cluster_on");
     BOOST_REQUIRE(is_cluster_on);
     BOOST_CHECK(is_cluster_on->isInteger());
     BOOST_CHECK_EQUAL(is_cluster_on->getLb(), 0);
     BOOST_CHECK_EQUAL(is_cluster_on->getUb(), 1);
-    auto* n_started_units = pb->getVariable("thermalCluster1.n_started_units");
+    auto* n_started_units = pb->lookupVariable("thermalCluster1.n_started_units");
     BOOST_REQUIRE(n_started_units);
     BOOST_CHECK(n_started_units->isInteger());
     BOOST_CHECK_EQUAL(n_started_units->getLb(), 0);
     BOOST_CHECK_EQUAL(n_started_units->getUb(), 17);
-    auto* p_per_unit = pb->getVariable("thermalCluster1.p_per_unit");
+    auto* p_per_unit = pb->lookupVariable("thermalCluster1.p_per_unit");
     BOOST_REQUIRE(p_per_unit);
     BOOST_CHECK(!p_per_unit->isInteger());
     BOOST_CHECK_EQUAL(p_per_unit->getLb(), 100.248);
@@ -435,12 +435,12 @@ BOOST_AUTO_TEST_CASE(one_model_two_components__dont_clash)
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 2);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 0);
-    auto* c1_var1 = pb->getVariable("component_1.var1");
+    auto* c1_var1 = pb->lookupVariable("component_1.var1");
     BOOST_REQUIRE(c1_var1);
     BOOST_CHECK(!c1_var1->isInteger());
     BOOST_CHECK_EQUAL(c1_var1->getLb(), -100);
     BOOST_CHECK_EQUAL(c1_var1->getUb(), 15);
-    auto* c2_var1 = pb->getVariable("component_2.var1");
+    auto* c2_var1 = pb->lookupVariable("component_2.var1");
     BOOST_REQUIRE(c2_var1);
     BOOST_CHECK(!c2_var1->isInteger());
     BOOST_CHECK_EQUAL(c2_var1->getLb(), -100);
@@ -465,12 +465,12 @@ BOOST_AUTO_TEST_CASE(ct_one_var__pb_contains_the_ct)
     createComponent("model", "componentToto");
     buildLinearProblem();
 
-    auto var = pb->getVariable("componentToto.var1");
+    auto var = pb->lookupVariable("componentToto.var1");
     BOOST_REQUIRE(var);
     BOOST_CHECK(var->isInteger());
     BOOST_CHECK_EQUAL(pb->variableCount(), 1);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 1);
-    auto ct = pb->getConstraint("componentToto.ct1");
+    auto ct = pb->lookupConstraint("componentToto.ct1");
     BOOST_REQUIRE(ct);
     BOOST_CHECK_EQUAL(ct->getLb(), -pb->infinity());
     BOOST_CHECK_EQUAL(ct->getUb(), 3);
@@ -502,11 +502,11 @@ BOOST_AUTO_TEST_CASE(ct_with_ten_vars__pb_contains_ten_ct)
 
     for (auto i = 0; i < nb_var; i++)
     {
-        auto ct = pb->getConstraint("componentToto.ct1_" + to_string(i));
+        auto ct = pb->lookupConstraint("componentToto.ct1_" + to_string(i));
         BOOST_REQUIRE(ct);
         BOOST_CHECK_EQUAL(ct->getLb(), -pb->infinity());
         BOOST_CHECK_EQUAL(ct->getUb(), 3);
-        auto var = pb->getVariable("componentToto.var1_t" + to_string(i));
+        auto var = pb->lookupVariable("componentToto.var1_t" + to_string(i));
         BOOST_REQUIRE(var);
         BOOST_CHECK(var->isInteger());
         BOOST_CHECK_EQUAL(ct->getCoefficient(var), 1);
@@ -577,11 +577,11 @@ BOOST_AUTO_TEST_CASE(ct_with_time_series_variable_bounds)
 
     for (const auto t: timeSteps)
     {
-        auto ct = pb->getConstraint("componentToto.ct1_" + to_string(t));
+        auto ct = pb->lookupConstraint("componentToto.ct1_" + to_string(t));
         BOOST_REQUIRE(ct);
         BOOST_CHECK_EQUAL(ct->getLb(), -pb->infinity());
         BOOST_CHECK_EQUAL(ct->getUb(), -5 + 3);
-        auto var = pb->getVariable("componentToto.var1_t" + to_string(t));
+        auto var = pb->lookupVariable("componentToto.var1_t" + to_string(t));
         BOOST_REQUIRE(var);
         BOOST_CHECK(var->isInteger());
         BOOST_CHECK_EQUAL(ct->getCoefficient(var), -1);
@@ -612,12 +612,12 @@ BOOST_AUTO_TEST_CASE(ct_one_var_with_coef__pb_contains_the_ct)
     buildLinearProblem();
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 1);
-    BOOST_CHECK_NO_THROW(pb->getVariable("componentTata.var__1"));
-    auto var = pb->getVariable("componentTata.var__1");
+    BOOST_CHECK_NO_THROW(pb->lookupVariable("componentTata.var__1"));
+    auto var = pb->lookupVariable("componentTata.var__1");
     BOOST_REQUIRE(var);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 1);
-    BOOST_CHECK_NO_THROW(pb->getConstraint("componentTata.ct_1"));
-    auto ct = pb->getConstraint("componentTata.ct_1");
+    BOOST_CHECK_NO_THROW(pb->lookupConstraint("componentTata.ct_1"));
+    auto ct = pb->lookupConstraint("componentTata.ct_1");
     BOOST_CHECK(ct);
     BOOST_CHECK_EQUAL(ct->getLb(), 5);
     BOOST_CHECK_EQUAL(ct->getUb(), pb->infinity());
@@ -663,15 +663,15 @@ BOOST_AUTO_TEST_CASE(ct_with_two_vars)
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 2);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 1);
-    BOOST_CHECK_NO_THROW(pb->getConstraint("my_component.constraint1"));
-    auto ct = pb->getConstraint("my_component.constraint1");
+    BOOST_CHECK_NO_THROW(pb->lookupConstraint("my_component.constraint1"));
+    auto ct = pb->lookupConstraint("my_component.constraint1");
     BOOST_CHECK(ct);
     BOOST_CHECK_EQUAL(ct->getLb(), 77);
     BOOST_CHECK_EQUAL(ct->getUb(), 77);
-    auto* cv1 = pb->getVariable("my_component.v1");
+    auto* cv1 = pb->lookupVariable("my_component.v1");
     BOOST_REQUIRE(cv1);
     BOOST_CHECK_EQUAL(ct->getCoefficient(cv1), -23);
-    auto* cv2 = pb->getVariable("my_component.v2");
+    auto* cv2 = pb->lookupVariable("my_component.v2");
     BOOST_REQUIRE(cv2);
     BOOST_CHECK_EQUAL(ct->getCoefficient(cv2), 3);
 }
@@ -704,33 +704,33 @@ BOOST_AUTO_TEST_CASE(two_constraints__they_are_created)
     BOOST_CHECK_EQUAL(pb->variableCount(), 2);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 2);
 
-    BOOST_CHECK_NO_THROW(pb->getConstraint("my_component.ct1"));
-    auto ct1 = pb->getConstraint("my_component.ct1");
+    BOOST_CHECK_NO_THROW(pb->lookupConstraint("my_component.ct1"));
+    auto ct1 = pb->lookupConstraint("my_component.ct1");
     BOOST_CHECK(ct1);
     BOOST_CHECK_EQUAL(ct1->getLb(), -numeric_limits<float>::infinity());
     BOOST_CHECK_EQUAL(ct1->getUb(), 2);
 
     {
-        auto* cv1 = pb->getVariable("my_component.v1");
+        auto* cv1 = pb->lookupVariable("my_component.v1");
         BOOST_REQUIRE(cv1);
         BOOST_CHECK_EQUAL(ct1->getCoefficient(cv1), 3);
-        auto* cv2 = pb->getVariable("my_component.v2");
+        auto* cv2 = pb->lookupVariable("my_component.v2");
         BOOST_REQUIRE(cv2);
         BOOST_CHECK_EQUAL(ct1->getCoefficient(cv2), -1);
     }
 
-    BOOST_CHECK_NO_THROW(pb->getConstraint("my_component.ct2"));
-    auto ct2 = pb->getConstraint("my_component.ct2");
+    BOOST_CHECK_NO_THROW(pb->lookupConstraint("my_component.ct2"));
+    auto ct2 = pb->lookupConstraint("my_component.ct2");
     BOOST_REQUIRE(ct2);
     BOOST_CHECK_EQUAL(ct2->getLb(), -numeric_limits<float>::infinity());
     BOOST_CHECK_EQUAL(ct2->getUb(), 0);
 
     {
-        auto* cv1 = pb->getVariable("my_component.v1");
+        auto* cv1 = pb->lookupVariable("my_component.v1");
         BOOST_REQUIRE(cv1);
         BOOST_CHECK_EQUAL(ct2->getCoefficient(cv1), -0.5);
 
-        auto* cv2 = pb->getVariable("my_component.v2");
+        auto* cv2 = pb->lookupVariable("my_component.v2");
         BOOST_REQUIRE(cv2);
         BOOST_CHECK_EQUAL(ct2->getCoefficient(cv2), 1);
     }
@@ -749,8 +749,8 @@ BOOST_AUTO_TEST_CASE(one_var_with_objective)
     buildLinearProblem();
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 1);
-    BOOST_CHECK_NO_THROW(pb->getVariable("componentA.x"));
-    BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->getVariable("componentA.x")), 1);
+    BOOST_CHECK_NO_THROW(pb->lookupVariable("componentA.x"));
+    BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->lookupVariable("componentA.x")), 1);
 }
 
 BOOST_AUTO_TEST_CASE(one_time_dependent_var_with_objective)
@@ -769,8 +769,8 @@ BOOST_AUTO_TEST_CASE(one_time_dependent_var_with_objective)
     for (auto i = 0; i < nb_var; i++)
     {
         const auto var_name = "componentA.x_t" + to_string(i);
-        BOOST_CHECK_NO_THROW(pb->getVariable(var_name));
-        BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->getVariable(var_name)), 1);
+        BOOST_CHECK_NO_THROW(pb->lookupVariable(var_name));
+        BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->lookupVariable(var_name)), 1);
     }
 }
 
@@ -785,10 +785,10 @@ BOOST_AUTO_TEST_CASE(two_vars_but_only_one_in_objective)
     buildLinearProblem();
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 2);
-    BOOST_CHECK_NO_THROW(pb->getVariable("componentA.v1"));
-    BOOST_CHECK_NO_THROW(pb->getVariable("componentA.v2"));
-    BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->getVariable("componentA.v1")), 0);
-    BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->getVariable("componentA.v2")), 37);
+    BOOST_CHECK_NO_THROW(pb->lookupVariable("componentA.v1"));
+    BOOST_CHECK_NO_THROW(pb->lookupVariable("componentA.v2"));
+    BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->lookupVariable("componentA.v1")), 0);
+    BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->lookupVariable("componentA.v2")), 37);
 }
 
 BOOST_AUTO_TEST_CASE(one_var_with_param_objective)
@@ -801,8 +801,8 @@ BOOST_AUTO_TEST_CASE(one_var_with_param_objective)
     buildLinearProblem();
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 1);
-    BOOST_CHECK_NO_THROW(pb->getVariable("componentA.x"));
-    BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->getVariable("componentA.x")), -25);
+    BOOST_CHECK_NO_THROW(pb->lookupVariable("componentA.x"));
+    BOOST_CHECK_EQUAL(pb->getObjectiveCoefficient(pb->lookupVariable("componentA.x")), -25);
 }
 
 BOOST_AUTO_TEST_CASE(offset_in_objective__throws_exception)
@@ -896,7 +896,12 @@ public:
         return integer ? addIntVariable(lb, ub, name) : addNumVariable(lb, ub, name);
     }
 
-    MockMipVariable* getVariable(const std::string& name) const override
+    MockMipVariable* getVariable(std::size_t idx) const override
+    {
+        return variables_[idx].get();
+    }
+
+    MockMipVariable* lookupVariable(const std::string& name) const override
     {
         for (const auto& var: variables_)
         {
@@ -918,7 +923,12 @@ public:
         return nullptr;
     }
 
-    IMipConstraint* getConstraint(const std::string& name) const override
+    IMipConstraint* lookupConstraint(const std::string& name) const override
+    {
+        return nullptr;
+    }
+
+    IMipConstraint* getConstraint(std::size_t idx) const override
     {
         return nullptr;
     }


### PR DESCRIPTION
- No need to check for duplicates
- For `LegacyFiller`, get variables & constraints by index instead of re-constructing the names
- Rename `getXXX` -> `lookupXXX`
- Use a `std::vector<T*>` to keep track of the elements
- Add lookup methods for tests (not production)