### PR TITLE
Remove special value "default" for scenario-group field

### DIFF
--- a/docs/user-guide/modeler/02-inputs.md
+++ b/docs/user-guide/modeler/02-inputs.md
@@ -376,7 +376,7 @@ components:
   "model_id" is the ID of the model as it is defined inside the [model library](#models).
 - **scenario-group** _(only needed if the model has scenario-dependent parameters)_: the ID of the scenario group this
   component belongs to. Must be correctly configured in the [scenario builder](#scenario-builder), and
-  respect [these rules](#rules-for-ids).
+  respect [these rules](#rules-for-ids). Default value is "" (empty string).
 - **parameters** _(not needed if model has no parameters)_: a collection of values for the model's parameters. Note that
   all the parameters of the model should have their values assigned by the component.
     - **id**: the ID of the parameter, as defined by the [model](#models)

--- a/src/io/inputs/yml-system/decoders.hxx
+++ b/src/io/inputs/yml-system/decoders.hxx
@@ -73,7 +73,7 @@ struct convert<Antares::IO::Inputs::YmlSystem::Component>
         }
         rhs.id = node["id"].as<std::string>();
         rhs.model = node["model"].as<std::string>();
-        rhs.scenarioGroup = node["scenario-group"].as<std::string>("default");
+        rhs.scenarioGroup = node["scenario-group"].as<std::string>("");
         rhs.parameters = as_fallback_default<
           std::vector<Antares::IO::Inputs::YmlSystem::Parameter>>(node["parameters"]);
         return true;

--- a/src/solver/optim-model-filler/scenarioGroupRepo.cpp
+++ b/src/solver/optim-model-filler/scenarioGroupRepo.cpp
@@ -47,11 +47,10 @@ public:
 const LinearProblemApi::IScenario& ScenarioGroupRepository::scenario(
   const std::string& groupId) const
 {
-    // A component require a group id. Assuming that the default group id is "default"
-    if (groupId.empty() || groupId == "default")
+    // A component requires a group ID
+    if (groupId.empty())
     {
-        static DefaultScenario defaultScenario(
-          "default");           // Todo: default ou empty for consistency ?
+        static DefaultScenario defaultScenario("");
         return defaultScenario; // Default rank for empty groupId
     }
     if (!scenarioGroups_.contains(groupId))

--- a/src/study/system-model/component.cpp
+++ b/src/study/system-model/component.cpp
@@ -39,10 +39,6 @@ static void checkComponentDataValidity(const ComponentData& data)
     {
         throw std::invalid_argument("A component can't have an empty model");
     }
-    if (data.scenario_group_id.empty())
-    {
-        throw std::invalid_argument("A component can't have an empty scenario_group_id");
-    }
     // Check that parameters values are coherent with the model
     if (data.model->Parameters().size() != data.parameter_values.size())
     {

--- a/src/tests/inmemory-modeler/include/inmemory-modeler.h
+++ b/src/tests/inmemory-modeler/include/inmemory-modeler.h
@@ -93,7 +93,7 @@ struct LinearProblemBuildingFixture
       const std::string& componentId,
       std::map<std::string, Antares::Expressions::Visitors::ParameterTypeAndValue> parameterValues
       = {},
-      std::string scenarioGroupId = "default");
+      std::string scenarioGroupId = "");
 
     Antares::Expressions::Nodes::Node* literal(double value);
 

--- a/src/tests/src/modeler/loadFiles/testLoadModelerFiles.cpp
+++ b/src/tests/src/modeler/loadFiles/testLoadModelerFiles.cpp
@@ -248,7 +248,7 @@ BOOST_FIXTURE_TEST_CASE(scenario_group_is_optional, FixtureLoadFile)
 
     auto libraries = Antares::Solver::LoadFiles::loadLibraries(studyPath);
     auto system = Antares::Solver::LoadFiles::loadSystem(studyPath, libraries);
-    BOOST_CHECK_EQUAL(system.Components().at("K").getScenarioGroupId(), "default");
+    BOOST_CHECK_EQUAL(system.Components().at("K").getScenarioGroupId(), "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/study/system-model/test_component.cpp
+++ b/src/tests/src/study/system-model/test_component.cpp
@@ -153,15 +153,6 @@ BOOST_AUTO_TEST_CASE(fail_on_no_model)
                           checkMessage("A component can't have an empty model"));
 }
 
-BOOST_AUTO_TEST_CASE(fail_on_no_scenario_group_id)
-{
-    Model model = createModelWithoutParameters();
-    auto component = component_builder.withId("component").withModel(&model);
-    BOOST_CHECK_EXCEPTION(component_builder.build(),
-                          std::invalid_argument,
-                          checkMessage("A component can't have an empty scenario_group_id"));
-}
-
 BOOST_AUTO_TEST_CASE(fail_on_no_params1)
 {
     Model model = createModelWithParameters();


### PR DESCRIPTION
Use the empty string instead of "default". This way there is only one special value instead of two ("default" and "'"), which makes things easier to understand.