### PR TITLE
Cache chocolatey and installed utilities (Windows)

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -57,7 +57,14 @@ jobs:
           echo "ORTOOLS_URL=https://github.com/rte-france/or-tools-rte/releases/download/$(cat ortools_tag)/ortools_cxx_windows-latest_static_sirius_Release.zip" >> $GITHUB_ENV
         shell: bash
 
+      - name: actions/cache@v4
+        id: chococache
+        with:
+          path: C:\ProgramData\chocolatey
+          key: chocolatey-cache
+
       - name: Pre-requisites
+        if: steps.chococache.outputs.cache-hit != 'true'
         shell: cmd
         run: |
           choco install wget unzip zip --no-progress

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -57,7 +57,8 @@ jobs:
           echo "ORTOOLS_URL=https://github.com/rte-france/or-tools-rte/releases/download/$(cat ortools_tag)/ortools_cxx_windows-latest_static_sirius_Release.zip" >> $GITHUB_ENV
         shell: bash
 
-      - name: actions/cache@v4
+      - name: "Cache chocolatey and installed utilities"
+        uses: actions/cache@v4
         id: chococache
         with:
           path: C:\ProgramData\chocolatey


### PR DESCRIPTION
Try to restore directory C:\ProgramData\chocolatey. Install choco & utilities only if the cache restore fails.