### PR TITLE
Factorise antlr4 lib linking resolution

### DIFF
--- a/src/cmake/utils.cmake
+++ b/src/cmake/utils.cmake
@@ -1,33 +1,33 @@
 macro(copy_dependency deps target)
 
-        if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-            get_target_property( DEP_SHARED_LIB_PATH ${deps} IMPORTED_LOCATION_RELEASE )
-        else()
-            get_target_property( DEP_SHARED_LIB_PATH ${deps} IMPORTED_LOCATION_DEBUG )
-        endif()
+    if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+        get_target_property(DEP_SHARED_LIB_PATH ${deps} IMPORTED_LOCATION_RELEASE)
+    else ()
+        get_target_property(DEP_SHARED_LIB_PATH ${deps} IMPORTED_LOCATION_DEBUG)
+    endif ()
 
-	if (NOT "${DEP_SHARED_LIB_PATH}" STREQUAL "DEP_SHARED_LIB_PATH-NOTFOUND")
+    if (NOT "${DEP_SHARED_LIB_PATH}" STREQUAL "DEP_SHARED_LIB_PATH-NOTFOUND")
 
-            # Copy the shared lib file
-            add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${DEP_SHARED_LIB_PATH} $<TARGET_FILE_DIR:${target}>)
-            
-            # Add to install
-            install(FILES ${DEP_SHARED_LIB_PATH} TYPE BIN)
+        # Copy the shared lib file
+        add_custom_command(TARGET ${target} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${DEP_SHARED_LIB_PATH} $<TARGET_FILE_DIR:${target}>)
 
-	endif()
+        # Add to install
+        install(FILES ${DEP_SHARED_LIB_PATH} TYPE BIN)
+
+    endif ()
 
 endmacro()
 
 function(get_linux_lsb_release_information)
     find_program(LSB_RELEASE_EXEC lsb_release)
-    if(NOT LSB_RELEASE_EXEC)
-    
+    if (NOT LSB_RELEASE_EXEC)
+
         message("Could not detect lsb_release executable, can not gather required information. Use of default information (ID : Linux / Version : Unknown / Codename : Unknown")
-        
+
         set(LSB_RELEASE_ID_SHORT "Linux" PARENT_SCOPE)
         set(LSB_RELEASE_VERSION_SHORT "Unknown" PARENT_SCOPE)
-        set(LSB_RELEASE_CODENAME_SHORT "Unknown" PARENT_SCOPE)        
-    else()
+        set(LSB_RELEASE_CODENAME_SHORT "Unknown" PARENT_SCOPE)
+    else ()
         execute_process(COMMAND "${LSB_RELEASE_EXEC}" --short --id OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
         execute_process(COMMAND "${LSB_RELEASE_EXEC}" --short --release OUTPUT_VARIABLE LSB_RELEASE_VERSION_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
         execute_process(COMMAND "${LSB_RELEASE_EXEC}" --short --codename OUTPUT_VARIABLE LSB_RELEASE_CODENAME_SHORT OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -35,8 +35,8 @@ function(get_linux_lsb_release_information)
         set(LSB_RELEASE_ID_SHORT "${LSB_RELEASE_ID_SHORT}" PARENT_SCOPE)
         set(LSB_RELEASE_VERSION_SHORT "${LSB_RELEASE_VERSION_SHORT}" PARENT_SCOPE)
         set(LSB_RELEASE_CODENAME_SHORT "${LSB_RELEASE_CODENAME_SHORT}" PARENT_SCOPE)
-    endif()
-    
+    endif ()
+
 endfunction()
 
 
@@ -44,18 +44,26 @@ function(find_python_module module)
     set(Python3_FIND_REGISTRY "LAST")
     find_package(Python3 COMPONENTS Interpreter)
 
-    if(Python3_Interpreter_FOUND)
+    if (Python3_Interpreter_FOUND)
         execute_process(
-            COMMAND ${Python3_EXECUTABLE} -c "import ${module}"
-            RESULT_VARIABLE EXIT_CODE
-            OUTPUT_QUIET
-            ERROR_QUIET
+                COMMAND ${Python3_EXECUTABLE} -c "import ${module}"
+                RESULT_VARIABLE EXIT_CODE
+                OUTPUT_QUIET
+                ERROR_QUIET
         )
-        
+
         if (${EXIT_CODE} EQUAL 0)
             set(PYTHON_MODULE_${module}_FOUND "true" PARENT_SCOPE)
-        endif()
-        
-    endif()
-    
+        endif ()
+
+    endif ()
+
 endfunction()
+
+macro(link_antlr4 proj)
+    if (MSVC)
+        target_link_libraries(${proj} PUBLIC antlr4_shared) # vcpkg triplet x64-windows provides shared lib
+    else ()
+        target_link_libraries(${proj} PUBLIC antlr4_static) # vcpkg triplet x64-linux provides static lib
+    endif ()
+endmacro()

--- a/src/expressions/antlr-interface/CMakeLists.txt
+++ b/src/expressions/antlr-interface/CMakeLists.txt
@@ -16,11 +16,7 @@ Set(SRCS
 add_library(${PROJ} ${SRCS})
 add_library(Antares::${PROJ} ALIAS ${PROJ})
 
-if (MSVC)
-    target_link_libraries(${PROJ} PUBLIC antlr4_shared) # vcpkg triplet x64-windows provides shared lib
-else ()
-    target_link_libraries(${PROJ} PUBLIC antlr4_static) # vcpkg triplet x64-linux provides static lib
-endif ()
+link_antlr4(${PROJ})
 
 target_include_directories(${PROJ}
         PUBLIC

--- a/src/libs/antares/additionalConstraintRhsExpression/CMakeLists.txt
+++ b/src/libs/antares/additionalConstraintRhsExpression/CMakeLists.txt
@@ -16,11 +16,7 @@ Set(SRCS
 add_library(${PROJ} ${SRCS})
 add_library(Antares::${PROJ} ALIAS ${PROJ})
 
-if (MSVC)
-    target_link_libraries(${PROJ} PUBLIC antlr4_shared) # vcpkg triplet x64-windows provides shared lib
-else ()
-    target_link_libraries(${PROJ} PUBLIC antlr4_static) # vcpkg triplet x64-linux provides static lib
-endif ()
+link_antlr4(${PROJ})
 
 target_include_directories(${PROJ}
         PUBLIC

--- a/src/libs/antares/scenarioGroupParser/scenarioBuilderExpression/CMakeLists.txt
+++ b/src/libs/antares/scenarioGroupParser/scenarioBuilderExpression/CMakeLists.txt
@@ -17,11 +17,7 @@ Set(SRCS
 add_library(${PROJ} ${SRCS})
 add_library(Antares::${PROJ} ALIAS ${PROJ})
 
-if (MSVC)
-    target_link_libraries(${PROJ} PUBLIC antlr4_shared) # vcpkg triplet x64-windows provides shared lib
-else ()
-    target_link_libraries(${PROJ} PUBLIC antlr4_static) # vcpkg triplet x64-linux provides static lib
-endif ()
+link_antlr4(${PROJ})
 
 target_include_directories(${PROJ}
         PUBLIC


### PR DESCRIPTION
https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/2824/files#r2109244580

This pull request introduces a new `link_antlr4` macro to centralize the logic for linking Antlr4 libraries based on the platform, and replaces repetitive code with calls to this macro across multiple `CMakeLists.txt` files. This change improves maintainability and reduces duplication.

### Centralizing Antlr4 linking logic:

* [`src/cmake/utils.cmake`](diffhunk://#diff-6b12360adc5f32cb85c6d0362b5aedb195c480a0feeda6eb08957d26c692bde6R62-R69): Added the `link_antlr4` macro to encapsulate the logic for linking Antlr4 libraries based on the platform (`MSVC` for Windows and static linking for Linux).

### Refactoring `CMakeLists.txt` files:

* [`src/expressions/antlr-interface/CMakeLists.txt`](diffhunk://#diff-2169f6d38efba395fd179669afa78b29d479cca384aad44ef5c2e6cc2993db57L19-R19): Replaced the platform-specific Antlr4 linking logic with a call to the new `link_antlr4` macro.
* [`src/libs/antares/additionalConstraintRhsExpression/CMakeLists.txt`](diffhunk://#diff-e4d3d44a67d05cce3918477cf56c598bb6c1ae16c57b6fb2f9501ed157565b5fL19-R19): Updated to use the `link_antlr4` macro for linking Antlr4 libraries.
* [`src/libs/antares/scenarioGroupParser/scenarioBuilderExpression/CMakeLists.txt`](diffhunk://#diff-7d188cb9e54ac5efc041b8d8c469b5369f2b90059496c05b3c7bd5590a81fd11L20-R20): Simplified Antlr4 library linking by utilizing the `link_antlr4` macro.