### PR TITLE
Remove verbose log

### DIFF
--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -53,10 +53,6 @@ static void checkSetSolverSpecificParameters(bool status,
     {
         throw Antares::Error::InvalidSolverSpecificParameters(solverName, specificParameters);
     }
-    else
-    {
-        Antares::logs.info() << "  Successfully set " + solverName + " solver specific parameters";
-    }
 }
 
 static void TuneSolverSpecificOptions(MPSolver* solver,


### PR DESCRIPTION
A log is displayed for each problem of the simulation, that is once for every week of every year. Also this log doesn't convene meaningful information, hence the suppression