### PR TITLE
Generate & upload HTML report for unit tests

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -220,7 +220,7 @@ jobs:
           cd _build
           ctest -C Release --output-on-failure -L "unit|end-to-end"
           cd tests
-          ${{github.workspace}}/src/tests/merge_generate_all.sh ${{github.workspace}}/src/tests/format_xml_report.xsl
+          ${{github.workspace}}/src/tests/merge_all.sh ${{github.workspace}}/src/tests/format_xml_report.xsl
 
       - name: Upload report as artifact
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -88,6 +88,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install uuid-dev libwxgtk3.0-gtk3-dev
           sudo apt-get install g++-10 gcc-10
+          sudo apt-get install xsltproc
 
       - name: Config OR-Tools URL
         run: |
@@ -214,12 +215,16 @@ jobs:
           cd _build
           ctest -C Release --output-on-failure -R "^unfeasible$"
 
-      - name: Run unit and end-to-end tests, generate reports
+      - name: Run unit and end-to-end tests
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         run: |
           cd _build
           ctest -C Release --output-on-failure -L "unit|end-to-end"
-          cd tests
+
+      - name: Merge XML reports into single HTML
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+        run: |
+          cd _build/tests
           ${{github.workspace}}/src/tests/merge_all.sh ${{github.workspace}}/src/tests/format_xml_report.xsl
 
       - name: Upload report as artifact

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -220,7 +220,7 @@ jobs:
           cd _build
           ctest -C Release --output-on-failure -L "unit|end-to-end"
           cd tests
-          {{github.workspace}}/src/tests/merge_generate_all.sh {{github.workspace}}/src/tests/format_xml_report.xsl
+          ${{github.workspace}}/src/tests/merge_generate_all.sh ${{github.workspace}}/src/tests/format_xml_report.xsl
 
       - name: Upload report as artifact
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -227,12 +227,19 @@ jobs:
           cd _build/tests
           ${{github.workspace}}/src/tests/merge_all.sh ${{github.workspace}}/src/tests/format_xml_report.xsl
 
-      - name: Upload report as artifact
+      - name: Rename report
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
-        uses: actions/upload-artifact@v4
+        run: |
+          mkdir testing-report
+          mv ${{ github.workspace }}/_build/tests/report.html testing-report/$(git rev-parse HEAD).html
+
+      - name: Deploy to antares-simulator-reports.surge.sh
+        uses: dswistowski/surge-sh-action@v1
         with:
-          name: unit-test-report
-          path: ${{ github.workspace }}/_build/tests/report.html
+          domain: 'antares-simulator-reports.surge.sh'
+          project: 'testing-report'
+          login: ${{ secrets.SURGE_LOGIN }}
+          token: ${{ secrets.SURGE_TOKEN }}
 
       - name: Upload logs for failed tests
         if: ${{ failure() }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -231,7 +231,9 @@ jobs:
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         run: |
           mkdir testing-report
-          mv ${{ github.workspace }}/_build/tests/report.html testing-report/$(git rev-parse HEAD).html
+          mv ${{ github.workspace }}/_build/tests/report.html testing-report/$PAGE
+        env:
+          PAGE: ${{ github.sha }}.html
 
       - name: Deploy to antares-simulator-reports.surge.sh
         uses: dswistowski/surge-sh-action@v1
@@ -240,6 +242,14 @@ jobs:
           project: 'testing-report'
           login: ${{ secrets.SURGE_LOGIN }}
           token: ${{ secrets.SURGE_TOKEN }}
+
+      - name: Add PR comment
+        if: ${{ success() }}
+        run: gh pr comment "$PR_URL" --body "Unit test report available [here](https://antares-simulator-reports.surge.sh/$PAGE)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PAGE: ${{ github.sha }}.html
 
       - name: Upload logs for failed tests
         if: ${{ failure() }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -214,12 +214,20 @@ jobs:
           cd _build
           ctest -C Release --output-on-failure -R "^unfeasible$"
 
-      - name: Run unit and end-to-end tests
+      - name: Run unit and end-to-end tests, generate reports
         if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
         run: |
           cd _build
           ctest -C Release --output-on-failure -L "unit|end-to-end"
+          cd tests
+          {{github.workspace}}/src/tests/merge_generate_all.sh {{github.workspace}}/src/tests/format_xml_report.xsl
 
+      - name: Upload report as artifact
+        if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-report
+          path: ${{ github.workspace }}/_build/tests/report.html
 
       - name: Upload logs for failed tests
         if: ${{ failure() }}

--- a/src/tests/format_xml_report.xsl
+++ b/src/tests/format_xml_report.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="html" indent="yes"/>
+
+  <xsl:template match="/AllTestResults">
+    <html>
+      <head>
+        <title>Combined Boost Test Report</title>
+        <style>
+          body { font-family: sans-serif; padding: 1em; }
+          .passed { color: green; } .failed { color: red; }
+          table { border-collapse: collapse; width: 100%; margin-bottom: 2em; }
+          th, td { padding: 8px; border: 1px solid #ccc; text-align: left; }
+        </style>
+      </head>
+      <body>
+        <h1>Combined Boost Test Report</h1>
+        <xsl:apply-templates select="//TestSuite"/>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="TestSuite">
+    <h2>
+      Test Suite: <xsl:value-of select="@name"/>
+      <span class="{@result}">(<xsl:value-of select="@result"/>)</span>
+    </h2>
+    <table>
+      <tr>
+        <th>Test Case</th>
+        <th>Result</th>
+        <th>Assertions Passed</th>
+        <th>Assertions Failed</th>
+      </tr>
+      <xsl:apply-templates select="TestCase"/>
+    </table>
+  </xsl:template>
+
+  <xsl:template match="TestCase">
+    <tr>
+      <td><xsl:value-of select="@name"/></td>
+      <td class="{@result}"><xsl:value-of select="@result"/></td>
+      <td><xsl:value-of select="@assertions_passed"/></td>
+      <td><xsl:value-of select="@assertions_failed"/></td>
+    </tr>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/tests/macros.cmake
+++ b/src/tests/macros.cmake
@@ -27,7 +27,11 @@ function(add_boost_test)
       target_include_directories(${TEST_NAME} PRIVATE ${arg_INCLUDE})
     endif()
 
-    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME}
+      --output_format=XML
+      --report_level=detailed
+      --report_sink=report_${TEST_NAME}.xml
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
 
     # Adding labels allows ctest filter what tests to run
     set_property(TEST ${TEST_NAME} PROPERTY LABELS unit)

--- a/src/tests/merge_all.sh
+++ b/src/tests/merge_all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+(
+  echo "<AllTestResults>"
+  for file in report_*.xml; do
+    # Strip <?xml ...> if present
+    sed '/<?xml/d' "$file"
+  done
+  echo "</AllTestResults>"
+) > all_reports.xml
+
+xsltproc $1 all_reports.xml > report.html


### PR DESCRIPTION
1. Add output_sink to boost tests
2. Collect all XML files into a large XML file
3. Use command `xsltproc` to generate the human-readable report
4. Upload the HTML to [http://antares-simulator-reports.surge.sh](http://antares-simulator-reports.surge.sh)