### PR TITLE
Remove useless dependency to `Boost::unit_test_framework` library

### DIFF
--- a/src/tests/libs/antares/optimization-options/CMakeLists.txt
+++ b/src/tests/libs/antares/optimization-options/CMakeLists.txt
@@ -7,5 +7,4 @@ add_boost_test(TestOptimizationOptions
         LIBS
         Antares::optimization-options
         Antares::checks
-        Antares::exception
-        Boost::unit_test_framework)
+        Antares::exception)

--- a/src/tests/src/io/data-series-csv-importer/CMakeLists.txt
+++ b/src/tests/src/io/data-series-csv-importer/CMakeLists.txt
@@ -6,5 +6,4 @@ add_boost_test(TestDataSeriesCsvImporter
   testDataSeriesCsvImporter.cpp
   LIBS
   Antares::data-series-csv-importer
-  Boost::unit_test_framework
   test_utils_unit)

--- a/src/tests/src/study/system-model/CMakeLists.txt
+++ b/src/tests/src/study/system-model/CMakeLists.txt
@@ -6,11 +6,10 @@ add_boost_test(test-system-model
   test_system.cpp
   test_library.cpp
   LIBS
-  Boost::unit_test_framework
-        Antares::expressions
-        Antares::model-converter
-        Antares::yml-model
-        Antares::yml-system
-        Antares::antares-study-system-model
-        Antares::antlr-interface
-        test_utils_unit)
+  Antares::expressions
+  Antares::model-converter
+  Antares::yml-model
+  Antares::yml-system
+  Antares::antares-study-system-model
+  Antares::antlr-interface
+  test_utils_unit)


### PR DESCRIPTION
Macro `add_boost_test` already adds it automatically.

https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/70f3418204810016f619362b627944f0ce179967/src/tests/macros.cmake#L1-L6