### PR TITLE
Package OR-Tools shared libs [ANT-3227]

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -5,8 +5,6 @@ on:
     types: [ created ]
   push:
     branches:
-      - develop
-      - dependabot/*
   schedule:
     - cron: '21 2 * * *'
   workflow_call:
@@ -49,7 +47,7 @@ jobs:
           echo "DOCKERFILE=$(pwd)/docker/Dockerfile" >> $GITHUB_ENV
           echo "DOCKERDIR=$(pwd)/docker" >> $GITHUB_ENV
 
-  
+
 
 
       - name: check if DockerFiles has changed

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -49,7 +49,7 @@ jobs:
           echo "DOCKERFILE=$(pwd)/docker/Dockerfile" >> $GITHUB_ENV
           echo "DOCKERDIR=$(pwd)/docker" >> $GITHUB_ENV
 
-  
+
 
 
       - name: check if DockerFiles has changed

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -139,6 +139,11 @@ jobs:
           ls -la .ccache
           docker rm $container_id
 
+      - name: Push artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: targz
+          path: archive/*.tar.gz
 
       - name: Publish assets
         if: ${{ env.IS_RELEASE == 'true' }}

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - develop
       - dependabot/*
-      - feature/package_all_libs
   schedule:
     - cron: '21 2 * * *'
   workflow_call:

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -5,6 +5,8 @@ on:
     types: [ created ]
   push:
     branches:
+      - develop
+      - dependabot/*
   schedule:
     - cron: '21 2 * * *'
   workflow_call:
@@ -47,7 +49,7 @@ jobs:
           echo "DOCKERFILE=$(pwd)/docker/Dockerfile" >> $GITHUB_ENV
           echo "DOCKERDIR=$(pwd)/docker" >> $GITHUB_ENV
 
-
+  
 
 
       - name: check if DockerFiles has changed

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - develop
       - dependabot/*
+      - feature/package_all_libs
   schedule:
     - cron: '21 2 * * *'
   workflow_call:

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Installer .rpm creation
         run: |
           cd _build
-          cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
+          cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib;bin"
 
       - name: Solver archive creation
         run: |
@@ -134,7 +134,7 @@ jobs:
       - name: .tar.gz creation
         run: |
           cd _build
-          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
+          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib;bin"
 
       - name: Installer TGZ push
         uses: actions/upload-artifact@v4

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Installer .rpm creation
         run: |
           cd _build
-          cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib;bin"
+          cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib64;bin"
 
       - name: Solver archive creation
         run: |
@@ -127,14 +127,14 @@ jobs:
           cmake --install . --prefix install
           pushd .
           cd install/bin
-          tar czf ../../antares-solver_oracle8.tar.gz antares-solver libsirius_solver.so ${{ env.ORTOOLS_DIR }}/install/lib/*.so*
+          tar czf ../../antares-solver_oracle8.tar.gz antares-solver libsirius_solver.so ${{ env.ORTOOLS_DIR }}/install/lib64/*.so*
           popd
           rm -rf install
 
       - name: .tar.gz creation
         run: |
           cd _build
-          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib;bin"
+          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib64;bin"
 
       - name: Installer TGZ push
         uses: actions/upload-artifact@v4

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -121,20 +121,21 @@ jobs:
           cd _build
           cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib64;bin"
 
+      - name: .tar.gz creation
+        run: |
+          cd _build
+          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib64;bin"
+
       - name: Solver archive creation
         run: |
           cd _build
           cmake --install . --prefix install
           pushd .
           cd install/bin
-          tar czf ../../antares-solver_oracle8.tar.gz antares-solver libsirius_solver.so ${{ env.ORTOOLS_DIR }}/install/lib64/*.so*
+          cp ${{ env.ORTOOLS_DIR }}/install/lib64/*.so* .
+          tar czf ../../antares-solver_oracle8.tar.gz antares-solver libsirius_solver.so *.so*
           popd
           rm -rf install
-
-      - name: .tar.gz creation
-        run: |
-          cd _build
-          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib64;bin"
 
       - name: Installer TGZ push
         uses: actions/upload-artifact@v4

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -2,7 +2,7 @@ name: Oracle 8 CI (push and/or release)
 
 on:
   release:
-    types: [ created ]
+    types: [created]
   push:
     branches:
       - develop

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -2,7 +2,7 @@ name: Oracle 8 CI (push and/or release)
 
 on:
   release:
-    types: [created]
+    types: [ created ]
   push:
     branches:
       - develop

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - develop
       - dependabot/*
-      - feature/package_all_libs
   schedule:
     - cron: '21 2 * * *'
   workflow_call:

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -2,7 +2,7 @@ name: Oracle 8 CI (push and/or release)
 
 on:
   release:
-    types: [created]
+    types: [ created ]
   push:
     branches:
       - develop
@@ -36,139 +36,139 @@ jobs:
 
     steps:
 
-    - name: Set up Python
-      run: |
-           dnf update -y
-           dnf install -y python3 python3-pip
+      - name: Set up Python
+        run: |
+          dnf update -y
+          dnf install -y python3 python3-pip
 
-    - name: Install libraries
-      run: |
-           dnf install -y epel-release git cmake wget rpm-build redhat-lsb-core
-           dnf install -y unzip libuuid-devel boost-test boost-devel gcc-toolset-11 zlib-devel
+      - name: Install libraries
+        run: |
+          dnf install -y epel-release git cmake wget rpm-build redhat-lsb-core
+          dnf install -y unzip libuuid-devel boost-test boost-devel gcc-toolset-11 zlib-devel
 
-    - name: Checkout
-      run: |
-        git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${{ env.REF }} .
-        git config --global safe.directory '*'
+      - name: Checkout
+        run: |
+          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${{ env.REF }} .
+          git config --global safe.directory '*'
 
-    - name: Install VCPKG
-      # Note: we need to use environment variables instead of workflow variables
-      #       because github messes up path variables when running in container,
-      #       see https://github.com/actions/runner/issues/2058
-      run: |
-        git submodule update --init vcpkg && ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
-        echo "VCPKG_ROOT=$GITHUB_WORKSPACE/vcpkg" >> $GITHUB_ENV
-        echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg_cache" >> $GITHUB_ENV
-        echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg_cache,readwrite" >> $GITHUB_ENV
+      - name: Install VCPKG
+        # Note: we need to use environment variables instead of workflow variables
+        #       because github messes up path variables when running in container,
+        #       see https://github.com/actions/runner/issues/2058
+        run: |
+          git submodule update --init vcpkg && ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          echo "VCPKG_ROOT=$GITHUB_WORKSPACE/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg_cache" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg_cache,readwrite" >> $GITHUB_ENV
 
-    - name: Restore vcpkg binary dir from cache
-      id: cache-vcpkg-binary
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ env.VCPKG_CACHE_DIR }}
-        key: vcpkg-cache-oracle8-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}
-        # Allows to restore a cache when deps have only partially changed (like adding a dependency)
-        restore-keys: vcpkg-cache-oracle8-
+      - name: Restore vcpkg binary dir from cache
+        id: cache-vcpkg-binary
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.VCPKG_CACHE_DIR }}
+          key: vcpkg-cache-oracle8-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}
+          # Allows to restore a cache when deps have only partially changed (like adding a dependency)
+          restore-keys: vcpkg-cache-oracle8-
 
-    - name: Config OR-Tools URL
-      run: |
+      - name: Config OR-Tools URL
+        run: |
           echo "ORTOOLS_URL=https://github.com/rte-france/or-tools-rte/releases/download/$(cat ortools_tag)/ortools_cxx_oraclelinux-8_static_sirius.zip" >> $GITHUB_ENV
 
-    - name: Download & extract OR-Tools
-      run: |
-           mkdir -p  ${{env.ORTOOLS_DIR}}
-           cd ${{env.ORTOOLS_DIR}}
-           wget ${{env.ORTOOLS_URL}} -O ortools.zip
-           unzip ortools.zip
-           rm ortools.zip
+      - name: Download & extract OR-Tools
+        run: |
+          mkdir -p  ${{env.ORTOOLS_DIR}}
+          cd ${{env.ORTOOLS_DIR}}
+          wget ${{env.ORTOOLS_URL}} -O ortools.zip
+          unzip ortools.zip
+          rm ortools.zip
 
-    - name: Install dependencies
-      run: |
+      - name: Install dependencies
+        run: |
           pip3 install -r src/tests/examples/requirements.txt
 
-    - name: Install gh if needed
-      if: ${{ env.IS_RELEASE == 'true' || github.ref == 'refs/heads/develop'}}
-      run: |
-           dnf -y install 'dnf-command(config-manager)'
-           dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-           dnf -y install gh
+      - name: Install gh if needed
+        if: ${{ env.IS_RELEASE == 'true' || github.ref == 'refs/heads/develop'}}
+        run: |
+          dnf -y install 'dnf-command(config-manager)'
+          dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          dnf -y install gh
 
-    - name: Configure
-      run: |
-        source /opt/rh/gcc-toolset-11/enable
-        cmake -B _build -S src \
-          -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/vcpkg/scripts/buildsystems/vcpkg.cmake \
-          -DVCPKG_TARGET_TRIPLET=x64-linux-release \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DBUILD_TESTING=ON \
-          -DBUILD_TOOLS=ON \
-          -DBUILD_UI=OFF \
-          -DCMAKE_PREFIX_PATH=${{ env.ORTOOLS_DIR }}/install
+      - name: Configure
+        run: |
+          source /opt/rh/gcc-toolset-11/enable
+          cmake -B _build -S src \
+            -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DVCPKG_TARGET_TRIPLET=x64-linux-release \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=ON \
+            -DBUILD_TOOLS=ON \
+            -DBUILD_UI=OFF \
+            -DCMAKE_PREFIX_PATH=${{ env.ORTOOLS_DIR }}/install
 
-    - name: Build
-      run: |
-           source /opt/rh/gcc-toolset-11/enable
-           cmake --build _build --config Release -j$(nproc)
+      - name: Build
+        run: |
+          source /opt/rh/gcc-toolset-11/enable
+          cmake --build _build --config Release -j$(nproc)
 
-    - name: Run unit and end-to-end tests
-      if: ${{ env.IS_PUSH == 'true' }}
-      run: |
-        cd _build
-        ctest -C Release --output-on-failure -L "unit|end-to-end"
+      - name: Run unit and end-to-end tests
+        if: ${{ env.IS_PUSH == 'true' }}
+        run: |
+          cd _build
+          ctest -C Release --output-on-failure -L "unit|end-to-end"
 
-    - name: Installer .rpm creation
-      run: |
-           cd _build
-           cpack -G RPM
+      - name: Installer .rpm creation
+        run: |
+          cd _build
+          cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
 
-    - name: Solver archive creation
-      run: |
-           cd _build
-           cmake --install . --prefix install
-           pushd .
-           cd install/bin
-           tar czf ../../antares-solver_oracle8.tar.gz antares-solver libsirius_solver.so
-           popd
-           rm -rf install
+      - name: Solver archive creation
+        run: |
+          cd _build
+          cmake --install . --prefix install
+          pushd .
+          cd install/bin
+          tar czf ../../antares-solver_oracle8.tar.gz antares-solver libsirius_solver.so ${{ env.ORTOOLS_DIR }}/install/lib/*.so*
+          popd
+          rm -rf install
 
-    - name: .tar.gz creation
-      run: |
-           cd _build
-           cpack -G TGZ
+      - name: .tar.gz creation
+        run: |
+          cd _build
+          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
 
-    - name: Installer TGZ push
-      uses: actions/upload-artifact@v4
-      with:
-        name: oracle-targz
-        path: _build/*.tar.gz
+      - name: Installer TGZ push
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle-targz
+          path: _build/*.tar.gz
 
-    - name: Installer RPM push
-      uses: actions/upload-artifact@v4
-      with:
-        name: oracle-rpm
-        path: _build/*.rpm
+      - name: Installer RPM push
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle-rpm
+          path: _build/*.rpm
 
-    - name: Publish assets
-      if: ${{ env.IS_RELEASE == 'true' }}
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-        tag: ${{ github.event.inputs.release_tag }}
-      run: |
-        gh release upload "$tag" _build/*.tar.gz _build/*.rpm
+      - name: Publish assets
+        if: ${{ env.IS_RELEASE == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          tag: ${{ github.event.inputs.release_tag }}
+        run: |
+          gh release upload "$tag" _build/*.tar.gz _build/*.rpm
 
-    - name: Update continuous-delivery release
-      if: github.ref == 'refs/heads/develop'
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        mv _build/antares-*-OracleServer-8.10.tar.gz _build/antares-cd-OracleServer-8.10.tar.gz
-        mv _build/antares-*-OracleServer-8.10.rpm _build/antares-cd-OracleServer-8.10.rpm
-        gh release upload --clobber continuous-delivery _build/*.tar.gz _build/*.rpm
+      - name: Update continuous-delivery release
+        if: github.ref == 'refs/heads/develop'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mv _build/antares-*-OracleServer-8.10.tar.gz _build/antares-cd-OracleServer-8.10.tar.gz
+          mv _build/antares-*-OracleServer-8.10.rpm _build/antares-cd-OracleServer-8.10.rpm
+          gh release upload --clobber continuous-delivery _build/*.tar.gz _build/*.rpm
 
-    - name: Cache vcpkg binary dir
-      if: always()
-      id: save-cache-vcpkg-binary
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ env.VCPKG_CACHE_DIR }}
-        key: vcpkg-cache-oracle8-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}
+      - name: Cache vcpkg binary dir
+        if: always()
+        id: save-cache-vcpkg-binary
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.VCPKG_CACHE_DIR }}
+          key: vcpkg-cache-oracle8-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - develop
       - dependabot/*
+      - feature/package_all_libs
   schedule:
     - cron: '21 2 * * *'
   workflow_call:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -363,7 +363,7 @@ jobs:
           cmake --install . --prefix install
           pushd .
           cd install/bin
-          tar czf ../../antares-solver_ubuntu22.04.tar.gz antares-solver libsirius_solver.so -D ${{ env.ORTOOLS_DIR }}/install/lib/*.so*
+          tar czf ../../antares-solver_ubuntu22.04.tar.gz antares-solver libsirius_solver.so ${{ env.ORTOOLS_DIR }}/install/lib/*.so*
           popd
           rm -rf install
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -363,7 +363,8 @@ jobs:
           cmake --install . --prefix install
           pushd .
           cd install/bin
-          tar czf ../../antares-solver_ubuntu22.04.tar.gz antares-solver libsirius_solver.so ${{ env.ORTOOLS_DIR }}/install/lib/*.so*
+          cp ${{ env.ORTOOLS_DIR }}/install/lib/*.so* .
+          tar czf ../../antares-solver_ubuntu22.04.tar.gz antares-solver libsirius_solver.so *.so*
           popd
           rm -rf install
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -350,12 +350,12 @@ jobs:
       - name: Installer .deb creation
         run: |
           cd _build
-          cpack -G DEB -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
+          cpack -G DEB -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib;bin"
 
       - name: .tar.gz creation
         run: |
           cd _build
-          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
+          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib;bin"
 
       - name: Solver archive creation
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -350,12 +350,12 @@ jobs:
       - name: Installer .deb creation
         run: |
           cd _build
-          cpack -G DEB
+          cpack -G DEB -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
 
       - name: .tar.gz creation
         run: |
           cd _build
-          cpack -G TGZ
+          cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
 
       - name: Solver archive creation
         run: |
@@ -363,7 +363,7 @@ jobs:
           cmake --install . --prefix install
           pushd .
           cd install/bin
-          tar czf ../../antares-solver_ubuntu22.04.tar.gz antares-solver libsirius_solver.so
+          tar czf ../../antares-solver_ubuntu22.04.tar.gz antares-solver libsirius_solver.so -D ${{ env.ORTOOLS_DIR }}/install/lib/*.so*
           popd
           rm -rf install
 

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -90,7 +90,7 @@ jobs:
           ccache --set-config=compression=true
           ccache -p
           ccache -z            
-      
+
       - name: Install VCPKG
         shell: bash
         run: |
@@ -147,7 +147,7 @@ jobs:
 
       - name: Add OR-Tools to PATH
         run: echo "D:\a\Antares_Simulator\Antares_Simulator/or-tools/install/bin" | Out-File -Append -Encoding ascii $env:GITHUB_PATH
-      
+
       - name: Read simtest version
         shell: bash
         run: |
@@ -354,7 +354,7 @@ jobs:
         shell: bash
         run: |
           cd _build
-          zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll
+          zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll ${{ env.ORTOOLS_DIR }}/install/lib/*.dll*
 
       - name: NSIS Installer creation
         shell: bash
@@ -375,7 +375,7 @@ jobs:
       - name: .zip creation
         run: |
           cd _build
-          cpack -G ZIP
+          cpack -G ZIP -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
 
       - name: Installer upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -354,7 +354,6 @@ jobs:
         shell: bash
         run: |
           cd _build
-          set -x
           FIXED_PATH=${ORTOOLS_DIR//\\//}
           cp ${FIXED_PATH}/install/bin/*.dll* solver/Release
           zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -354,7 +354,7 @@ jobs:
         shell: bash
         run: |
           cd _build
-          zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll ${{ env.ORTOOLS_DIR }}/install/lib/*.dll*
+          zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll ${ env.ORTOOLS_DIR//\\// }/install/lib/*.dll*
 
       - name: NSIS Installer creation
         shell: bash

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -355,6 +355,8 @@ jobs:
         run: |
           cd _build
           ODIR=${{ env.ORTOOLS_DIR }}
+          set -x
+          ls ${ODIR//\\//}/install/lib/*.dll*
           zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll ${ODIR//\\//}/install/lib/*.dll*
 
       - name: NSIS Installer creation

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -354,7 +354,9 @@ jobs:
         shell: bash
         run: |
           cd _build
-          cp ${{ env.ORTOOLS_DIR }}/install/bin/*.dll* solver/Release
+          set -x
+          FIXED_PATH=${ORTOOLS_DIR//\\//}
+          cp ${FIXED_PATH}/install/bin/*.dll* solver/Release
           zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll
 
       - name: NSIS Installer creation

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -354,9 +354,8 @@ jobs:
         shell: bash
         run: |
           cd _build
-          ODIR=${{ env.ORTOOLS_DIR }}
-          set -x
-          zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll ${ODIR//\\//}/install/lib/*.dll*
+          cp ${{ env.ORTOOLS_DIR }}/install/bin/*.dll* solver/Release
+          zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll
 
       - name: NSIS Installer creation
         shell: bash

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -375,7 +375,7 @@ jobs:
       - name: .zip creation
         run: |
           cd _build
-          cpack -G ZIP -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install;bin"
+          cpack -G ZIP -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib;bin"
 
       - name: Installer upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -356,7 +356,6 @@ jobs:
           cd _build
           ODIR=${{ env.ORTOOLS_DIR }}
           set -x
-          ls ${ODIR//\\//}/install/lib/*.dll*
           zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll ${ODIR//\\//}/install/lib/*.dll*
 
       - name: NSIS Installer creation

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -354,7 +354,8 @@ jobs:
         shell: bash
         run: |
           cd _build
-          zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll ${ env.ORTOOLS_DIR//\\// }/install/lib/*.dll*
+          ODIR=${{ env.ORTOOLS_DIR }}
+          zip -r antares-solver_windows.zip solver/Release/antares-solver.exe solver/Release/*.dll ${ODIR//\\//}/install/lib/*.dll*
 
       - name: NSIS Installer creation
         shell: bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,6 +69,16 @@ RUN  source /opt/rh/devtoolset-11/enable && \
      cmake --build _build --config Release -j${NPROC} &&\
      ccache -s
 
+RUN echo "DEBUG" && \
+    ls / && \
+    echo "------------------------------------------" &&
+    ls /ortools && \
+    echo "------------------------------------------" && \
+    ls /ortools/install && \
+    echo "------------------------------------------" && \
+    ls /ortools/install/lib64
+
+
 #Installer .rpm creation
 RUN cd _build && \
     cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib64;bin"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,13 +82,13 @@ RUN cd _build && \
     pushd . && \
     cd install/bin && \
     ls / \
-    ls "-----------" \
+    echo "-----------" \
     ls /ortools/install/ \
-    ls "-----------" \
+    echo "-----------" \
     ls /ortools/install/lib/ \
-    ls "-----------" \
+    echo "-----------" \
     ls /ortools/install/lib/*.so* \
-    ls "-----------" \
+    echo "-----------" \
     tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so /ortools/install/lib/*.so* && \
     popd && \
     rm -rf install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,17 +71,17 @@ RUN  source /opt/rh/devtoolset-11/enable && \
 
 #Installer .rpm creation
 RUN cd _build && \
-    cpack -G RPM
+    cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install;bin"
 
 #Solver archive creation
 RUN cd _build && \
-     cpack -G RPM
+     cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install;bin"
 
 RUN cd _build && \
     cmake --install . --prefix install && \
     pushd . && \
     cd install/bin && \
-    tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so && \
+    tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so /ortools/install/lib/*.so* && \
     popd && \
     rm -rf install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,25 +71,17 @@ RUN  source /opt/rh/devtoolset-11/enable && \
 
 #Installer .rpm creation
 RUN cd _build && \
-    cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib;bin"
+    cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib64;bin"
 
 #Solver archive creation
 RUN cd _build && \
-     cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib;bin"
+     cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib64;bin"
 
 RUN cd _build && \
     cmake --install . --prefix install && \
     pushd . && \
     cd install/bin && \
-    ls / && \
-    echo "-----------" && \
-    ls /ortools/install/ && \
-    echo "-----------" && \
-    ls /ortools/install/lib/ && \
-    echo "-----------" && \
-    ls /ortools/install/lib/*.so* && \
-    echo "-----------" && \
-    tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so /ortools/install/lib/*.so* && \
+    tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so /ortools/install/lib64/*.so* && \
     popd && \
     rm -rf install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,11 +71,11 @@ RUN  source /opt/rh/devtoolset-11/enable && \
 
 #Installer .rpm creation
 RUN cd _build && \
-    cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install;bin"
+    cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib;bin"
 
 #Solver archive creation
 RUN cd _build && \
-     cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install;bin"
+     cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib;bin"
 
 RUN cd _build && \
     cmake --install . --prefix install && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,14 +81,14 @@ RUN cd _build && \
     cmake --install . --prefix install && \
     pushd . && \
     cd install/bin && \
-    ls / \
-    echo "-----------" \
-    ls /ortools/install/ \
-    echo "-----------" \
-    ls /ortools/install/lib/ \
-    echo "-----------" \
-    ls /ortools/install/lib/*.so* \
-    echo "-----------" \
+    ls / && \
+    echo "-----------" && \
+    ls /ortools/install/ && \
+    echo "-----------" && \
+    ls /ortools/install/lib/ && \
+    echo "-----------" && \
+    ls /ortools/install/lib/*.so* && \
+    echo "-----------" && \
     tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so /ortools/install/lib/*.so* && \
     popd && \
     rm -rf install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN  source /opt/rh/devtoolset-11/enable && \
 
 RUN echo "DEBUG" && \
     ls / && \
-    echo "------------------------------------------" &&
+    echo "------------------------------------------" && \
     ls /ortools && \
     echo "------------------------------------------" && \
     ls /ortools/install && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,7 +75,7 @@ RUN cd _build && \
 
 #Solver archive creation
 RUN cd _build && \
-     cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib64;bin"
+     cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib64;bin"
 
 RUN cd _build && \
     cmake --install . --prefix install && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,16 +69,6 @@ RUN  source /opt/rh/devtoolset-11/enable && \
      cmake --build _build --config Release -j${NPROC} &&\
      ccache -s
 
-RUN echo "DEBUG" && \
-    ls / && \
-    echo "------------------------------------------" && \
-    ls /ortools && \
-    echo "------------------------------------------" && \
-    ls /ortools/install && \
-    echo "------------------------------------------" && \
-    ls /ortools/install/lib64
-
-
 #Installer .rpm creation
 RUN cd _build && \
     cpack -G RPM -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib64;bin"
@@ -87,9 +77,6 @@ RUN cd _build && \
 RUN cd _build && \
      cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib64;bin"
 
-#.tar.gz creation
-RUN cd _build && \
-    cpack -G TGZ
 #mv .rpm and .tar.gz
 RUN cd _build && \
     mkdir archive && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,14 +77,6 @@ RUN cd _build && \
 RUN cd _build && \
      cpack -G TGZ -D CPACK_INSTALLED_DIRECTORIES="/ortools/install/lib64;bin"
 
-RUN cd _build && \
-    cmake --install . --prefix install && \
-    pushd . && \
-    cd install/bin && \
-    tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so /ortools/install/lib64/*.so* && \
-    popd && \
-    rm -rf install
-
 #.tar.gz creation
 RUN cd _build && \
     cpack -G TGZ
@@ -93,3 +85,12 @@ RUN cd _build && \
     mkdir archive && \
     mv *.tar.gz archive && \
     mv *.rpm archive
+
+RUN cd _build && \
+    cmake --install . --prefix install && \
+    pushd . && \
+    cd install/bin && \
+    cp /ortools/install/lib64/*.so* . && \
+    tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so *.so* && \
+    popd && \
+    rm -rf install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,6 +81,14 @@ RUN cd _build && \
     cmake --install . --prefix install && \
     pushd . && \
     cd install/bin && \
+    ls / \
+    ls "-----------" \
+    ls /ortools/install/ \
+    ls "-----------" \
+    ls /ortools/install/lib/ \
+    ls "-----------" \
+    ls /ortools/install/lib/*.so* \
+    ls "-----------" \
     tar czf ../../antares-solver_centos7.tar.gz antares-solver libsirius_solver.so /ortools/install/lib/*.so* && \
     popd && \
     rm -rf install


### PR DESCRIPTION
Since version 9.12 or-tools is not build as static library, instead ortools and it's dependencies are built as shared libraries.

This causes an issue where trying to execute antares-solver fail because of missing libraries. One way to locally solve this issue is to point LD_LIBRARY_PATH to ortools/install/lib directory.

With this PR we package ortools and subsequent dependencies in the assets. This way users can continue to use antares-solver as before without having to rely on an extarnal or-tools installation