### PR TITLE
Add study builder

### DIFF
--- a/src/libs/antares/study/CMakeLists.txt
+++ b/src/libs/antares/study/CMakeLists.txt
@@ -220,6 +220,7 @@ set(SRC_STUDY
         runtime/runtime.cpp
         include/antares/study/runtime.h
         include/antares/study/study.h
+	include/antares/study/builder.h
         include/antares/study/fwd.h
         fwd.cpp
         include/antares/study/study.h

--- a/src/libs/antares/study/include/antares/study/builder.h
+++ b/src/libs/antares/study/include/antares/study/builder.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <antares/study/study.h>
+
+class StudyFiller
+{
+public:
+    class Area
+    {
+    public:
+        Area& setName(const std::string& name)
+        {
+            this->name = name;
+            return *this;
+        }
+
+        Area& setNodalOptimization(unsigned int nodalOptimization)
+        {
+            this->nodalOptimization = nodalOptimization;
+            return *this;
+        }
+
+        Area& setUnsuppliedEnergyCost(double cost)
+        {
+            this->unsuppliedEnergyCost = cost;
+            return *this;
+        }
+
+        Area& setSpilledEnergyCost(double cost)
+        {
+            this->spilledEnergyCost = cost;
+            return *this;
+        }
+
+        // Area& setAdequacyPatchMode(AdequacyPatch::AdequacyPatchMode mode);
+        friend class StudyFiller;
+
+    private:
+        std::string name;
+        unsigned int nodalOptimization = 0;
+        double unsuppliedEnergyCost = 0.;
+        double spilledEnergyCost = 0.;
+        // AdequacyPatch::AdequacyPatchMode adequacyPatchMode;
+    };
+
+    StudyFiller(Antares::Data::Study& study):
+        study(study)
+    {
+    }
+
+    StudyFiller& addArea(const Area& area)
+    {
+        areas.emplace_back(std::move(area));
+        return *this;
+    }
+
+    void build()
+    {
+        for (const auto& area: areas)
+        {
+            auto toAdd = new Antares::Data::Area(area.name);
+            toAdd->nodalOptimization = area.nodalOptimization;
+            toAdd->thermal.unsuppliedEnergyCost = area.unsuppliedEnergyCost;
+            toAdd->thermal.spilledEnergyCost = area.spilledEnergyCost;
+            study.areas.add(toAdd);
+        }
+    }
+
+private:
+    Antares::Data::Study& study;
+    std::vector<StudyFiller::Area> areas;
+};

--- a/src/libs/antares/study/include/antares/study/builder.h
+++ b/src/libs/antares/study/include/antares/study/builder.h
@@ -5,38 +5,55 @@
 
 #include <antares/study/study.h>
 
-class StudyFiller
+class StudyBuilder
 {
 public:
-    class Area
+    class AreaBuilder
     {
     public:
-        Area& setName(const std::string& name)
+        AreaBuilder(StudyBuilder& builder, Antares::Data::AreaList& areas):
+            builder(builder),
+            areas(areas)
+        {
+        }
+
+        AreaBuilder& setName(const std::string& name)
         {
             this->name = name;
             return *this;
         }
 
-        Area& setNodalOptimization(unsigned int nodalOptimization)
+        AreaBuilder& setNodalOptimization(unsigned int nodalOptimization)
         {
             this->nodalOptimization = nodalOptimization;
             return *this;
         }
 
-        Area& setUnsuppliedEnergyCost(double cost)
+        AreaBuilder& setUnsuppliedEnergyCost(double cost)
         {
             this->unsuppliedEnergyCost = cost;
             return *this;
         }
 
-        Area& setSpilledEnergyCost(double cost)
+        AreaBuilder& setSpilledEnergyCost(double cost)
         {
             this->spilledEnergyCost = cost;
             return *this;
         }
 
+        StudyBuilder& add()
+        {
+            auto toAdd = new Antares::Data::Area(name);
+            toAdd->nodalOptimization = nodalOptimization;
+            toAdd->thermal.unsuppliedEnergyCost = unsuppliedEnergyCost;
+            toAdd->thermal.spilledEnergyCost = spilledEnergyCost;
+
+            areas.add(toAdd);
+            return builder;
+        }
+
         // Area& setAdequacyPatchMode(AdequacyPatch::AdequacyPatchMode mode);
-        friend class StudyFiller;
+        friend class StudyBuilder;
 
     private:
         std::string name;
@@ -44,32 +61,26 @@ public:
         double unsuppliedEnergyCost = 0.;
         double spilledEnergyCost = 0.;
         // AdequacyPatch::AdequacyPatchMode adequacyPatchMode;
+        StudyBuilder& builder;
+        Antares::Data::AreaList& areas;
     };
 
-    StudyFiller(Antares::Data::Study& study):
-        study(study)
+    StudyBuilder(Antares::Data::Study& study):
+        study(study),
+        areaBuilder(*this, study.areas)
     {
     }
 
-    StudyFiller& addArea(const Area& area)
+    AreaBuilder& addArea()
     {
-        areas.emplace_back(std::move(area));
-        return *this;
+        return areaBuilder;
     }
 
     void build()
     {
-        for (const auto& area: areas)
-        {
-            auto toAdd = new Antares::Data::Area(area.name);
-            toAdd->nodalOptimization = area.nodalOptimization;
-            toAdd->thermal.unsuppliedEnergyCost = area.unsuppliedEnergyCost;
-            toAdd->thermal.spilledEnergyCost = area.spilledEnergyCost;
-            study.areas.add(toAdd);
-        }
     }
 
 private:
     Antares::Data::Study& study;
-    std::vector<StudyFiller::Area> areas;
+    AreaBuilder areaBuilder;
 };

--- a/src/tests/src/libs/antares/study/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/CMakeLists.txt
@@ -16,6 +16,10 @@ add_boost_test(test-study
   SRC test_study.cpp
   LIBS Antares::study)
 
+add_boost_test(test-study-builder
+  SRC test_study_builder.cpp
+  LIBS Antares::study)
+
 add_boost_test(test-duplicates
   SRC test_duplicates.cpp
   LIBS

--- a/src/tests/src/libs/antares/study/test_study_builder.cpp
+++ b/src/tests/src/libs/antares/study/test_study_builder.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2007-2024, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
+
+#define BOOST_TEST_MODULE study
+#define WIN32_LEAN_AND_MEAN
+#include <boost/test/unit_test.hpp>
+
+#include "antares/study/builder.h"
+
+BOOST_AUTO_TEST_CASE(two_areas)
+{
+    auto study = std::make_unique<Antares::Data::Study>(true);
+    StudyFiller filler(*study);
+    filler
+      .addArea(StudyFiller::Area()
+                 .setName("hello")
+                 .setUnsuppliedEnergyCost(221)
+                 .setSpilledEnergyCost(20)
+                 .setNodalOptimization(2))
+      .addArea(StudyFiller::Area()
+                 .setName("world")
+                 .setUnsuppliedEnergyCost(221)
+                 .setSpilledEnergyCost(20)
+                 .setNodalOptimization(2))
+      .build();
+    BOOST_CHECK_EQUAL(study->areas.size(), 2);
+}

--- a/src/tests/src/libs/antares/study/test_study_builder.cpp
+++ b/src/tests/src/libs/antares/study/test_study_builder.cpp
@@ -28,18 +28,19 @@
 BOOST_AUTO_TEST_CASE(two_areas)
 {
     auto study = std::make_unique<Antares::Data::Study>(true);
-    StudyFiller filler(*study);
-    filler
-      .addArea(StudyFiller::Area()
-                 .setName("hello")
-                 .setUnsuppliedEnergyCost(221)
-                 .setSpilledEnergyCost(20)
-                 .setNodalOptimization(2))
-      .addArea(StudyFiller::Area()
-                 .setName("world")
-                 .setUnsuppliedEnergyCost(221)
-                 .setSpilledEnergyCost(20)
-                 .setNodalOptimization(2))
+    StudyBuilder builder(*study);
+    builder.addArea()
+      .setName("hello")
+      .setUnsuppliedEnergyCost(221)
+      .setSpilledEnergyCost(20)
+      .setNodalOptimization(2)
+      .add()
+      .addArea()
+      .setName("world")
+      .setUnsuppliedEnergyCost(221)
+      .setSpilledEnergyCost(20)
+      .setNodalOptimization(2)
+      .add()
       .build();
     BOOST_CHECK_EQUAL(study->areas.size(), 2);
 }


### PR DESCRIPTION
## Goals
- Make it easy to create studies in-memory
- Make it easy to test optimization problems (not results)
- (optional) Use the `StudyBuilder` as a single way to create a study, for example while loading a study from files

## Difficulties
- It is simple to add a single object knowing all it's attributes, but in practice attributes may become known progressively. We need to edit an existing object, or object builder (e.g `AreaBuilder`)
- Binding existing objects inside the study (e.g 2 areas for links, thermal clusters for binding constraints)
- Some setters for `Antares::Data::Study` are used for the GUI, others for the file loader. Using a single entry point would require a bit of work (to postone after the removal of the GUI ?)