### PR TITLE
Add fixed variables support to OR-Tools quadratic wrapper

### DIFF
--- a/src/solver/utils/ortools_quadratic_wrapper.cpp
+++ b/src/solver/utils/ortools_quadratic_wrapper.cpp
@@ -89,6 +89,9 @@ void BuildVariablesAndObjective(PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre, 
         double lb, ub;
         switch (ProblemeAResoudre->TypeDeVariable[i])
         {
+        case VARIABLE_FIXE:
+            lb = ub = 0.5 * (ProblemeAResoudre->Xmax[i] + ProblemeAResoudre->Xmin[i]);
+            break;
         case VARIABLE_BORNEE_DES_DEUX_COTES:
             lb = ProblemeAResoudre->Xmin[i];
             ub = ProblemeAResoudre->Xmax[i];

--- a/src/solver/utils/ortools_quadratic_wrapper.cpp
+++ b/src/solver/utils/ortools_quadratic_wrapper.cpp
@@ -84,7 +84,7 @@ void SolveQuadraticProblemWithOrtools(const SingleOptimOptions& options,
 void BuildVariablesAndObjective(PROBLEME_ANTARES_A_RESOUDRE* ProblemeAResoudre, Model& model)
 {
     QuadraticExpression objective(0);
-    for (auto i = 0; i < ProblemeAResoudre->NombreDeVariables; ++i)
+    for (size_t i = 0; i < ProblemeAResoudre->NombreDeVariables; ++i)
     {
         double lb, ub;
         switch (ProblemeAResoudre->TypeDeVariable[i])

--- a/src/tests/cucumber/features/solver-features/short_tests.feature
+++ b/src/tests/cucumber/features/solver-features/short_tests.feature
@@ -127,7 +127,7 @@ Feature: short tests
     Given the solver study path is "Antares_Simulator_Tests_NR/short-tests/021 Four areas - DC law"
     When I run antares simulator
     Then the simulation succeeds
-    And the simulation takes less than 20 seconds
+    And the simulation takes less than 25 seconds
     And the annual system cost is
       | EXP       | STD       | MIN       | MAX       |
       | 7.972e+10 | 2.258e+10 | 5.613e+10 | 1.082e+11 |

--- a/src/tests/src/solver/utils/test_ortools_quadratic_wrapper.cpp
+++ b/src/tests/src/solver/utils/test_ortools_quadratic_wrapper.cpp
@@ -85,14 +85,7 @@ struct QpFixture
         int type = VARIABLE_NON_BORNEE;
         if (std::isfinite(lb) && std::isfinite(ub))
         {
-            if (std::abs(lb - ub) <= 1e-3)
-            {
-                type = VARIABLE_FIXE;
-            }
-            else
-            {
-                type = VARIABLE_BORNEE_DES_DEUX_COTES;
-            }
+            type = ub - lb < 1e-3 ? VARIABLE_FIXE : VARIABLE_BORNEE_DES_DEUX_COTES;
         }
         else if (std::isfinite(lb))
         {

--- a/src/tests/src/solver/utils/test_ortools_quadratic_wrapper.cpp
+++ b/src/tests/src/solver/utils/test_ortools_quadratic_wrapper.cpp
@@ -85,7 +85,14 @@ struct QpFixture
         int type = VARIABLE_NON_BORNEE;
         if (std::isfinite(lb) && std::isfinite(ub))
         {
-            type = VARIABLE_BORNEE_DES_DEUX_COTES;
+            if (std::abs(lb - ub) <= 1e-3)
+            {
+                type = VARIABLE_FIXE;
+            }
+            else
+            {
+                type = VARIABLE_BORNEE_DES_DEUX_COTES;
+            }
         }
         else if (std::isfinite(lb))
         {
@@ -199,6 +206,18 @@ BOOST_AUTO_TEST_CASE(simple_qp_one_var)
     checkPrimalSolution({0.25});
     checkDualSolution({});
     checkReducedCosts({0});
+}
+
+BOOST_AUTO_TEST_CASE(simple_qp_one_var_fixed)
+{
+    // minimize(x * x - 0.5 * x)
+    // such that 0.24 <= x <= 0.2408
+    // although optimal value of x would be 0.25, the wrapper's handling of case VARIABLE_FIXE
+    // would set lb = ub = 0.5 * (0.24 + 0.2408) = 0.2404
+    addVar("x", 0.24, 0.2408, -0.5, 1);
+    solve();
+    BOOST_CHECK_EQUAL(OUI_PI, problemeAResoudre.ExistenceDUneSolution);
+    checkPrimalSolution({0.2404});
 }
 
 BOOST_AUTO_TEST_CASE(simple_qp_two_vars_1)


### PR DESCRIPTION
In some cases, variables can be fixed in the quadratic problem (see [here](https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/754538ede4f8d56c4140a2b301a013cb342c0128/src/solver/optimisation/opt_gestion_des_bornes_cas_quadratique.cpp#L54)).
This allows the OR-Tools wrapper to handle those cases.