### PR TITLE
[ANT-3680] Use vector instead of map in linear expressions

### DIFF
--- a/src/solver/optim-model-filler/LinearExpression.cpp
+++ b/src/solver/optim-model-filler/LinearExpression.cpp
@@ -62,7 +62,8 @@ LinearExpression::LinearExpression(double offset, FullKeyMap coef_per_var):
 std::vector<LinearExpression::RawTerm> LinearExpression::scaleTerms(const std::vector<RawTerm>& src,
                                                                     double factor)
 {
-    if (factor == 1.0)
+    constexpr double epsilon = 1e-12;
+    if (std::abs(factor - 1.0) < epsilon)
     {
         return src; // copy elision
     }

--- a/src/solver/optim-model-filler/LinearExpression.cpp
+++ b/src/solver/optim-model-filler/LinearExpression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2024, RTE (https://www.rte-france.com)
+ * Copyright 2007-2025, RTE (https://www.rte-france.com)
  * See AUTHORS.txt
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of Antares-Simulator,
@@ -37,6 +37,7 @@ namespace Antares::Optimization
 FullKeyMap scale_map(const FullKeyMap& map, double scale)
 {
     FullKeyMap result;
+    result.reserve(map.size());
     for (auto [key, value]: map)
     {
         result[key] = scale * value;
@@ -46,8 +47,47 @@ FullKeyMap scale_map(const FullKeyMap& map, double scale)
 
 LinearExpression::LinearExpression(double offset, FullKeyMap coef_per_var):
     offset_(offset),
-    coef_per_var_(std::move(coef_per_var))
+    terms_(),
+    cache_(std::move(coef_per_var)),
+    cacheValid_(true)
 {
+    terms_.reserve(cache_.size());
+    for (const auto& [k, v]: cache_)
+    {
+        terms_.emplace_back(k, v);
+    }
+}
+
+// Static helper: scale vector of terms
+std::vector<LinearExpression::RawTerm> LinearExpression::scaleTerms(const std::vector<RawTerm>& src,
+                                                                    double factor)
+{
+    if (factor == 1.0)
+    {
+        return src; // copy elision
+    }
+    std::vector<RawTerm> out;
+    out.reserve(src.size());
+    for (const auto& [k, v]: src)
+    {
+        out.emplace_back(k, v * factor);
+    }
+    return out;
+}
+
+void LinearExpression::materialize() const
+{
+    if (cacheValid_)
+    {
+        return;
+    }
+    cache_.clear();
+    cache_.reserve(terms_.size());
+    for (const auto& [k, v]: terms_)
+    {
+        cache_[k] += v; // accumulate duplicates
+    }
+    cacheValid_ = true;
 }
 
 LinearExpression LinearExpression::operator+(const LinearExpression& other) const
@@ -59,13 +99,20 @@ LinearExpression LinearExpression::operator+(const LinearExpression& other) cons
 
 const FullKeyMap& LinearExpression::coefPerVar() const
 {
-    return coef_per_var_;
+    materialize();
+    return cache_;
 }
 
 LinearExpression& LinearExpression::operator+=(const LinearExpression& other)
 {
-    this->offset_ += other.offset_;
-    add_maps(coef_per_var_, other.coef_per_var_);
+    offset_ += other.offset_;
+    if (!other.terms_.empty())
+    {
+        terms_.reserve(terms_.size() + other.terms_.size());
+        terms_.insert(terms_.end(), other.terms_.begin(), other.terms_.end());
+    }
+    // If other had pre-materialized unique map but no raw terms (should not happen), ignore.
+    invalidate();
     return *this;
 }
 
@@ -78,13 +125,24 @@ LinearExpression LinearExpression::operator-(const LinearExpression& other) cons
 
 LinearExpression LinearExpression::operator*(const LinearExpression& other) const
 {
-    if (coef_per_var_.empty())
+    if (terms_.empty())
     {
-        return {offset_ * other.offset_, scale_map(other.coef_per_var_, offset_)};
+        // this is constant; scale other's terms
+        auto scaledTerms = scaleTerms(other.terms_, offset_);
+        LinearExpression out;
+        out.offset_ = offset_ * other.offset_;
+        out.terms_ = std::move(scaledTerms);
+        out.invalidate();
+        return out;
     }
-    else if (other.coef_per_var_.empty())
+    else if (other.terms_.empty())
     {
-        return {offset_ * other.offset_, scale_map(coef_per_var_, other.offset_)};
+        auto scaledTerms = scaleTerms(terms_, other.offset_);
+        LinearExpression out;
+        out.offset_ = offset_ * other.offset_;
+        out.terms_ = std::move(scaledTerms);
+        out.invalidate();
+        return out;
     }
     else
     {
@@ -94,16 +152,27 @@ LinearExpression LinearExpression::operator*(const LinearExpression& other) cons
 
 LinearExpression LinearExpression::operator/(const LinearExpression& other) const
 {
-    if (!other.coef_per_var_.empty())
+    if (!other.terms_.empty())
     {
         throw std::invalid_argument("A linear expression can't have a variable as a dividend.");
     }
-    return LinearExpression(offset_ / other.offset_, scale_map(coef_per_var_, 1 / other.offset_));
+    double inv = 1.0 / other.offset_;
+    auto scaledTerms = scaleTerms(terms_, inv);
+    LinearExpression out;
+    out.offset_ = offset_ * inv;
+    out.terms_ = std::move(scaledTerms);
+    out.invalidate();
+    return out;
 }
 
 LinearExpression LinearExpression::operator-() const
 {
-    return {-offset_, scale_map(coef_per_var_, -1)};
+    auto scaledTerms = scaleTerms(terms_, -1.0);
+    LinearExpression out;
+    out.offset_ = -offset_;
+    out.terms_ = std::move(scaledTerms);
+    out.invalidate();
+    return out;
 }
 
 double LinearExpression::offset() const

--- a/src/solver/optim-model-filler/VariableDictionary.cpp
+++ b/src/solver/optim-model-filler/VariableDictionary.cpp
@@ -101,7 +101,7 @@ unsigned int Dimensions::getNumberOfTimesteps() const
 void VariableDictionary::VectorWithOffset::resize(size_t initial_size, unsigned int offset)
 {
     offset_ = offset;
-    values_.resize(initial_size);
+    values_.assign(initial_size, nullptr); // initialize all slots to nullptr
 }
 
 VariableDictionary::Value& VariableDictionary::VectorWithOffset::operator[](unsigned int index)

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/FullKey.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/FullKey.h
@@ -60,6 +60,7 @@ public:
     [[nodiscard]] std::optional<unsigned int> getTimestep() const;
 
     auto operator<=>(const FullKey&) const = default; // Automatically generates <, >, ==, etc.
+    auto operator==(const FullKey&) const -> bool = default;
 
 private:
     PartialKey pk;

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/LinearExpression.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/LinearExpression.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2024, RTE (https://www.rte-france.com)
+ * Copyright 2007-2025, RTE (https://www.rte-france.com)
  * See AUTHORS.txt
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of Antares-Simulator,
@@ -24,12 +24,12 @@
 #include <functional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <antares/solver/optim-model-filler/FullKey.h>
 
 namespace Antares::Optimization
 {
-
 using FullKeyMap = std::unordered_map<FullKey, double, FullKeyHash>;
 
 /**
@@ -153,7 +153,6 @@ public:
     LinearExpression operator/(const LinearExpression& other) const;
     /// Multiply linear expression by -1
     LinearExpression operator-() const;
-
     /// Get the offset
     double offset() const;
 
@@ -162,9 +161,20 @@ public:
 
     LinearExpression& operator+=(const LinearExpression& value);
 
-private:
+    using RawTerm = std::pair<FullKey, double>;
     double offset_ = 0;
-    FullKeyMap coef_per_var_;
-};
+    std::vector<RawTerm> terms_; // may contain duplicates
+    mutable FullKeyMap cache_;   // aggregated unique sums
+    mutable bool cacheValid_ = false;
+    /// Mise à l'échelle d'un ensemble de termes (utilitaire)
+    static std::vector<RawTerm> scaleTerms(const std::vector<RawTerm>& src, double factor);
 
+    void invalidate()
+    {
+        cacheValid_ = false;
+    }
+
+    /// Construction paresseuse de cache_ si nécessaire
+    void materialize() const;
+};
 } // namespace Antares::Optimization

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/PartialKey.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/PartialKey.h
@@ -34,6 +34,7 @@ public:
     const std::string& getVariable() const;
 
     auto operator<=>(const PartialKey&) const = default; // Automatically generates <, >, ==, etc.
+    auto operator==(const PartialKey&) const -> bool = default;
 
 private:
     std::string component_id;


### PR DESCRIPTION
### Change applied:
* LinearExpression no longer inserts on the fly into an unordered_map.
* Storage now as std::vector<rawterm> (FullKey, double pairs) concatenated during operations (+, -, *, /).
* Aggregation (sum of duplicates) lazily done in coefPerVar() via a cache (unordered_map) rebuilt only if invalidated.
* Public API (coefPerVar(), offset(), operators) unchanged, existing tests should remain valid. scale_map and constructor accepting a FullKeyMap retained for compatibility (these terms are recopied in RawTerm at ctor).</rawterm>
*
### Optimizations added:
* Capacity reservation before concatenation.
* Invalidation/controlled materialization (cacheValid_).
* No hash cost each time a term is added.

### Points to watch / possible consequences:
* If coefPerVar() called very often without modification, cache avoids recomputation (OK).
* Future possibility: detect “sparse gros” case and order terms_ for better cache localization.
* Check that sites consuming coefPerVar() (ComponentFiller, constraints) add up correctly (they already browse the aggregated map => duplicates neutralized).
