### PR TITLE
(v9.2.x) missing ortools dll in zip asset (win)

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -376,9 +376,11 @@ jobs:
           path: _build/_CPack_Packages/win64/NSIS/NSISOutput.log
 
       - name: .zip creation
+        shell: bash
         run: |
           cd _build
-          cpack -G ZIP -D CPACK_INSTALLED_DIRECTORIES="${{ env.ORTOOLS_DIR }}/install/lib;bin"
+          FIXED_PATH=${ORTOOLS_DIR//\\//}
+          cpack -G ZIP -D CPACK_INSTALLED_DIRECTORIES="${FIXED_PATH}/install/bin;bin"
 
       - name: Installer upload
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes ticket [ANT-3349](https://gopro-tickets.rte-france.com/browse/ANT-3349)

This PR is a cherry pick of commit : 

**Fix missing ortools dll in windows zip asset (#2840)
82907afa4cead3e377fb9af6dad118a6baaf5279**

from branch **develop** to branch **release/9.2.x** 