### PR TITLE
Rename lp-solver -> linear-solver, move some options in the "Optimization" section in the help page

### DIFF
--- a/docs/user-guide/solver/04-parameters.md
+++ b/docs/user-guide/solver/04-parameters.md
@@ -483,12 +483,12 @@ _**This section is under construction**_
 > _**Note:**_ You can find more information on this parameter [here](08-appendix.md#details-on-the-include-unfeasible-problem-behavior-parameter).
 
 ---
-#### lp-solver-param
+#### linear-solver-param
 - **Expected value:** a string
 - **Required:** **no**
 - **Default value:** empty
-- **Usage:** Set solver-specific parameters for linear problems, for instance `--lp-solver-param="THREADS 1 PRESOLVE 1"` 
-  for XPRESS or `--lp-solver-param="parallel/maxnthreads 1, lp/presolving TRUE"` for SCIP. Syntax is solver-dependent, and only supported for SCIP & XPRESS.
+- **Usage:** Set solver-specific parameters for linear problems, for instance `--linear-solver-param="THREADS 1 PRESOLVE 1"` 
+  for XPRESS or `--linear-solver-param="parallel/maxnthreads 1, lp/presolving TRUE"` for SCIP. Syntax is solver-dependent, and only supported for SCIP & XPRESS.
 
 ---
 #### quadratic-solver-param
@@ -840,4 +840,4 @@ They are **required** if [thematic-trimming](#thematic-trimming) is set to `true
 ---
 ## Model-wise parameters
 [//]: # (TODO: link to model-wise parameters documentation)
-_**This section is under construction**_ 
+_**This section is under construction**_

--- a/docs/user-guide/solver/10-command-line.md
+++ b/docs/user-guide/solver/10-command-line.md
@@ -18,9 +18,9 @@ hide:
 | --parallel                      | Enable [parallel](optional-features/multi-threading.md) computation of MC years                                                                                       |
 | --force-parallel=VALUE          | Override the max number of years computed [simultaneously](optional-features/multi-threading.md)                                                                      |
 | --linear-solver=VALUE           | The optimization solver to use for linear problems. Possible values are: `sirius` (default, LP only), `coin`, `xpress`, `scip` (MIP only), `glpk` (Linux only), `highs`, `pdlp` (LP only) |
-| --lp-solver-param=VALUE         | Linear solver-specific parameters. Syntax is solver-dependent, and only supported for `scip` and `xpress` |
-| --lp-solver-param-optim-1=VALUE | Linear solver-specific parameters for first optimization. Only supported for `scip` and `xpress`. |
-| --lp-solver-param-optim-2=VALUE |  Linear solver-specific parameters for second optimization. Only supported for `scip` and `xpress`. |
+| --linear-solver-param=VALUE         | Linear solver-specific parameters. Syntax is solver-dependent, and only supported for `scip` and `xpress` |
+| --linear-solver-param-optim-1=VALUE | Linear solver-specific parameters for first optimization. Only supported for `scip` and `xpress`. |
+| --linear-solver-param-optim-2=VALUE |  Linear solver-specific parameters for second optimization. Only supported for `scip` and `xpress`. |
 | --use-optim-1-basis-next-week   |  Use basis of first optimization in next week's first optimization |
 | --use-optim-1-basis-optim-2     | Use basis of first optimization in second optimization |
 | --quadratic-solver=VALUE        | The optimization solver to use for quadratic problems. Possible values are: `sirius` (default), `pdlp` |
@@ -50,7 +50,7 @@ hide:
 | -m, --mps-export         | Export anonymous MPS, weekly or daily optimal UC+dispatch linear (MPS will be named if the problem is infeasible)                                                                                                                                                                     |
 | -s, --named-mps-problems | Export named MPS, weekly or daily optimal UC+dispatch linear                                                                                                                                                                                                                          |
 | --solver-logs            | Print solver logs                                                                                                                                                                                                                                                                     |
-| --lp-solver-param        | Set solver-specific parameters for linear problems, for instance `--lp-solver-param="THREADS 1 PRESOLVE 1"` for XPRESS or `--linear-solver-parameters="parallel/maxnthreads 1, lp/presolving TRUE"` for SCIP. Syntax is solver-dependent, and only supported for SCIP, XPRESS & PDLP. |
+| --linear-solver-param        | Set solver-specific parameters for linear problems, for instance `--linear-solver-param="THREADS 1 PRESOLVE 1"` for XPRESS or `--linear-solver-parameters="parallel/maxnthreads 1, lp/presolving TRUE"` for SCIP. Syntax is solver-dependent, and only supported for SCIP, XPRESS & PDLP. |
 | --quadratic-solver-param | Set solver-specific parameters for quadratic problems.                                                                                                                                                                                                                                |
 
 ## Misc.

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -65,6 +65,45 @@ std::unique_ptr<Yuni::GetOpt::Parser> CreateParser(Settings& settings, StudyLoad
                 "force-parallel",
                 "Override the max number of years computed simultaneously");
 
+    parser->addParagraph("\nParameters");
+    // --name
+    parser->add(settings.simulationName, 'n', "name", "Name of the current simulation");
+    // --generators-only
+    parser->addFlag(settings.tsGeneratorsOnly,
+                    'g',
+                    "generators-only",
+                    "Run the time-series generators only");
+
+    // --comment-file
+    parser->add(settings.commentFile,
+                'c',
+                "comment-file",
+                "Specify the file to copy as comments of the simulation");
+    // --force
+    parser->addFlag(settings.ignoreWarningsErrors, 'f', "force", "Ignore all warnings at loading");
+    // --no-output
+    parser->addFlag(settings.noOutput,
+                    ' ',
+                    "no-output",
+                    "Do not write the results in the output folder");
+    // --year
+    parser->add(options.nbYears, 'y', "year", "Override the number of MC years");
+    // --year-by-year
+    parser->addFlag(options.forceYearByYear,
+                    ' ',
+                    "year-by-year",
+                    "Force the writing the result output for each year (economy only)");
+    // --derated
+    parser->addFlag(options.forceDerated, ' ', "derated", "Force the derated mode");
+
+    // --output-force-zip
+    parser->addFlag(settings.forceZipOutput,
+                    'z',
+                    "zip-output",
+                    "Force the write output into a single zip archive");
+
+    parser->addParagraph("\nOptimization");
+
     //--linear-solver
     parser->add(options.solverOptions.linearSolver,
                 ' ',
@@ -76,7 +115,7 @@ std::unique_ptr<Yuni::GetOpt::Parser> CreateParser(Settings& settings, StudyLoad
     parser->add(options.solverOptions.linearSolver,
                 ' ',
                 "solver",
-                "Deprecated, use linear-solver instead.");
+                "Deprecated, use --linear-solver instead.");
 
     //--linear-solver-param
     parser->add(options.solverOptions.linearSolverParameters,
@@ -91,7 +130,7 @@ std::unique_ptr<Yuni::GetOpt::Parser> CreateParser(Settings& settings, StudyLoad
     parser->add(options.solverOptions.linearSolverParameters,
                 ' ',
                 "solver-parameters",
-                "Deprecated, use linear-solver-param instead.");
+                "Deprecated, use --linear-solver-param instead.");
 
     // --linear-solver-param-optim-1
     parser->add(options.solverOptions.lpSolverParamOptim1,
@@ -134,45 +173,6 @@ std::unique_ptr<Yuni::GetOpt::Parser> CreateParser(Settings& settings, StudyLoad
                 "Quadratic solver-specific parameters, for instance \"THREADS 8\""
                 " for XPRESS or \"parallel/maxnthreads 8\" for SCIP. "
                 "Syntax is solver-dependent.");
-
-    parser->addParagraph("\nParameters");
-    // --name
-    parser->add(settings.simulationName, 'n', "name", "Name of the current simulation");
-    // --generators-only
-    parser->addFlag(settings.tsGeneratorsOnly,
-                    'g',
-                    "generators-only",
-                    "Run the time-series generators only");
-
-    // --comment-file
-    parser->add(settings.commentFile,
-                'c',
-                "comment-file",
-                "Specify the file to copy as comments of the simulation");
-    // --force
-    parser->addFlag(settings.ignoreWarningsErrors, 'f', "force", "Ignore all warnings at loading");
-    // --no-output
-    parser->addFlag(settings.noOutput,
-                    ' ',
-                    "no-output",
-                    "Do not write the results in the output folder");
-    // --year
-    parser->add(options.nbYears, 'y', "year", "Override the number of MC years");
-    // --year-by-year
-    parser->addFlag(options.forceYearByYear,
-                    ' ',
-                    "year-by-year",
-                    "Force the writing the result output for each year (economy only)");
-    // --derated
-    parser->addFlag(options.forceDerated, ' ', "derated", "Force the derated mode");
-
-    // --output-force-zip
-    parser->addFlag(settings.forceZipOutput,
-                    'z',
-                    "zip-output",
-                    "Force the write output into a single zip archive");
-
-    parser->addParagraph("\nOptimization");
 
     // --optimization-range
     parser->addFlag(settings.simplexOptimRange,

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -78,10 +78,10 @@ std::unique_ptr<Yuni::GetOpt::Parser> CreateParser(Settings& settings, StudyLoad
                 "solver",
                 "Deprecated, use linear-solver instead.");
 
-    //--lp-solver-param
+    //--linear-solver-param
     parser->add(options.solverOptions.linearSolverParameters,
                 ' ',
-                "lp-solver-param",
+                "linear-solver-param",
                 "Linear solver-specific parameters, for instance \"THREADS 1 "
                 "PRESOLVE 1\""
                 " for XPRESS or \"parallel/maxnthreads 1, lp/presolving TRUE\" for "
@@ -91,19 +91,19 @@ std::unique_ptr<Yuni::GetOpt::Parser> CreateParser(Settings& settings, StudyLoad
     parser->add(options.solverOptions.linearSolverParameters,
                 ' ',
                 "solver-parameters",
-                "Deprecated, use lp-solver-param instead.");
+                "Deprecated, use linear-solver-param instead.");
 
-    // --lp-solver-param-optim-1
+    // --linear-solver-param-optim-1
     parser->add(options.solverOptions.lpSolverParamOptim1,
                 ' ',
-                "lp-solver-param-optim-1",
+                "linear-solver-param-optim-1",
                 "Linear solver-specific parameters for first optimization."
                 " Only supported for SCIP & XPRESS.");
 
-    // --lp-solver-param-optim-2
+    // --linear-solver-param-optim-2
     parser->add(options.solverOptions.lpSolverParamOptim2,
                 ' ',
-                "lp-solver-param-optim-2",
+                "linear-solver-param-optim-2",
                 "Linear solver-specific parameters for second optimization."
                 " Only supported for SCIP & XPRESS.");
 

--- a/src/tools/batchrun/main.cpp
+++ b/src/tools/batchrun/main.cpp
@@ -176,7 +176,7 @@ int main(int argc, const char* argv[])
                         // Wrap spaces around quotes, if any
                         // example
                         // antares-batchrun directory --solver xpress
-                        // --lp-solver-param "PRESOLVE 1"
+                        // --linear-solver-param "PRESOLVE 1"
                         cmd << " \"" << arg << "\"";
                     }
                 }


### PR DESCRIPTION
Help page after the change
```
Optimization
      --linear-solver=VALUE  Solver used for linear optimizations during
                             simulation. Available solver list :
                             coin,glpk,pdlp,scip,sirius,xpress.
      --solver=VALUE         Deprecated, use --linear-solver instead.
      --linear-solver-param=VALUE
                             Linear solver-specific parameters, for instance
                             "THREADS 1 PRESOLVE 1" for XPRESS or
                             "parallel/maxnthreads 1, lp/presolving TRUE" for
                             SCIP. Syntax is solver-dependent, and only
                             supported for SCIP & XPRESS.
      --solver-parameters=VALUE
                             Deprecated, use --linear-solver-param instead.
      --linear-solver-param-optim-1=VALUE
                             Linear solver-specific parameters for first
                             optimization. Only supported for SCIP & XPRESS.
      --linear-solver-param-optim-2=VALUE
                             Linear solver-specific parameters for second
                             optimization. Only supported for SCIP & XPRESS.
      --use-optim-1-basis-next-week
                             Use basis of first optimization in next week's
                             first optimization
      --use-optim-1-basis-optim-2
                             Use basis of first optimization in second optimization
```