### PR TITLE
Hydro remix : more simplifications

### DIFF
--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -280,6 +280,7 @@ static void RunAccurateShavePeaks(const Data::AreaList& areas,
           const auto& dtgMrgArray = area.scratchpad[numSpace].dispatchableGenerationMargin;
           const std::vector<double> dtgMrg(dtgMrgArray, dtgMrgArray + HOURS_IN_WEEK);
 
+
           auto hydroStorage = makeHydroForRemix(hydroGen,
                                                 unsupE,
                                                 levels,
@@ -292,6 +293,8 @@ static void RunAccurateShavePeaks(const Data::AreaList& areas,
                                                 capacity,
                                                 efficiency,
                                                 reservoirManagement);
+
+          checkInput(load, unsupE, spillage, dtgMrg, hydroStorage->initialGen());
 
           shavePeaksByRemixingStorageGen(load, unsupE, spillage, dtgMrg, hydroStorage);
       });

--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -280,7 +280,6 @@ static void RunAccurateShavePeaks(const Data::AreaList& areas,
           const auto& dtgMrgArray = area.scratchpad[numSpace].dispatchableGenerationMargin;
           const std::vector<double> dtgMrg(dtgMrgArray, dtgMrgArray + HOURS_IN_WEEK);
 
-
           auto hydroStorage = makeHydroForRemix(hydroGen,
                                                 unsupE,
                                                 levels,

--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -224,19 +224,6 @@ static bool Remix(const Data::AreaList& areas,
     return status;
 }
 
-std::vector<double> computeTotalGenWithoutHydro(const std::vector<double>& load,
-                                                const std::vector<double>& unsupE,
-                                                const std::vector<double>& hydroGen)
-{
-    // Can be computed (for any hour) as : load - unsupplied energy - hydro
-    std::vector<double> to_return = load;
-    for (size_t i = 0; i < to_return.size(); ++i)
-    {
-        to_return[i] -= unsupE[i] + hydroGen[i];
-    }
-    return to_return;
-}
-
 std::vector<double> extractLoadForCurrentWeek(const Data::Area& area,
                                               const unsigned int year,
                                               const unsigned int firstHourOfWeek)
@@ -276,7 +263,6 @@ static void RunAccurateShavePeaks(const Data::AreaList& areas,
           auto& unsupE = weeklyResults.ValeursHorairesDeDefaillancePositive;
           auto& hydroGen = weeklyResults.TurbinageHoraire;
           auto& levels = weeklyResults.niveauxHoraires;
-          const auto DispatchGen = computeTotalGenWithoutHydro(load, unsupE, hydroGen);
           const auto& hydroPmax = problem.CaracteristiquesHydrauliques[area.index]
                                     .ContrainteDePmaxHydrauliqueHoraire;
           const auto hydroPmin = extractHydroPmin(area, problem.year, firstHourOfWeek);
@@ -307,7 +293,7 @@ static void RunAccurateShavePeaks(const Data::AreaList& areas,
                                                 efficiency,
                                                 reservoirManagement);
 
-          shavePeaksByRemixingStorageGen(unsupE, DispatchGen, spillage, dtgMrg, hydroStorage);
+          shavePeaksByRemixingStorageGen(load, unsupE, spillage, dtgMrg, hydroStorage);
       });
 }
 

--- a/src/solver/simulation/hydro-for-remix.cpp
+++ b/src/solver/simulation/hydro-for-remix.cpp
@@ -47,6 +47,7 @@ HydroForRemix::HydroForRemix(std::vector<double>& generation,
                              const std::vector<double>& Pmax,
                              const std::vector<double>& Pmin):
     generation_(generation),
+    initialGen_(generation),
     unsupE_(unsupE),
     pmax_(Pmax),
     pmin_(Pmin)
@@ -91,6 +92,11 @@ void HydroForRemix::checkInput(size_t size)
 
 void HydroForRemix::update()
 {
+}
+
+const std::vector<double>& HydroForRemix::initialGen()
+{
+    return initialGen_;
 }
 
 std::vector<double>& HydroForRemix::generation()

--- a/src/solver/simulation/include/antares/solver/simulation/hydro-for-remix.h
+++ b/src/solver/simulation/include/antares/solver/simulation/hydro-for-remix.h
@@ -15,12 +15,14 @@ public:
 
     double maxExchange(unsigned hourOfMaxGen, unsigned hourOfMinGen) override;
     void update() override;
+    const std::vector<double>& initialGen() override;
     std::vector<double>& generation() override;
 
 protected:
     void checkInput(size_t size) override;
 
     std::vector<double>& generation_;
+    const std::vector<double> initialGen_;
     std::vector<double>& unsupE_;
     const std::vector<double>& pmax_;
     const std::vector<double>& pmin_;

--- a/src/solver/simulation/include/antares/solver/simulation/remix-utils.h
+++ b/src/solver/simulation/include/antares/solver/simulation/remix-utils.h
@@ -37,4 +37,18 @@ inline std::vector<double> operator-(const std::vector<double>& v, const double 
     return to_return;
 }
 
+inline std::vector<double> operator+(std::vector<double>& a, std::vector<double>& b)
+{
+    std::vector<double> out = a;
+    std::transform(out.begin(), out.end(), b.begin(), out.begin(), std::plus<>());
+    return out;
+}
+
+inline std::vector<double> operator-(std::vector<double>& a, std::vector<double>& b)
+{
+    std::vector<double> out = a;
+    std::transform(out.begin(), out.end(), b.begin(), out.begin(), std::minus<>());
+    return out;
+}
+
 }; // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/include/antares/solver/simulation/remix-utils.h
+++ b/src/solver/simulation/include/antares/solver/simulation/remix-utils.h
@@ -37,14 +37,14 @@ inline std::vector<double> operator-(const std::vector<double>& v, const double 
     return to_return;
 }
 
-inline std::vector<double> operator+(std::vector<double>& a, std::vector<double>& b)
+inline std::vector<double> operator+(const std::vector<double>& a, const std::vector<double>& b)
 {
     std::vector<double> out = a;
     std::transform(out.begin(), out.end(), b.begin(), out.begin(), std::plus<>());
     return out;
 }
 
-inline std::vector<double> operator-(std::vector<double>& a, std::vector<double>& b)
+inline std::vector<double> operator-(const std::vector<double>& a, const std::vector<double>& b)
 {
     std::vector<double> out = a;
     std::transform(out.begin(), out.end(), b.begin(), out.begin(), std::minus<>());

--- a/src/solver/simulation/include/antares/solver/simulation/remix-utils.h
+++ b/src/solver/simulation/include/antares/solver/simulation/remix-utils.h
@@ -37,18 +37,16 @@ inline std::vector<double> operator-(const std::vector<double>& v, const double 
     return to_return;
 }
 
-inline std::vector<double> operator+(const std::vector<double>& a, const std::vector<double>& b)
+inline std::vector<double> operator+(std::vector<double> a, const std::vector<double>& b)
 {
-    std::vector<double> out = a;
-    std::transform(out.begin(), out.end(), b.begin(), out.begin(), std::plus<>());
-    return out;
+    std::transform(a.begin(), a.end(), b.begin(), a.begin(), std::plus<>());
+    return a;
 }
 
-inline std::vector<double> operator-(const std::vector<double>& a, const std::vector<double>& b)
+inline std::vector<double> operator-(std::vector<double> a, const std::vector<double>& b)
 {
-    std::vector<double> out = a;
-    std::transform(out.begin(), out.end(), b.begin(), out.begin(), std::minus<>());
-    return out;
+    std::transform(a.begin(), a.end(), b.begin(), a.begin(), std::minus<>());
+    return a;
 }
 
 }; // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/include/antares/solver/simulation/remix-utils.h
+++ b/src/solver/simulation/include/antares/solver/simulation/remix-utils.h
@@ -4,48 +4,50 @@
 #include <ranges>
 #include <vector>
 
+namespace rng = std::ranges;
+
 namespace Antares::Solver::Simulation
 {
 inline bool operator<=(const std::vector<double>& a, const std::vector<double>& b)
 {
     return a.size() == b.size()
-           && std::ranges::all_of(std::views::iota(size_t{0}, a.size()),
-                                  [&](size_t i) { return a[i] <= b[i]; });
+           && rng::all_of(std::views::iota(size_t{0}, a.size()),
+                          [&](size_t i) { return a[i] <= b[i]; });
 }
 
 inline bool operator<=(const std::vector<double>& v, const double c)
 {
-    return std::ranges::all_of(v, [&c](double e) { return e <= c; });
+    return rng::all_of(v, [&c](double e) { return e <= c; });
 }
 
 inline bool operator>=(const std::vector<double>& v, const double c)
 {
-    return std::ranges::all_of(v, [&c](double e) { return e >= c; });
+    return rng::all_of(v, [&c](double e) { return e >= c; });
 }
 
 inline std::vector<double> operator+(const std::vector<double>& v, const double c)
 {
     std::vector<double> to_return = v;
-    std::ranges::for_each(to_return, [&c](double& e) { e = e + c; });
+    rng::for_each(to_return, [&c](double& e) { e = e + c; });
     return to_return;
 }
 
 inline std::vector<double> operator-(const std::vector<double>& v, const double c)
 {
     std::vector<double> to_return = v;
-    std::ranges::for_each(to_return, [&c](double& e) { e = e - c; });
+    rng::for_each(to_return, [&c](double& e) { e = e - c; });
     return to_return;
 }
 
 inline std::vector<double> operator+(std::vector<double> a, const std::vector<double>& b)
 {
-    std::transform(a.begin(), a.end(), b.begin(), a.begin(), std::plus<>());
+    rng::transform(a, b, a.begin(), std::plus<double>());
     return a;
 }
 
 inline std::vector<double> operator-(std::vector<double> a, const std::vector<double>& b)
 {
-    std::transform(a.begin(), a.end(), b.begin(), a.begin(), std::minus<>());
+    rng::transform(a, b, a.begin(), std::minus<double>());
     return a;
 }
 

--- a/src/solver/simulation/include/antares/solver/simulation/shave-peaks-by-remix-storage-gen.h
+++ b/src/solver/simulation/include/antares/solver/simulation/shave-peaks-by-remix-storage-gen.h
@@ -8,8 +8,8 @@
 
 namespace Antares::Solver::Simulation
 {
-void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
-                                    const std::vector<double>& DispatchGen,
+void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
+                                    std::vector<double>& UnsupE,
                                     const std::vector<double>& Spillage,
                                     const std::vector<double>& DTG_MRG,
                                     std::shared_ptr<StorageForRemix> storage);

--- a/src/solver/simulation/include/antares/solver/simulation/shave-peaks-by-remix-storage-gen.h
+++ b/src/solver/simulation/include/antares/solver/simulation/shave-peaks-by-remix-storage-gen.h
@@ -14,4 +14,10 @@ void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
                                     const std::vector<double>& DTG_MRG,
                                     std::shared_ptr<StorageForRemix> storage);
 
+void checkInput(const std::vector<double>& Load,
+                const std::vector<double>& UnsupE,
+                const std::vector<double>& Spillage,
+                const std::vector<double>& DTG_MRG,
+                const std::vector<double>& storageGen);
+
 } // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/include/antares/solver/simulation/storage-for-remix.h
+++ b/src/solver/simulation/include/antares/solver/simulation/storage-for-remix.h
@@ -10,6 +10,7 @@ class StorageForRemix
 public:
     virtual double maxExchange(unsigned hourOfMaxGen, unsigned hourOfMinGen) = 0;
     virtual void update() = 0;
+    virtual const std::vector<double>& initialGen() = 0;
     virtual std::vector<double>& generation() = 0;
 
 private:

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -151,7 +151,9 @@ static double makeExchange(const std::vector<double>& DispatchGen,
 
                 storage->update();
 
-                TotalGen = updateTotalGen(DispatchGen, storage->generation());
+                TotalGen[hourOfMaxGen] -= exchange;
+                TotalGen[hourOfMinGen] += exchange;
+
                 return exchange;
             }
             triedMaxs[hourOfMaxGen] = true;

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -28,8 +28,8 @@ static std::set<unsigned> ValidHours(const std::vector<double>& Spillage,
     auto filter = [&](int h)
     { return std::abs(Spillage[h] + DTG_MRG[h]) < eps && StorageGen[h] + UnsupE[h] > 0.; };
 
-    auto filterHoursView = vws::iota(0, static_cast<int>(Spillage.size())) | vws::filter(filter);
-    return {filterHoursView.begin(), filterHoursView.end()};
+    auto validHoursView = vws::iota(0, static_cast<int>(Spillage.size())) | vws::filter(filter);
+    return {validHoursView.begin(), validHoursView.end()};
 }
 
 void checkInput(const std::vector<double>& Load,

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -66,7 +66,7 @@ static double makeExchange(std::vector<double>& TotalGen,
     std::set<unsigned> validHoursForMin(validHours);
     while (true)
     {
-        std::erase_if(validHoursForMin, [&](int h) { return UnsupE[h] <= 0.; });
+        std::erase_if(validHoursForMin, [&](int h) { return UnsupE[h] <= eps; });
         if (!validHoursForMin.size())
         {
             return 0.;

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -107,10 +107,8 @@ static double makeExchange(const std::vector<double>& DispatchGen,
                            const std::vector<bool>& validHours,
                            std::shared_ptr<StorageForRemix>& storage)
 {
-    double exchange = 0; // to be returned
-    size_t nbHours = DispatchGen.size();
-    double top = *rng::max_element(DispatchGen) + *rng::max_element(storage->initialGen())
-                 + *rng::max_element(UnsupEinit) + 1;
+    double exchange = 0; // To be returned
+    size_t nbHours = TotalGen.size();
 
     std::vector<bool> triedMins(nbHours, false);
     while (true)
@@ -122,10 +120,6 @@ static double makeExchange(const std::vector<double>& DispatchGen,
         }
 
         unsigned hourOfMinGen = hourForTotalGenMin(TotalGen, filteredHours);
-        if (TotalGen[hourOfMinGen] > top)
-        {
-            return 0.;
-        }
 
         std::vector<bool> triedMaxs(nbHours, false);
         while (true)

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -172,7 +172,7 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
                                     const std::vector<double>& DTG_MRG,
                                     std::shared_ptr<StorageForRemix> storage)
 {
-    const std::vector<double> storageGenInit = storage->generation();
+    const std::vector<double> storageGenInit = storage->initialGen();
     const std::vector<double> UnsupEinit = UnsupE;
 
     checkInput(DispatchGen, UnsupEinit, Spillage, DTG_MRG, storageGenInit);

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -1,6 +1,5 @@
 #include "include/antares/solver/simulation/shave-peaks-by-remix-storage-gen.h"
 
-#include <algorithm>
 #include <ranges>
 #include <set>
 #include <stdexcept>
@@ -118,7 +117,6 @@ void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
                                     std::shared_ptr<StorageForRemix> storage)
 {
     const std::vector<double> UnsupEinit = UnsupE;
-
     std::vector<double> TotalGen = Load - UnsupEinit;
 
     unsigned nbLoops = maxNbLoops;

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -100,12 +100,12 @@ static std::vector<bool> ValidHours(const std::vector<double>& Spillage,
     return validHours;
 }
 
-static double makeExchange(std::vector<double>& UnsupE,
-                           const std::vector<bool>& validHours,
+static double makeExchange(const std::vector<double>& DispatchGen,
                            std::vector<double>& TotalGen,
-                           std::shared_ptr<StorageForRemix>& storage,
+                           std::vector<double>& UnsupE,
                            const std::vector<double>& UnsupEinit,
-                           const std::vector<double>& DispatchGen)
+                           const std::vector<bool>& validHours,
+                           std::shared_ptr<StorageForRemix>& storage)
 {
     double exchange = 0; // to be returned
     size_t nbHours = DispatchGen.size();
@@ -184,12 +184,12 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
     unsigned nbLoops = maxNbLoops;
     while (nbLoops-- > 0)
     {
-        double exchange = makeExchange(UnsupE,
-                                       validHours,
-                                       TotalGen,
-                                       storage,
+        double exchange = makeExchange(DispatchGen,
+                                       TotalGen, 
+                                       UnsupE,
                                        UnsupEinit,
-                                       DispatchGen);
+                                       validHours,
+                                       storage);
 
         if (exchange <= eps)
         {

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -121,7 +121,7 @@ void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
     while (nbLoops-- > 0)
     {
         std::set<unsigned> hoursForStorage;
-        auto predicate = [&](int h) { return storage->initialGen()[h] + UnsupE[h] > eps; };
+        auto predicate = [&](int h) { return storage->initialGen()[h] + UnsupEinit[h] > eps; };
         rng::copy_if(validHours, std::inserter(hoursForStorage, hoursForStorage.end()), predicate);
 
         double exchange = makeExchange(hoursForStorage, TotalGen, UnsupE, storage);

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -55,9 +55,9 @@ void checkInput(const std::vector<double>& Load,
     }
 }
 
-static double makeExchange(std::vector<double>& TotalGen,
+static double makeExchange(const std::set<unsigned>& validHours,
+                           std::vector<double>& TotalGen,
                            std::vector<double>& UnsupE,
-                           const std::set<unsigned>& validHours,
                            std::shared_ptr<StorageForRemix>& storage)
 {
     double exchange = 0.; // To be returned
@@ -124,7 +124,7 @@ void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
     {
         // Valid hours could be computed once for all, not at each iterations.
         const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
-        double exchange = makeExchange(TotalGen, UnsupE, validHours, storage);
+        double exchange = makeExchange(validHours, TotalGen, UnsupE, storage);
 
         if (exchange <= eps)
         {

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -179,7 +179,7 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
     while (nbLoops-- > 0)
     {
         double exchange = makeExchange(DispatchGen,
-                                       TotalGen, 
+                                       TotalGen,
                                        UnsupE,
                                        UnsupEinit,
                                        validHours,

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -48,14 +48,14 @@ static unsigned hourForTotalGenMax(const std::vector<double>& TotalGen,
     return *rng::max_element(filteredHours, {}, [&](int h) { return TotalGen[h]; });
 }
 
-static void checkInput(const std::vector<double>& DispatchGen,
-                       const std::vector<double>& UnsupE,
-                       const std::vector<double>& Spillage,
-                       const std::vector<double>& DTG_MRG,
-                       const std::vector<double>& storageGen)
+void checkInput(const std::vector<double>& Load,
+                const std::vector<double>& UnsupE,
+                const std::vector<double>& Spillage,
+                const std::vector<double>& DTG_MRG,
+                const std::vector<double>& storageGen)
 {
     // Arrays sizes must be identical
-    std::vector<size_t> sizes = {DispatchGen.size(),
+    std::vector<size_t> sizes = {Load.size(),
                                  UnsupE.size(),
                                  Spillage.size(),
                                  DTG_MRG.size(),
@@ -66,7 +66,7 @@ static void checkInput(const std::vector<double>& DispatchGen,
         throw std::invalid_argument(error_msg_start + "arrays of different sizes");
     }
 
-    if (!DispatchGen.size())
+    if (!Load.size())
     {
         throw std::invalid_argument(error_msg_start + "all arrays of sizes 0");
     }
@@ -157,8 +157,6 @@ void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
                                     std::shared_ptr<StorageForRemix> storage)
 {
     const std::vector<double> UnsupEinit = UnsupE;
-
-    checkInput(Load, UnsupEinit, Spillage, DTG_MRG, storage->initialGen());
 
     const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
 

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -150,19 +150,19 @@ static double makeExchange(std::vector<double>& TotalGen,
     }
 }
 
-void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
-                                    const std::vector<double>& DispatchGen,
+void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
+                                    std::vector<double>& UnsupE,
                                     const std::vector<double>& Spillage,
                                     const std::vector<double>& DTG_MRG,
                                     std::shared_ptr<StorageForRemix> storage)
 {
     const std::vector<double> UnsupEinit = UnsupE;
 
-    checkInput(DispatchGen, UnsupEinit, Spillage, DTG_MRG, storage->initialGen());
+    checkInput(Load, UnsupEinit, Spillage, DTG_MRG, storage->initialGen());
 
     const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
 
-    std::vector<double> TotalGen = DispatchGen + storage->initialGen();
+    std::vector<double> TotalGen = Load - UnsupEinit;
 
     unsigned nbLoops = maxNbLoops;
     while (nbLoops-- > 0)

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -72,18 +72,6 @@ static void checkInput(const std::vector<double>& DispatchGen,
     }
 }
 
-static std::vector<double> updateTotalGen(const std::vector<double>& DispatchGen,
-                                          const std::vector<double>& StorageGen)
-{
-    std::vector<double> totalGen(DispatchGen.size());
-    std::transform(DispatchGen.begin(),
-                   DispatchGen.end(),
-                   StorageGen.begin(),
-                   totalGen.begin(),
-                   std::plus<>());
-    return totalGen;
-}
-
 static std::vector<bool> ValidHours(const std::vector<double>& Spillage,
                                     const std::vector<double>& DTG_MRG,
                                     const std::vector<double>& StorageGen,
@@ -100,8 +88,7 @@ static std::vector<bool> ValidHours(const std::vector<double>& Spillage,
     return validHours;
 }
 
-static double makeExchange(const std::vector<double>& DispatchGen,
-                           std::vector<double>& TotalGen,
+static double makeExchange(std::vector<double>& TotalGen,
                            std::vector<double>& UnsupE,
                            const std::vector<double>& UnsupEinit,
                            const std::vector<bool>& validHours,
@@ -175,17 +162,12 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
 
     const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
 
-    std::vector<double> TotalGen = updateTotalGen(DispatchGen, storage->initialGen());
+    std::vector<double> TotalGen = DispatchGen + storage->initialGen();
 
     unsigned nbLoops = maxNbLoops;
     while (nbLoops-- > 0)
     {
-        double exchange = makeExchange(DispatchGen,
-                                       TotalGen,
-                                       UnsupE,
-                                       UnsupEinit,
-                                       validHours,
-                                       storage);
+        double exchange = makeExchange(TotalGen, UnsupE, UnsupEinit, validHours, storage);
 
         if (exchange <= eps)
         {

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -94,7 +94,7 @@ static double makeExchange(std::vector<double>& TotalGen,
                            const std::vector<bool>& validHours,
                            std::shared_ptr<StorageForRemix>& storage)
 {
-    double exchange = 0; // To be returned
+    double exchange = 0.; // To be returned
     size_t nbHours = TotalGen.size();
 
     std::vector<bool> triedMins(nbHours, false);
@@ -128,11 +128,10 @@ static double makeExchange(std::vector<double>& TotalGen,
             {
                 storage->generation()[hourOfMaxGen] -= exchange;
                 storage->generation()[hourOfMinGen] += exchange;
+                storage->update();
 
                 UnsupE[hourOfMaxGen] += exchange;
                 UnsupE[hourOfMinGen] -= exchange;
-
-                storage->update();
 
                 TotalGen[hourOfMaxGen] -= exchange;
                 TotalGen[hourOfMinGen] += exchange;

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -8,7 +8,7 @@
 #include "include/antares/solver/simulation/remix-utils.h"
 
 namespace rng = std::ranges;
-namespace vws = std::ranges::views;
+namespace vws = std::views;
 
 constexpr double eps = 1e-3;
 constexpr unsigned maxNbLoops = 1000;
@@ -20,13 +20,9 @@ namespace Antares::Solver::Simulation
 {
 
 static std::set<unsigned> ValidHours(const std::vector<double>& Spillage,
-                                     const std::vector<double>& DTG_MRG,
-                                     const std::vector<double>& StorageGen,
-                                     const std::vector<double>& UnsupE)
+                                     const std::vector<double>& DTG_MRG)
 {
-    auto filter = [&](int h)
-    { return std::abs(Spillage[h] + DTG_MRG[h]) < eps && StorageGen[h] + UnsupE[h] > eps; };
-
+    auto filter = [&](int h) { return std::abs(Spillage[h] + DTG_MRG[h]) < eps; };
     auto validHoursView = vws::iota(0, static_cast<int>(Spillage.size())) | vws::filter(filter);
     return {validHoursView.begin(), validHoursView.end()};
 }
@@ -119,12 +115,16 @@ void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
     const std::vector<double> UnsupEinit = UnsupE;
     std::vector<double> TotalGen = Load - UnsupEinit;
 
+    const auto validHours = ValidHours(Spillage, DTG_MRG);
+
     unsigned nbLoops = maxNbLoops;
     while (nbLoops-- > 0)
     {
-        // Valid hours could be computed once for all, not at each iterations.
-        const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
-        double exchange = makeExchange(validHours, TotalGen, UnsupE, storage);
+        std::set<unsigned> hoursForStorage;
+        auto predicate = [&](int h) { return storage->initialGen()[h] + UnsupE[h] > eps; };
+        rng::copy_if(validHours, std::inserter(hoursForStorage, hoursForStorage.end()), predicate);
+
+        double exchange = makeExchange(hoursForStorage, TotalGen, UnsupE, storage);
 
         if (exchange <= eps)
         {

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -25,7 +25,7 @@ static std::set<unsigned> ValidHours(const std::vector<double>& Spillage,
                                      const std::vector<double>& UnsupE)
 {
     auto filter = [&](int h)
-    { return std::abs(Spillage[h] + DTG_MRG[h]) < eps && StorageGen[h] + UnsupE[h] > 0.; };
+    { return std::abs(Spillage[h] + DTG_MRG[h]) < eps && StorageGen[h] + UnsupE[h] > eps; };
 
     auto validHoursView = vws::iota(0, static_cast<int>(Spillage.size())) | vws::filter(filter);
     return {validHoursView.begin(), validHoursView.end()};

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -10,6 +10,7 @@ namespace rng = std::ranges;
 namespace vws = std::ranges::views;
 
 constexpr double eps = 1e-3;
+constexpr unsigned maxNbLoops = 1000;
 const std::string error_msg_start = "Remix storage input : ";
 
 namespace Antares::Solver::Simulation
@@ -102,7 +103,6 @@ static std::vector<bool> ValidHours(const std::vector<double>& Spillage,
 static double makeExchange(std::vector<double>& UnsupE,
                            const std::vector<bool>& validHours,
                            std::vector<double>& TotalGen,
-                           double top,
                            std::shared_ptr<StorageForRemix>& storage,
                            const std::vector<double>& storageGenInit,
                            const std::vector<double>& UnsupEinit,
@@ -110,6 +110,8 @@ static double makeExchange(std::vector<double>& UnsupE,
 {
     double exchange = 0; // to be returned
     size_t nbHours = DispatchGen.size();
+    double top = *rng::max_element(DispatchGen) + *rng::max_element(storageGenInit)
+                 + *rng::max_element(UnsupEinit) + 1;
 
     std::vector<bool> triedMins(nbHours, false);
     while (true)
@@ -175,20 +177,16 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
 
     checkInput(DispatchGen, UnsupEinit, Spillage, DTG_MRG, storageGenInit);
 
-    int loop = 1000;
-    double top = *rng::max_element(DispatchGen) + *rng::max_element(storageGenInit)
-                 + *rng::max_element(UnsupEinit) + 1;
-
     const auto validHours = ValidHours(Spillage, DTG_MRG, storageGenInit, UnsupEinit);
 
     std::vector<double> TotalGen = updateTotalGen(DispatchGen, storageGenInit);
 
-    while (loop-- > 0)
+    unsigned nbLoops = maxNbLoops;
+    while (nbLoops-- > 0)
     {
         double exchange = makeExchange(UnsupE,
                                        validHours,
                                        TotalGen,
-                                       top,
                                        storage,
                                        storageGenInit,
                                        UnsupEinit,

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -19,10 +19,10 @@ namespace Antares::Solver::Simulation
 
 static std::vector<unsigned> filterHoursForMin(const std::vector<double>& UnsupE,
                                                const std::vector<bool>& triedMins,
-                                               const std::vector<bool>& validHours)
+                                               const std::vector<unsigned>& validHours)
 {
-    auto filter = [&](int h) { return UnsupE[h] > 0 && !triedMins[h] && validHours[h]; };
-    auto filterHoursView = vws::iota(0, static_cast<int>(UnsupE.size())) | vws::filter(filter);
+    auto filter = [&](int h) { return UnsupE[h] > 0 && !triedMins[h]; };
+    auto filterHoursView = validHours | vws::filter(filter);
     return {filterHoursView.begin(), filterHoursView.end()};
 }
 
@@ -34,12 +34,11 @@ static unsigned hourForTotalGenMin(const std::vector<double>& TotalGen,
 
 static std::vector<unsigned> filterHoursForMax(const std::vector<double>& TotalGen,
                                                const std::vector<bool>& triedMaxs,
-                                               const std::vector<bool>& validHours,
+                                               const std::vector<unsigned>& validHours,
                                                double minTotalGen)
 {
-    auto filter = [&](int h)
-    { return TotalGen[h] >= minTotalGen + eps && !triedMaxs[h] && validHours[h]; };
-    auto filterHoursView = vws::iota(0, static_cast<int>(TotalGen.size())) | vws::filter(filter);
+    auto filter = [&](int h) { return TotalGen[h] >= minTotalGen + eps && !triedMaxs[h]; };
+    auto filterHoursView = validHours | vws::filter(filter);
     return {filterHoursView.begin(), filterHoursView.end()};
 }
 
@@ -73,25 +72,21 @@ void checkInput(const std::vector<double>& Load,
     }
 }
 
-static std::vector<bool> ValidHours(const std::vector<double>& Spillage,
-                                    const std::vector<double>& DTG_MRG,
-                                    const std::vector<double>& StorageGen,
-                                    const std::vector<double>& UnsupE)
+static std::vector<unsigned> ValidHours(const std::vector<double>& Spillage,
+                                        const std::vector<double>& DTG_MRG,
+                                        const std::vector<double>& StorageGen,
+                                        const std::vector<double>& UnsupE)
 {
-    std::vector<bool> validHours(Spillage.size(), false);
-    for (unsigned h = 0; h < validHours.size(); h++)
-    {
-        if (Spillage[h] + DTG_MRG[h] == 0. && StorageGen[h] + UnsupE[h] > 0.)
-        {
-            validHours[h] = true;
-        }
-    }
-    return validHours;
+    auto filter = [&](int h)
+    { return std::abs(Spillage[h] + DTG_MRG[h]) < eps && StorageGen[h] + UnsupE[h] > 0.; };
+
+    auto filterHoursView = vws::iota(0, static_cast<int>(Spillage.size())) | vws::filter(filter);
+    return {filterHoursView.begin(), filterHoursView.end()};
 }
 
 static double makeExchange(std::vector<double>& TotalGen,
                            std::vector<double>& UnsupE,
-                           const std::vector<bool>& validHours,
+                           const std::vector<unsigned>& validHours,
                            std::shared_ptr<StorageForRemix>& storage)
 {
     double exchange = 0.; // To be returned

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <ranges>
+#include <set>
 #include <stdexcept>
 #include <vector>
 
@@ -14,38 +15,21 @@ constexpr double eps = 1e-3;
 constexpr unsigned maxNbLoops = 1000;
 const std::string error_msg_start = "Remix storage input : ";
 
+using set_iterator = std::set<unsigned>::iterator;
+
 namespace Antares::Solver::Simulation
 {
 
-static std::vector<unsigned> filterHoursForMin(const std::vector<double>& UnsupE,
-                                               const std::vector<bool>& triedMins,
-                                               const std::vector<unsigned>& validHours)
+static std::set<unsigned> ValidHours(const std::vector<double>& Spillage,
+                                     const std::vector<double>& DTG_MRG,
+                                     const std::vector<double>& StorageGen,
+                                     const std::vector<double>& UnsupE)
 {
-    auto filter = [&](int h) { return UnsupE[h] > 0 && !triedMins[h]; };
-    auto filterHoursView = validHours | vws::filter(filter);
+    auto filter = [&](int h)
+    { return std::abs(Spillage[h] + DTG_MRG[h]) < eps && StorageGen[h] + UnsupE[h] > 0.; };
+
+    auto filterHoursView = vws::iota(0, static_cast<int>(Spillage.size())) | vws::filter(filter);
     return {filterHoursView.begin(), filterHoursView.end()};
-}
-
-static unsigned hourForTotalGenMin(const std::vector<double>& TotalGen,
-                                   const std::vector<unsigned>& filteredHours)
-{
-    return *rng::min_element(filteredHours, {}, [&](int h) { return TotalGen[h]; });
-}
-
-static std::vector<unsigned> filterHoursForMax(const std::vector<double>& TotalGen,
-                                               const std::vector<bool>& triedMaxs,
-                                               const std::vector<unsigned>& validHours,
-                                               double minTotalGen)
-{
-    auto filter = [&](int h) { return TotalGen[h] >= minTotalGen + eps && !triedMaxs[h]; };
-    auto filterHoursView = validHours | vws::filter(filter);
-    return {filterHoursView.begin(), filterHoursView.end()};
-}
-
-static unsigned hourForTotalGenMax(const std::vector<double>& TotalGen,
-                                   const std::vector<unsigned>& filteredHours)
-{
-    return *rng::max_element(filteredHours, {}, [&](int h) { return TotalGen[h]; });
 }
 
 void checkInput(const std::vector<double>& Load,
@@ -72,71 +56,58 @@ void checkInput(const std::vector<double>& Load,
     }
 }
 
-static std::vector<unsigned> ValidHours(const std::vector<double>& Spillage,
-                                        const std::vector<double>& DTG_MRG,
-                                        const std::vector<double>& StorageGen,
-                                        const std::vector<double>& UnsupE)
-{
-    auto filter = [&](int h)
-    { return std::abs(Spillage[h] + DTG_MRG[h]) < eps && StorageGen[h] + UnsupE[h] > 0.; };
-
-    auto filterHoursView = vws::iota(0, static_cast<int>(Spillage.size())) | vws::filter(filter);
-    return {filterHoursView.begin(), filterHoursView.end()};
-}
-
 static double makeExchange(std::vector<double>& TotalGen,
                            std::vector<double>& UnsupE,
-                           const std::vector<unsigned>& validHours,
+                           const std::set<unsigned>& validHours,
                            std::shared_ptr<StorageForRemix>& storage)
 {
     double exchange = 0.; // To be returned
-    size_t nbHours = TotalGen.size();
+    auto totalGenProjection = [&](int h) { return TotalGen[h]; };
 
-    std::vector<bool> triedMins(nbHours, false);
+    std::set<unsigned> validHoursForMin(validHours);
     while (true)
     {
-        auto filteredHours = filterHoursForMin(UnsupE, triedMins, validHours);
-        if (!filteredHours.size())
+        std::erase_if(validHoursForMin, [&](int h) { return UnsupE[h] <= 0.; });
+        if (!validHoursForMin.size())
         {
             return 0.;
         }
 
-        unsigned hourOfMinGen = hourForTotalGenMin(TotalGen, filteredHours);
+        auto hourOfMinGen = rng::min_element(validHoursForMin, {}, totalGenProjection);
 
-        std::vector<bool> triedMaxs(nbHours, false);
+        std::set<unsigned> validHoursForMax(validHours);
         while (true)
         {
-            double totaGenMin = TotalGen[hourOfMinGen];
-            filteredHours = filterHoursForMax(TotalGen, triedMaxs, validHours, totaGenMin);
-            if (!filteredHours.size())
+            double totaGenMin = TotalGen[*hourOfMinGen];
+            std::erase_if(validHoursForMax, [&](int h) { return TotalGen[h] < totaGenMin + eps; });
+            if (!validHoursForMax.size())
             {
                 break;
             }
 
-            unsigned hourOfMaxGen = hourForTotalGenMax(TotalGen, filteredHours);
+            auto hourOfMaxGen = rng::max_element(validHoursForMax, {}, totalGenProjection);
 
-            double maxVariation = std::max(TotalGen[hourOfMaxGen] - TotalGen[hourOfMinGen], 0.);
-            double maxExchangeFromStorage = storage->maxExchange(hourOfMaxGen, hourOfMinGen);
+            double maxVariation = std::max(TotalGen[*hourOfMaxGen] - TotalGen[*hourOfMinGen], 0.);
+            double maxExchangeFromStorage = storage->maxExchange(*hourOfMaxGen, *hourOfMinGen);
             exchange = std::max(std::min(maxExchangeFromStorage, maxVariation / 2.), 0.);
 
             if (exchange > eps)
             {
-                storage->generation()[hourOfMaxGen] -= exchange;
-                storage->generation()[hourOfMinGen] += exchange;
+                storage->generation()[*hourOfMaxGen] -= exchange;
+                storage->generation()[*hourOfMinGen] += exchange;
                 storage->update();
 
-                UnsupE[hourOfMaxGen] += exchange;
-                UnsupE[hourOfMinGen] -= exchange;
+                UnsupE[*hourOfMaxGen] += exchange;
+                UnsupE[*hourOfMinGen] -= exchange;
 
-                TotalGen[hourOfMaxGen] -= exchange;
-                TotalGen[hourOfMinGen] += exchange;
+                TotalGen[*hourOfMaxGen] -= exchange;
+                TotalGen[*hourOfMinGen] += exchange;
 
                 return exchange;
             }
-            triedMaxs[hourOfMaxGen] = true;
+            validHoursForMax.erase(hourOfMaxGen);
         }
-
-        triedMins[hourOfMinGen] = true;
+        validHoursForMin.erase(hourOfMinGen);
     }
 }
 

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -121,9 +121,9 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
 
     while (loop-- > 0)
     {
-        std::vector<bool> triedMins(nbHours, false);
-        double maxExchange = 0;
+        double exchange = 0;
 
+        std::vector<bool> triedMins(nbHours, false);
         while (true)
         {
             auto filteredHours = filterHoursForMin(UnsupE, triedMins, validHours);
@@ -152,12 +152,12 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
 
                 double maxVariation = std::max(TotalGen[hourOfMaxGen] - TotalGen[hourOfMinGen], 0.);
                 double maxExchangeFromStorage = storage->maxExchange(hourOfMaxGen, hourOfMinGen);
-                maxExchange = std::max(std::min(maxExchangeFromStorage, maxVariation / 2.), 0.);
+                exchange = std::max(std::min(maxExchangeFromStorage, maxVariation / 2.), 0.);
 
-                if (maxExchange > eps)
+                if (exchange > eps)
                 {
-                    storage->generation()[hourOfMaxGen] -= maxExchange;
-                    storage->generation()[hourOfMinGen] += maxExchange;
+                    storage->generation()[hourOfMaxGen] -= exchange;
+                    storage->generation()[hourOfMinGen] += exchange;
 
                     UnsupE[hourOfMaxGen] = storageGenInit[hourOfMaxGen] + UnsupEinit[hourOfMaxGen]
                                            - storage->generation()[hourOfMaxGen];
@@ -172,14 +172,14 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
                 triedMaxs[hourOfMaxGen] = true;
             }
 
-            if (maxExchange > eps)
+            if (exchange > eps)
             {
                 break;
             }
             triedMins[hourOfMinGen] = true;
         }
 
-        if (maxExchange <= eps)
+        if (exchange <= eps)
         {
             break;
         }

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -1,6 +1,7 @@
 #include "include/antares/solver/simulation/shave-peaks-by-remix-storage-gen.h"
 
 #include <algorithm>
+#include <ranges>
 #include <stdexcept>
 #include <vector>
 
@@ -90,7 +91,6 @@ static std::vector<bool> ValidHours(const std::vector<double>& Spillage,
 
 static double makeExchange(std::vector<double>& TotalGen,
                            std::vector<double>& UnsupE,
-                           const std::vector<double>& UnsupEinit,
                            const std::vector<bool>& validHours,
                            std::shared_ptr<StorageForRemix>& storage)
 {
@@ -129,12 +129,8 @@ static double makeExchange(std::vector<double>& TotalGen,
                 storage->generation()[hourOfMaxGen] -= exchange;
                 storage->generation()[hourOfMinGen] += exchange;
 
-                UnsupE[hourOfMaxGen] = storage->initialGen()[hourOfMaxGen]
-                                       + UnsupEinit[hourOfMaxGen]
-                                       - storage->generation()[hourOfMaxGen];
-                UnsupE[hourOfMinGen] = storage->initialGen()[hourOfMinGen]
-                                       + UnsupEinit[hourOfMinGen]
-                                       - storage->generation()[hourOfMinGen];
+                UnsupE[hourOfMaxGen] += exchange;
+                UnsupE[hourOfMinGen] -= exchange;
 
                 storage->update();
 
@@ -165,7 +161,7 @@ void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
     {
         // Valid hours could be computed once for all, not at each iterations.
         const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
-        double exchange = makeExchange(TotalGen, UnsupE, UnsupEinit, validHours, storage);
+        double exchange = makeExchange(TotalGen, UnsupE, validHours, storage);
 
         if (exchange <= eps)
         {

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -99,6 +99,71 @@ static std::vector<bool> ValidHours(const std::vector<double>& Spillage,
     return validHours;
 }
 
+static double makeExchange(std::vector<double>& UnsupE,
+                           const std::vector<bool>& validHours,
+                           std::vector<double>& TotalGen,
+                           double top,
+                           std::shared_ptr<StorageForRemix>& storage,
+                           const std::vector<double>& storageGenInit,
+                           const std::vector<double>& UnsupEinit,
+                           const std::vector<double>& DispatchGen)
+{
+    double exchange = 0; // to be returned
+    size_t nbHours = DispatchGen.size();
+
+    std::vector<bool> triedMins(nbHours, false);
+    while (true)
+    {
+        auto filteredHours = filterHoursForMin(UnsupE, triedMins, validHours);
+        if (!filteredHours.size())
+        {
+            return 0.;
+        }
+
+        unsigned hourOfMinGen = hourForTotalGenMin(TotalGen, filteredHours);
+        if (TotalGen[hourOfMinGen] > top)
+        {
+            return 0.;
+        }
+
+        std::vector<bool> triedMaxs(nbHours, false);
+        while (true)
+        {
+            double totaGenMin = TotalGen[hourOfMinGen];
+            filteredHours = filterHoursForMax(TotalGen, triedMaxs, validHours, totaGenMin);
+            if (!filteredHours.size())
+            {
+                break;
+            }
+
+            unsigned hourOfMaxGen = hourForTotalGenMax(TotalGen, filteredHours);
+
+            double maxVariation = std::max(TotalGen[hourOfMaxGen] - TotalGen[hourOfMinGen], 0.);
+            double maxExchangeFromStorage = storage->maxExchange(hourOfMaxGen, hourOfMinGen);
+            exchange = std::max(std::min(maxExchangeFromStorage, maxVariation / 2.), 0.);
+
+            if (exchange > eps)
+            {
+                storage->generation()[hourOfMaxGen] -= exchange;
+                storage->generation()[hourOfMinGen] += exchange;
+
+                UnsupE[hourOfMaxGen] = storageGenInit[hourOfMaxGen] + UnsupEinit[hourOfMaxGen]
+                                       - storage->generation()[hourOfMaxGen];
+                UnsupE[hourOfMinGen] = storageGenInit[hourOfMinGen] + UnsupEinit[hourOfMinGen]
+                                       - storage->generation()[hourOfMinGen];
+
+                storage->update();
+
+                TotalGen = updateTotalGen(DispatchGen, storage->generation());
+                return exchange;
+            }
+            triedMaxs[hourOfMaxGen] = true;
+        }
+
+        triedMins[hourOfMinGen] = true;
+    }
+}
+
 void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
                                     const std::vector<double>& DispatchGen,
                                     const std::vector<double>& Spillage,
@@ -109,7 +174,6 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
     const std::vector<double> UnsupEinit = UnsupE;
 
     checkInput(DispatchGen, UnsupEinit, Spillage, DTG_MRG, storageGenInit);
-    size_t nbHours = DispatchGen.size();
 
     int loop = 1000;
     double top = *rng::max_element(DispatchGen) + *rng::max_element(storageGenInit)
@@ -121,63 +185,14 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
 
     while (loop-- > 0)
     {
-        double exchange = 0;
-
-        std::vector<bool> triedMins(nbHours, false);
-        while (true)
-        {
-            auto filteredHours = filterHoursForMin(UnsupE, triedMins, validHours);
-            if (!filteredHours.size())
-            {
-                break;
-            }
-
-            unsigned hourOfMinGen = hourForTotalGenMin(TotalGen, filteredHours);
-            if (TotalGen[hourOfMinGen] > top)
-            {
-                break;
-            }
-
-            std::vector<bool> triedMaxs(nbHours, false);
-            while (true)
-            {
-                double totaGenMin = TotalGen[hourOfMinGen];
-                filteredHours = filterHoursForMax(TotalGen, triedMaxs, validHours, totaGenMin);
-                if (!filteredHours.size())
-                {
-                    break;
-                }
-
-                unsigned hourOfMaxGen = hourForTotalGenMax(TotalGen, filteredHours);
-
-                double maxVariation = std::max(TotalGen[hourOfMaxGen] - TotalGen[hourOfMinGen], 0.);
-                double maxExchangeFromStorage = storage->maxExchange(hourOfMaxGen, hourOfMinGen);
-                exchange = std::max(std::min(maxExchangeFromStorage, maxVariation / 2.), 0.);
-
-                if (exchange > eps)
-                {
-                    storage->generation()[hourOfMaxGen] -= exchange;
-                    storage->generation()[hourOfMinGen] += exchange;
-
-                    UnsupE[hourOfMaxGen] = storageGenInit[hourOfMaxGen] + UnsupEinit[hourOfMaxGen]
-                                           - storage->generation()[hourOfMaxGen];
-                    UnsupE[hourOfMinGen] = storageGenInit[hourOfMinGen] + UnsupEinit[hourOfMinGen]
-                                           - storage->generation()[hourOfMinGen];
-
-                    storage->update();
-
-                    TotalGen = updateTotalGen(DispatchGen, storage->generation());
-                    break;
-                }
-                triedMaxs[hourOfMaxGen] = true;
-            }
-
-            if (exchange > eps)
-            {
-                break;
-            }
-            triedMins[hourOfMinGen] = true;
-        }
+        double exchange = makeExchange(UnsupE,
+                                       validHours,
+                                       TotalGen,
+                                       top,
+                                       storage,
+                                       storageGenInit,
+                                       UnsupEinit,
+                                       DispatchGen);
 
         if (exchange <= eps)
         {

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -104,13 +104,12 @@ static double makeExchange(std::vector<double>& UnsupE,
                            const std::vector<bool>& validHours,
                            std::vector<double>& TotalGen,
                            std::shared_ptr<StorageForRemix>& storage,
-                           const std::vector<double>& storageGenInit,
                            const std::vector<double>& UnsupEinit,
                            const std::vector<double>& DispatchGen)
 {
     double exchange = 0; // to be returned
     size_t nbHours = DispatchGen.size();
-    double top = *rng::max_element(DispatchGen) + *rng::max_element(storageGenInit)
+    double top = *rng::max_element(DispatchGen) + *rng::max_element(storage->initialGen())
                  + *rng::max_element(UnsupEinit) + 1;
 
     std::vector<bool> triedMins(nbHours, false);
@@ -149,9 +148,11 @@ static double makeExchange(std::vector<double>& UnsupE,
                 storage->generation()[hourOfMaxGen] -= exchange;
                 storage->generation()[hourOfMinGen] += exchange;
 
-                UnsupE[hourOfMaxGen] = storageGenInit[hourOfMaxGen] + UnsupEinit[hourOfMaxGen]
+                UnsupE[hourOfMaxGen] = storage->initialGen()[hourOfMaxGen]
+                                       + UnsupEinit[hourOfMaxGen]
                                        - storage->generation()[hourOfMaxGen];
-                UnsupE[hourOfMinGen] = storageGenInit[hourOfMinGen] + UnsupEinit[hourOfMinGen]
+                UnsupE[hourOfMinGen] = storage->initialGen()[hourOfMinGen]
+                                       + UnsupEinit[hourOfMinGen]
                                        - storage->generation()[hourOfMinGen];
 
                 storage->update();
@@ -172,14 +173,13 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
                                     const std::vector<double>& DTG_MRG,
                                     std::shared_ptr<StorageForRemix> storage)
 {
-    const std::vector<double> storageGenInit = storage->initialGen();
     const std::vector<double> UnsupEinit = UnsupE;
 
-    checkInput(DispatchGen, UnsupEinit, Spillage, DTG_MRG, storageGenInit);
+    checkInput(DispatchGen, UnsupEinit, Spillage, DTG_MRG, storage->initialGen());
 
-    const auto validHours = ValidHours(Spillage, DTG_MRG, storageGenInit, UnsupEinit);
+    const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
 
-    std::vector<double> TotalGen = updateTotalGen(DispatchGen, storageGenInit);
+    std::vector<double> TotalGen = updateTotalGen(DispatchGen, storage->initialGen());
 
     unsigned nbLoops = maxNbLoops;
     while (nbLoops-- > 0)
@@ -188,7 +188,6 @@ void shavePeaksByRemixingStorageGen(std::vector<double>& UnsupE,
                                        validHours,
                                        TotalGen,
                                        storage,
-                                       storageGenInit,
                                        UnsupEinit,
                                        DispatchGen);
 

--- a/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
+++ b/src/solver/simulation/shave-peaks-by-remix-storage-gen.cpp
@@ -158,13 +158,13 @@ void shavePeaksByRemixingStorageGen(const std::vector<double>& Load,
 {
     const std::vector<double> UnsupEinit = UnsupE;
 
-    const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
-
     std::vector<double> TotalGen = Load - UnsupEinit;
 
     unsigned nbLoops = maxNbLoops;
     while (nbLoops-- > 0)
     {
+        // Valid hours could be computed once for all, not at each iterations.
+        const auto validHours = ValidHours(Spillage, DTG_MRG, storage->initialGen(), UnsupEinit);
         double exchange = makeExchange(TotalGen, UnsupE, UnsupEinit, validHours, storage);
 
         if (exchange <= eps)

--- a/src/tests/src/solver/simulation/test-hydro-remix.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-remix.cpp
@@ -8,8 +8,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include "antares/solver/simulation/shave-peaks-by-remix-storage-gen.h"
 #include "antares/solver/simulation/remix-utils.h"
+#include "antares/solver/simulation/shave-peaks-by-remix-storage-gen.h"
 
 using namespace Antares::Solver::Simulation;
 
@@ -54,8 +54,8 @@ struct InputFixture
         shavePeaksByRemixingStorageGen(Load, UnsupE, Spillage, DTG_MRG, hydroForRemix);
     }
 
-    std::vector<double> TotalGenNoHydro, Load, HydroGen, UnsupE, levels, HydroPmax, HydroPmin, inflows,
-      ovf, pump, Spillage, DTG_MRG;
+    std::vector<double> TotalGenNoHydro, Load, HydroGen, UnsupE, levels, HydroPmax, HydroPmin,
+      inflows, ovf, pump, Spillage, DTG_MRG;
     std::shared_ptr<StorageForRemix> hydroForRemix;
     double init_level = 0.;
     double capacity = std::numeric_limits<double>::max();

--- a/src/tests/src/solver/simulation/test-hydro-remix.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-remix.cpp
@@ -30,7 +30,7 @@ struct InputFixture
         DTG_MRG.assign(size, 0.);
     }
 
-    std::shared_ptr<StorageForRemix> createHydroRemix()
+    std::shared_ptr<StorageForRemix> createHydroForRemix()
     {
         return std::make_shared<HydroForRemixWithLevels>(HydroGen,
                                                          UnsupE,
@@ -47,7 +47,7 @@ struct InputFixture
 
     void callRemixStorageAlgorithm()
     {
-        hydroForRemix = createHydroRemix();
+        hydroForRemix = createHydroForRemix();
         shavePeaksByRemixingStorageGen(UnsupE, TotalGenNoHydro, Spillage, DTG_MRG, hydroForRemix);
     }
 
@@ -66,7 +66,7 @@ BOOST_FIXTURE_TEST_CASE(input_vectors_of_different_sizes__exception_raised, Inpu
 {
     HydroGen = {0., 0.};
     err_msg = "Remix hydro input : arrays of different sizes";
-    BOOST_CHECK_EXCEPTION(createHydroRemix(), std::invalid_argument, checkMessage(err_msg));
+    BOOST_CHECK_EXCEPTION(createHydroForRemix(), std::invalid_argument, checkMessage(err_msg));
 }
 
 BOOST_FIXTURE_TEST_CASE(input_init_level_exceeds_capacity__exception_raised, InputFixture<1>)
@@ -74,7 +74,7 @@ BOOST_FIXTURE_TEST_CASE(input_init_level_exceeds_capacity__exception_raised, Inp
     init_level = 2.;
     capacity = 1.;
     err_msg = "Remix hydro input : initial level > reservoir capacity";
-    BOOST_CHECK_EXCEPTION(createHydroRemix(), std::invalid_argument, checkMessage(err_msg));
+    BOOST_CHECK_EXCEPTION(createHydroForRemix(), std::invalid_argument, checkMessage(err_msg));
 }
 
 BOOST_FIXTURE_TEST_CASE(all_input_arrays_of_size_0__exception_raised, InputFixture<0>)
@@ -82,7 +82,7 @@ BOOST_FIXTURE_TEST_CASE(all_input_arrays_of_size_0__exception_raised, InputFixtu
     init_level = 0.;
     capacity = 1.;
     err_msg = "Remix hydro input : all arrays of sizes 0";
-    BOOST_CHECK_EXCEPTION(createHydroRemix(), std::invalid_argument, checkMessage(err_msg));
+    BOOST_CHECK_EXCEPTION(createHydroForRemix(), std::invalid_argument, checkMessage(err_msg));
 }
 
 BOOST_FIXTURE_TEST_CASE(Hydro_gen_not_smaller_than_pmax__exception_raised, InputFixture<5>)
@@ -92,7 +92,7 @@ BOOST_FIXTURE_TEST_CASE(Hydro_gen_not_smaller_than_pmax__exception_raised, Input
     init_level = 0.;
     capacity = 1.;
     err_msg = "Remix hydro input : Hydro generation not smaller than Pmax everywhere";
-    BOOST_CHECK_EXCEPTION(createHydroRemix(), std::invalid_argument, checkMessage(err_msg));
+    BOOST_CHECK_EXCEPTION(createHydroForRemix(), std::invalid_argument, checkMessage(err_msg));
 }
 
 BOOST_FIXTURE_TEST_CASE(Hydro_gen_not_greater_than_pmin__exception_raised, InputFixture<5>)
@@ -102,14 +102,14 @@ BOOST_FIXTURE_TEST_CASE(Hydro_gen_not_greater_than_pmin__exception_raised, Input
     init_level = 0.;
     capacity = 1.;
     err_msg = "Remix hydro input : Hydro generation not greater than Pmin everywhere";
-    BOOST_CHECK_EXCEPTION(createHydroRemix(), std::invalid_argument, checkMessage(err_msg));
+    BOOST_CHECK_EXCEPTION(createHydroForRemix(), std::invalid_argument, checkMessage(err_msg));
 }
 
 BOOST_FIXTURE_TEST_CASE(input_is_acceptable__no_exception_raised, InputFixture<1>)
 {
     init_level = 0.;
     capacity = 1.;
-    BOOST_CHECK_NO_THROW(hydroForRemix = createHydroRemix());
+    BOOST_CHECK_NO_THROW(hydroForRemix = createHydroForRemix());
     BOOST_CHECK_NO_THROW(
       shavePeaksByRemixingStorageGen(UnsupE, TotalGenNoHydro, Spillage, DTG_MRG, hydroForRemix));
 }
@@ -259,7 +259,7 @@ BOOST_FIXTURE_TEST_CASE(input_leads_to_levels_over_capacity___exception_raised, 
     std::ranges::fill(inflows, 25);  // Cause levels to increase
     std::ranges::fill(pump, 20);     // Cause levels to increase
     err_msg = "Remix hydro input : levels computed from input don't respect reservoir bounds";
-    BOOST_CHECK_EXCEPTION(createHydroRemix(), std::invalid_argument, checkMessage(err_msg));
+    BOOST_CHECK_EXCEPTION(createHydroForRemix(), std::invalid_argument, checkMessage(err_msg));
 }
 
 BOOST_FIXTURE_TEST_CASE(input_leads_to_levels_less_than_zero___exception_raised, InputFixture<5>)
@@ -270,7 +270,7 @@ BOOST_FIXTURE_TEST_CASE(input_leads_to_levels_less_than_zero___exception_raised,
     std::ranges::fill(inflows, 5);   // Cause levels to increase
     std::ranges::fill(pump, 10);     // Cause levels to increase
     err_msg = "Remix hydro input : levels computed from input don't respect reservoir bounds";
-    BOOST_CHECK_EXCEPTION(createHydroRemix(), std::invalid_argument, checkMessage(err_msg));
+    BOOST_CHECK_EXCEPTION(createHydroForRemix(), std::invalid_argument, checkMessage(err_msg));
 }
 
 BOOST_FIXTURE_TEST_CASE(influence_of_capacity_on_algorithm___case_where_no_influence,

--- a/src/tests/src/solver/simulation/test-hydro-remix.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-remix.cpp
@@ -9,6 +9,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "antares/solver/simulation/shave-peaks-by-remix-storage-gen.h"
+#include "antares/solver/simulation/remix-utils.h"
 
 using namespace Antares::Solver::Simulation;
 
@@ -18,6 +19,7 @@ struct InputFixture
     InputFixture()
     {
         TotalGenNoHydro.assign(size, 0.);
+        Load.assign(size, 0.);
         HydroGen.assign(size, 0.);
         UnsupE.assign(size, 0.);
         levels.assign(size, 0.);
@@ -48,10 +50,11 @@ struct InputFixture
     void callRemixStorageAlgorithm()
     {
         hydroForRemix = createHydroForRemix();
-        shavePeaksByRemixingStorageGen(UnsupE, TotalGenNoHydro, Spillage, DTG_MRG, hydroForRemix);
+        Load = TotalGenNoHydro + UnsupE + HydroGen;
+        shavePeaksByRemixingStorageGen(Load, UnsupE, Spillage, DTG_MRG, hydroForRemix);
     }
 
-    std::vector<double> TotalGenNoHydro, HydroGen, UnsupE, levels, HydroPmax, HydroPmin, inflows,
+    std::vector<double> TotalGenNoHydro, Load, HydroGen, UnsupE, levels, HydroPmax, HydroPmin, inflows,
       ovf, pump, Spillage, DTG_MRG;
     std::shared_ptr<StorageForRemix> hydroForRemix;
     double init_level = 0.;
@@ -109,9 +112,11 @@ BOOST_FIXTURE_TEST_CASE(input_is_acceptable__no_exception_raised, InputFixture<1
 {
     init_level = 0.;
     capacity = 1.;
+    Load = TotalGenNoHydro + UnsupE + HydroGen;
+
     BOOST_CHECK_NO_THROW(hydroForRemix = createHydroForRemix());
     BOOST_CHECK_NO_THROW(
-      shavePeaksByRemixingStorageGen(UnsupE, TotalGenNoHydro, Spillage, DTG_MRG, hydroForRemix));
+      shavePeaksByRemixingStorageGen(Load, UnsupE, Spillage, DTG_MRG, hydroForRemix));
 }
 
 BOOST_FIXTURE_TEST_CASE(

--- a/src/tests/src/solver/simulation/test-hydro-remix.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-remix.cpp
@@ -128,7 +128,7 @@ BOOST_FIXTURE_TEST_CASE(
     callRemixStorageAlgorithm();
 
     std::vector<double> expected_HydroGen = {20., 20., 20., 20., 20.};
-    // UnsupE such as TotalGenNoHydro + HydroGen + UnsupE remains flat
+    // UnsupE such as Load = TotalGenNoHydro + HydroGen + UnsupE remains flat
     std::vector<double> expected_UnsupE = {60., 50., 40., 30., 20.};
     BOOST_CHECK(HydroGen == expected_HydroGen);
     BOOST_CHECK(UnsupE == expected_UnsupE);
@@ -146,7 +146,7 @@ BOOST_FIXTURE_TEST_CASE(Pmax_does_not_impact_results_when_greater_than_40mwh, In
     callRemixStorageAlgorithm();
 
     std::vector<double> expected_HydroGen = {20., 20., 20., 20., 20.};
-    // UnsupE such as TotalGenNoHydro + HydroGen + UnsupE remains constant at each hour
+    // UnsupE such as Load = TotalGenNoHydro + HydroGen + UnsupE remains constant at each hour
     std::vector<double> expected_UnsupE = {60., 50., 40., 30., 20.};
     BOOST_CHECK(HydroGen == expected_HydroGen);
     BOOST_CHECK(UnsupE == expected_UnsupE);
@@ -166,7 +166,7 @@ BOOST_FIXTURE_TEST_CASE(
     callRemixStorageAlgorithm();
 
     std::vector<double> expected_HydroGen = {20., 20., 20., 20., 20.};
-    // UnsupE such as TotalGenNoHydro + HydroGen + UnsupE remains constant at each hour
+    // UnsupE such as Load = TotalGenNoHydro + HydroGen + UnsupE remains constant at each hour
     std::vector<double> expected_UnsupE = {20., 30., 40., 50., 60.};
     BOOST_CHECK(HydroGen == expected_HydroGen);
     BOOST_CHECK(UnsupE == expected_UnsupE);

--- a/src/tests/src/solver/simulation/test-hydro-remix.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-remix.cpp
@@ -56,7 +56,7 @@ struct InputFixture
     std::shared_ptr<StorageForRemix> hydroForRemix;
     double init_level = 0.;
     double capacity = std::numeric_limits<double>::max();
-    const double pumpEff = 1.0;
+    const double pumpEff = 1.;
     const bool reservoirManagement = true;
 
     std::string err_msg;
@@ -121,7 +121,7 @@ BOOST_FIXTURE_TEST_CASE(
     std::ranges::fill(HydroPmax, 40.);
     std::ranges::fill(TotalGenNoHydro, 100.);
     HydroGen = {0., 10., 20., 30., 40.}; // we have Pmin <= HydroGen <= Pmax
-    UnsupE = {80.0, 60., 40., 20., 0.};
+    UnsupE = {80., 60., 40., 20., 0.};
     init_level = 500.;
     capacity = 1000.;
 
@@ -139,7 +139,7 @@ BOOST_FIXTURE_TEST_CASE(Pmax_does_not_impact_results_when_greater_than_40mwh, In
     std::ranges::fill(HydroPmax, 50.);
     std::ranges::fill(TotalGenNoHydro, 100.);
     HydroGen = {0., 10., 20., 30., 40.};
-    UnsupE = {80.0, 60., 40., 20., 0.};
+    UnsupE = {80., 60., 40., 20., 0.};
     init_level = 500.;
     capacity = 1000.;
 


### PR DESCRIPTION
Some more simplifications / clarifications of remix hydro algo + a step further towards [ticket ANT-3175](https://gopro-tickets.rte-france.com/browse/ANT-3175).

**Examples of things done** : 
- [ ] on study **short-tests/hydro_monthly_heuristic_gen_capa**, we had a regression that commit **"Hydro remix : fix a regression"** solves. No unit test could catch the problem. We should have such a unit test.
- [x] no more **DispatchGen** among the arguments of the algorithm : this vector was **Total Generation - hydro generation**, that is : **Load - Demand - Hydro - Unsupplied Energy**.
It was depending on **Hydro**, so on a particular  storage.
Instead, we have **Load** as argument. Unit tests were adapted accordingly.
- [x] checking algo input is now required outside (see **checkInput** function) algorithm, to separate responsibilities.
- [x] There used to be 2 kind of vectors allowing to filter hours where to find a **min** or a **max** for **TotalGen**. 
  - **validHours** (a **std::vector\<unsigned\>** of hours)
  - **triedMins** and **triedMaxs** (**std::vector\<bool\>**, telling if a min / max was already tried in the loop it belongs to)
 
  Now each of them are **std::set\<unsigned\>**, named **validHours**, **validHoursForMin** and **validHoursForMax**.
  The 2 last ones are built from the first.
- [x] updating impacted variable after finding a slice of energy to exchange was simplified
- [x] some free functions became so simple that they could be replaced with std algorithms
- [x] local variable **top**'s definition and use were removed : this variable turned out to be useless 