### PR TITLE
Improve helper class `ThermalClusterConfig`

### DIFF
--- a/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
+++ b/src/tests/end-to-end/binding_constraints/test_binding_constraints.cpp
@@ -57,7 +57,7 @@ StudyForBCTest::StudyForBCTest()
 
     cluster = addClusterToArea(area1, "some cluster");
 
-    ThermalClusterConfig(cluster.get())
+    ThermalClusterConfig(cluster)
       .setNominalCapacity(100.)
       .setAvailablePower(0, 100.)
       .setCosts(50.)

--- a/src/tests/end-to-end/binding_constraints/test_binding_constraints_with_mustrun.cpp
+++ b/src/tests/end-to-end/binding_constraints/test_binding_constraints_with_mustrun.cpp
@@ -48,7 +48,7 @@ StudyWithTwoClusters::StudyWithTwoClusters()
 
     // Adding a dispatchable cluster to the previous area
     cluster_dispatch = addClusterToArea(area, "dispatch-cluster");
-    ThermalClusterConfig(cluster_dispatch.get())
+    ThermalClusterConfig(cluster_dispatch)
       .setNominalCapacity(1000.)
       .setAvailablePower(0, 1000.)
       .setCosts(50.)
@@ -57,7 +57,7 @@ StudyWithTwoClusters::StudyWithTwoClusters()
     // Adding a mustrun cluster to the previous area
     cluster_mustrun = addClusterToArea(area, "mustrun-cluster");
     cluster_mustrun->mustrun = true;
-    ThermalClusterConfig(cluster_mustrun.get())
+    ThermalClusterConfig(cluster_mustrun)
       .setNominalCapacity(100.)
       .setAvailablePower(0, 100.)
       .setCosts(10.)

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -57,7 +57,7 @@ StudyFixture::StudyFixture()
     loadTSconfig.setDimensions(1).fillColumnWith(0, loadInArea);
 
     clusterCost = 2.;
-    clusterConfig = ThermalClusterConfig(cluster.get());
+    clusterConfig = ThermalClusterConfig(cluster);
     clusterConfig.setNominalCapacity(100.)
       .setAvailablePower(0, 50.)
       .setCosts(clusterCost)

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -37,8 +37,8 @@ struct StudyFixture: public StudyBuilder
     StudyFixture();
 
     // Data members
-    std::shared_ptr<ThermalCluster> cluster;
     Area* area = nullptr;
+    std::shared_ptr<ThermalCluster> cluster;
     double loadInArea = 0.;
     double clusterCost = 0.;
     ThermalClusterConfig clusterConfig;
@@ -46,11 +46,11 @@ struct StudyFixture: public StudyBuilder
 };
 
 StudyFixture::StudyFixture():
+    area(addAreaToStudy("Some area")),
+    cluster(addClusterToArea(area, "some cluster")),
     clusterConfig(cluster)
 {
     simulationBetweenDays(0, 7);
-    area = addAreaToStudy("Some area");
-    cluster = addClusterToArea(area, "some cluster");
 
     loadInArea = 7.0;
     loadTSconfig = TimeSeriesConfigurer(area->load.series.timeSeries);

--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -34,7 +34,6 @@ using namespace Antares::Data;
 // =================================
 struct StudyFixture: public StudyBuilder
 {
-    using StudyBuilder::StudyBuilder;
     StudyFixture();
 
     // Data members
@@ -46,7 +45,8 @@ struct StudyFixture: public StudyBuilder
     TimeSeriesConfigurer loadTSconfig;
 };
 
-StudyFixture::StudyFixture()
+StudyFixture::StudyFixture():
+    clusterConfig(cluster)
 {
     simulationBetweenDays(0, 7);
     area = addAreaToStudy("Some area");
@@ -57,7 +57,6 @@ StudyFixture::StudyFixture()
     loadTSconfig.setDimensions(1).fillColumnWith(0, loadInArea);
 
     clusterCost = 2.;
-    clusterConfig = ThermalClusterConfig(cluster);
     clusterConfig.setNominalCapacity(100.)
       .setAvailablePower(0, 50.)
       .setCosts(clusterCost)

--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -80,7 +80,7 @@ TimeSeriesConfigurer& TimeSeriesConfigurer::fillColumnWith(unsigned column,
     return *this;
 }
 
-ThermalClusterConfig::ThermalClusterConfig(ThermalCluster* cluster):
+ThermalClusterConfig::ThermalClusterConfig(std::shared_ptr<ThermalCluster> cluster):
     cluster_(cluster),
     tsAvailablePowerConfig_(cluster_->series.timeSeries)
 {

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -55,7 +55,7 @@ class ThermalClusterConfig
 {
 public:
     ThermalClusterConfig() = delete;
-    ThermalClusterConfig(std::shared_ptr<ThermalCluster> cluster);
+    explicit ThermalClusterConfig(std::shared_ptr<ThermalCluster> cluster);
     ThermalClusterConfig& setNominalCapacity(double nominalCapacity);
     ThermalClusterConfig& setUnitCount(unsigned unitCount);
     ThermalClusterConfig& setCosts(double cost);

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -55,7 +55,7 @@ class ThermalClusterConfig
 {
 public:
     ThermalClusterConfig() = default;
-    ThermalClusterConfig(ThermalCluster* cluster);
+    ThermalClusterConfig(std::shared_ptr<ThermalCluster> cluster);
     ThermalClusterConfig& setNominalCapacity(double nominalCapacity);
     ThermalClusterConfig& setUnitCount(unsigned unitCount);
     ThermalClusterConfig& setCosts(double cost);
@@ -63,7 +63,7 @@ public:
     ThermalClusterConfig& setAvailablePower(unsigned column, double value);
 
 private:
-    ThermalCluster* cluster_ = nullptr;
+    std::shared_ptr<ThermalCluster> cluster_ = nullptr;
     TimeSeriesConfigurer tsAvailablePowerConfig_;
 };
 

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -54,7 +54,7 @@ private:
 class ThermalClusterConfig
 {
 public:
-    ThermalClusterConfig() = default;
+    ThermalClusterConfig() = delete;
     ThermalClusterConfig(std::shared_ptr<ThermalCluster> cluster);
     ThermalClusterConfig& setNominalCapacity(double nominalCapacity);
     ThermalClusterConfig& setUnitCount(unsigned unitCount);


### PR DESCRIPTION
- Remove default constructor (makes no sense)
- Use `std::shared_ptr` to guarantee no dangling references