### PR TITLE
[ANT-2034] Various warnings or linter fixes

### DIFF
--- a/src/expressions/include/antares/expressions/visitors/EvaluationContext.h
+++ b/src/expressions/include/antares/expressions/visitors/EvaluationContext.h
@@ -65,9 +65,9 @@ public:
     [[nodiscard]] std::string getSystemParameterValue(const std::string& key) const;
 
     [[nodiscard]] double getParameterValue(const std::string& key,
-                             const std::string& scenarioGroup,
-                             unsigned scenario,
-                             unsigned int hour) const;
+                                           const std::string& scenarioGroup,
+                                           unsigned scenario,
+                                           unsigned int hour) const;
 
     [[nodiscard]] ParameterType getParameterType(const std::string& key) const;
     [[nodiscard]] ParameterTypeAndValue getParameter(const std::string& key) const;

--- a/src/expressions/include/antares/expressions/visitors/EvaluationContext.h
+++ b/src/expressions/include/antares/expressions/visitors/EvaluationContext.h
@@ -52,7 +52,7 @@ public:
      * @return The value of the variable.
      * @throws std::out_of_range If the variable is not found.
      */
-    double getVariableValue(const std::string& key) const;
+    [[nodiscard]] double getVariableValue(const std::string& key) const;
 
     /**
      * @brief Retrieves the value of a parameter.
@@ -61,17 +61,17 @@ public:
      * @return The value of the parameter.
      * @throws std::out_of_range If the parameter is not found.
      */
-    double getSystemParameterValueAsDouble(const std::string& key) const;
-    std::string getSystemParameterValue(const std::string& key) const;
+    [[nodiscard]] double getSystemParameterValueAsDouble(const std::string& key) const;
+    [[nodiscard]] std::string getSystemParameterValue(const std::string& key) const;
 
-    double getParameterValue(const std::string& key,
+    [[nodiscard]] double getParameterValue(const std::string& key,
                              const std::string& scenarioGroup,
-                             const unsigned scenario,
+                             unsigned scenario,
                              unsigned int hour) const;
 
-    ParameterType getParameterType(const std::string& key) const;
-    ParameterTypeAndValue getParameter(const std::string& key) const;
-    Optimisation::LinearProblemApi::ILinearProblemData& data() const;
+    [[nodiscard]] ParameterType getParameterType(const std::string& key) const;
+    [[nodiscard]] ParameterTypeAndValue getParameter(const std::string& key) const;
+    [[nodiscard]] Optimisation::LinearProblemApi::ILinearProblemData& data() const;
 
     template<class T>
     struct CouldNotEvaluateConstantParameter: T

--- a/src/expressions/include/antares/expressions/visitors/NodeVisitor.h
+++ b/src/expressions/include/antares/expressions/visitors/NodeVisitor.h
@@ -20,9 +20,7 @@
 */
 #pragma once
 #include <functional>
-#include <optional>
 #include <typeindex>
-#include <vector>
 
 #include <antares/expressions/IName.h>
 #include <antares/expressions/nodes/Node.h>
@@ -86,7 +84,7 @@ template<class R, class... Args>
 class NodeVisitor: public IName
 {
 public:
-    virtual ~NodeVisitor() = default;
+    ~NodeVisitor() override = default;
 
     /**
      * Dispatches a node to an appropriate visitor function based on its type.
@@ -134,9 +132,10 @@ public:
         {
             return nodeVisitList.at(typeid(*node))(node, *this, args...);
         }
-        catch (std::exception&)
+        catch (std::exception& e)
         {
-            log_.error("Antares::Expressions::Visitor: could not visit the node!");
+            using namespace std::string_literals;
+            log_.error("Antares::Expressions::Visitor: could not visit the node! "s + e.what());
             throw;
         }
     }

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -25,7 +25,6 @@
 
 #include <antares/expressions/nodes/ExpressionsNodes.h>
 #include <antares/optimisation/linear-problem-api/ILinearProblemData.h>
-#include "antares/expressions/RotateIndex.h"
 #include "antares/expressions/ShiftVector.h"
 
 namespace Antares::Expressions::Visitors
@@ -94,22 +93,19 @@ EvaluationResult EvalVisitor::visit(const Nodes::ParameterNode* node)
                           + " scenario in library but not in system";
         throw std::invalid_argument(msg);
     }
-    else if (systemParameter.type == ParameterType::CONSTANT)
+    if (systemParameter.type == ParameterType::CONSTANT)
     {
         return EvaluationResult{context_.getSystemParameterValueAsDouble(node->value())};
     }
-    else
+    std::vector<double> params;
+    params.reserve(fillContext_.getNumberOfTimestep());
+    for (auto timeStep = fillContext_.getFirstTimeStep();
+         timeStep <= fillContext_.getLastTimeStep();
+         ++timeStep)
     {
-        std::vector<double> params;
-        params.reserve(fillContext_.getNumberOfTimestep());
-        for (auto timeStep = fillContext_.getFirstTimeStep();
-             timeStep <= fillContext_.getLastTimeStep();
-             ++timeStep)
-        {
-            params.emplace_back(context_.getParameterValue(node->value(), "", 0, timeStep));
-        }
-        return EvaluationResult{params};
+        params.emplace_back(context_.getParameterValue(node->value(), "", 0, timeStep));
     }
+    return EvaluationResult{params};
 }
 
 EvaluationResult EvalVisitor::visit(const Nodes::LiteralNode* node)

--- a/src/expressions/visitors/EvaluationContext.cpp
+++ b/src/expressions/visitors/EvaluationContext.cpp
@@ -7,7 +7,7 @@ namespace Antares::Expressions::Visitors
 {
 EvaluationContext::EvaluationContext(std::map<std::string, ParameterTypeAndValue> system_parameters,
                                      std::map<std::string, double> variables,
-                                     Optimisation::LinearProblemApi::ILinearProblemData& data):
+                                     ILinearProblemData& data):
     parameters_types_and_values_(std::move(system_parameters)),
     variables_(std::move(variables)),
     data_(data)

--- a/src/libs/antares/study/CMakeLists.txt
+++ b/src/libs/antares/study/CMakeLists.txt
@@ -29,10 +29,10 @@ set(SRC_STUDY_SCENARIO_BUILDER
         scenario-builder/WindTSNumberData.cpp
         include/antares/study/scenario-builder/LoadTSNumberData.h
         scenario-builder/LoadTSNumberData.cpp
-	include/antares/study/scenario-builder/ShortTermInflowsTSNumberData.h
-	scenario-builder/ShortTermInflowsTSNumberData.cpp
-	include/antares/study/scenario-builder/ShortTermAdditionalConstraintsTSNumberData.h
-	scenario-builder/ShortTermAdditionalConstraintsTSNumberData.cpp
+        include/antares/study/scenario-builder/ShortTermInflowsTSNumberData.h
+        scenario-builder/ShortTermInflowsTSNumberData.cpp
+        include/antares/study/scenario-builder/ShortTermAdditionalConstraintsTSNumberData.h
+        scenario-builder/ShortTermAdditionalConstraintsTSNumberData.cpp
         include/antares/study/scenario-builder/applyToMatrix.hxx
 )
 source_group("study\\scenario builder" FILES ${SRC_MATRIX})
@@ -108,9 +108,9 @@ set(SRC_STUDY_PART_SHORT_TERM_STORAGE
         include/antares/study/parts/short-term-storage/additionalConstraints.h
         parts/short-term-storage/cluster.cpp
         parts/short-term-storage/additionalConstraints.cpp
-	include/antares/study/parts/short-term-storage/makeGroupsOfHoursFromString.h
-	parts/short-term-storage/makeGroupsOfHoursFromString.cpp
-	include/antares/study/parts/short-term-storage/HoursCollectorVisitor.h
+        include/antares/study/parts/short-term-storage/makeGroupsOfHoursFromString.h
+        parts/short-term-storage/makeGroupsOfHoursFromString.cpp
+        include/antares/study/parts/short-term-storage/HoursCollectorVisitor.h
 )
 source_group("study\\part\\short-term-storage" FILES ${SRC_STUDY_PART_SHORT_TERM_SOTRAGE})
 
@@ -226,7 +226,7 @@ set(SRC_STUDY
         fwd.cpp
         include/antares/study/study.h
         study.cpp
-	duplicates.cpp
+        duplicates.cpp
         include/antares/study/duplicates.h
         include/antares/study/correlation-updater.hxx
         study.importprepro.cpp
@@ -317,7 +317,7 @@ target_link_libraries(study
         Antares::exception
         Antares::benchmarking
         antares-solver-variable
-		Antares::additional-constraint-rhs-antlr-interface
+        Antares::additional-constraint-rhs-antlr-interface
 )
 
 target_include_directories(study

--- a/src/libs/antares/study/include/antares/study/scenario-builder/ShortTermInflowsTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/ShortTermInflowsTSNumberData.h
@@ -51,7 +51,7 @@ public:
 
 private:
     std::map<const ShortTermStorage::STStorageCluster*, MatrixType> rules_;
-    const Area* pArea;
+    const Area* pArea{nullptr};
 };
 
 inline CString<512, false> ShortTermInflowsTSNumberData::get_prefix() const

--- a/src/libs/antares/study/include/antares/study/scenario-builder/TSnumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/TSnumberData.h
@@ -63,7 +63,7 @@ public:
     uint height() const override;
 
     double get_value(uint x, uint y) const;
-    void set_value(uint x, uint y, uint value);
+    void set_value(uint x, uint y, uint value) const;
 
 protected:
     virtual CString<512, false> get_prefix() const = 0;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/scBuilderDataInterface.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/scBuilderDataInterface.h
@@ -28,45 +28,40 @@
 
 using namespace Yuni;
 
-namespace Antares
-{
-namespace Data
-{
-namespace ScenarioBuilder
-{
-/*!
+namespace Antares::Data::ScenarioBuilder {
+    /*!
 ** \brief Interface for scenario builder data (time series, hydro levels, ...)
 */
-class dataInterface
-{
-public:
-    //! \name Data manupulation
-    //@{
-    /*!
+    class dataInterface
+    {
+    public:
+        virtual ~dataInterface() = default;
+
+        //! \name Data manupulation
+        //@{
+        /*!
     ** \brief Reset data from the study
     */
-    virtual bool reset(const Study& study) = 0;
+        virtual bool reset(const Study& study) = 0;
 
-    /*!
+        /*!
     ** \brief Export the data into a mere INI file
     */
-    virtual void saveToINIFile(const Study& study, Yuni::IO::File::Stream& file) const = 0;
+        virtual void saveToINIFile(const Study& study, Yuni::IO::File::Stream& file) const = 0;
 
-    virtual uint width() const = 0;
+        [[nodiscard]] virtual uint width() const = 0;
 
-    virtual uint height() const = 0;
+        [[nodiscard]] virtual uint height() const = 0;
 
-    /*!
+        /*!
     ** \brief Apply the changes to the study corresponding data (time series, hydro levels, ...)
     **
     ** This method is only useful when launched from the solver.
     */
-    virtual bool apply(Study& study) = 0;
+        virtual bool apply(Study& study) = 0;
 
-}; // class dataInterface
+    }; // class dataInterface
 
-} // namespace ScenarioBuilder
-} // namespace Data
-} // namespace Antares
+}
 
 #endif // __LIBS_STUDY_SCENARIO_BUILDER_DATA_INTERFACE_H__

--- a/src/libs/antares/study/include/antares/study/scenario-builder/scBuilderDataInterface.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/scBuilderDataInterface.h
@@ -28,40 +28,41 @@
 
 using namespace Yuni;
 
-namespace Antares::Data::ScenarioBuilder {
+namespace Antares::Data::ScenarioBuilder
+{
+/*!
+ ** \brief Interface for scenario builder data (time series, hydro levels, ...)
+ */
+class dataInterface
+{
+public:
+    virtual ~dataInterface() = default;
+
+    //! \name Data manupulation
+    //@{
     /*!
-** \brief Interface for scenario builder data (time series, hydro levels, ...)
-*/
-    class dataInterface
-    {
-    public:
-        virtual ~dataInterface() = default;
+     ** \brief Reset data from the study
+     */
+    virtual bool reset(const Study& study) = 0;
 
-        //! \name Data manupulation
-        //@{
-        /*!
-    ** \brief Reset data from the study
-    */
-        virtual bool reset(const Study& study) = 0;
+    /*!
+     ** \brief Export the data into a mere INI file
+     */
+    virtual void saveToINIFile(const Study& study, Yuni::IO::File::Stream& file) const = 0;
 
-        /*!
-    ** \brief Export the data into a mere INI file
-    */
-        virtual void saveToINIFile(const Study& study, Yuni::IO::File::Stream& file) const = 0;
+    [[nodiscard]] virtual uint width() const = 0;
 
-        [[nodiscard]] virtual uint width() const = 0;
+    [[nodiscard]] virtual uint height() const = 0;
 
-        [[nodiscard]] virtual uint height() const = 0;
+    /*!
+     ** \brief Apply the changes to the study corresponding data (time series, hydro levels, ...)
+     **
+     ** This method is only useful when launched from the solver.
+     */
+    virtual bool apply(Study& study) = 0;
 
-        /*!
-    ** \brief Apply the changes to the study corresponding data (time series, hydro levels, ...)
-    **
-    ** This method is only useful when launched from the solver.
-    */
-        virtual bool apply(Study& study) = 0;
+}; // class dataInterface
 
-    }; // class dataInterface
-
-}
+} // namespace Antares::Data::ScenarioBuilder
 
 #endif // __LIBS_STUDY_SCENARIO_BUILDER_DATA_INTERFACE_H__

--- a/src/libs/antares/study/parts/short-term-storage/makeGroupsOfHoursFromString.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/makeGroupsOfHoursFromString.cpp
@@ -29,7 +29,7 @@
 namespace Antares::Data::ShortTermStorage
 {
 
-void CustomErrorListener::syntaxError(antlr4::Recognizer* recognizer,
+void CustomErrorListener::syntaxError(antlr4::Recognizer*,
                                       antlr4::Token* offendingSymbol,
                                       size_t line,
                                       size_t charPositionInLine,

--- a/src/libs/antares/study/scenario-builder/ShortTermAdditionalConstraintsTSNumberData.cpp
+++ b/src/libs/antares/study/scenario-builder/ShortTermAdditionalConstraintsTSNumberData.cpp
@@ -25,7 +25,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-uint ShortTermAdditionalConstraintsTSNumberData::get_tsGenCount(const Study& study) const
+uint ShortTermAdditionalConstraintsTSNumberData::get_tsGenCount(const Study&) const
 {
     return 0;
 }

--- a/src/libs/antares/study/scenario-builder/ShortTermInflowsTSNumberData.cpp
+++ b/src/libs/antares/study/scenario-builder/ShortTermInflowsTSNumberData.cpp
@@ -25,7 +25,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-uint ShortTermInflowsTSNumberData::get_tsGenCount(const Study& study) const
+uint ShortTermInflowsTSNumberData::get_tsGenCount(const Study&) const
 {
     return 0;
 }

--- a/src/libs/antares/study/scenario-builder/TSnumberData.cpp
+++ b/src/libs/antares/study/scenario-builder/TSnumberData.cpp
@@ -72,8 +72,7 @@ void TSNumberData::setTSnumber(uint areaindex, uint year, uint value)
     }
 }
 
-void TSNumberData::set_value(uint x, uint y, uint value)
-{
+void TSNumberData::set_value(uint x, uint y, uint value) const {
     pTSNumberRules.entry[y][x] = value;
 }
 

--- a/src/libs/antares/study/scenario-builder/TSnumberData.cpp
+++ b/src/libs/antares/study/scenario-builder/TSnumberData.cpp
@@ -72,7 +72,8 @@ void TSNumberData::setTSnumber(uint areaindex, uint year, uint value)
     }
 }
 
-void TSNumberData::set_value(uint x, uint y, uint value) const {
+void TSNumberData::set_value(uint x, uint y, uint value) const
+{
     pTSNumberRules.entry[y][x] = value;
 }
 

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/ILinearProblemData.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/ILinearProblemData.h
@@ -15,17 +15,17 @@ public:
     {
     }
 
-    unsigned getFirstTimeStep() const
+    [[nodiscard]] unsigned getFirstTimeStep() const
     {
         return firstTimeStep;
     }
 
-    unsigned getLastTimeStep() const
+    [[nodiscard]] unsigned getLastTimeStep() const
     {
         return lastTimeStep;
     }
 
-    unsigned int getNumberOfTimestep() const
+    [[nodiscard]] unsigned int getNumberOfTimestep() const
     {
         return lastTimeStep - firstTimeStep + 1;
     }
@@ -50,10 +50,12 @@ private:
 class ILinearProblemData
 {
 public:
+    virtual ~ILinearProblemData() = default;
+
     virtual double getData(const std::string& dataSetId,
                            const std::string& scenarioGroup,
-                           const unsigned scenario,
-                           const unsigned hour)
+                           unsigned scenario,
+                           unsigned hour)
       = 0;
 };
 

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/linearProblem.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/linearProblem.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <map>
 #include <string>
 
 #include "mipConstraint.h"
@@ -53,17 +52,17 @@ public:
       = 0;
 
     // Variables observers
-    virtual IMipVariable* getVariable(std::size_t index) const = 0;
-    virtual IMipVariable* lookupVariable(const std::string& name) const = 0;
-    virtual int variableCount() const = 0;
+    [[nodiscard]] virtual IMipVariable* getVariable(std::size_t index) const = 0;
+    [[nodiscard]] virtual IMipVariable* lookupVariable(const std::string& name) const = 0;
+    [[nodiscard]] virtual int variableCount() const = 0;
 
     /// Add a bounded constraint to the problem
     virtual IMipConstraint* addConstraint(double lb, double ub, const std::string& name) = 0;
 
     // Constraints observers
-    virtual IMipConstraint* getConstraint(std::size_t index) const = 0;
-    virtual IMipConstraint* lookupConstraint(const std::string& name) const = 0;
-    virtual int constraintCount() const = 0;
+    [[nodiscard]] virtual IMipConstraint* getConstraint(std::size_t index) const = 0;
+    [[nodiscard]] virtual IMipConstraint* lookupConstraint(const std::string& name) const = 0;
+    [[nodiscard]] virtual int constraintCount() const = 0;
 
     /// Set the objective coefficient for a given variable
     virtual void setObjectiveCoefficient(IMipVariable* var, double coefficient) = 0;
@@ -74,16 +73,16 @@ public:
     /// Sets the optimization direction to maximize
     virtual void setMaximization() = 0;
 
-    virtual bool isMinimization() const = 0;
-    virtual bool isMaximization() const = 0;
+    [[nodiscard]] virtual bool isMinimization() const = 0;
+    [[nodiscard]] virtual bool isMaximization() const = 0;
 
     /// Solve the problem, returns a IMipSolution
     virtual IMipSolution* solve(bool verboseSolver) = 0;
 
-    virtual void WriteLP(const std::string& filename) = 0;
+    virtual void WriteLP(const std::string& filename) const = 0;
 
     // Definition of infinity
-    virtual double infinity() const = 0;
+    [[nodiscard]] virtual double infinity() const = 0;
 };
 
 } // namespace Antares::Optimisation::LinearProblemApi

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipConstraint.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipConstraint.h
@@ -31,7 +31,7 @@ class IMipConstraint: public IHasBounds, public IHasName
 public:
     virtual void setCoefficient(IMipVariable* var, double coefficient) = 0;
 
-    virtual double getCoefficient(IMipVariable* var) = 0;
+    virtual double getCoefficient(const LinearProblemApi::IMipVariable *var) const = 0;
 };
 
 } // namespace Antares::Optimisation::LinearProblemApi

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipConstraint.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipConstraint.h
@@ -31,7 +31,7 @@ class IMipConstraint: public IHasBounds, public IHasName
 public:
     virtual void setCoefficient(IMipVariable* var, double coefficient) = 0;
 
-    virtual double getCoefficient(const LinearProblemApi::IMipVariable *var) const = 0;
+    virtual double getCoefficient(const LinearProblemApi::IMipVariable* var) const = 0;
 };
 
 } // namespace Antares::Optimisation::LinearProblemApi

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipSolution.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipSolution.h
@@ -49,11 +49,11 @@ class IMipSolution
 public:
     virtual ~IMipSolution() = default;
 
-    virtual MipStatus getStatus() const = 0;
-    virtual double getObjectiveValue() const = 0;
-    virtual double getOptimalValue(const IMipVariable* var) const = 0;
-    virtual std::vector<double> getOptimalValues(const std::vector<IMipVariable*>& vars) const = 0;
-    virtual const std::map<std::string, double>& getOptimalValues() const = 0;
+    [[nodiscard]] virtual MipStatus getStatus() const = 0;
+    [[nodiscard]] virtual double getObjectiveValue() const = 0;
+    [[nodiscard]] virtual double getOptimalValue(const IMipVariable* var) const = 0;
+    [[nodiscard]] virtual std::vector<double> getOptimalValues(const std::vector<IMipVariable*>& vars) const = 0;
+    [[nodiscard]] virtual const std::map<std::string, double>& getOptimalValues() const = 0;
 };
 
 } // namespace Antares::Optimisation::LinearProblemApi

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipSolution.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipSolution.h
@@ -52,7 +52,8 @@ public:
     [[nodiscard]] virtual MipStatus getStatus() const = 0;
     [[nodiscard]] virtual double getObjectiveValue() const = 0;
     [[nodiscard]] virtual double getOptimalValue(const IMipVariable* var) const = 0;
-    [[nodiscard]] virtual std::vector<double> getOptimalValues(const std::vector<IMipVariable*>& vars) const = 0;
+    [[nodiscard]] virtual std::vector<double>
+    getOptimalValues(const std::vector<IMipVariable*>& vars) const = 0;
     [[nodiscard]] virtual const std::map<std::string, double>& getOptimalValues() const = 0;
 };
 

--- a/src/optimisation/linear-problem-data-impl/dataSeriesRepo.cpp
+++ b/src/optimisation/linear-problem-data-impl/dataSeriesRepo.cpp
@@ -12,8 +12,7 @@ void DataSeriesRepository::addDataSeries(std::unique_ptr<IDataSeries> dataSeries
     dataSeries_[name] = std::move(dataSeries);
 }
 
-IDataSeries& DataSeriesRepository::getDataSeries(const std::string& setId)
-{
+IDataSeries& DataSeriesRepository::getDataSeries(const std::string& setId) const {
     if (dataSeries_.empty())
     {
         throw Empty();
@@ -22,6 +21,6 @@ IDataSeries& DataSeriesRepository::getDataSeries(const std::string& setId)
     {
         throw DataSeriesNotExist(setId);
     }
-    return *(dataSeries_[setId]);
+    return *(dataSeries_.at(setId));
 }
 } // namespace Antares::Optimisation::LinearProblemDataImpl

--- a/src/optimisation/linear-problem-data-impl/dataSeriesRepo.cpp
+++ b/src/optimisation/linear-problem-data-impl/dataSeriesRepo.cpp
@@ -12,7 +12,8 @@ void DataSeriesRepository::addDataSeries(std::unique_ptr<IDataSeries> dataSeries
     dataSeries_[name] = std::move(dataSeries);
 }
 
-IDataSeries& DataSeriesRepository::getDataSeries(const std::string& setId) const {
+IDataSeries& DataSeriesRepository::getDataSeries(const std::string& setId) const
+{
     if (dataSeries_.empty())
     {
         throw Empty();

--- a/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/dataSeries.h
+++ b/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/dataSeries.h
@@ -10,12 +10,14 @@ namespace Antares::Optimisation::LinearProblemDataImpl
 class IDataSeries
 {
 public:
-    IDataSeries(std::string name):
+    virtual ~IDataSeries() = default;
+
+    explicit IDataSeries(std::string name):
         name_(std::move(name))
     {
     }
 
-    virtual double getData(unsigned int rank, unsigned int hour) = 0;
+    virtual double getData(unsigned int rank, unsigned int hour) const = 0;
 
     std::string name() const
     {

--- a/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/dataSeriesRepo.h
+++ b/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/dataSeriesRepo.h
@@ -15,7 +15,7 @@ class DataSeriesRepository
 {
 public:
     void addDataSeries(std::unique_ptr<IDataSeries> dataSeries);
-    IDataSeries& getDataSeries(const std::string& setId);
+    [[nodiscard]] IDataSeries& getDataSeries(const std::string& setId) const;
 
 private:
     std::map<std::string, std::unique_ptr<IDataSeries>> dataSeries_;

--- a/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/linearProblemData.h
+++ b/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/linearProblemData.h
@@ -41,10 +41,10 @@ public:
     {
     }
 
-    double getData(const std::string& dataSetId,
-                   const std::string& scenarioGroup,
-                   const unsigned scenario,
-                   const unsigned hour) override;
+    [[nodiscard]] double getData(const std::string& dataSetId,
+                                 const std::string& scenarioGroup,
+                                 unsigned scenario,
+                                 unsigned hour) override;
 
     void addScenarioGroup(const std::string& groupId, std::pair<unsigned, unsigned> scenarioToRank);
     void addDataSeries(std::unique_ptr<IDataSeries> dataSeries);

--- a/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/timeSeriesSet.h
+++ b/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/timeSeriesSet.h
@@ -11,7 +11,7 @@ class TimeSeriesSet: public IDataSeries
 public:
     explicit TimeSeriesSet(std::string name, unsigned height);
     void add(const std::vector<double>& ts);
-    double getData(unsigned rank, unsigned hour) override;
+    double getData(unsigned rank, unsigned hour) const override;
 
 private:
     unsigned height_ = 0;

--- a/src/optimisation/linear-problem-data-impl/linearProblemData.cpp
+++ b/src/optimisation/linear-problem-data-impl/linearProblemData.cpp
@@ -37,8 +37,8 @@ void LinearProblemData::addDataSeries(std::unique_ptr<IDataSeries> dataSeries)
 
 double LinearProblemData::getData(const std::string& dataSetId,
                                   const std::string& scenarioGroup,
-                                  const unsigned scenario,
-                                  const unsigned hour)
+                                  unsigned scenario,
+                                  unsigned hour)
 {
     // TODO: use the following line to add scenario group support
     // unsigned rank = groupRepository_.getDataRank(scenarioGroup, scenario);

--- a/src/optimisation/linear-problem-data-impl/timeSeriesSet.cpp
+++ b/src/optimisation/linear-problem-data-impl/timeSeriesSet.cpp
@@ -20,8 +20,7 @@ void TimeSeriesSet::add(const std::vector<double>& ts)
     tsSet_.push_back(std::move(ts));
 }
 
-double TimeSeriesSet::getData(unsigned rank, unsigned hour)
-{
+double TimeSeriesSet::getData(unsigned rank, unsigned hour) const {
     if (tsSet_.empty())
     {
         throw Empty(name());

--- a/src/optimisation/linear-problem-data-impl/timeSeriesSet.cpp
+++ b/src/optimisation/linear-problem-data-impl/timeSeriesSet.cpp
@@ -20,7 +20,8 @@ void TimeSeriesSet::add(const std::vector<double>& ts)
     tsSet_.push_back(std::move(ts));
 }
 
-double TimeSeriesSet::getData(unsigned rank, unsigned hour) const {
+double TimeSeriesSet::getData(unsigned rank, unsigned hour) const
+{
     if (tsSet_.empty())
     {
         throw Empty(name());

--- a/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/linearProblem.h
+++ b/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/linearProblem.h
@@ -72,7 +72,7 @@ public:
     bool isMaximization() const override;
 
     OrtoolsMipSolution* solve(bool verboseSolver) override;
-    void WriteLP(const std::string& filename) override;
+    void WriteLP(const std::string& filename) const override;
 
     double infinity() const override;
 

--- a/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/mipConstraint.h
+++ b/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/mipConstraint.h
@@ -43,7 +43,7 @@ public:
     [[nodiscard]] double getLb() const override;
     [[nodiscard]] double getUb() const override;
 
-    [[nodiscard]] double getCoefficient(const LinearProblemApi::IMipVariable *var) const override;
+    [[nodiscard]] double getCoefficient(const LinearProblemApi::IMipVariable* var) const override;
 
     [[nodiscard]] const std::string& getName() const override;
 

--- a/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/mipConstraint.h
+++ b/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/mipConstraint.h
@@ -40,12 +40,12 @@ public:
     void setBounds(double lb, double ub) override;
     void setCoefficient(LinearProblemApi::IMipVariable* var, double coefficient) override;
 
-    double getLb() const override;
-    double getUb() const override;
+    [[nodiscard]] double getLb() const override;
+    [[nodiscard]] double getUb() const override;
 
-    double getCoefficient(LinearProblemApi::IMipVariable* var) override;
+    [[nodiscard]] double getCoefficient(const LinearProblemApi::IMipVariable *var) const override;
 
-    const std::string& getName() const override;
+    [[nodiscard]] const std::string& getName() const override;
 
     ~OrtoolsMipConstraint() override = default;
 

--- a/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/mipSolution.h
+++ b/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/mipSolution.h
@@ -40,11 +40,11 @@ public:
     ~OrtoolsMipSolution() override = default;
 
     LinearProblemApi::MipStatus getStatus() const override;
-    double getObjectiveValue() const override;
-    double getOptimalValue(const LinearProblemApi::IMipVariable* var) const override;
-    std::vector<double> getOptimalValues(
+    [[nodiscard]] double getObjectiveValue() const override;
+    [[nodiscard]] double getOptimalValue(const LinearProblemApi::IMipVariable* var) const override;
+    [[nodiscard]] std::vector<double> getOptimalValues(
       const std::vector<LinearProblemApi::IMipVariable*>& vars) const override;
-    const std::map<std::string, double>& getOptimalValues() const override;
+    [[nodiscard]] const std::map<std::string, double>& getOptimalValues() const override;
 
 private:
     operations_research::MPSolver::ResultStatus status_;

--- a/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
@@ -171,7 +171,8 @@ bool OrtoolsLinearProblem::isMaximization() const
     return objective_->maximization();
 }
 
-void OrtoolsLinearProblem::WriteLP(const std::string& filename) const {
+void OrtoolsLinearProblem::WriteLP(const std::string& filename) const
+{
     std::string out;
     mpSolver_->ExportModelAsLpFormat(false, &out);
     std::ofstream of(filename);

--- a/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/linearProblem.cpp
@@ -171,8 +171,7 @@ bool OrtoolsLinearProblem::isMaximization() const
     return objective_->maximization();
 }
 
-void OrtoolsLinearProblem::WriteLP(const std::string& filename)
-{
+void OrtoolsLinearProblem::WriteLP(const std::string& filename) const {
     std::string out;
     mpSolver_->ExportModelAsLpFormat(false, &out);
     std::ofstream of(filename);

--- a/src/optimisation/linear-problem-mpsolver-impl/mipConstraint.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/mipConstraint.cpp
@@ -71,7 +71,8 @@ void OrtoolsMipConstraint::setCoefficient(LinearProblemApi::IMipVariable* var, d
     mpConstraint_->SetCoefficient(mpvar->getMpVar(), coefficient);
 }
 
-double OrtoolsMipConstraint::getCoefficient(const LinearProblemApi::IMipVariable *var) const {
+double OrtoolsMipConstraint::getCoefficient(const LinearProblemApi::IMipVariable* var) const
+{
     const auto* mpvar = dynamic_cast<const OrtoolsMipVariable*>(var);
     if (!mpvar)
     {

--- a/src/optimisation/linear-problem-mpsolver-impl/mipConstraint.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/mipConstraint.cpp
@@ -71,9 +71,8 @@ void OrtoolsMipConstraint::setCoefficient(LinearProblemApi::IMipVariable* var, d
     mpConstraint_->SetCoefficient(mpvar->getMpVar(), coefficient);
 }
 
-double OrtoolsMipConstraint::getCoefficient(LinearProblemApi::IMipVariable* var)
-{
-    auto* mpvar = dynamic_cast<OrtoolsMipVariable*>(var);
+double OrtoolsMipConstraint::getCoefficient(const LinearProblemApi::IMipVariable *var) const {
+    const auto* mpvar = dynamic_cast<const OrtoolsMipVariable*>(var);
     if (!mpvar)
     {
         logs.error()

--- a/src/solver/optim-model-filler/ReadLinearConstraintVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearConstraintVisitor.cpp
@@ -104,82 +104,82 @@ static std::invalid_argument IllegalNodeException()
     return std::invalid_argument("Root node of a constraint must be a comparator.");
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const SumNode* sum_node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const SumNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const SubtractionNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const SubtractionNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const MultiplicationNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const MultiplicationNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const DivisionNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const DivisionNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const NegationNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const NegationNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const VariableNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const VariableNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const ParameterNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const ParameterNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const LiteralNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const LiteralNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const PortFieldNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const PortFieldNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const PortFieldSumNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const PortFieldSumNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const ComponentVariableNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const ComponentVariableNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const ComponentParameterNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const ComponentParameterNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const TimeShiftNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const TimeShiftNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const TimeIndexNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const TimeIndexNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const TimeSumNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const TimeSumNode*)
 {
     throw IllegalNodeException();
 }
 
-std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const AllTimeSumNode* node)
+std::vector<LinearConstraint> ReadLinearConstraintVisitor::visit(const AllTimeSumNode*)
 {
     throw IllegalNodeException();
 }

--- a/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
@@ -38,8 +38,8 @@ ReadLinearExpressionVisitor::ReadLinearExpressionVisitor(
   EvaluationContext evalContext,
   Optimisation::LinearProblemApi::FillContext fillContext,
   const SystemModel::Component& component):
-    evalContext_(std::move(evalContext)),
     fillContext_(std::move(fillContext)),
+    evalContext_(std::move(evalContext)),
     component_(component),
     evalVisitor_(evalContext_, fillContext_)
 {
@@ -56,7 +56,7 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const SumNode* 
     return std::accumulate(std::begin(operands),
                            std::end(operands),
                            TimeDependentLinearExpression(fillContext_),
-                           [this](TimeDependentLinearExpression sum, Node* operand)
+                           [this](const TimeDependentLinearExpression& sum,const Node* operand)
                            { return sum + dispatch(operand); });
 }
 
@@ -75,17 +75,17 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const DivisionN
     return dispatch(node->left()) / dispatch(node->right());
 }
 
-TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const EqualNode* node)
+TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const EqualNode*)
 {
     throw std::invalid_argument("A linear expression can't contain comparison operators.");
 }
 
-TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const LessThanOrEqualNode* node)
+TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const LessThanOrEqualNode*)
 {
     throw std::invalid_argument("A linear expression can't contain comparison operators.");
 }
 
-TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const GreaterThanOrEqualNode* node)
+TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const GreaterThanOrEqualNode*)
 {
     throw std::invalid_argument("A linear expression can't contain comparison operators.");
 }
@@ -103,20 +103,18 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const VariableN
           fillContext_,
           LinearExpression(0, {{FullKey(component_.Id(), node->value()), 1}}));
     }
-    else // only dependent
-    {
-        LinearExpressionMap linearExpressions;
+    // only dependent
+    LinearExpressionMap linearExpressions;
 
-        for (unsigned int timeStep = fillContext_.getFirstTimeStep();
-             timeStep <= fillContext_.getLastTimeStep();
-             ++timeStep)
-        {
-            linearExpressions[timeStep] = LinearExpression(
-              0,
-              {{FullKey(component_.Id(), node->value(), 0 /*TODO */, timeStep), 1}});
-        }
-        return TimeDependentLinearExpression(linearExpressions);
+    for (unsigned int timeStep = fillContext_.getFirstTimeStep();
+         timeStep <= fillContext_.getLastTimeStep();
+         ++timeStep)
+    {
+        linearExpressions[timeStep] = LinearExpression(
+            0,
+            {{FullKey(component_.Id(), node->value(), 0 /*TODO */, timeStep), 1}});
     }
+    return TimeDependentLinearExpression(linearExpressions);
 }
 
 TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const ParameterNode* node)
@@ -129,26 +127,24 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Parameter
           "Parameter " + node->value()
           + " is declared constant in time and scenario in library but not in system");
     }
-    else if (systemParameter.type == ParameterType::CONSTANT)
+    if (systemParameter.type == ParameterType::CONSTANT)
     {
         return TimeDependentLinearExpression(
-          fillContext_,
-          LinearExpression(evalContext_.getSystemParameterValueAsDouble(node->value()), {}));
+            fillContext_,
+            LinearExpression(evalContext_.getSystemParameterValueAsDouble(node->value()), {}));
     }
-    else // only dependent
-    {
-        LinearExpressionMap linearExpressions;
+    // only dependent
+    LinearExpressionMap linearExpressions;
 
-        for (auto timeStep = fillContext_.getFirstTimeStep();
-             timeStep <= fillContext_.getLastTimeStep();
-             ++timeStep)
-        {
-            linearExpressions[timeStep] = LinearExpression(
-              evalContext_.getParameterValue(node->value(), "", 0, timeStep),
-              {});
-        }
-        return TimeDependentLinearExpression(linearExpressions);
+    for (auto timeStep = fillContext_.getFirstTimeStep();
+         timeStep <= fillContext_.getLastTimeStep();
+         ++timeStep)
+    {
+        linearExpressions[timeStep] = LinearExpression(
+            evalContext_.getParameterValue(node->value(), "", 0, timeStep),
+            {});
     }
+    return TimeDependentLinearExpression(linearExpressions);
 }
 
 TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const LiteralNode* node)
@@ -156,7 +152,7 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const LiteralNo
     return TimeDependentLinearExpression(fillContext_, LinearExpression(node->value(), {}));
 }
 
-TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const PortFieldNode* node)
+TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const PortFieldNode*)
 {
     throw std::invalid_argument("ReadLinearExpressionVisitor cannot visit PortFieldNodes");
 }
@@ -186,12 +182,12 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const PortField
     return to_return;
 }
 
-TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const ComponentVariableNode* node)
+TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const ComponentVariableNode*)
 {
     throw std::invalid_argument("ReadLinearExpressionVisitor cannot visit ComponentVariableNodes");
 }
 
-TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const ComponentParameterNode* node)
+TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const ComponentParameterNode*)
 {
     throw std::invalid_argument("ReadLinearExpressionVisitor cannot visit ComponentParameterNodes");
 }

--- a/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
@@ -56,7 +56,7 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const SumNode* 
     return std::accumulate(std::begin(operands),
                            std::end(operands),
                            TimeDependentLinearExpression(fillContext_),
-                           [this](const TimeDependentLinearExpression& sum,const Node* operand)
+                           [this](const TimeDependentLinearExpression& sum, const Node* operand)
                            { return sum + dispatch(operand); });
 }
 
@@ -111,8 +111,8 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const VariableN
          ++timeStep)
     {
         linearExpressions[timeStep] = LinearExpression(
-            0,
-            {{FullKey(component_.Id(), node->value(), 0 /*TODO */, timeStep), 1}});
+          0,
+          {{FullKey(component_.Id(), node->value(), 0 /*TODO */, timeStep), 1}});
     }
     return TimeDependentLinearExpression(linearExpressions);
 }
@@ -130,8 +130,8 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Parameter
     if (systemParameter.type == ParameterType::CONSTANT)
     {
         return TimeDependentLinearExpression(
-            fillContext_,
-            LinearExpression(evalContext_.getSystemParameterValueAsDouble(node->value()), {}));
+          fillContext_,
+          LinearExpression(evalContext_.getSystemParameterValueAsDouble(node->value()), {}));
     }
     // only dependent
     LinearExpressionMap linearExpressions;
@@ -141,8 +141,8 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Parameter
          ++timeStep)
     {
         linearExpressions[timeStep] = LinearExpression(
-            evalContext_.getParameterValue(node->value(), "", 0, timeStep),
-            {});
+          evalContext_.getParameterValue(node->value(), "", 0, timeStep),
+          {});
     }
     return TimeDependentLinearExpression(linearExpressions);
 }

--- a/src/solver/optim-model-filler/TimeDependentLinearExpression.cpp
+++ b/src/solver/optim-model-filler/TimeDependentLinearExpression.cpp
@@ -48,8 +48,8 @@ TimeDependentLinearExpression::TimeDependentLinearExpression(
 }
 
 TimeDependentLinearExpression::TimeDependentLinearExpression(
-  const LinearExpressionMap& linearExpressions):
-    linearExpressions_(linearExpressions)
+  LinearExpressionMap linearExpressions):
+    linearExpressions_(std::move(linearExpressions))
 
 {
 }

--- a/src/solver/optim-model-filler/TimeDependentLinearExpression.cpp
+++ b/src/solver/optim-model-filler/TimeDependentLinearExpression.cpp
@@ -47,8 +47,7 @@ TimeDependentLinearExpression::TimeDependentLinearExpression(
 {
 }
 
-TimeDependentLinearExpression::TimeDependentLinearExpression(
-  LinearExpressionMap linearExpressions):
+TimeDependentLinearExpression::TimeDependentLinearExpression(LinearExpressionMap linearExpressions):
     linearExpressions_(std::move(linearExpressions))
 
 {

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
@@ -43,7 +43,7 @@ public:
     explicit TimeDependentLinearExpression(
       const Optimisation::LinearProblemApi::FillContext& fillContext,
       const LinearExpression& linearExpression);
-    explicit TimeDependentLinearExpression(const LinearExpressionMap& linearExpressions);
+    explicit TimeDependentLinearExpression(LinearExpressionMap linearExpressions);
 
     /// Sum two linear expressions
     TimeDependentLinearExpression operator+(const TimeDependentLinearExpression& other) const;

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/VariableDictionary.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/VariableDictionary.h
@@ -103,8 +103,8 @@ class VariableDictionary
         VectorWithOffset() = default;
         void resize(size_t initial_size, unsigned offset);
         Value& operator[](unsigned int index);
-        const Value& operator[](unsigned int index) const;
-        const Value& at(unsigned int index) const;
+        [[nodiscard]] const Value& operator[](unsigned int index) const;
+        [[nodiscard]] const Value& at(unsigned int index) const;
         Value& at(unsigned int index);
 
     private:

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -48,9 +48,9 @@ ComponentToAreaConnectionFiller::ComponentToAreaConnectionFiller(
     }
 }
 
-void ComponentToAreaConnectionFiller::addVariables(ILinearProblem& pb,
-                                                   ILinearProblemData& data,
-                                                   FillContext& ctx)
+void ComponentToAreaConnectionFiller::addVariables(ILinearProblem&,
+                                                   ILinearProblemData&,
+                                                   FillContext&)
 {
     // nothing to do
 }
@@ -139,9 +139,9 @@ void ComponentToAreaConnectionFiller::addConstraints(ILinearProblem& pb,
     }
 }
 
-void ComponentToAreaConnectionFiller::addObjective(ILinearProblem& pb,
-                                                   ILinearProblemData& data,
-                                                   FillContext& ctx)
+void ComponentToAreaConnectionFiller::addObjective(ILinearProblem&,
+                                                   ILinearProblemData&,
+                                                   FillContext&)
 {
     // nothing to do
 }

--- a/src/solver/optimisation/LegacyFiller.cpp
+++ b/src/solver/optimisation/LegacyFiller.cpp
@@ -34,20 +34,20 @@ LegacyFiller::LegacyFiller(const PROBLEME_HEBDO* problemeHebdo):
 {
 }
 
-void LegacyFiller::addVariables(ILinearProblem& pb, ILinearProblemData& data, FillContext& ctx)
+void LegacyFiller::addVariables(ILinearProblem& pb, ILinearProblemData&, FillContext&)
 {
     // Create the variables and set objective cost.
     CopyVariables(pb);
 }
 
-void LegacyFiller::addConstraints(ILinearProblem& pb, ILinearProblemData& data, FillContext& ctx)
+void LegacyFiller::addConstraints(ILinearProblem& pb, ILinearProblemData&, FillContext&)
 {
     // Create constraints and set coefs
     CopyRows(pb);
     CopyMatrix(pb);
 }
 
-void LegacyFiller::addObjective(ILinearProblem& pb, ILinearProblemData& data, FillContext& ctx)
+void LegacyFiller::addObjective(ILinearProblem&, ILinearProblemData&, FillContext&)
 {
     // nothing to do: objective coefficients are set along with variables definition
 }

--- a/src/tests/src/expressions/test_PrintAndEvalNodes.cpp
+++ b/src/tests/src/expressions/test_PrintAndEvalNodes.cpp
@@ -609,8 +609,8 @@ struct MockLinearProblemData: Antares::Optimisation::LinearProblemApi::ILinearPr
 {
     double getData(const std::string& dataSetId,
                    const std::string& scenarioGroup,
-                   const unsigned scenario,
-                   const unsigned hour) override
+                   unsigned scenario,
+                   unsigned hour) override
     {
         return hour; // for test
     }

--- a/src/tests/src/solver/optim-model-filler/test_componentFiller.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_componentFiller.cpp
@@ -1042,7 +1042,7 @@ public:
         return nullptr;
     }
 
-    void WriteLP(const std::string& filename) override
+    void WriteLP(const std::string& filename) const override
     {
     }
 

--- a/src/tests/src/solver/optim-model-filler/test_readLinearExpressionVisitor.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_readLinearExpressionVisitor.cpp
@@ -105,8 +105,8 @@ struct MockLinearProblemData: Antares::Optimisation::LinearProblemApi::ILinearPr
 {
     double getData(const std::string& dataSetId,
                    const std::string& scenarioGroup,
-                   const unsigned scenario,
-                   const unsigned hour) override
+                   unsigned scenario,
+                   unsigned hour) override
     {
         return hour; // for test
     }

--- a/src/tests/src/solver/optimisation/test_componentToAreaConnectionFiller.cpp
+++ b/src/tests/src/solver/optimisation/test_componentToAreaConnectionFiller.cpp
@@ -238,26 +238,26 @@ BOOST_AUTO_TEST_CASE(add_one_term_to_balance_constraint_named)
 
     auto balance_ct = linearProblem.lookupConstraint("AreaBalance::area<area1>::hour<0>");
     BOOST_CHECK_EQUAL(balance_ct->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.not_connected_var_t0")),
+                        "connected_component_var.not_connected_var_t0")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct->getCoefficient(
-                            linearProblem.lookupVariable("connected_component_var.connected_var_1_t0")),
+                        linearProblem.lookupVariable("connected_component_var.connected_var_1_t0")),
                       -5);
     BOOST_CHECK_EQUAL(balance_ct->getCoefficient(
-                            linearProblem.lookupVariable("connected_component_var.connected_var_2_t0")),
+                        linearProblem.lookupVariable("connected_component_var.connected_var_2_t0")),
                       37);
     BOOST_CHECK_EQUAL(balance_ct->getLb(), 10 + 2 * 4 - 6);
     BOOST_CHECK_EQUAL(balance_ct->getUb(), 10 + 2 * 4 - 6);
 
     auto other_ct = linearProblem.lookupConstraint("whatever");
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.not_connected_var_t0")),
+                        "connected_component_var.not_connected_var_t0")),
                       0);
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(
-                            linearProblem.lookupVariable("connected_component_var.connected_var_1_t0")),
+                        linearProblem.lookupVariable("connected_component_var.connected_var_1_t0")),
                       0);
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(
-                            linearProblem.lookupVariable("connected_component_var.connected_var_2_t0")),
+                        linearProblem.lookupVariable("connected_component_var.connected_var_2_t0")),
                       0);
     BOOST_CHECK_EQUAL(other_ct->getLb(), 10);
     BOOST_CHECK_EQUAL(other_ct->getUb(), 10);
@@ -281,44 +281,44 @@ BOOST_AUTO_TEST_CASE(add_two_terms_to_balance_constraint_not_named)
     auto balance_ct_t11 = linearProblem.lookupConstraint("c2");
 
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.not_connected_var_t10")),
+                        "connected_component_var.not_connected_var_t10")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.connected_var_1_t10")),
+                        "connected_component_var.connected_var_1_t10")),
                       -5);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.connected_var_2_t10")),
+                        "connected_component_var.connected_var_2_t10")),
                       37);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.not_connected_var_t11")),
+                        "connected_component_var.not_connected_var_t11")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.connected_var_1_t11")),
+                        "connected_component_var.connected_var_1_t11")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.connected_var_2_t11")),
+                        "connected_component_var.connected_var_2_t11")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getLb(), -100 + 2 * -51 - 6);
     BOOST_CHECK_EQUAL(balance_ct_t10->getUb(), -100 + 2 * -51 - 6);
     ;
 
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.not_connected_var_t10")),
+                        "connected_component_var.not_connected_var_t10")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.connected_var_1_t10")),
+                        "connected_component_var.connected_var_1_t10")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.connected_var_2_t10")),
+                        "connected_component_var.connected_var_2_t10")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.not_connected_var_t11")),
+                        "connected_component_var.not_connected_var_t11")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.connected_var_1_t11")),
+                        "connected_component_var.connected_var_1_t11")),
                       -5);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                          "connected_component_var.connected_var_2_t11")),
+                        "connected_component_var.connected_var_2_t11")),
                       37);
     BOOST_CHECK_EQUAL(balance_ct_t11->getLb(), -100 + 2 * 8.3 - 6);
     BOOST_CHECK_EQUAL(balance_ct_t11->getUb(), -100 + 2 * 8.3 - 6);

--- a/src/tests/src/solver/optimisation/test_componentToAreaConnectionFiller.cpp
+++ b/src/tests/src/solver/optimisation/test_componentToAreaConnectionFiller.cpp
@@ -238,26 +238,26 @@ BOOST_AUTO_TEST_CASE(add_one_term_to_balance_constraint_named)
 
     auto balance_ct = linearProblem.lookupConstraint("AreaBalance::area<area1>::hour<0>");
     BOOST_CHECK_EQUAL(balance_ct->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.not_connected_var_t0")),
+                          "connected_component_var.not_connected_var_t0")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct->getCoefficient(
-                        linearProblem.lookupVariable("connected_component_var.connected_var_1_t0")),
+                            linearProblem.lookupVariable("connected_component_var.connected_var_1_t0")),
                       -5);
     BOOST_CHECK_EQUAL(balance_ct->getCoefficient(
-                        linearProblem.lookupVariable("connected_component_var.connected_var_2_t0")),
+                            linearProblem.lookupVariable("connected_component_var.connected_var_2_t0")),
                       37);
     BOOST_CHECK_EQUAL(balance_ct->getLb(), 10 + 2 * 4 - 6);
     BOOST_CHECK_EQUAL(balance_ct->getUb(), 10 + 2 * 4 - 6);
 
     auto other_ct = linearProblem.lookupConstraint("whatever");
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.not_connected_var_t0")),
+                          "connected_component_var.not_connected_var_t0")),
                       0);
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(
-                        linearProblem.lookupVariable("connected_component_var.connected_var_1_t0")),
+                            linearProblem.lookupVariable("connected_component_var.connected_var_1_t0")),
                       0);
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(
-                        linearProblem.lookupVariable("connected_component_var.connected_var_2_t0")),
+                            linearProblem.lookupVariable("connected_component_var.connected_var_2_t0")),
                       0);
     BOOST_CHECK_EQUAL(other_ct->getLb(), 10);
     BOOST_CHECK_EQUAL(other_ct->getUb(), 10);
@@ -281,44 +281,44 @@ BOOST_AUTO_TEST_CASE(add_two_terms_to_balance_constraint_not_named)
     auto balance_ct_t11 = linearProblem.lookupConstraint("c2");
 
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.not_connected_var_t10")),
+                          "connected_component_var.not_connected_var_t10")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.connected_var_1_t10")),
+                          "connected_component_var.connected_var_1_t10")),
                       -5);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.connected_var_2_t10")),
+                          "connected_component_var.connected_var_2_t10")),
                       37);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.not_connected_var_t11")),
+                          "connected_component_var.not_connected_var_t11")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.connected_var_1_t11")),
+                          "connected_component_var.connected_var_1_t11")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.connected_var_2_t11")),
+                          "connected_component_var.connected_var_2_t11")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getLb(), -100 + 2 * -51 - 6);
     BOOST_CHECK_EQUAL(balance_ct_t10->getUb(), -100 + 2 * -51 - 6);
     ;
 
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.not_connected_var_t10")),
+                          "connected_component_var.not_connected_var_t10")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.connected_var_1_t10")),
+                          "connected_component_var.connected_var_1_t10")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.connected_var_2_t10")),
+                          "connected_component_var.connected_var_2_t10")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.not_connected_var_t11")),
+                          "connected_component_var.not_connected_var_t11")),
                       0);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.connected_var_1_t11")),
+                          "connected_component_var.connected_var_1_t11")),
                       -5);
     BOOST_CHECK_EQUAL(balance_ct_t11->getCoefficient(linearProblem.lookupVariable(
-                        "connected_component_var.connected_var_2_t11")),
+                          "connected_component_var.connected_var_2_t11")),
                       37);
     BOOST_CHECK_EQUAL(balance_ct_t11->getLb(), -100 + 2 * 8.3 - 6);
     BOOST_CHECK_EQUAL(balance_ct_t11->getUb(), -100 + 2 * 8.3 - 6);


### PR DESCRIPTION
Various warning or linter fixes:

- Remove parameter names when unused
- Add some [[nodiscard]] specifiers
- Add some constness