### PR TITLE
(v9.2.x) Part 1/2 : Set primal tolerance to 1e-6 in ortools_utils [ANT-3122]

### DIFF
--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -43,6 +43,12 @@ static void setGenericParameters(MPSolverParameters& params)
 {
     params.SetIntegerParam(MPSolverParameters::SCALING, 0);
     params.SetIntegerParam(MPSolverParameters::PRESOLVE, 0);
+    // ortools default is 1e-7 for primal tolerance, but this may be too high as we manipulate large
+    // values in the problem. Then 1e-7 may be too hard to achieve and has lead to declare some
+    // problems infeasible whereas they were not (contraints were active but not violated). Sirius
+    // uses 1e-6 (and this cannot be changed with ortools), this has effect for all solvers except
+    // sirius
+    params.SetDoubleParam(MPSolverParameters::PRIMAL_TOLERANCE, 1e-6);
 }
 
 static void checkSetSolverSpecificParameters(bool status,


### PR DESCRIPTION
Fixes sub-task **ANT-3122** of ticket **ANT-3183**.

It a cherry pick of a commit of branch **develop** onto branch **v9.2.x** 




























































