### PR TITLE
Modeler - fix various problems with time & scenarios [ANT-3712]

### DIFF
--- a/src/expressions/include/antares/expressions/RotateIndex.h
+++ b/src/expressions/include/antares/expressions/RotateIndex.h
@@ -78,12 +78,12 @@ inline int rotatedIndex(unsigned key,
                         int shift,
                         const Antares::Optimisation::LinearProblemApi::FillContext& fillContext)
 {
-    unsigned rangeSize = fillContext.getNumberOfTimestep();
+    unsigned rangeSize = fillContext.getLocalNumberOfTimeSteps();
 
     // Normalize shift within bounds (to prevent negative indexing)
     shift = (shift % static_cast<int>(rangeSize) + rangeSize) % static_cast<int>(rangeSize);
 
     // Compute which key's value should be assigned to `key`
-    return fillContext.getFirstTimeStep()
-           + (key - fillContext.getFirstTimeStep() + shift) % rangeSize;
+    return fillContext.getLocalFirstTimeStep()
+           + (key - fillContext.getLocalFirstTimeStep() + shift) % rangeSize;
 }

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -98,9 +98,9 @@ EvaluationResult EvalVisitor::visit(const Nodes::ParameterNode* node)
         return EvaluationResult{context_.getSystemParameterValueAsDouble(node->value())};
     }
     std::vector<double> params;
-    params.reserve(fillContext_.getNumberOfTimestep());
-    for (auto timeStep = fillContext_.getFirstTimeStep();
-         timeStep <= fillContext_.getLastTimeStep();
+    params.reserve(fillContext_.getLocalNumberOfTimeSteps());
+    for (auto timeStep = fillContext_.getGlobalFirstTimeStep();
+         timeStep <= fillContext_.getGlobalLastTimeStep();
          ++timeStep)
     {
         params.emplace_back(
@@ -171,7 +171,7 @@ EvaluationResult EvalVisitor::visit(const Nodes::TimeSumNode* node)
 EvaluationResult EvalVisitor::visit(const Nodes::AllTimeSumNode* node)
 {
     const EvaluationResult expression = dispatch(node->child());
-    return expression.alltimeSum(fillContext_.getNumberOfTimestep());
+    return expression.alltimeSum(fillContext_.getLocalNumberOfTimeSteps());
 }
 
 std::string EvalVisitor::name() const

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -38,7 +38,7 @@ EvalVisitor::EvalVisitor(EvaluationContext context,
 
 EvaluationResult EvalVisitor::visit(const Nodes::SumNode* node)
 {
-    auto operands = node->getOperands();
+    const auto& operands = node->getOperands();
     return std::accumulate(std::begin(operands),
                            std::end(operands),
                            EvaluationResult{0.},

--- a/src/expressions/visitors/LinearityVisitor.cpp
+++ b/src/expressions/visitors/LinearityVisitor.cpp
@@ -31,7 +31,7 @@ namespace Antares::Expressions::Visitors
 
 LinearStatus LinearityVisitor::visit(const Nodes::SumNode* node)
 {
-    auto operands = node->getOperands();
+    const auto& operands = node->getOperands();
     return std::accumulate(std::begin(operands),
                            std::end(operands),
                            LinearStatus::CONSTANT,

--- a/src/expressions/visitors/PrintVisitor.cpp
+++ b/src/expressions/visitors/PrintVisitor.cpp
@@ -30,7 +30,7 @@ namespace Antares::Expressions::Visitors
 {
 std::string PrintVisitor::visit(const Nodes::SumNode* node)
 {
-    auto operands = node->getOperands();
+    const auto& operands = node->getOperands();
     if (operands.empty())
     {
         return "()";

--- a/src/expressions/visitors/TimeIndexVisitor.cpp
+++ b/src/expressions/visitors/TimeIndexVisitor.cpp
@@ -31,7 +31,7 @@ namespace Antares::Expressions::Visitors
 
 TimeIndex TimeIndexVisitor::visit(const Nodes::SumNode* node)
 {
-    auto operands = node->getOperands();
+    const auto& operands = node->getOperands();
     return std::accumulate(std::begin(operands),
                            std::end(operands),
                            TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO,

--- a/src/libs/antares/study/include/antares/study/study.h
+++ b/src/libs/antares/study/include/antares/study/study.h
@@ -636,6 +636,11 @@ public:
         return modelerInput_.dataSeries.get();
     }
 
+    Optimisation::ScenarioGroupRepository* getScenarioGroupRepository()
+    {
+        return &modelerInput_.scenario_group_repository;
+    }
+
 protected:
     //! \name Loading
     //@{

--- a/src/modeler/modeler/Modeler.cpp
+++ b/src/modeler/modeler/Modeler.cpp
@@ -82,7 +82,12 @@ public:
 
         LinearProblemBuilder linear_problem_builder(fillers_ptr);
         // Todo: scenario
-        FillContext time_scenario_ctx = {parameters.firstTimeStep, parameters.lastTimeStep, 0};
+        FillContext time_scenario_ctx = {
+          parameters.firstTimeStep,
+          parameters.lastTimeStep,
+          parameters.firstTimeStep, // global = local, single time block in pure modeler (for now)
+          parameters.lastTimeStep,  // global = local
+          0};
         linear_problem_builder.build(pb, *dataSeries, time_scenario_ctx);
     }
 

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/ILinearProblemData.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/ILinearProblemData.h
@@ -33,26 +33,40 @@ namespace Antares::Optimisation::LinearProblemApi
 class FillContext
 {
 public:
-    FillContext(unsigned first, unsigned last, unsigned year):
-        firstTimeStep(first),
-        lastTimeStep(last),
-        year_{year}
+    FillContext(unsigned localFirstTimeStep,
+                unsigned localLastTimeStep,
+                unsigned globalFirstTimeStep,
+                unsigned globalLastTimeStep,
+                unsigned year):
+        local{localFirstTimeStep, localLastTimeStep},
+        global{globalFirstTimeStep, globalLastTimeStep},
+        year_(year)
     {
     }
 
-    [[nodiscard]] unsigned getFirstTimeStep() const
+    [[nodiscard]] unsigned getLocalFirstTimeStep() const
     {
-        return firstTimeStep;
+        return local.first;
     }
 
-    [[nodiscard]] unsigned getLastTimeStep() const
+    [[nodiscard]] unsigned getLocalLastTimeStep() const
     {
-        return lastTimeStep;
+        return local.last;
     }
 
-    [[nodiscard]] unsigned int getNumberOfTimestep() const
+    [[nodiscard]] unsigned getGlobalFirstTimeStep() const
     {
-        return lastTimeStep - firstTimeStep + 1;
+        return global.first;
+    }
+
+    [[nodiscard]] unsigned getGlobalLastTimeStep() const
+    {
+        return global.last;
+    }
+
+    [[nodiscard]] unsigned int getLocalNumberOfTimeSteps() const
+    {
+        return local.last - local.first + 1;
     }
 
     [[nodiscard]] std::vector<unsigned> getSelectedScenarios() const
@@ -73,8 +87,15 @@ public:
 private:
     std::vector<unsigned> selectedScenario;
 
-    unsigned firstTimeStep = 0;
-    unsigned lastTimeStep = 0;
+    struct TimeInterval
+    {
+        unsigned first = 0; // included
+        unsigned last = 0;  // included
+    };
+
+    TimeInterval local;
+    TimeInterval global;
+
     unsigned year_ = 0;
 };
 

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/ILinearProblemData.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/ILinearProblemData.h
@@ -87,14 +87,20 @@ public:
 private:
     std::vector<unsigned> selectedScenario;
 
-    struct TimeInterval
+    struct LocalTimeInterval
     {
         unsigned first = 0; // included
         unsigned last = 0;  // included
     };
 
-    TimeInterval local;
-    TimeInterval global;
+    struct GlobalTimeInterval
+    {
+        unsigned first = 0; // included
+        unsigned last = 0;  // included
+    };
+
+    LocalTimeInterval local;
+    GlobalTimeInterval global;
 
     unsigned year_ = 0;
 };

--- a/src/solver/optim-model-filler/ComponentFiller.cpp
+++ b/src/solver/optim-model-filler/ComponentFiller.cpp
@@ -147,7 +147,7 @@ ComponentFiller::ComponentFiller(const ModelerStudy::SystemModel::Component& com
 
 bool checkTimeSteps(Optimisation::LinearProblemApi::FillContext& ctx)
 {
-    return ctx.getFirstTimeStep() <= ctx.getLastTimeStep();
+    return ctx.getLocalFirstTimeStep() <= ctx.getLocalLastTimeStep();
 }
 
 void ComponentFiller::addVariables(Optimisation::LinearProblemApi::ILinearProblem& pb,
@@ -189,7 +189,8 @@ void ComponentFiller::addVariables(Optimisation::LinearProblemApi::ILinearProble
             const Optimization::Dimensions dim(
               Optimization::IntegerInterval{ctx.getYear(),
                                             ctx.getYear()}, /*TODO Handle range of year ? */
-              Optimization::IntegerInterval(ctx.getFirstTimeStep(), ctx.getLastTimeStep()));
+              Optimization::IntegerInterval(ctx.getLocalFirstTimeStep(),
+                                            ctx.getLocalLastTimeStep()));
             // std::visit to handle the 4 cases: double/double, vector/double,
             // double/vector and vector/vector.
             std::visit(
@@ -308,7 +309,7 @@ void ComponentFiller::addObjective(Optimisation::LinearProblemApi::ILinearProble
     const auto timeDependentLinearExpression = visitor.dispatch(model->Objective().RootNode());
     const auto& linear_expressions = timeDependentLinearExpression.GetLinearExpressions();
 
-    if (abs(linear_expressions.at(ctx.getFirstTimeStep()).offset()) > 1e-10)
+    if (abs(linear_expressions.at(ctx.getLocalFirstTimeStep()).offset()) > 1e-10)
     {
         throw std::invalid_argument("Antares does not support objective offsets (found in model '"
                                     + model->Id() + "' of component '" + component_.Id() + "').");

--- a/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
@@ -145,14 +145,16 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Parameter
     // only dependent
     LinearExpressionMap linearExpressions;
 
-    for (auto timeStep = fillContext_.getLocalFirstTimeStep();
-         timeStep <= fillContext_.getLocalLastTimeStep();
-         ++timeStep)
+    int idx = 0;
+    for (auto localTimeStep = fillContext_.getLocalFirstTimeStep();
+         localTimeStep <= fillContext_.getLocalLastTimeStep();
+         ++localTimeStep)
     {
-        // TODO: pass year
-        linearExpressions[timeStep] = LinearExpression(
-          evalContext_.getParameterValue(node->value(), fillContext_.getYear(), timeStep),
+        auto globalTimeStep = fillContext_.getGlobalFirstTimeStep() + idx;
+        linearExpressions[localTimeStep] = LinearExpression(
+          evalContext_.getParameterValue(node->value(), fillContext_.getYear(), globalTimeStep),
           {});
+        idx++;
     }
     return TimeDependentLinearExpression(fillContext_, linearExpressions);
 }

--- a/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
@@ -52,7 +52,7 @@ std::string ReadLinearExpressionVisitor::name() const
 
 TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const SumNode* node)
 {
-    auto operands = node->getOperands();
+    const auto& operands = node->getOperands();
     TimeDependentLinearExpression ret(fillContext_);
     for (auto* operand: operands)
     {

--- a/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
@@ -53,14 +53,12 @@ std::string ReadLinearExpressionVisitor::name() const
 TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const SumNode* node)
 {
     auto operands = node->getOperands();
-    return std::accumulate(std::begin(operands),
-                           std::end(operands),
-                           TimeDependentLinearExpression(fillContext_),
-                           [this](TimeDependentLinearExpression&& sum, Node* operand)
-                           {
-                               sum += dispatch(operand);
-                               return std::move(sum);
-                           });
+    TimeDependentLinearExpression ret(fillContext_);
+    for (auto* operand: operands)
+    {
+        ret += dispatch(operand);
+    }
+    return ret;
 }
 
 TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const SubtractionNode* node)
@@ -113,8 +111,8 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const VariableN
     // only dependent
     LinearExpressionMap linearExpressions;
 
-    for (unsigned int timeStep = fillContext_.getFirstTimeStep();
-         timeStep <= fillContext_.getLastTimeStep();
+    for (unsigned int timeStep = fillContext_.getLocalFirstTimeStep();
+         timeStep <= fillContext_.getLocalLastTimeStep();
          ++timeStep)
     {
         linearExpressions[timeStep] = LinearExpression(0,
@@ -125,7 +123,7 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const VariableN
                                                                  timeStep),
                                                          1}});
     }
-    return TimeDependentLinearExpression(linearExpressions);
+    return TimeDependentLinearExpression(fillContext_, linearExpressions);
 }
 
 TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const ParameterNode* node)
@@ -147,8 +145,8 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Parameter
     // only dependent
     LinearExpressionMap linearExpressions;
 
-    for (auto timeStep = fillContext_.getFirstTimeStep();
-         timeStep <= fillContext_.getLastTimeStep();
+    for (auto timeStep = fillContext_.getLocalFirstTimeStep();
+         timeStep <= fillContext_.getLocalLastTimeStep();
          ++timeStep)
     {
         // TODO: pass year
@@ -156,7 +154,7 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Parameter
           evalContext_.getParameterValue(node->value(), fillContext_.getYear(), timeStep),
           {});
     }
-    return TimeDependentLinearExpression(linearExpressions);
+    return TimeDependentLinearExpression(fillContext_, linearExpressions);
 }
 
 TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const LiteralNode* node)

--- a/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
@@ -152,10 +152,9 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Parameter
          ++timeStep)
     {
         // TODO: pass year
-        linearExpressions[timeStep] = LinearExpression(evalContext_.getParameterValue(node->value(),
-                                                                                      0,
-                                                                                      timeStep),
-                                                       {});
+        linearExpressions[timeStep] = LinearExpression(
+          evalContext_.getParameterValue(node->value(), fillContext_.getYear(), timeStep),
+          {});
     }
     return TimeDependentLinearExpression(linearExpressions);
 }

--- a/src/solver/optim-model-filler/TimeDependentLinearExpression.cpp
+++ b/src/solver/optim-model-filler/TimeDependentLinearExpression.cpp
@@ -33,9 +33,11 @@ namespace Antares::Optimization
 
 TimeDependentLinearExpression::TimeDependentLinearExpression(
   const Optimisation::LinearProblemApi::FillContext& fillContext,
-  const LinearExpression& linearExpression)
+  const LinearExpression& linearExpression):
+    fillContext_(fillContext)
 {
-    for (auto timestep(fillContext.getFirstTimeStep()); timestep <= fillContext.getLastTimeStep();
+    for (auto timestep = fillContext.getLocalFirstTimeStep();
+         timestep <= fillContext.getLocalLastTimeStep();
          ++timestep)
     {
         linearExpressions_.emplace(timestep, linearExpression);
@@ -48,9 +50,11 @@ TimeDependentLinearExpression::TimeDependentLinearExpression(
 {
 }
 
-TimeDependentLinearExpression::TimeDependentLinearExpression(LinearExpressionMap linearExpressions):
-    linearExpressions_(std::move(linearExpressions))
-
+TimeDependentLinearExpression::TimeDependentLinearExpression(
+  const Optimisation::LinearProblemApi::FillContext& fillContext,
+  LinearExpressionMap linearExpressions):
+    linearExpressions_(std::move(linearExpressions)),
+    fillContext_(fillContext)
 {
 }
 
@@ -85,9 +89,11 @@ TimeDependentLinearExpression TimeDependentLinearExpression::operator-(
 }
 
 template<typename BinaryOperator>
-TimeDependentLinearExpression BinaryOpLinearExpression(const LinearExpressionMap& left,
-                                                       const LinearExpressionMap& right,
-                                                       BinaryOperator op)
+TimeDependentLinearExpression BinaryOpLinearExpression(
+  const LinearExpressionMap& left,
+  const LinearExpressionMap& right,
+  BinaryOperator op,
+  const Optimisation::LinearProblemApi::FillContext& fillContext)
 {
     auto result(left);
     for (const auto& [timeStep, other_linear_expression]: right)
@@ -101,7 +107,7 @@ TimeDependentLinearExpression BinaryOpLinearExpression(const LinearExpressionMap
             it->second = op(it->second, other_linear_expression);
         }
     }
-    return TimeDependentLinearExpression(std::move(result));
+    return TimeDependentLinearExpression(fillContext, std::move(result));
 }
 
 TimeDependentLinearExpression TimeDependentLinearExpression::operator*(
@@ -109,7 +115,8 @@ TimeDependentLinearExpression TimeDependentLinearExpression::operator*(
 {
     return BinaryOpLinearExpression(GetLinearExpressions(),
                                     other.GetLinearExpressions(),
-                                    std::multiplies<>());
+                                    std::multiplies<>(),
+                                    fillContext_);
 }
 
 TimeDependentLinearExpression TimeDependentLinearExpression::operator/(
@@ -117,7 +124,8 @@ TimeDependentLinearExpression TimeDependentLinearExpression::operator/(
 {
     return BinaryOpLinearExpression(GetLinearExpressions(),
                                     other.GetLinearExpressions(),
-                                    std::divides<>());
+                                    std::divides<>(),
+                                    fillContext_);
 }
 
 TimeDependentLinearExpression TimeDependentLinearExpression::operator-() const
@@ -128,7 +136,7 @@ TimeDependentLinearExpression TimeDependentLinearExpression::operator-() const
     {
         result.emplace(timeStep, -linearExpression);
     }
-    return TimeDependentLinearExpression(std::move(result));
+    return TimeDependentLinearExpression(fillContext_, std::move(result));
 }
 
 const LinearExpressionMap& TimeDependentLinearExpression::GetLinearExpressions() const
@@ -144,32 +152,25 @@ size_t TimeDependentLinearExpression::getSize() const
 TimeDependentLinearExpression TimeDependentLinearExpression::shiftLinearExpressions(
   int shiftValue) const
 {
-    const Optimisation::LinearProblemApi::FillContext
-      fillContext{linearExpressions_.begin()->first, linearExpressions_.rbegin()->first, 0};
-
     LinearExpressionMap linearExpressions;
     for (const auto& timeStep: linearExpressions_ | std::views::keys)
     {
         linearExpressions.emplace(timeStep,
                                   linearExpressions_.at(
-                                    rotatedIndex(timeStep, shiftValue, fillContext)));
+                                    rotatedIndex(timeStep, shiftValue, fillContext_)));
     }
-    return TimeDependentLinearExpression(std::move(linearExpressions));
+    return TimeDependentLinearExpression(fillContext_, std::move(linearExpressions));
 }
 
 TimeDependentLinearExpression TimeDependentLinearExpression::operator[](int timeStep) const
 {
-    const Optimisation::LinearProblemApi::FillContext
-      fillContext{linearExpressions_.begin()->first, linearExpressions_.rbegin()->first, 0};
-    return TimeDependentLinearExpression(fillContext, linearExpressions_.at(timeStep));
+    return TimeDependentLinearExpression(fillContext_, linearExpressions_.at(timeStep));
 }
 
 TimeDependentLinearExpression TimeDependentLinearExpression::timeSumLinearExpressions(int from,
                                                                                       int to) const
 {
-    const Optimisation::LinearProblemApi::FillContext
-      fillContext{linearExpressions_.begin()->first, linearExpressions_.rbegin()->first, 0};
-    TimeDependentLinearExpression ret(fillContext);
+    TimeDependentLinearExpression ret(fillContext_);
 
     for (auto shift = from; shift <= to; ++shift)
     {
@@ -180,14 +181,12 @@ TimeDependentLinearExpression TimeDependentLinearExpression::timeSumLinearExpres
 
 TimeDependentLinearExpression TimeDependentLinearExpression::allTimeSumLinearExpressions() const
 {
-    const Optimisation::LinearProblemApi::FillContext
-      fillContext{linearExpressions_.begin()->first, linearExpressions_.rbegin()->first, 0};
     LinearExpression sum;
     for (const auto& expr: linearExpressions_ | std::views::values)
     {
         sum += expr;
     }
-    return TimeDependentLinearExpression(fillContext, sum);
+    return TimeDependentLinearExpression(fillContext_, sum);
 }
 
 } // namespace Antares::Optimization

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include <map>
 #include <string>
-#include <unordered_map>
 
 #include <antares/solver/optim-model-filler/LinearExpression.h>
 #include "antares/optimisation/linear-problem-api/ILinearProblemData.h"

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
@@ -42,7 +42,9 @@ public:
     explicit TimeDependentLinearExpression(
       const Optimisation::LinearProblemApi::FillContext& fillContext,
       const LinearExpression& linearExpression);
-    explicit TimeDependentLinearExpression(LinearExpressionMap linearExpressions);
+    explicit TimeDependentLinearExpression(
+      const Optimisation::LinearProblemApi::FillContext& fillContext,
+      LinearExpressionMap linearExpressions);
     explicit TimeDependentLinearExpression(
       const TimeDependentLinearExpression& timeDependentLinearExpression)
       = default;
@@ -78,5 +80,6 @@ public:
 
 private:
     LinearExpressionMap linearExpressions_;
+    const Optimisation::LinearProblemApi::FillContext& fillContext_;
 };
 } // namespace Antares::Optimization

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -147,17 +147,14 @@ static void writeModelerSolutions(const MPSolver* solver,
 FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo)
 {
     auto nTsInDay = static_cast<unsigned>(problemeHebdo->NombreDePasDeTempsDUneJournee);
-    unsigned firstTimestep = 0;
-    unsigned lastTimestep;
-    if (problemeHebdo->OptimisationAuPasHebdomadaire)
-    {
-        lastTimestep = nTsInDay * problemeHebdo->NombreDeJours - 1;
-    }
-    else
-    {
-        lastTimestep = nTsInDay - 1;
-    }
-    return {firstTimestep, lastTimestep, problemeHebdo->year}; // TODO: handle scenarios/year
+
+    const unsigned globalFirst = problemeHebdo->weekInTheYear * nTsInDay
+                                 * problemeHebdo->NombreDeJours;
+    const unsigned globalLast = globalFirst + nTsInDay * problemeHebdo->NombreDeJours - 1;
+    const unsigned localFirst = 0;
+    const unsigned localLast = nTsInDay * problemeHebdo->NombreDeJours - 1;
+
+    return {localFirst, localLast, globalFirst, globalLast, problemeHebdo->year};
 }
 
 // Returns a non-owning pointer

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -144,28 +144,24 @@ static void writeModelerSolutions(const MPSolver* solver,
     writer.addEntryFromBuffer(modelerSolutionFilename, content);
 }
 
-FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo, int NumIntervalle)
+FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo)
 {
-    unsigned firstTimestep, lastTimestep;
     auto nTsInDay = static_cast<unsigned>(problemeHebdo->NombreDePasDeTempsDUneJournee);
+    unsigned firstTimestep = 0;
+    unsigned lastTimestep;
     if (problemeHebdo->OptimisationAuPasHebdomadaire)
     {
-        firstTimestep = problemeHebdo->weekInTheYear * nTsInDay * problemeHebdo->NombreDeJours;
-        lastTimestep = firstTimestep + nTsInDay * problemeHebdo->NombreDeJours - 1;
+        lastTimestep = nTsInDay * problemeHebdo->NombreDeJours - 1;
     }
     else
     {
-        firstTimestep = (problemeHebdo->weekInTheYear * problemeHebdo->NombreDeJours
-                         + static_cast<unsigned>(NumIntervalle))
-                        * nTsInDay;
-        lastTimestep = firstTimestep + nTsInDay - 1;
+        lastTimestep = nTsInDay - 1;
     }
     return {firstTimestep, lastTimestep, problemeHebdo->year}; // TODO: handle scenarios/year
 }
 
 // Returns a non-owning pointer
 MPSolver* convertToMPSolver(const PROBLEME_HEBDO* problemeHebdo,
-                            const int NumIntervalle,
                             const SingleOptimOptions& options,
                             bool namedProblems)
 {
@@ -191,7 +187,7 @@ MPSolver* convertToMPSolver(const PROBLEME_HEBDO* problemeHebdo,
         fillersCollection.push_back(&componentToAreaConnectionFiller);
     }
 
-    FillContext fillCtx = buildFillContext(problemeHebdo, NumIntervalle);
+    FillContext fillCtx = buildFillContext(problemeHebdo);
     LinearProblemBuilder linearProblemBuilder(fillersCollection);
 
     // Note that the modeler is only called for the 1st simulation week,
@@ -221,7 +217,7 @@ static SimplexResult OPT_TryToCallSimplex(const SingleOptimOptions& options,
 
     ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
 
-    solver = convertToMPSolver(problemeHebdo, NumIntervalle, options, problemeHebdo->NamedProblems);
+    solver = convertToMPSolver(problemeHebdo, options, problemeHebdo->NamedProblems);
 
     const std::string filename = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
 
@@ -343,8 +339,7 @@ bool OPT_AppelDuSimplexe(const SingleOptimOptions& options,
     }
     else
     {
-        std::unique_ptr<MPSolver> MPproblem(
-          convertToMPSolver(problemeHebdo, NumIntervalle, options, true));
+        std::unique_ptr<MPSolver> MPproblem(convertToMPSolver(problemeHebdo, options, true));
 
         auto analyzer = makeUnfeasiblePbAnalyzer();
         analyzer->run(MPproblem.get());

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -144,23 +144,37 @@ static void writeModelerSolutions(const MPSolver* solver,
     writer.addEntryFromBuffer(modelerSolutionFilename, content);
 }
 
-FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo)
+FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo, int NumIntervalle)
 {
+    unsigned globalFirst, globalLast;
+    unsigned localFirst = 0, localLast;
     auto nTsInDay = static_cast<unsigned>(problemeHebdo->NombreDePasDeTempsDUneJournee);
-
-    const unsigned globalFirst = problemeHebdo->weekInTheYear * nTsInDay
-                                 * problemeHebdo->NombreDeJours;
-    const unsigned globalLast = globalFirst + nTsInDay * problemeHebdo->NombreDeJours - 1;
-    const unsigned localFirst = 0;
-    const unsigned localLast = nTsInDay * problemeHebdo->NombreDeJours - 1;
-
-    return {localFirst, localLast, globalFirst, globalLast, problemeHebdo->year};
+    if (problemeHebdo->OptimisationAuPasHebdomadaire)
+    {
+        globalFirst = problemeHebdo->weekInTheYear * nTsInDay * problemeHebdo->NombreDeJours;
+        globalLast = globalFirst + nTsInDay * problemeHebdo->NombreDeJours - 1;
+        localLast = nTsInDay * problemeHebdo->NombreDeJours - 1;
+    }
+    else
+    {
+        globalFirst = (problemeHebdo->weekInTheYear * problemeHebdo->NombreDeJours
+                       + static_cast<unsigned>(NumIntervalle))
+                      * nTsInDay;
+        globalLast = globalFirst + nTsInDay - 1;
+        localLast = nTsInDay - 1;
+    }
+    return {localFirst,
+            localLast,
+            globalFirst,
+            globalLast,
+            problemeHebdo->year}; // TODO: handle scenarios/year
 }
 
 // Returns a non-owning pointer
 MPSolver* convertToMPSolver(const PROBLEME_HEBDO* problemeHebdo,
                             const SingleOptimOptions& options,
-                            bool namedProblems)
+                            bool namedProblems,
+                            unsigned int NumIntervalle)
 {
     LegacyOrtoolsLinearProblem ortoolsProblem(problemeHebdo->ProblemeAResoudre->isMIP(),
                                               options.solverName);
@@ -184,7 +198,7 @@ MPSolver* convertToMPSolver(const PROBLEME_HEBDO* problemeHebdo,
         fillersCollection.push_back(&componentToAreaConnectionFiller);
     }
 
-    FillContext fillCtx = buildFillContext(problemeHebdo);
+    FillContext fillCtx = buildFillContext(problemeHebdo, NumIntervalle);
     LinearProblemBuilder linearProblemBuilder(fillersCollection);
 
     // Note that the modeler is only called for the 1st simulation week,
@@ -214,7 +228,7 @@ static SimplexResult OPT_TryToCallSimplex(const SingleOptimOptions& options,
 
     ProblemeAResoudre->ProblemesSpx[NumIntervalle] = nullptr;
 
-    solver = convertToMPSolver(problemeHebdo, options, problemeHebdo->NamedProblems);
+    solver = convertToMPSolver(problemeHebdo, options, problemeHebdo->NamedProblems, NumIntervalle);
 
     const std::string filename = createMPSfilename(optPeriodStringGenerator, optimizationNumber);
 
@@ -336,7 +350,8 @@ bool OPT_AppelDuSimplexe(const SingleOptimOptions& options,
     }
     else
     {
-        std::unique_ptr<MPSolver> MPproblem(convertToMPSolver(problemeHebdo, options, true));
+        std::unique_ptr<MPSolver> MPproblem(
+          convertToMPSolver(problemeHebdo, options, true, NumIntervalle));
 
         auto analyzer = makeUnfeasiblePbAnalyzer();
         analyzer->run(MPproblem.get());

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -85,14 +85,11 @@ struct SimplexResult
     double objectiveValue;
 };
 
-class EmptyScenarioGroupRepository: public Optimisation::ScenarioGroupRepository
-{
-};
-
 static void fillModelerComponents(
   std::vector<std::unique_ptr<Optimisation::ComponentFiller>>& componentFillers,
   std::vector<LinearProblemFiller*>& fillersCollection,
   const ModelerStudy::SystemModel::System* modelerSystem,
+  const Optimisation::ScenarioGroupRepository& scenarioGroupRepository,
   VariableDictionary& variableDictionary)
 {
     if (!modelerSystem)
@@ -101,13 +98,12 @@ static void fillModelerComponents(
         return;
     }
 
-    static const EmptyScenarioGroupRepository emptyScenarioGroupRepository;
     for (const auto& [_, component]: modelerSystem->Components())
     {
         componentFillers.push_back(
           std::make_unique<Optimisation::ComponentFiller>(component,
                                                           variableDictionary,
-                                                          emptyScenarioGroupRepository));
+                                                          scenarioGroupRepository));
         // TODO: use scenario group repository
     }
     for (auto& component_filler: componentFillers)
@@ -185,12 +181,13 @@ MPSolver* convertToMPSolver(const PROBLEME_HEBDO* problemeHebdo,
     VariableDictionary variableDictionary;
     ComponentToAreaConnectionFiller componentToAreaConnectionFiller(problemeHebdo,
                                                                     variableDictionary);
-    if (problemeHebdo->modelerSystem)
+    if (problemeHebdo->modelerSystem && problemeHebdo->scenarioGroupRepository)
     {
         // All LP variables coordinates (component id, variable id, scenario, time step)
         fillModelerComponents(componentFillers,
                               fillersCollection,
                               problemeHebdo->modelerSystem,
+                              *problemeHebdo->scenarioGroupRepository,
                               variableDictionary);
 
         // Add compatibility filler that connects components to areas

--- a/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <vector>
 
+#include "antares/solver/optim-model-filler/scenarioGroupRepo.h"
 #include "antares/solver/optimisation/opt_constants.h"
 #include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
 #include "antares/solver/utils/optimization_statistics.h"
@@ -609,5 +610,6 @@ public:
     // TODO: 1 study but several PROBLEME_HEBDO, may cause race conditions
     const ModelerStudy::SystemModel::System* modelerSystem;                   // for hybrid studies
     Optimisation::LinearProblemApi::ILinearProblemData* linear_problem_data_; // for hybrid studies
+    Antares::Optimisation::ScenarioGroupRepository* scenarioGroupRepository;  // for hybrid studies
 };
 #endif

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -96,6 +96,7 @@ void SIM_InitialisationProblemeHebdo(Study& study,
     // For hybrid studies
     problem.modelerSystem = study.getModelerSystem();
     problem.linear_problem_data_ = study.getModelerData();
+    problem.scenarioGroupRepository = study.getScenarioGroupRepository();
 
     problem.Expansion = (parameters.mode == Data::SimulationMode::Expansion);
 

--- a/src/tests/inmemory-modeler/inmemory-modeler.cpp
+++ b/src/tests/inmemory-modeler/inmemory-modeler.cpp
@@ -86,7 +86,7 @@ void LinearProblemBuildingFixture::buildLinearProblem(
 
 void LinearProblemBuildingFixture::buildLinearProblem()
 {
-    Antares::Optimisation::LinearProblemApi::FillContext time_scenario_ctx = {0, 0, 0};
+    Antares::Optimisation::LinearProblemApi::FillContext time_scenario_ctx = {0, 0, 0, 0, 0};
     buildLinearProblem(time_scenario_ctx);
 }
 

--- a/src/tests/src/expressions/test_DeepWideTrees.cpp
+++ b/src/tests/src/expressions/test_DeepWideTrees.cpp
@@ -50,7 +50,7 @@ struct MyDummyFixture: Registry<Node>
     Antares::Optimisation::LinearProblemApi::EmptyScenario emptyScenario;
     Antares::Optimisation::LinearProblemDataImpl::LinearProblemData data;
     EvaluationContext evaluationContext{{}, {}, data, emptyScenario};
-    EvalVisitor evalVisitor{evaluationContext, {0, 0, 0}};
+    EvalVisitor evalVisitor{evaluationContext, {0, 0, 0, 0, 0}};
 };
 
 BOOST_FIXTURE_TEST_CASE(deep_tree_even, MyDummyFixture)

--- a/src/tests/src/expressions/test_PrintAndEvalNodes.cpp
+++ b/src/tests/src/expressions/test_PrintAndEvalNodes.cpp
@@ -402,7 +402,7 @@ struct MyDummyFixture: Registry<Node>
     Antares::Optimisation::LinearProblemDataImpl::LinearProblemData data;
     Antares::Optimisation::LinearProblemApi::EmptyScenario emptyScenario;
     EvaluationContext evaluationContext{{}, {}, data, emptyScenario};
-    Antares::Optimisation::LinearProblemApi::FillContext fillContext{0, 0, 0};
+    Antares::Optimisation::LinearProblemApi::FillContext fillContext{0, 0, 0, 0, 0};
     EvalVisitor evalVisitor{evaluationContext, fillContext};
 };
 
@@ -638,7 +638,7 @@ BOOST_FIXTURE_TEST_CASE(evaluate_time_dependent_param, MyDummyFixture)
 
     unsigned hour_0 = 0;
     unsigned hour_1 = 1;
-    EvalVisitor evalVisitor(context, {hour_0, hour_1 /*two hours*/, 0});
+    EvalVisitor evalVisitor(context, {hour_0, hour_1 /*two hours*/, hour_0, hour_1, 0});
     const auto eval = evalVisitor.dispatch(&root).valuesAsVector();
 
     BOOST_CHECK_EQUAL(eval[0], hour_0);
@@ -670,7 +670,7 @@ EvaluationResult CreateAndEvaluateTimeNode(const right& p)
 
     unsigned first = 0;
     unsigned last = 2;
-    EvalVisitor evalVisitor(context, {first, last /*three hours*/, 0});
+    EvalVisitor evalVisitor(context, {first, last /*three hours*/, first, last, 0});
     return evalVisitor.dispatch(&root);
 }
 
@@ -711,7 +711,7 @@ EvaluationResult CreateAndEvaluateTimeSumNode(Node* from, Node* to)
 
     unsigned first = 0;
     unsigned last = 2;
-    EvalVisitor evalVisitor(context, {first, last /*three hours*/, 0});
+    EvalVisitor evalVisitor(context, {first, last /*three hours*/, first, last, 0});
     return evalVisitor.dispatch(&root);
 }
 
@@ -742,7 +742,7 @@ EvaluationResult CreateAndEvaluateAllTimeSumNode()
 
     unsigned first = 0;
     unsigned last = 2;
-    EvalVisitor evalVisitor(context, {first, last /*three hours*/, 0});
+    EvalVisitor evalVisitor(context, {first, last /*three hours*/, first, last, 0});
     return evalVisitor.dispatch(&root);
 }
 
@@ -771,7 +771,7 @@ BOOST_FIXTURE_TEST_CASE(evaluate_time_dependent_multiplication, MyDummyFixture)
 
     unsigned hour_0 = 0;
     unsigned hour_1 = 1;
-    EvalVisitor evalVisitor(context, {hour_0, hour_1 /*two hours*/, 0});
+    EvalVisitor evalVisitor(context, {hour_0, hour_1 /*two hours*/, hour_0, hour_1, 0});
     const auto eval = evalVisitor.dispatch(&root).valuesAsVector();
 
     BOOST_CHECK_EQUAL(eval[0], hour_0 * literal.value());
@@ -822,7 +822,7 @@ void evaluate_time_dependent_operation()
       emptyScenario);
     unsigned hour_0 = 0;
     unsigned hour_1 = 1;
-    EvalVisitor evalVisitor(context, {hour_0, hour_1 /*two hours*/, 0});
+    EvalVisitor evalVisitor(context, {hour_0, hour_1 /*two hours*/, hour_0, hour_1, 0});
     const auto eval = evalVisitor.dispatch(&root).valuesAsVector();
 
     BOOST_CHECK_EQUAL(eval[0], evalExpected<BinaryNode>(hour_0, literal.value()));
@@ -849,7 +849,8 @@ void evaluate_time_dependent_operation_on_TimeShiftNode(Node* timeShift)
 
     std::vector<unsigned int> hours = {0, 1};
 
-    EvalVisitor evalVisitor(context, {hours.at(0), hours.at(1) /*two hours*/, 0});
+    EvalVisitor evalVisitor(context,
+                            {hours.at(0), hours.at(1) /*two hours*/, hours.at(0), hours.at(1), 0});
     const auto eval = evalVisitor.dispatch(&root).valuesAsVector();
 
     std::vector<double> result_before_timeShift = {evalExpected<BinaryNode>(hours.at(0),
@@ -884,7 +885,8 @@ void evaluate_time_dependent_operation_on_TimeIndexNode(Node* timeIndex)
 
     std::vector<unsigned int> hours = {0, 1};
 
-    EvalVisitor evalVisitor(context, {hours.at(0), hours.at(1) /*two hours*/, 0});
+    EvalVisitor evalVisitor(context,
+                            {hours.at(0), hours.at(1) /*two hours*/, hours.at(0), hours.at(1), 0});
     const auto eval = evalVisitor.dispatch(&root).valueAsDouble();
 
     std::vector<double> result_before_timeIndex = {evalExpected<BinaryNode>(hours.at(0),

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -132,7 +132,7 @@ BOOST_FIXTURE_TEST_CASE(addTwoLiterals, ExpressionToNodeConvertorEmptyModel)
 
     auto* nodeSum = dynamic_cast<Nodes::SumNode*>(expr.node);
     BOOST_REQUIRE(nodeSum);
-    auto operands = nodeSum->getOperands();
+    const auto& operands = nodeSum->getOperands();
     BOOST_CHECK_EQUAL(toLiteral(operands[0])->value(), 1);
     BOOST_CHECK_EQUAL(toLiteral(operands[1])->value(), 2);
 }

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/FillerContext.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/FillerContext.h
@@ -21,7 +21,8 @@ void VarFillerContext::addVariables(ILinearProblem& pb,
                                     [[maybe_unused]] ILinearProblemData& data,
                                     [[maybe_unused]] FillContext& ctx)
 {
-    for (unsigned timestep = ctx.getFirstTimeStep(); timestep < ctx.getLastTimeStep(); timestep++)
+    for (unsigned timestep = ctx.getLocalFirstTimeStep(); timestep < ctx.getLocalLastTimeStep();
+         timestep++)
     {
         for (unsigned scenario: ctx.getSelectedScenarios())
         {

--- a/src/tests/src/optimisation/linear-problem/testLinearProblemBuilder.cpp
+++ b/src/tests/src/optimisation/linear-problem/testLinearProblemBuilder.cpp
@@ -44,7 +44,7 @@ struct Fixture
 
     std::vector<LinearProblemFiller*> fillers;
     LinearProblemData LP_Data;
-    FillContext ctx = {0, 0, 0}; // dummy value for other tests than context
+    FillContext ctx = {0, 0, 0, 0, 0}; // dummy value for other tests than context
     std::unique_ptr<ILinearProblem> pb;
 };
 
@@ -121,7 +121,7 @@ BOOST_FIXTURE_TEST_CASE(FillerWithContext, Fixture)
     auto varFiller = std::make_unique<VarFillerContext>();
     fillers = {varFiller.get()};
 
-    ctx = FillContext(0, 5, 0);
+    ctx = FillContext(0, 5, 0, 5, 0);
 
     ctx.addSelectedScenarios(0);
     ctx.addSelectedScenarios(2);

--- a/src/tests/src/solver/optim-model-filler/test_componentFiller.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_componentFiller.cpp
@@ -77,9 +77,9 @@ BOOST_AUTO_TEST_CASE(ten_timesteps_var_with_literal_bounds_to_filler__problem_co
                                true);
     createComponent("some_model", "some_component");
     constexpr unsigned int last_time_step = 9;
-    FillContext ctx{0, last_time_step, 0};
+    FillContext ctx{0, last_time_step, 0, 0, 0};
     buildLinearProblem(ctx);
-    const auto nb_var = ctx.getNumberOfTimestep(); // = 10
+    const auto nb_var = ctx.getLocalNumberOfTimeSteps(); // = 10
     BOOST_CHECK_EQUAL(pb->variableCount(), nb_var);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 0);
     for (unsigned int i = 0; i < nb_var; i++)
@@ -216,9 +216,9 @@ BOOST_AUTO_TEST_CASE(
     createComponent("m1", "component_1");
     createComponent("m2", "component_2");
     constexpr unsigned int last_time_step = 9;
-    FillContext ctx{0, last_time_step, 0};
+    FillContext ctx{0, last_time_step, 0, last_time_step, 0};
     buildLinearProblem(ctx);
-    const auto nb_var = ctx.getNumberOfTimestep(); // = 10
+    const auto nb_var = ctx.getLocalNumberOfTimeSteps(); // = 10
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 2 * 10);
     for (unsigned i = 0; i < nb_var; i++)
@@ -367,9 +367,9 @@ BOOST_AUTO_TEST_CASE(ct_with_ten_vars__pb_contains_ten_ct)
     constexpr unsigned int last_time_step = 9;
     std::vector<unsigned int> timeSteps(last_time_step + 1);
     std::ranges::generate(timeSteps, [i = 0]() mutable { return i++; });
-    FillContext ctx{0, last_time_step, 0};
+    FillContext ctx{0, last_time_step, 0, last_time_step, 0};
     buildLinearProblem(ctx);
-    const auto nb_var = ctx.getNumberOfTimestep(); // = 10
+    const auto nb_var = ctx.getLocalNumberOfTimeSteps(); // = 10
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 10);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 10);
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE(ct_with_time_series_variable_bounds)
       {build_context_parameter_with("bounds", "bounds", Visitors::ParameterType::TIMESERIE)});
 
     const vector<unsigned int> timeSteps{1, 2};
-    FillContext ctx{timeSteps.at(0), timeSteps.at(1), 0};
+    FillContext ctx{timeSteps.at(0), timeSteps.at(1), timeSteps.at(0), timeSteps.at(1), 0};
 
     auto bounds_time_series = std::make_unique<TimeSeriesSet>("bounds", 3);
     // setting 3 hours (including h 1 and 2)
@@ -445,7 +445,7 @@ BOOST_AUTO_TEST_CASE(ct_with_time_series_variable_bounds)
 
     std::vector<std::unique_ptr<IScenario>> scenarios;
     buildLinearProblem(ctx, data, scenarios);
-    const auto nb_var = ctx.getNumberOfTimestep(); // = 2
+    const auto nb_var = ctx.getLocalNumberOfTimeSteps(); // = 2
 
     BOOST_CHECK_EQUAL(pb->variableCount(), 2);
     BOOST_CHECK_EQUAL(pb->constraintCount(), 2);
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(get_timeseriesNumber_for_given_year)
       "groupeName");
 
     const vector<unsigned int> timeSteps{1, 2};
-    FillContext ctx{timeSteps.at(0), timeSteps.at(1), 3};
+    FillContext ctx{timeSteps.at(0), timeSteps.at(1), timeSteps.at(0), timeSteps.at(1), 3};
 
     auto bounds_time_series = std::make_unique<TimeSeriesSet>("bounds", 3);
     // setting 3 hours (including h 1 and 2)
@@ -701,9 +701,9 @@ BOOST_AUTO_TEST_CASE(one_time_dependent_var_with_objective)
     createComponent("model", "componentA", {});
 
     constexpr unsigned int last_time_step = 9;
-    FillContext ctx{0, last_time_step, 0};
+    FillContext ctx{0, last_time_step, 0, last_time_step, 0};
     buildLinearProblem(ctx);
-    const auto nb_var = ctx.getNumberOfTimestep(); // = 10
+    const auto nb_var = ctx.getLocalNumberOfTimeSteps(); // = 10
 
     BOOST_CHECK_EQUAL(pb->variableCount(), nb_var);
     for (unsigned i = 0; i < nb_var; i++)

--- a/src/tests/src/solver/optim-model-filler/test_linearExpression.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_linearExpression.cpp
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(negate_linear_expression)
 // Test default constructor
 BOOST_AUTO_TEST_CASE(DefaultConstructor)
 {
-    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
     TimeDependentLinearExpression expr(context);
     BOOST_TEST(expr.getSize() == 3); // Should create expressions for 3 timesteps
 }
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(ConstructorWithLinearExpression)
 {
     auto component = "compo";
 
-    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
     LinearExpression le(5.0, {{FullKey(component, "x"), 2.0}});
     TimeDependentLinearExpression expr(context, le);
 
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(ConstructorWithMap)
                                        {1,
                                         LinearExpression(2.0, {{FullKey(component, "b"), 3.0}})}};
 
-    TimeDependentLinearExpression expr(expressions);
+    TimeDependentLinearExpression expr({0, 2, 0, 2, 0}, expressions);
     BOOST_TEST(expr.getSize() == 2);
     BOOST_TEST(expr.GetLinearExpressions().at(0).offset() == 1.0);
     BOOST_TEST(expr.GetLinearExpressions().at(1).offset() == 2.0);
@@ -236,7 +236,8 @@ BOOST_AUTO_TEST_CASE(AdditionOperator)
     LinearExpressionMap exp2 = {{0, LinearExpression(2.0, {{FullKey(component, "x"), 2.0}})},
                                 {1, LinearExpression(1.0, {{FullKey(component, "y"), 1.0}})}};
 
-    TimeDependentLinearExpression expr1(exp1), expr2(exp2);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    TimeDependentLinearExpression expr1(context, exp1), expr2(context, exp2);
     TimeDependentLinearExpression result = expr1 + expr2;
 
     BOOST_TEST(result.GetLinearExpressions().at(0).offset() == 5.0);
@@ -254,7 +255,8 @@ BOOST_AUTO_TEST_CASE(SubtractionOperator)
     LinearExpressionMap exp2 = {{0, LinearExpression(3.0, {{FullKey(component, "x"), 2.0}})},
                                 {1, LinearExpression(2.0, {{FullKey(component, "y"), 1.0}})}};
 
-    TimeDependentLinearExpression expr1(exp1), expr2(exp2);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    TimeDependentLinearExpression expr1(context, exp1), expr2(context, exp2);
     TimeDependentLinearExpression result = expr1 - expr2;
 
     BOOST_TEST(result.GetLinearExpressions().at(0).offset() == 2.0);
@@ -266,13 +268,14 @@ BOOST_AUTO_TEST_CASE(SubtractionOperator)
 BOOST_AUTO_TEST_CASE(MultiplicationOperator)
 {
     auto component = "compo";
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
 
     LinearExpressionMap exp1 = {{0, LinearExpression(2.0, {{FullKey(component, "x"), 3.0}})}};
     LinearExpressionMap exp2 = {
       {0, LinearExpression(4.0, {})} // Only scalar allowed
     };
 
-    TimeDependentLinearExpression expr1(exp1), expr2(exp2);
+    TimeDependentLinearExpression expr1(context, exp1), expr2(context, exp2);
     TimeDependentLinearExpression result = expr1 * expr2;
 
     BOOST_TEST(result.GetLinearExpressions().at(0).offset() == 8.0);
@@ -290,7 +293,8 @@ BOOST_AUTO_TEST_CASE(DivisionOperator)
       {0, LinearExpression(2.0, {})} // Only scalar allowed
     };
 
-    TimeDependentLinearExpression expr1(exp1), expr2(exp2);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    TimeDependentLinearExpression expr1(context, exp1), expr2(context, exp2);
     TimeDependentLinearExpression result = expr1 / expr2;
 
     BOOST_TEST(result.GetLinearExpressions().at(0).offset() == 3.0);
@@ -305,7 +309,8 @@ BOOST_AUTO_TEST_CASE(NegationOperator)
     LinearExpressionMap exp = {{0, LinearExpression(3.0, {{FullKey(component, "x"), 2.0}})},
                                {1, LinearExpression(4.0, {{FullKey(component, "y"), 1.0}})}};
 
-    TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    TimeDependentLinearExpression expr(context, exp);
     TimeDependentLinearExpression result = -expr;
 
     BOOST_TEST(result.GetLinearExpressions().at(0).offset() == -3.0);
@@ -323,7 +328,8 @@ BOOST_AUTO_TEST_CASE(GetLinearExpressionsMethod)
     LinearExpressionMap exp = {{0, LinearExpression(5.0, {{FullKey(component, "x"), 2.0}})},
                                {1, LinearExpression(3.0, {{FullKey(component, "y"), 4.0}})}};
 
-    TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    TimeDependentLinearExpression expr(context, exp);
     auto expressions = expr.GetLinearExpressions();
 
     BOOST_TEST(expressions.size() == 2);
@@ -339,8 +345,8 @@ BOOST_AUTO_TEST_CASE(GetSizeMethod)
     LinearExpressionMap exp = {{0, LinearExpression(1.0, {{FullKey(component, "x"), 1.0}})},
                                {1, LinearExpression(2.0, {{FullKey(component, "y"), 2.0}})},
                                {2, LinearExpression(3.0, {{FullKey(component, "z"), 3.0}})}};
-
-    TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    TimeDependentLinearExpression expr(context, exp);
     BOOST_TEST(expr.getSize() == 3);
 }
 
@@ -353,7 +359,8 @@ BOOST_AUTO_TEST_CASE(ShiftLinearExpressionsPositive)
                                {1, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {2, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     Antares::Optimization::TimeDependentLinearExpression result = expr.shiftLinearExpressions(1);
 
     BOOST_TEST(result.getSize() == 3);
@@ -370,8 +377,8 @@ BOOST_AUTO_TEST_CASE(ShiftLinearExpressionsNegative)
     LinearExpressionMap exp = {{0, LinearExpression(1.0, {{FullKey(component, "a"), 1.0}})},
                                {1, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {2, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
-
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     Antares::Optimization::TimeDependentLinearExpression result = expr.shiftLinearExpressions(-1);
 
     BOOST_TEST(result.getSize() == 3);
@@ -389,7 +396,8 @@ BOOST_AUTO_TEST_CASE(ShiftLinearExpressionsZero)
                                {1, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {2, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     Antares::Optimization::TimeDependentLinearExpression result = expr.shiftLinearExpressions(0);
 
     BOOST_TEST(result.getSize() == 3);
@@ -407,7 +415,8 @@ BOOST_AUTO_TEST_CASE(ShiftLinearExpressionsGreaterThanSize)
                                {1, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {2, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     Antares::Optimization::TimeDependentLinearExpression result = expr.shiftLinearExpressions(4);
 
     BOOST_TEST(result.getSize() == 3);
@@ -425,7 +434,8 @@ BOOST_AUTO_TEST_CASE(OperatorIndexValid)
                                {1, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {2, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     Antares::Optimization::TimeDependentLinearExpression indexed = expr[1];
 
     const auto result = indexed.GetLinearExpressions().cbegin()->second;
@@ -442,7 +452,8 @@ BOOST_AUTO_TEST_CASE(OperatorIndexInvalid)
                                {1, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {2, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     BOOST_CHECK_THROW(expr[3], std::out_of_range);
 }
 
@@ -455,7 +466,8 @@ BOOST_AUTO_TEST_CASE(ShiftLinearExpressionsNegativeGreaterThanSize)
                                {1, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {2, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 2, 0, 2, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     Antares::Optimization::TimeDependentLinearExpression result = expr.shiftLinearExpressions(-4);
 
     BOOST_TEST(result.getSize() == 3);
@@ -474,11 +486,12 @@ BOOST_AUTO_TEST_CASE(TimeSumLinearExpressions)
                                {2, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {3, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 3, 0, 3, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     Antares::Optimization::TimeDependentLinearExpression result = expr.timeSumLinearExpressions(0,
                                                                                                 3);
 
-    BOOST_TEST(result.getSize() == 4);
+    BOOST_CHECK_EQUAL(result.getSize(), 4);
     for (const auto& expression: result.GetLinearExpressions() | std::views::values)
     {
         BOOST_TEST(expression.offset() == (1.0 + 1.0 + 2.0 + 3.0));
@@ -498,7 +511,8 @@ BOOST_AUTO_TEST_CASE(AllTimeSumLinearExpressions)
                                {2, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {3, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 3, 0, 3, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
     Antares::Optimization::TimeDependentLinearExpression result = expr
                                                                     .allTimeSumLinearExpressions();
 
@@ -522,12 +536,13 @@ BOOST_AUTO_TEST_CASE(TimeSumLinearExpressionsOutOfBounds)
                                {2, LinearExpression(2.0, {{FullKey(component, "b"), 2.0}})},
                                {3, LinearExpression(3.0, {{FullKey(component, "c"), 3.0}})}};
 
-    Antares::Optimization::TimeDependentLinearExpression expr(exp);
+    Antares::Optimisation::LinearProblemApi::FillContext context(0, 3, 0, 3, 0);
+    Antares::Optimization::TimeDependentLinearExpression expr(context, exp);
 
     // Case where 'from' is negative
     Antares::Optimization::TimeDependentLinearExpression result1 = expr.timeSumLinearExpressions(-1,
                                                                                                  2);
-    BOOST_TEST(result1.getSize() == 4);
+    BOOST_CHECK_EQUAL(result1.getSize(), 4);
     for (const auto& expression: result1.GetLinearExpressions() | std::views::values)
     {
         BOOST_TEST(expression.offset() == (1.0 + 1.0 + 2.0 + 3.0));

--- a/src/tests/src/solver/optim-model-filler/test_readLinExprVisitor_sum_connections.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_readLinExprVisitor_sum_connections.cpp
@@ -132,7 +132,7 @@ BOOST_FIXTURE_TEST_CASE(sum_conections_connects_2_components_with_a_port_field,
                                          ConnectionEnd(&generatorComponent, &injection_port));
 
     // Visitor associated to component named "N"
-    ReadLinearExpressionVisitor visitor{evaluationContext, {0, 0, 0}, nodeComponent};
+    ReadLinearExpressionVisitor visitor{evaluationContext, {0, 0, 0, 0, 0}, nodeComponent};
 
     auto timeDependentLinExpr = visitor.dispatch(sum_connections_node);
 
@@ -246,7 +246,7 @@ BOOST_FIXTURE_TEST_CASE(sum_conections_connects_3_components_with_a_port_field,
     nodeComponent.addComponentConnection(portId, ConnectionEnd(&demandComponent, &injection_port));
 
     // Visitor associated to component named "N"
-    ReadLinearExpressionVisitor visitor{evaluationContext, {0, 0, 0}, nodeComponent};
+    ReadLinearExpressionVisitor visitor{evaluationContext, {0, 0, 0, 0, 0}, nodeComponent};
 
     auto timeDependentLinExpr = visitor.dispatch(sum_connections_node);
 

--- a/src/tests/src/solver/optim-model-filler/test_readLinearConstraintVisitor.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_readLinearConstraintVisitor.cpp
@@ -50,7 +50,7 @@ struct MyDummyFixture: Registry<Node>
                                                .withModel(&m)
                                                .withScenarioGroupId("group")
                                                .build();
-    ReadLinearConstraintVisitor visitor{evaluationContext, {0, 0, 0}, component};
+    ReadLinearConstraintVisitor visitor{evaluationContext, {0, 0, 0, 0, 0}, component};
 };
 
 BOOST_FIXTURE_TEST_CASE(test_name, MyDummyFixture)
@@ -79,7 +79,7 @@ BOOST_FIXTURE_TEST_CASE(test_visit_equal_node, MyDummyFixture)
                               {},
                               data,
                               empty_scenario);
-    ReadLinearConstraintVisitor visitor(context, {0, 0, 0}, component);
+    ReadLinearConstraintVisitor visitor(context, {0, 0, 0, 0, 0}, component);
     auto constraint = visitor.dispatch(node)[0];
     BOOST_CHECK_EQUAL(constraint.lb, -14.);
     BOOST_CHECK_EQUAL(constraint.ub, -14.);
@@ -105,7 +105,7 @@ BOOST_FIXTURE_TEST_CASE(test_visit_less_than_or_equal_node, MyDummyFixture)
                               {},
                               data,
                               empty_scenario);
-    ReadLinearConstraintVisitor visitor(context, {0, 0, 0}, component);
+    ReadLinearConstraintVisitor visitor(context, {0, 0, 0, 0, 0}, component);
     auto constraint = visitor.dispatch(node)[0];
     BOOST_CHECK_EQUAL(constraint.lb, -std::numeric_limits<double>::infinity());
     BOOST_CHECK_EQUAL(constraint.ub, -1.);
@@ -134,7 +134,7 @@ BOOST_FIXTURE_TEST_CASE(test_visit_greater_than_or_equal_node, MyDummyFixture)
                               {},
                               data,
                               empty_scenario);
-    ReadLinearConstraintVisitor visitor(context, {0, 0, 0}, component);
+    ReadLinearConstraintVisitor visitor(context, {0, 0, 0, 0, 0}, component);
     auto constraint = visitor.dispatch(node)[0];
     BOOST_CHECK_EQUAL(constraint.lb, -14);
     BOOST_CHECK_EQUAL(constraint.ub, std::numeric_limits<double>::infinity());

--- a/src/tests/src/solver/optim-model-filler/test_readLinearExpressionVisitor.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_readLinearExpressionVisitor.cpp
@@ -51,7 +51,7 @@ struct CreateVisitorFixture: Registry<Node>
                                                .withModel(&m)
                                                .withScenarioGroupId("group")
                                                .build();
-    ReadLinearExpressionVisitor visitor{evaluationContext, {0, 0, 0}, component};
+    ReadLinearExpressionVisitor visitor{evaluationContext, {0, 0, 0, 0, 0}, component};
 };
 
 BOOST_FIXTURE_TEST_CASE(name, CreateVisitorFixture)
@@ -83,7 +83,7 @@ BOOST_FIXTURE_TEST_CASE(visit_literal_plus_param, CreateVisitorFixture)
                                          {},
                                          data,
                                          emptyScenario);
-    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 0, 0}, component);
+    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 0, 0, 0, 0}, component);
     auto linear_expression = visitor.dispatch(sum).GetLinearExpressions().at(0);
     BOOST_CHECK_EQUAL(linear_expression.offset(), 8.);
     BOOST_CHECK(linear_expression.coefPerVar().empty());
@@ -99,7 +99,7 @@ BOOST_FIXTURE_TEST_CASE(visit_literal_plus_param_plus_var, CreateVisitorFixture)
                                          {},
                                          data,
                                          emptyScenario);
-    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 0, 0}, component);
+    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 0, 0, 0, 0}, component);
     auto linear_expression = visitor.dispatch(sum).GetLinearExpressions().at(0);
     BOOST_CHECK_EQUAL(linear_expression.offset(), 55.);
     BOOST_CHECK_EQUAL(linear_expression.coefPerVar().size(), 1);
@@ -133,7 +133,7 @@ BOOST_FIXTURE_TEST_CASE(visit_timeSum, CreateVisitorFixture)
       {},
       my_data,
       emptyScenario);
-    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 2, 0}, component);
+    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 2, 0, 2, 0}, component);
     auto linear_expressions = visitor.dispatch(sum).GetLinearExpressions();
     BOOST_CHECK_EQUAL(linear_expressions.at(0).offset(), 9.);
     BOOST_CHECK(linear_expressions.at(0).coefPerVar().empty());
@@ -154,7 +154,7 @@ BOOST_FIXTURE_TEST_CASE(visit_AllTimeSum, CreateVisitorFixture)
       {},
       my_data,
       emptyScenario);
-    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 2, 0}, component);
+    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 2, 0, 2, 0}, component);
     auto linear_expressions = visitor.dispatch(sum).GetLinearExpressions();
     BOOST_CHECK_EQUAL(linear_expressions.at(0).offset(), 8.);
     BOOST_CHECK(linear_expressions.at(0).coefPerVar().empty());
@@ -176,7 +176,9 @@ BOOST_FIXTURE_TEST_CASE(visit_literal_plus_time_dependent_param_plus_var, Create
 
     unsigned hour_0 = 0;
     unsigned hour_1 = 1;
-    ReadLinearExpressionVisitor visitor(evaluation_context, {hour_0, hour_1, 0}, component);
+    ReadLinearExpressionVisitor visitor(evaluation_context,
+                                        {hour_0, hour_1, hour_0, hour_1, 0},
+                                        component);
     auto linear_expressions = visitor.dispatch(sum).GetLinearExpressions();
     BOOST_CHECK_EQUAL(linear_expressions.at(0).offset(), 60.);
     BOOST_CHECK_EQUAL(linear_expressions.at(1).offset(), 61.);
@@ -199,7 +201,7 @@ BOOST_FIXTURE_TEST_CASE(visit_param_declared_const_in_library_but_time_dep_in_sy
       data,
       emptyScenario);
 
-    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 1, 0}, component);
+    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 1, 0, 1, 0}, component);
     BOOST_CHECK_THROW(visitor.dispatch(&p), std::invalid_argument);
 }
 
@@ -256,7 +258,7 @@ BOOST_FIXTURE_TEST_CASE(visit_complex_expression, CreateVisitorFixture)
                                          {},
                                          data,
                                          emptyScenario);
-    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 0, 0}, component);
+    ReadLinearExpressionVisitor visitor(evaluation_context, {0, 0, 0, 0, 0}, component);
     auto linear_expression = visitor.dispatch(big_sum).GetLinearExpressions().at(0);
     BOOST_CHECK_EQUAL(linear_expression.offset(), 10.);
     BOOST_CHECK_EQUAL(linear_expression.coefPerVar().size(), 2);

--- a/src/tests/src/solver/optimisation/test_componentToAreaConnectionFiller.cpp
+++ b/src/tests/src/solver/optimisation/test_componentToAreaConnectionFiller.cpp
@@ -211,7 +211,7 @@ struct ComponentToAreaConnectionFillerFixture
                      std::vector<double> some_param_value)
     {
         problemeHebdo->NombreDePasDeTempsPourUneOptimisation = ts_end - ts_start + 1;
-        FillContext fillCtx(ts_start, ts_end, 0);
+        FillContext fillCtx(ts_start, ts_end, ts_start, ts_end, 0);
         auto tss = std::make_unique<TimeSeriesSet>("some_param_value", some_param_value.size());
         tss->add(some_param_value);
         DataSeriesRepository ds;


### PR DESCRIPTION
## Problem: invalid indices starting from the 2nd week in `expr[t-1]` expressions
Starting from the 2nd week, this expression makes the expression parser crash
```
gen1_prop_cost[t-1] + gen2_p * gen2_prop_cost
```
## Solution
In `FillContext`, exhibit two time indices
- local (within the timeblock, starting at 0) used to assign names to variables, and for the time operator `[]`
- global (within the year) used to retrieve timeseries coefficients

## Problem: invalid timeseries coefficients starting from the 2nd week
The coefficients are those used for the 1st week
## Solution
Use the global time index to retrieve timeseries coefficients

## Problem: invalid coefficients starting from the 2nd year (scenarization)
When using scenarized timeseries, 
```yaml
scenario-group: mygroup
...
parameters:
   - id: inflows
       - value: inflows_ts
       - scenario-dependent: true
```
## Solution
Stop using an empty scenario group repository, use the scenario group repository that was parsed at startup.