### PR TITLE
Test problems in-memory [ANT-3514]

### DIFF
--- a/src/tests/end-to-end/simple_study/simple-study.cpp
+++ b/src/tests/end-to-end/simple_study/simple-study.cpp
@@ -460,6 +460,59 @@ BOOST_FIXTURE_TEST_CASE(sts_scenarized_withdrawal_constraint, StudyBuilder)
 
 BOOST_AUTO_TEST_SUITE_END()
 
+BOOST_AUTO_TEST_SUITE(IN_MEMORY_PROBLEM_BUILDING)
+
+BOOST_FIXTURE_TEST_CASE(STS_efficiency_for_injection_and_withdrawal, StudyFixture)
+{
+    setNumberMCyears(1);
+
+    auto* sts = addSTSToArea(area, "my-sts");
+
+    const double initialLevel = .5;
+    const double reservoirCapacity = 100;
+
+    ShortTermStorageConfig stsConfig(*sts);
+    stsConfig.setInjectionNominalCapacity(10)
+      .setWithdrawalNominalCapacity(10)
+      .setReservoirCapacity(reservoirCapacity)
+      .setInjectionEfficiency(.6)
+      .setWithdrawalEfficiency(.8)
+      .setInitialLevel(initialLevel)
+      .setInitialLevelOptim(false)
+      .setGroupName("Some STS group");
+    // Default values for series
+    sts->series->fillDefaultSeriesIfEmpty();
+
+    simulation.create();
+    simulation.run();
+
+    const auto& observer = simulation.getObserver();
+    BOOST_REQUIRE_EQUAL(observer.problems.size(), 2);
+    BOOST_REQUIRE(observer.problems.contains({2, "problem-1-1--optim-nb-2.mps"}));
+    const auto& problem = observer.problems.at({2, "problem-1-1--optim-nb-2.mps"});
+
+    // Withdrawal variable
+    const std::string withdrawalKey = "Withdrawal::area<some*area>::ShortTermStorage<my-sts>::hour<"
+                                      "38>";
+    BOOST_REQUIRE(problem.variables.contains(withdrawalKey));
+
+    const auto& withdrawal_h38 = problem.variables.at(withdrawalKey);
+    BOOST_CHECK_EQUAL(withdrawal_h38.Xmin, 0);
+    BOOST_CHECK_EQUAL(withdrawal_h38.Xmax, 10);
+    BOOST_CHECK_EQUAL(withdrawal_h38.objectiveCoefficient, 0);
+
+    // Level constraint
+    const std::string levelKey = "Level::area<some*area>::ShortTermStorage<my-sts>::hour<38>";
+    const std::string injectionKey = "Injection::area<some*area>::ShortTermStorage<my-sts>::hour<"
+                                     "38>";
+    BOOST_REQUIRE(problem.constraints.contains(levelKey));
+    const auto& level_h38 = problem.constraints.at(levelKey);
+    BOOST_CHECK_EQUAL(level_h38.coefficients.at(withdrawalKey), 0.8); // withdrawalEfficiency
+    BOOST_CHECK_EQUAL(level_h38.coefficients.at(injectionKey), -0.6); // -injectionEfficiency
+    BOOST_CHECK_EQUAL(level_h38.rhs, 0);                              // no inflows
+}
+BOOST_AUTO_TEST_SUITE_END()
+
 BOOST_AUTO_TEST_SUITE(HYDRO_MAX_POWER)
 
 BOOST_FIXTURE_TEST_CASE(basic, HydroMaxPowerStudy)

--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -198,25 +198,30 @@ void TestingSimulationObserver::notifyHebdoProblem(const PROBLEME_HEBDO& problem
     std::string nameStr(name.begin(), name.end());
     auto& toInsert = problems[std::make_pair(optimizationNumber, nameStr)];
 
+    // Variables
     for (int varIdx = 0; varIdx < pb->NombreDeVariables; varIdx++)
     {
         const std::string& varName = pb->NomDesVariables[varIdx];
-        toInsert.Xmin[varName] = pb->Xmin[varIdx];
-        toInsert.Xmax[varName] = pb->Xmax[varIdx];
-        toInsert.Objective[varName] = pb->CoutLineaire[varIdx];
+        auto& insertedVariable = toInsert.variables[varName];
+        insertedVariable = {.Xmin = pb->Xmin[varIdx],
+                            .Xmax = pb->Xmax[varIdx],
+                            .objectiveCoefficient = pb->CoutLineaire[varIdx]};
     }
 
+    // Constraints
     for (int ctIdx = 0; ctIdx < pb->NombreDeContraintes; ctIdx++)
     {
         const std::string& ctName = pb->NomDesContraintes[ctIdx];
-        auto& constraint = toInsert.Coefficients[ctName];
+        auto& insertedConstraint = toInsert.constraints[ctName];
         int debutLigne = pb->IndicesDebutDeLigne[ctIdx];
         for (int coefIdx = 0; coefIdx < pb->NombreDeTermesDesLignes[ctIdx]; ++coefIdx)
         {
             int pos = debutLigne + coefIdx;
             int varIdx = pb->IndicesColonnes[pos];
             const std::string& varName = pb->NomDesVariables[varIdx];
-            constraint[varName] = pb->CoefficientsDeLaMatriceDesContraintes[pos];
+            insertedConstraint.coefficients[varName] = pb->CoefficientsDeLaMatriceDesContraintes
+                                                         [pos];
+            insertedConstraint.rhs = pb->SecondMembre[ctIdx];
         }
     }
 }

--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -188,6 +188,26 @@ ScenarioBuilderRule::ScenarioBuilderRule(Study& study)
 }
 
 // =====================
+// Simulation observer
+// =====================
+void TestingSimulationObserver::notifyHebdoProblem(const PROBLEME_HEBDO& problemeHebdo,
+                                                   int optimizationNumber,
+                                                   std::string_view name)
+{
+    auto* pb = problemeHebdo.ProblemeAResoudre.get();
+    std::string nameStr(name.begin(), name.end());
+    auto& toInsert = problems[std::make_pair(optimizationNumber, nameStr)];
+
+    for (int var = 0; var < pb->NombreDeVariables; var++)
+    {
+        const std::string& varName = pb->NomDesVariables[var];
+        toInsert.Xmin[varName] = pb->Xmin[var];
+        toInsert.Xmax[varName] = pb->Xmax[var];
+        toInsert.Objective[varName] = pb->CoutLineaire[var];
+    }
+}
+
+// =====================
 // Simulation handler
 // =====================
 
@@ -212,7 +232,7 @@ StudyBuilder::StudyBuilder():
 {
     // Make logs shrink to errors (and higher) only
     logs.verbosityLevel = Logs::Verbosity::Error::level;
-
+    study->parameters.namedProblems = true;
     initializeStudy(study.get());
 }
 

--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -198,12 +198,26 @@ void TestingSimulationObserver::notifyHebdoProblem(const PROBLEME_HEBDO& problem
     std::string nameStr(name.begin(), name.end());
     auto& toInsert = problems[std::make_pair(optimizationNumber, nameStr)];
 
-    for (int var = 0; var < pb->NombreDeVariables; var++)
+    for (int varIdx = 0; varIdx < pb->NombreDeVariables; varIdx++)
     {
-        const std::string& varName = pb->NomDesVariables[var];
-        toInsert.Xmin[varName] = pb->Xmin[var];
-        toInsert.Xmax[varName] = pb->Xmax[var];
-        toInsert.Objective[varName] = pb->CoutLineaire[var];
+        const std::string& varName = pb->NomDesVariables[varIdx];
+        toInsert.Xmin[varName] = pb->Xmin[varIdx];
+        toInsert.Xmax[varName] = pb->Xmax[varIdx];
+        toInsert.Objective[varName] = pb->CoutLineaire[varIdx];
+    }
+
+    for (int ctIdx = 0; ctIdx < pb->NombreDeContraintes; ctIdx++)
+    {
+        const std::string& ctName = pb->NomDesContraintes[ctIdx];
+        auto& constraint = toInsert.Coefficients[ctName];
+        int debutLigne = pb->IndicesDebutDeLigne[ctIdx];
+        for (int coefIdx = 0; coefIdx < pb->NombreDeTermesDesLignes[ctIdx]; ++coefIdx)
+        {
+            int pos = debutLigne + coefIdx;
+            int varIdx = pb->IndicesColonnes[pos];
+            const std::string& varName = pb->NomDesVariables[varIdx];
+            constraint[varName] = pb->CoefficientsDeLaMatriceDesContraintes[pos];
+        }
     }
 }
 

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -20,6 +20,8 @@
  */
 #pragma once
 #define WIN32_LEAN_AND_MEAN
+#include <limits>
+
 #include "antares/solver/simulation/ISimulationObserver.h"
 #include "antares/solver/simulation/economy.h"
 #include "antares/solver/simulation/simulation.h"
@@ -301,14 +303,19 @@ class TestingSimulationObserver: public Solver::Simulation::ISimulationObserver
 public:
     struct Variable
     {
-        double Xmin;
-        double Xmax;
-        double objectiveCoefficient;
+        // All comparisons with NaN return false, except for !=
+        // For example (NaN == 4.) => false
+        // (NaN == NaN) => false
+        // Using any other arbitrary value (infinity, 0, etc.) may result in false positives
+        // or false negatives
+        double Xmin = std::numeric_limits<double>::quiet_NaN();
+        double Xmax = std::numeric_limits<double>::quiet_NaN();
+        double objectiveCoefficient = std::numeric_limits<double>::quiet_NaN();
     };
 
     struct Constraint
     {
-        double rhs;
+        double rhs = std::numeric_limits<double>::quiet_NaN();
         std::map<std::string, double> coefficients;
     };
 

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 #define WIN32_LEAN_AND_MEAN
+#include "antares/solver/simulation/ISimulationObserver.h"
 #include "antares/solver/simulation/economy.h"
 #include "antares/solver/simulation/simulation.h"
 #include "antares/study/scenario-builder/rules.h"
@@ -198,6 +199,23 @@ private:
 // Simulation handler
 // =====================
 
+class TestingSimulationObserver: public Solver::Simulation::ISimulationObserver
+{
+public:
+    struct SingleProblem
+    {
+        std::map<std::string, double> Xmin;
+        std::map<std::string, double> Xmax;
+        std::map<std::string, double> Objective;
+    };
+
+    std::map<std::pair<int, std::string>, SingleProblem> problems;
+
+    void notifyHebdoProblem(const PROBLEME_HEBDO& problemeHebdo,
+                            int optimizationNumber,
+                            std::string_view name) override;
+};
+
 class SimulationHandler
 {
 public:
@@ -223,13 +241,19 @@ public:
         return *simulation_;
     }
 
+public:
+    const TestingSimulationObserver& getObserver() const
+    {
+        return observer_;
+    }
+
 private:
     std::shared_ptr<ISimulation<Economy>> simulation_;
     Benchmarking::DurationCollector durationCollector_;
     Settings settings_;
     Data::Study& study_;
     NullResultWriter resultWriter_;
-    NullSimulationObserver observer_;
+    TestingSimulationObserver observer_;
 };
 
 // =========================

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -207,6 +207,7 @@ public:
         std::map<std::string, double> Xmin;
         std::map<std::string, double> Xmax;
         std::map<std::string, double> Objective;
+        std::map<std::string, std::map<std::string, double>> Coefficients;
     };
 
     std::map<std::pair<int, std::string>, SingleProblem> problems;

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -202,12 +202,24 @@ private:
 class TestingSimulationObserver: public Solver::Simulation::ISimulationObserver
 {
 public:
-    struct SingleProblem
+    struct Variable
     {
-        std::map<std::string, double> Xmin;
-        std::map<std::string, double> Xmax;
-        std::map<std::string, double> Objective;
-        std::map<std::string, std::map<std::string, double>> Coefficients;
+        double Xmin;
+        double Xmax;
+        double objectiveCoefficient;
+    };
+
+    struct Constraint
+    {
+        double rhs;
+        std::map<std::string, double> coefficients;
+    };
+
+    struct SingleProblem
+
+    {
+        std::map<std::string, Variable> variables;
+        std::map<std::string, Constraint> constraints;
     };
 
     std::map<std::pair<int, std::string>, SingleProblem> problems;


### PR DESCRIPTION
Add observer implementation allowing to tests problems in-memory.

This way, tests are more unitary since we only test the problem creation from memory structures, not problem resolution, I/O and so forth.

![Untitled Diagram drawio(4)](https://github.com/user-attachments/assets/0ef61a64-9418-407d-b952-4bbce1fee8ba)

