### PR TITLE
Fix boost.test log format

### DIFF
--- a/src/tests/macros.cmake
+++ b/src/tests/macros.cmake
@@ -28,7 +28,7 @@ function(add_boost_test)
     endif()
 
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME}
-      --output_format=XML
+      --report_format=XML
       --report_level=detailed
       --report_sink=report_${TEST_NAME}.xml
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests)


### PR DESCRIPTION
- [output_format](https://www.boost.org/doc/libs/1_88_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/output_format.html) specifies the log format and the report format.
- [report_format](https://www.boost.org/doc/libs/1_88_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/report_format.html) specifies the report format.

See https://www.boost.org/doc/libs/1_88_0/libs/test/doc/html/boost_test/runtime_config/summary.html