### PR TITLE
Revert "Add Gurobi to list of queried solvers [ANT-3381] (#2865)"

### DIFF
--- a/src/solver/utils/ortools_utils.cpp
+++ b/src/solver/utils/ortools_utils.cpp
@@ -341,14 +341,12 @@ const std::map<std::string, struct OrtoolsUtils::SolverNames> OrtoolsUtils::mpSo
   {"glpk", {"glpk_lp", "glpk"}},
   {"scip", {std::nullopt, "scip"}}, // SCIP only supports MIPs
   {"highs", {"highs_lp", "highs"}},
-  {"pdlp", {"pdlp", std::nullopt}}, // PDLP only supports LPs
-  {"gurobi", {"gurobi_lp", "gurobi"}}};
+  {"pdlp", {"pdlp", std::nullopt}}}; // PDLP only supports LPs
 
 const std::map<std::string, math_opt::SolverType> OrtoolsUtils::mathoptSolverMap = {
   {"pdlp", math_opt::SolverType::kPdlp},
   {"scip", math_opt::SolverType::kGscip},
-  {"xpress", math_opt::SolverType::kXpress},
-  {"gurobi", math_opt::SolverType::kGurobi}};
+  {"xpress", math_opt::SolverType::kXpress}};
 
 std::list<std::string> availableLinearSolversList()
 {

--- a/src/tests/src/solver/utils/test_ortools_utils.cpp
+++ b/src/tests/src/solver/utils/test_ortools_utils.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(test_scip_support)
 
 BOOST_AUTO_TEST_CASE(test_quad_solvers_list)
 {
-    std::list<std::string> expected = {"sirius", "gurobi", "pdlp", "scip", "xpress"};
+    std::list<std::string> expected = {"sirius", "pdlp", "scip", "xpress"};
     BOOST_CHECK(availableQuadraticSolversList() == expected);
 }
 


### PR DESCRIPTION
Probably because of an [`Absl::Mutex` in OR-Tools](https://github.com/google/or-tools/blob/0d60e8afe450ec817f510aae965ab8898310cb41/ortools/gurobi/environment.cc#L421-L427), we get a systematic crash on Windows at startup

> ModLoad: 00007ffe`30310000 00007ffe`30340000   C:\WINDOWS\System32\IMM32.DLL
(55a8.d18): Access violation - code c0000005 (first chance)
First chance exceptions are reported before any exception handling.
This exception may be expected and handled.
MSVCP140!mtx_do_lock+0x74:
00007ffe`17a83020 488b00          mov     rax,qword ptr [rax] ds:00000000`00000000=????????????????

Since we don't really have the time to investigate, and don't really need Gurobi support, we won't support Gurobi for now.