### PR TITLE
[5.3 part 1/2] Add extra-outputs to models & ID unicity checks

### DIFF
--- a/docs/user-guide/modeler/02-inputs.md
+++ b/docs/user-guide/modeler/02-inputs.md
@@ -115,6 +115,9 @@ models:
   - port: injection
     field: flow
     definition: active_power
+  extra-outputs:
+  - id: total_cost_in_millions
+    expression: sum(active_power * proportional_cost) / 1000000
 - id: node
   description: A balance node with injections (productions and loads)
   ports:
@@ -173,6 +176,13 @@ models:
     - **field**: the field to define (refers to a field ID defined in the port type)
     - **definition**: an [expression](#expressions) representing the definition of the field. Can use scalars,
       parameters, and variables of the model.
+- **extra-outputs** _(optional)_: a collection of outputs relevant to the model, that can be computed after optimization
+  (i.e. using the optimal values of the variables). 
+  The values of these extra outputs will appear in the [output files](03-outputs.md) along with variable and port values.
+    - **id**: an ID for the extra-output. Must be unique inside the scope of the model, and
+      respect [these rules](#rules-for-ids).
+    - **expression**: the [expression](#expressions) of the output. Can use all operators, as long as the expression can be 
+      evaluated after optimization.
 
 ### Expressions
 

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -45,18 +45,8 @@ PortTypeDoesntContainsFields::PortTypeDoesntContainsFields(const std::string& id
 {
 }
 
-PortWithThisIdAlreadyExists::PortWithThisIdAlreadyExists(const std::string& id):
-    std::runtime_error("Port with this id already exists: " + id)
-{
-}
-
 PortTypeWithThisIdAlreadyExists::PortTypeWithThisIdAlreadyExists(const std::string& id):
     std::runtime_error("Port type with this id already exists: " + id)
-{
-}
-
-ConstraintWithThisIdAlreadyExists::ConstraintWithThisIdAlreadyExists(const std::string& id):
-    std::runtime_error("Constraint with this id already exists: " + id)
 {
 }
 
@@ -203,13 +193,6 @@ std::vector<ModelerStudy::SystemModel::Port> convertPorts(
     ports.reserve(model.ports.size());
     for (const auto& port: model.ports)
     {
-        // Can't have port with the same ID
-        if (std::ranges::find_if(ports, [&port](const auto& p) { return p.Id() == port.id; })
-            != ports.end())
-        {
-            throw PortWithThisIdAlreadyExists(port.id);
-        }
-
         const auto it = std::ranges::find_if(portTypes,
                                              [&port](const auto& pt)
                                              { return pt.Id() == port.type; });
@@ -281,14 +264,6 @@ static void addSingleConstraint(std::vector<ModelerStudy::SystemModel::Constrain
                                 const IO::Inputs::YmlModel::Constraint& constraint,
                                 const IO::Inputs::YmlModel::Model& model)
 {
-    // Can't have constraints with the same ID
-    if (std::ranges::find_if(constraints,
-                             [&constraint](const auto& c) { return c.Id() == constraint.id; })
-        != constraints.end())
-    {
-        throw ConstraintWithThisIdAlreadyExists(constraint.id);
-    }
-
     auto nodeRegistry = convertExpressionToNode(constraint.expression, model);
     constraints.emplace_back(constraint.id,
                              ModelerStudy::SystemModel::Expression{constraint.expression,
@@ -320,6 +295,28 @@ std::vector<ModelerStudy::SystemModel::Constraint> convertConstraints(
 }
 
 /**
+ * \brief Converts extra outputs from YmlModel::Model to SystemModel::ExtraOutput.
+ *
+ * \param model The YmlModel::Model object containing extra outputs.
+ * \return A vector of SystemModel::ExtraOutput objects.
+ */
+std::vector<ModelerStudy::SystemModel::ExtraOutput> convertExtraOutputs(
+  const IO::Inputs::YmlModel::Model& model)
+{
+    std::vector<ModelerStudy::SystemModel::ExtraOutput> extraOutputs;
+    extraOutputs.reserve(model.extra_outputs.size());
+
+    for (const auto& extraOutput: model.extra_outputs)
+    {
+        auto nodeRegistry = convertExpressionToNode(extraOutput.expression, model);
+        extraOutputs.emplace_back(extraOutput.id,
+                                  ModelerStudy::SystemModel::Expression{extraOutput.expression,
+                                                                        std::move(nodeRegistry)});
+    }
+    return extraOutputs;
+}
+
+/**
  * \brief Converts models from YmlModel::Library to SystemModel::Model.
  *
  * \param library The YmlModel::Library object containing models.
@@ -340,6 +337,8 @@ std::vector<ModelerStudy::SystemModel::Model> convertModels(
         std::vector<ModelerStudy::SystemModel::PortFieldDefinition>
           portFieldDefinitions = convertPortFieldDefinitions(model, ports);
         std::vector<ModelerStudy::SystemModel::Constraint> constraints = convertConstraints(model);
+        std::vector<ModelerStudy::SystemModel::ExtraOutput> extraOutputs = convertExtraOutputs(
+          model);
 
         auto nodeObjective = convertExpressionToNode(model.objective, model);
 
@@ -352,6 +351,7 @@ std::vector<ModelerStudy::SystemModel::Model> convertModels(
                           .withPorts(std::move(ports))
                           .withConstraints(std::move(constraints))
                           .withPortFieldDefinitions(std::move(portFieldDefinitions))
+                          .withExtraOutputs(std::move(extraOutputs))
                           .build();
         models.emplace_back(std::move(modelObj));
     }

--- a/src/io/inputs/yml-model/decoders.hxx
+++ b/src/io/inputs/yml-model/decoders.hxx
@@ -160,6 +160,21 @@ struct convert<Antares::IO::Inputs::YmlModel::Constraint>
 };
 
 template<>
+struct convert<Antares::IO::Inputs::YmlModel::ExtraOutput>
+{
+    static bool decode(const Node& node, Antares::IO::Inputs::YmlModel::ExtraOutput& rhs)
+    {
+        if (!node.IsMap())
+        {
+            return false;
+        }
+        rhs.id = node["id"].as<std::string>();
+        rhs.expression = node["expression"].as<std::string>();
+        return true;
+    }
+};
+
+template<>
 struct convert<Antares::IO::Inputs::YmlModel::Model>
 {
     static bool decode(const Node& node, Antares::IO::Inputs::YmlModel::Model& rhs)
@@ -184,6 +199,8 @@ struct convert<Antares::IO::Inputs::YmlModel::Model>
         rhs.binding_constraints = as_fallback_default<
           std::vector<Antares::IO::Inputs::YmlModel::Constraint>>(node["binding-constraints"]);
         rhs.objective = node["objective"].as<std::string>("");
+        rhs.extra_outputs = as_fallback_default<
+          std::vector<Antares::IO::Inputs::YmlModel::ExtraOutput>>(node["extra-outputs"]);
         return true;
     }
 };

--- a/src/io/inputs/yml-model/include/antares/io/inputs/yml-model/Library.h
+++ b/src/io/inputs/yml-model/include/antares/io/inputs/yml-model/Library.h
@@ -87,6 +87,12 @@ struct Constraint
     std::string expression;
 };
 
+struct ExtraOutput
+{
+    std::string id;
+    std::string expression;
+};
+
 struct Model
 {
     std::string id;
@@ -98,6 +104,7 @@ struct Model
     std::vector<Constraint> constraints;
     std::vector<Constraint> binding_constraints;
     std::string objective;
+    std::vector<ExtraOutput> extra_outputs;
 };
 
 struct PortType

--- a/src/solver/optim-model-filler/ComponentFiller.cpp
+++ b/src/solver/optim-model-filler/ComponentFiller.cpp
@@ -271,7 +271,7 @@ void ComponentFiller::addConstraints(Optimisation::LinearProblemApi::ILinearProb
                                                                data,
                                                                scenario);
     Optimization::ReadLinearConstraintVisitor visitor(evaluationContext, ctx, component_);
-    for (const auto& constraint: component_.getModel()->getConstraints() | std::views::values)
+    for (const auto& constraint: component_.getModel()->Constraints() | std::views::values)
     {
         auto* root_node = constraint.expression().RootNode();
         auto linear_constraints = visitor.dispatch(root_node);

--- a/src/study/system-model/CMakeLists.txt
+++ b/src/study/system-model/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRC_model
         include/antares/study/system-model/portFieldDefinition.h
         include/antares/study/system-model/portType.h
         include/antares/study/system-model/component.h
+        include/antares/study/system-model/extraOutput.h
         include/antares/study/system-model/system.h
         include/antares/study/system-model/timeAndScenarioType.h
         include/antares/study/system-model/connection.h
@@ -34,6 +35,8 @@ target_include_directories(antares-study-system-model
 target_link_libraries(antares-study-system-model
         PUBLIC
         Antares::expressions
+        PRIVATE
+        Antares::exception
 )
 install(DIRECTORY include/antares
         DESTINATION "include"

--- a/src/study/system-model/include/antares/study/system-model/constraint.h
+++ b/src/study/system-model/include/antares/study/system-model/constraint.h
@@ -39,8 +39,8 @@ namespace Antares::ModelerStudy::SystemModel
 class Constraint
 {
 public:
-    Constraint(std::string name, Expression expression):
-        id_(std::move(name)),
+    Constraint(std::string id, Expression expression):
+        id_(std::move(id)),
         expression_(std::move(expression))
     {
     }

--- a/src/study/system-model/include/antares/study/system-model/extraOutput.h
+++ b/src/study/system-model/include/antares/study/system-model/extraOutput.h
@@ -25,7 +25,6 @@
 
 #include <antares/expressions/expression.h>
 
-
 namespace Antares::ModelerStudy::SystemModel
 {
 

--- a/src/study/system-model/include/antares/study/system-model/extraOutput.h
+++ b/src/study/system-model/include/antares/study/system-model/extraOutput.h
@@ -1,0 +1,61 @@
+/*
+** Copyright 2007-2025, RTE (https://www.rte-france.com)
+** See AUTHORS.txt
+** SPDX-License-Identifier: MPL-2.0
+** This file is part of Antares-Simulator,
+** Adequacy and Performance assessment for interconnected energy networks.
+**
+** Antares_Simulator is free software: you can redistribute it and/or modify
+** it under the terms of the Mozilla Public Licence 2.0 as published by
+** the Mozilla Foundation, either version 2 of the License, or
+** (at your option) any later version.
+**
+** Antares_Simulator is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** Mozilla Public Licence 2.0 for more details.
+**
+** You should have received a copy of the Mozilla Public Licence 2.0
+** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+*/
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <antares/expressions/expression.h>
+
+namespace Antares::Expressions::Visitors
+{
+enum class TimeIndex : unsigned int;
+}
+
+namespace Antares::ModelerStudy::SystemModel
+{
+
+/// An extra output expression
+class ExtraOutput
+{
+public:
+    ExtraOutput(std::string name, Expression expression):
+        id_(std::move(name)),
+        expression_(std::move(expression))
+    {
+    }
+
+    const std::string& Id() const
+    {
+        return id_;
+    }
+
+    const Expression& expression() const
+    {
+        return expression_;
+    }
+
+private:
+    std::string id_;
+    Expression expression_;
+};
+
+} // namespace Antares::ModelerStudy::SystemModel

--- a/src/study/system-model/include/antares/study/system-model/extraOutput.h
+++ b/src/study/system-model/include/antares/study/system-model/extraOutput.h
@@ -25,10 +25,6 @@
 
 #include <antares/expressions/expression.h>
 
-namespace Antares::Expressions::Visitors
-{
-enum class TimeIndex : unsigned int;
-}
 
 namespace Antares::ModelerStudy::SystemModel
 {

--- a/src/study/system-model/include/antares/study/system-model/extraOutput.h
+++ b/src/study/system-model/include/antares/study/system-model/extraOutput.h
@@ -37,8 +37,8 @@ namespace Antares::ModelerStudy::SystemModel
 class ExtraOutput
 {
 public:
-    ExtraOutput(std::string name, Expression expression):
-        id_(std::move(name)),
+    ExtraOutput(std::string id, Expression expression):
+        id_(std::move(id)),
         expression_(std::move(expression))
     {
     }

--- a/src/study/system-model/include/antares/study/system-model/model.h
+++ b/src/study/system-model/include/antares/study/system-model/model.h
@@ -118,8 +118,6 @@ private:
     std::map<std::string, ExtraOutput> extraOutputs_;
 
     PortFieldMap portFieldDefinitions_;
-
-    void checkThatIdsAreUnique();
 };
 
 class ModelBuilder
@@ -133,7 +131,7 @@ public:
     ModelBuilder& withConstraints(std::vector<Constraint>&& constraints);
     ModelBuilder& withPortFieldDefinitions(std::vector<PortFieldDefinition>&& portFieldDefinitions);
     ModelBuilder& withExtraOutputs(std::vector<ExtraOutput>&& extraOutputs);
-    void checkIdUnicity(const std::string& id);
+    void checkThatIdIsNotUsed(const std::string& id);
     Model build();
 
 private:

--- a/src/study/system-model/include/antares/study/system-model/model.h
+++ b/src/study/system-model/include/antares/study/system-model/model.h
@@ -26,6 +26,7 @@
 #include <antares/expressions/expression.h>
 
 #include "constraint.h"
+#include "extraOutput.h"
 #include "parameter.h"
 #include "port.h"
 #include "portFieldDefinition.h"
@@ -74,7 +75,7 @@ public:
         return objective_;
     }
 
-    const std::map<std::string, Constraint>& getConstraints() const
+    const std::map<std::string, Constraint>& Constraints() const
     {
         return constraints_;
     }
@@ -100,6 +101,11 @@ public:
         return portFieldDefinitions_;
     }
 
+    const std::map<std::string, ExtraOutput>& ExtraOutputs() const
+    {
+        return extraOutputs_;
+    }
+
 private:
     friend class ModelBuilder;
     std::string id_;
@@ -109,8 +115,11 @@ private:
     std::map<std::string, Variable> variables_;
     std::map<std::string, Constraint> constraints_;
     std::map<std::string, Port> ports_;
+    std::map<std::string, ExtraOutput> extraOutputs_;
 
     PortFieldMap portFieldDefinitions_;
+
+    void checkThatIdsAreUnique();
 };
 
 class ModelBuilder
@@ -121,13 +130,17 @@ public:
     ModelBuilder& withParameters(std::vector<Parameter>&& parameters);
     ModelBuilder& withVariables(std::vector<Variable>&& variables);
     ModelBuilder& withPorts(std::vector<Port>&& ports);
-    Model build();
-
     ModelBuilder& withConstraints(std::vector<Constraint>&& constraints);
     ModelBuilder& withPortFieldDefinitions(std::vector<PortFieldDefinition>&& portFieldDefinitions);
+    ModelBuilder& withExtraOutputs(std::vector<ExtraOutput>&& extraOutputs);
+    void checkIdUnicity(const std::string& id);
+    Model build();
 
 private:
     Model model_;
+    std::vector<std::string> attribute_ids_;
+
+    void reset();
 };
 
 } // namespace Antares::ModelerStudy::SystemModel

--- a/src/study/system-model/include/antares/study/system-model/model.h
+++ b/src/study/system-model/include/antares/study/system-model/model.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <map>
+#include <unordered_set>
 #include <vector>
 
 #include <antares/expressions/expression.h>
@@ -137,7 +138,7 @@ public:
 private:
     Model model_;
     // List of IDs used internally to check for uniqueness of IDs at component level
-    std::vector<std::string> attribute_ids_;
+    std::unordered_set<std::string> attribute_ids_;
 
     void reset();
 };

--- a/src/study/system-model/include/antares/study/system-model/model.h
+++ b/src/study/system-model/include/antares/study/system-model/model.h
@@ -136,6 +136,7 @@ public:
 
 private:
     Model model_;
+    // List of IDs used internally to check for uniqueness of IDs at component level
     std::vector<std::string> attribute_ids_;
 
     void reset();

--- a/src/study/system-model/model.cpp
+++ b/src/study/system-model/model.cpp
@@ -39,7 +39,7 @@ std::size_t PortFieldKeyHash::operator()(const PortFieldKey& input) const
     return seed;
 }
 
-void ModelBuilder::checkIdUnicity(const std::string& id)
+void ModelBuilder::checkThatIdIsNotUsed(const std::string& id)
 {
     if (std::ranges::find(attribute_ids_, id) != attribute_ids_.end())
     {
@@ -99,13 +99,13 @@ ModelBuilder& ModelBuilder::withObjective(Expression&& objective)
  * \param parameters A vector of Parameter objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not guaranteed to be valid after the call
+ * inputs are not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withParameters(std::vector<Parameter>&& parameters)
 {
     for (const auto& parameter: parameters)
     {
-        checkIdUnicity(parameter.Id());
+        checkThatIdIsNotUsed(parameter.Id());
     }
     std::transform(parameters.begin(),
                    parameters.end(),
@@ -124,13 +124,13 @@ ModelBuilder& ModelBuilder::withParameters(std::vector<Parameter>&& parameters)
  * \param variables A vector of Variable objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not guaranteed to be valid after the call
+ * inputs are not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withVariables(std::vector<Variable>&& variables)
 {
     for (const auto& variable: variables)
     {
-        checkIdUnicity(variable.Id());
+        checkThatIdIsNotUsed(variable.Id());
     }
     std::ranges::transform(variables,
                            std::inserter(model_.variables_, model_.variables_.end()),
@@ -148,13 +148,13 @@ ModelBuilder& ModelBuilder::withVariables(std::vector<Variable>&& variables)
  * \param ports A vector of Port objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not garanteed to be valid after the call
+ * inputs are not garanteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withPorts(std::vector<Port>&& ports)
 {
     for (const auto& port: ports)
     {
-        checkIdUnicity(port.Id());
+        checkThatIdIsNotUsed(port.Id());
     }
     std::transform(ports.begin(),
                    ports.end(),
@@ -173,13 +173,13 @@ ModelBuilder& ModelBuilder::withPorts(std::vector<Port>&& ports)
  * \param constraints A vector of Constraint objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not guaranteed to be valid after the call
+ * inputs are not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withConstraints(std::vector<Constraint>&& constraints)
 {
     for (const auto& constraint: constraints)
     {
-        checkIdUnicity(constraint.Id());
+        checkThatIdIsNotUsed(constraint.Id());
     }
     std::transform(constraints.begin(),
                    constraints.end(),
@@ -198,7 +198,7 @@ ModelBuilder& ModelBuilder::withConstraints(std::vector<Constraint>&& constraint
  * \param portFieldDefinitions A vector of PortFieldDefinition objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not guaranteed to be valid after the call
+ * inputs are not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withPortFieldDefinitions(
   std::vector<PortFieldDefinition>&& portFieldDefinitions)
@@ -222,13 +222,13 @@ ModelBuilder& ModelBuilder::withPortFieldDefinitions(
  * \param extraOutputs A vector of ExtraOutput objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not guaranteed to be valid after the call
+ * inputs are not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withExtraOutputs(std::vector<ExtraOutput>&& extraOutputs)
 {
     for (const auto& extraOutput: extraOutputs)
     {
-        checkIdUnicity(extraOutput.Id());
+        checkThatIdIsNotUsed(extraOutput.Id());
     }
     std::transform(extraOutputs.begin(),
                    extraOutputs.end(),

--- a/src/study/system-model/model.cpp
+++ b/src/study/system-model/model.cpp
@@ -48,7 +48,7 @@ void ModelBuilder::checkThatIdIsNotUsed(const std::string& id)
         throw Error::RuntimeError("Model \"" + modelId + "\" contains multiple objects with ID \""
                                   + id + "\".");
     }
-    attribute_ids_.emplace_back(id);
+    attribute_ids_.emplace(id);
 }
 
 /**

--- a/src/study/system-model/model.cpp
+++ b/src/study/system-model/model.cpp
@@ -63,7 +63,7 @@ std::size_t PortFieldKeyHash::operator()(const PortFieldKey& input) const
 
 void ModelBuilder::checkThatIdIsNotUsed(const std::string& id)
 {
-    if (std::ranges::find(attribute_ids_, id) != attribute_ids_.end())
+    if (attribute_ids_.contains(id))
     {
         std::string modelId = model_.id_;
         reset();

--- a/src/study/system-model/model.cpp
+++ b/src/study/system-model/model.cpp
@@ -27,6 +27,7 @@
 #include <boost/container_hash/hash.hpp>
 
 #include <antares/study/system-model/model.h>
+#include "antares/exception/RuntimeError.hpp"
 
 namespace Antares::ModelerStudy::SystemModel
 {
@@ -38,6 +39,18 @@ std::size_t PortFieldKeyHash::operator()(const PortFieldKey& input) const
     return seed;
 }
 
+void ModelBuilder::checkIdUnicity(const std::string& id)
+{
+    if (std::ranges::find(attribute_ids_, id) != attribute_ids_.end())
+    {
+        std::string modelId = model_.id_;
+        reset();
+        throw Error::RuntimeError("Model \"" + modelId + "\" contains multiple objects with ID \""
+                                  + id + "\".");
+    }
+    attribute_ids_.emplace_back(id);
+}
+
 /**
  * \brief Builds and returns the Model object.
  *
@@ -46,8 +59,14 @@ std::size_t PortFieldKeyHash::operator()(const PortFieldKey& input) const
 Model ModelBuilder::build()
 {
     Model model = std::move(model_);
-    model_ = Model(); // makes ModelBuilder re-usable
+    reset();
     return model;
+}
+
+void ModelBuilder::reset()
+{
+    model_ = Model(); // makes ModelBuilder re-usable
+    attribute_ids_.clear();
 }
 
 /**
@@ -80,10 +99,14 @@ ModelBuilder& ModelBuilder::withObjective(Expression&& objective)
  * \param parameters A vector of Parameter objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not garanteed to be valid after the call
+ * inputs it not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withParameters(std::vector<Parameter>&& parameters)
 {
+    for (const auto& parameter: parameters)
+    {
+        checkIdUnicity(parameter.Id());
+    }
     std::transform(parameters.begin(),
                    parameters.end(),
                    std::inserter(model_.parameters_, model_.parameters_.end()),
@@ -101,10 +124,14 @@ ModelBuilder& ModelBuilder::withParameters(std::vector<Parameter>&& parameters)
  * \param variables A vector of Variable objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not garanteed to be valid after the call
+ * inputs it not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withVariables(std::vector<Variable>&& variables)
 {
+    for (const auto& variable: variables)
+    {
+        checkIdUnicity(variable.Id());
+    }
     std::ranges::transform(variables,
                            std::inserter(model_.variables_, model_.variables_.end()),
                            [](/*Non const to prevent copy*/ Variable& variable)
@@ -125,6 +152,10 @@ ModelBuilder& ModelBuilder::withVariables(std::vector<Variable>&& variables)
  */
 ModelBuilder& ModelBuilder::withPorts(std::vector<Port>&& ports)
 {
+    for (const auto& port: ports)
+    {
+        checkIdUnicity(port.Id());
+    }
     std::transform(ports.begin(),
                    ports.end(),
                    std::inserter(model_.ports_, model_.ports_.end()),
@@ -137,15 +168,19 @@ ModelBuilder& ModelBuilder::withPorts(std::vector<Port>&& ports)
 }
 
 /**
- * \brief Sets the ID of the library.
+ * \brief Sets the constraints of the model.
  *
- * \param id The ID to set.
- * \return Reference to the LibraryBuilder object.
+ * \param constraints A vector of Constraint objects to set.
+ * \return Reference to the ModelBuilder object.
  *
- * inputs it not garanteed to be valid after the call
+ * inputs it not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withConstraints(std::vector<Constraint>&& constraints)
 {
+    for (const auto& constraint: constraints)
+    {
+        checkIdUnicity(constraint.Id());
+    }
     std::transform(constraints.begin(),
                    constraints.end(),
                    std::inserter(model_.constraints_, model_.constraints_.end()),
@@ -158,12 +193,12 @@ ModelBuilder& ModelBuilder::withConstraints(std::vector<Constraint>&& constraint
 }
 
 /**
- * \brief Sets the ports of the model.
+ * \brief Sets the port-field definitions of the model.
  *
- * \param ports A vector of Port objects to set.
+ * \param portFieldDefinitions A vector of PortFieldDefinition objects to set.
  * \return Reference to the ModelBuilder object.
  *
- * inputs it not garanteed to be valid after the call
+ * inputs it not guaranteed to be valid after the call
  */
 ModelBuilder& ModelBuilder::withPortFieldDefinitions(
   std::vector<PortFieldDefinition>&& portFieldDefinitions)
@@ -177,6 +212,31 @@ ModelBuilder& ModelBuilder::withPortFieldDefinitions(
                        auto fieldId = pfd.field().Id();
                        return std::make_pair(PortFieldKey{.portId = id, .fieldId = fieldId},
                                              std::move(pfd));
+                   });
+    return *this;
+}
+
+/**
+ * \brief Sets the extra outputs of the model.
+ *
+ * \param extraOutputs A vector of ExtraOutput objects to set.
+ * \return Reference to the ModelBuilder object.
+ *
+ * inputs it not guaranteed to be valid after the call
+ */
+ModelBuilder& ModelBuilder::withExtraOutputs(std::vector<ExtraOutput>&& extraOutputs)
+{
+    for (const auto& extraOutput: extraOutputs)
+    {
+        checkIdUnicity(extraOutput.Id());
+    }
+    std::transform(extraOutputs.begin(),
+                   extraOutputs.end(),
+                   std::inserter(model_.extraOutputs_, model_.extraOutputs_.end()),
+                   [](/*Non const to prevent copy*/ ExtraOutput& extraOutput)
+                   {
+                       auto id = extraOutput.Id();
+                       return std::make_pair(id, std::move(extraOutput));
                    });
     return *this;
 }

--- a/src/tests/resources/modeler/7_1/input/model-libraries/antares_historic.yml
+++ b/src/tests/resources/modeler/7_1/input/model-libraries/antares_historic.yml
@@ -233,7 +233,7 @@ library:
           field: flow
           definition: p_withdrawal - p_injection
       constraints:
-        - id: initial_level
+        - id: initial_level_constraint
           expression: level[0] = initial_level * reservoir_capacity
         - id: Level equation
           expression: level[t+1] = level + efficiency_injection * p_injection - efficiency_withdrawal * p_withdrawal + inflows

--- a/src/tests/resources/modeler/7_2/input/model-libraries/antares_historic.yml
+++ b/src/tests/resources/modeler/7_2/input/model-libraries/antares_historic.yml
@@ -233,7 +233,7 @@ library:
           field: flow
           definition: p_withdrawal - p_injection
       constraints:
-        - id: initial_level
+        - id: initial_level_constraint
           expression: level[0] = initial_level * reservoir_capacity
         - id: Level equation
           expression: level[t+1] = level + efficiency_injection * p_injection - efficiency_withdrawal * p_withdrawal + inflows

--- a/src/tests/resources/modeler/7_3/input/model-libraries/antares_historic.yml
+++ b/src/tests/resources/modeler/7_3/input/model-libraries/antares_historic.yml
@@ -233,7 +233,7 @@ library:
           field: flow
           definition: p_withdrawal - p_injection
       constraints:
-        - id: initial_level
+        - id: initial_level_constraint
           expression: level[0] = initial_level * reservoir_capacity
         - id: Level equation
           expression: level[t+1] = level + efficiency_injection * p_injection - efficiency_withdrawal * p_withdrawal + inflows

--- a/src/tests/resources/modeler/7_4/input/model-libraries/antares_historic.yml
+++ b/src/tests/resources/modeler/7_4/input/model-libraries/antares_historic.yml
@@ -233,7 +233,7 @@ library:
           field: flow
           definition: p_withdrawal - p_injection
       constraints:
-        - id: initial_level
+        - id: initial_level_constraint
           expression: level[0] = initial_level * reservoir_capacity
         - id: Level equation
           expression: level[t+1] = level + efficiency_injection * p_injection - efficiency_withdrawal * p_withdrawal + inflows

--- a/src/tests/src/io/yml-importers/CMakeLists.txt
+++ b/src/tests/src/io/yml-importers/CMakeLists.txt
@@ -3,7 +3,7 @@ include(${CMAKE_SOURCE_DIR}/tests/macros.cmake)
 add_boost_test(TestYmlModel
         SRC
         testYmlModel.cpp
-        testModelTranslator.cpp
+        testModelConverter.cpp
         testConvertorVisitor.cpp
         test_full.cpp
         enum_operators.h
@@ -11,6 +11,7 @@ add_boost_test(TestYmlModel
         testSystemConverter.cpp
         test-system-with-connexions.cpp
         LIBS
+        Antares::exception
         Antares::expressions
         Antares::model-converter
         Antares::yml-model

--- a/src/tests/src/io/yml-importers/testModelConverter.cpp
+++ b/src/tests/src/io/yml-importers/testModelConverter.cpp
@@ -21,9 +21,11 @@
 #define WIN32_LEAN_AND_MEAN
 
 #include <iostream>
+#include <unit_test_utils.h>
 
 #include <boost/test/unit_test.hpp>
 
+#include "antares/exception/RuntimeError.hpp"
 #include "antares/expressions/nodes/Node.h"
 #include "antares/io/inputs/model-converter/modelConverter.h"
 #include "antares/io/inputs/yml-model/Library.h"
@@ -247,31 +249,17 @@ BOOST_FIXTURE_TEST_CASE(ports_errors_cases, Fixture)
     YmlModel::PortType portType1{"flow", "description", {"abc"}, ""};
     library.port_types = {portType1};
 
-    YmlModel::Model model1{.id = "model1",
-                           .description = "description",
-                           .parameters = {},
-                           .variables = {},
-                           .ports = {{"port1", "flow"}, {"port1", "flow"}},
-                           .port_field_definitions = {},
-                           .constraints = {},
-                           .binding_constraints = {},
-                           .objective = ""};
-    library.models = {model1};
-    BOOST_CHECK_EXCEPTION(ModelConverter::convert(library),
-                          ModelConverter::PortWithThisIdAlreadyExists,
-                          portAlreadyExists);
-
     // test port type not found
-    YmlModel::Model model2{.id = "model2",
-                           .description = "description",
-                           .parameters = {},
-                           .variables = {},
-                           .ports = {{"port2", "not flow"}},
-                           .port_field_definitions = {},
-                           .constraints = {},
-                           .binding_constraints = {},
-                           .objective = ""};
-    library.models = {model2};
+    YmlModel::Model model{.id = "model2",
+                          .description = "description",
+                          .parameters = {},
+                          .variables = {},
+                          .ports = {{"port2", "not flow"}},
+                          .port_field_definitions = {},
+                          .constraints = {},
+                          .binding_constraints = {},
+                          .objective = ""};
+    library.models = {model};
     BOOST_CHECK_EXCEPTION(ModelConverter::convert(library),
                           ModelConverter::PortTypeNotFound,
                           typeNotFound);
@@ -295,10 +283,10 @@ BOOST_FIXTURE_TEST_CASE(model_constraints_properly_translated, Fixture)
     library.models = {model1};
     SystemModel::Library lib = ModelConverter::convert(library);
     auto& model = lib.Models().at("model1");
-    BOOST_REQUIRE_EQUAL(model.getConstraints().size(), 3);
-    auto& constraint1 = model.getConstraints().at("constraint1");
-    auto& constraint2 = model.getConstraints().at("constraint2");
-    auto& constraint3 = model.getConstraints().at("constraint3");
+    BOOST_REQUIRE_EQUAL(model.Constraints().size(), 3);
+    auto& constraint1 = model.Constraints().at("constraint1");
+    auto& constraint2 = model.Constraints().at("constraint2");
+    auto& constraint3 = model.Constraints().at("constraint3");
     BOOST_CHECK_EQUAL(constraint1.Id(), "constraint1");
     BOOST_CHECK_EQUAL(constraint1.expression().Value(), "expression1");
     BOOST_CHECK_EQUAL(constraint2.Id(), "constraint2");
@@ -311,26 +299,6 @@ bool constraintAlreadyExists(const ModelConverter::ConstraintWithThisIdAlreadyEx
 {
     BOOST_CHECK_EQUAL(ex.what(), "Constraint with this id already exists: constraint1");
     return true;
-}
-
-// Test constraints errors
-BOOST_FIXTURE_TEST_CASE(constraints_error_cases, Fixture)
-{
-    YmlModel::Model model1{.id = "model1",
-                           .description = "description",
-                           .parameters = {{"expression1", true, false},
-                                          {"expression2", true, false}},
-                           .variables = {},
-                           .ports = {},
-                           .port_field_definitions = {},
-                           .constraints = {{"constraint1", "expression1"},
-                                           {"constraint1", "expression2"}},
-                           .binding_constraints = {},
-                           .objective = ""};
-    library.models = {model1};
-    BOOST_CHECK_EXCEPTION(ModelConverter::convert(library),
-                          ModelConverter::ConstraintWithThisIdAlreadyExists,
-                          constraintAlreadyExists);
 }
 
 // Test with 2 models
@@ -462,4 +430,30 @@ BOOST_FIXTURE_TEST_CASE(port_field_definition_error_cases, Fixture)
     BOOST_CHECK_EXCEPTION(ModelConverter::convert(library),
                           ModelConverter::PortInDefinition,
                           portInDef);
+}
+
+// Test one model with extra outputs
+BOOST_FIXTURE_TEST_CASE(model_extra_outputs_properly_translated, Fixture)
+{
+    YmlModel::Model model1{
+      .id = "model1",
+      .description = "description",
+      .parameters = {{"param1", true, false}},
+      .variables = {{"var1", "7", "8", YmlModel::ValueType::CONTINUOUS, true, true}},
+      .ports = {},
+      .port_field_definitions = {},
+      .constraints = {},
+      .binding_constraints = {},
+      .objective = "",
+      .extra_outputs = {{"output1", "5 * param1"}, {"output2", "param1 / var1 * 95.4"}}};
+    library.models = {model1};
+    SystemModel::Library lib = ModelConverter::convert(library);
+    auto& model = lib.Models().at("model1");
+    BOOST_REQUIRE_EQUAL(model.ExtraOutputs().size(), 2);
+    auto& output1 = model.ExtraOutputs().at("output1");
+    auto& output2 = model.ExtraOutputs().at("output2");
+    BOOST_CHECK_EQUAL(output1.Id(), "output1");
+    BOOST_CHECK_EQUAL(output1.expression().Value(), "5 * param1");
+    BOOST_CHECK_EQUAL(output2.Id(), "output2");
+    BOOST_CHECK_EQUAL(output2.expression().Value(), "param1 / var1 * 95.4");
 }

--- a/src/tests/src/io/yml-importers/testYmlModel.cpp
+++ b/src/tests/src/io/yml-importers/testYmlModel.cpp
@@ -622,7 +622,7 @@ BOOST_AUTO_TEST_CASE(model_is_not_scalar)
     BOOST_CHECK_THROW(parser.parse(library), std::runtime_error);
 }
 
-BOOST_AUTO_TEST_CASE(model_attributs_can_be_ommited)
+BOOST_AUTO_TEST_CASE(model_attributes_can_be_ommited)
 {
     Antares::IO::Inputs::YmlModel::Parser parser;
     const auto library = R"(
@@ -653,4 +653,37 @@ BOOST_AUTO_TEST_CASE(test_variable_to_string)
     BOOST_CHECK_EQUAL(YmlMod::toString(YmlMod::ValueType::INTEGER), "INTEGER");
     BOOST_CHECK_EQUAL(YmlMod::toString(YmlMod::ValueType::BOOL), "BOOL");
     BOOST_CHECK_EQUAL(YmlMod::toString(static_cast<YmlMod::ValueType>(5)), "UNKNOWN");
+}
+
+// Test library with one model containing multiple extra outputs
+BOOST_AUTO_TEST_CASE(model_can_contain_multiple_extra_outputs)
+{
+    Antares::IO::Inputs::YmlModel::Parser parser;
+    const auto library = R"(
+        library:
+            id: "lib_id"
+            description: "lib_description"
+            port-types: []
+            models:
+                - id: "model_id"
+                  description: "model_description"
+                  parameters: []
+                  variables: []
+                  ports: []
+                  port-field-definitions: []
+                  constraints: []
+                  extra-outputs:
+                      - id: "output_name1"
+                        expression: "expression1"
+                      - id: "output_name2"
+                        expression: "expression2"
+                  objective: "objective"
+        )"s;
+    Antares::IO::Inputs::YmlModel::Library libraryObj = parser.parse(library);
+    BOOST_REQUIRE_EQUAL(libraryObj.models.size(), 1);
+    BOOST_REQUIRE_EQUAL(libraryObj.models[0].extra_outputs.size(), 2);
+    BOOST_CHECK_EQUAL(libraryObj.models[0].extra_outputs[0].id, "output_name1");
+    BOOST_CHECK_EQUAL(libraryObj.models[0].extra_outputs[0].expression, "expression1");
+    BOOST_CHECK_EQUAL(libraryObj.models[0].extra_outputs[1].id, "output_name2");
+    BOOST_CHECK_EQUAL(libraryObj.models[0].extra_outputs[1].expression, "expression2");
 }

--- a/src/tests/src/io/yml-importers/test_full.cpp
+++ b/src/tests/src/io/yml-importers/test_full.cpp
@@ -127,6 +127,9 @@ library:
         - id: balance
           expression: injection_port.flow = 0
       objective: cost * generation
+      extra-outputs:
+        - id: total_cost_in_millions
+          expression: sum(cost * generation) / 1000000
 
     - id: node
       description: A basic balancing node model
@@ -295,8 +298,10 @@ library:
         auto& model0 = lib.Models().at("generator");
         BOOST_CHECK_EQUAL(model0.Id(), "generator");
         BOOST_CHECK_EQUAL(model0.Objective().Value(), "cost * generation");
+        BOOST_CHECK_EQUAL(model0.ExtraOutputs().at("total_cost_in_millions").expression().Value(),
+                          "sum(cost * generation) / 1000000");
 
-        BOOST_REQUIRE_EQUAL(model0.getConstraints().size(), 1);
+        BOOST_REQUIRE_EQUAL(model0.Constraints().size(), 1);
         BOOST_REQUIRE_EQUAL(model0.Parameters().size(), 2);
         BOOST_REQUIRE_EQUAL(model0.Variables().size(), 1);
         BOOST_REQUIRE_EQUAL(model0.Ports().size(), 1);
@@ -317,7 +322,7 @@ library:
 
         auto& model1 = lib.Models().at("node");
         BOOST_CHECK_EQUAL(model1.Id(), "node");
-        BOOST_REQUIRE_EQUAL(model1.getConstraints().size(), 0);
+        BOOST_REQUIRE_EQUAL(model1.Constraints().size(), 0);
         BOOST_REQUIRE_EQUAL(model1.Parameters().size(), 0);
         BOOST_REQUIRE_EQUAL(model1.Variables().size(), 0);
         BOOST_REQUIRE_EQUAL(model1.Ports().size(), 1);
@@ -325,7 +330,7 @@ library:
 
         auto& model2 = lib.Models().at("spillage");
         BOOST_CHECK_EQUAL(model2.Id(), "spillage");
-        BOOST_REQUIRE_EQUAL(model2.getConstraints().size(), 0);
+        BOOST_REQUIRE_EQUAL(model2.Constraints().size(), 0);
         BOOST_REQUIRE_EQUAL(model2.Parameters().size(), 1);
         BOOST_REQUIRE_EQUAL(model2.Variables().size(), 1);
         BOOST_REQUIRE_EQUAL(model2.Ports().size(), 1);
@@ -342,7 +347,7 @@ library:
 
         auto& model3 = lib.Models().at("unsupplied");
         BOOST_CHECK_EQUAL(model3.Id(), "unsupplied");
-        BOOST_REQUIRE_EQUAL(model3.getConstraints().size(), 0);
+        BOOST_REQUIRE_EQUAL(model3.Constraints().size(), 0);
         BOOST_REQUIRE_EQUAL(model3.Parameters().size(), 1);
         BOOST_REQUIRE_EQUAL(model3.Variables().size(), 1);
         BOOST_REQUIRE_EQUAL(model3.Ports().size(), 1);
@@ -358,7 +363,7 @@ library:
 
         auto& model4 = lib.Models().at("demand");
         BOOST_CHECK_EQUAL(model4.Id(), "demand");
-        BOOST_REQUIRE_EQUAL(model4.getConstraints().size(), 0);
+        BOOST_REQUIRE_EQUAL(model4.Constraints().size(), 0);
         BOOST_REQUIRE_EQUAL(model4.Parameters().size(), 1);
         BOOST_REQUIRE_EQUAL(model4.Variables().size(), 0);
         BOOST_REQUIRE_EQUAL(model4.Ports().size(), 1);
@@ -367,7 +372,7 @@ library:
 
         auto& model5 = lib.Models().at("short-term-storage");
         BOOST_CHECK_EQUAL(model5.Id(), "short-term-storage");
-        BOOST_REQUIRE_EQUAL(model5.getConstraints().size(), 1);
+        BOOST_REQUIRE_EQUAL(model5.Constraints().size(), 1);
         BOOST_REQUIRE_EQUAL(model5.Parameters().size(), 6);
         BOOST_REQUIRE_EQUAL(model5.Variables().size(), 3);
         BOOST_REQUIRE_EQUAL(model5.Ports().size(), 1);
@@ -399,13 +404,13 @@ library:
                       SystemModel::ValueType::FLOAT,
                       SystemModel::TimeDependent::NO,
                       SystemModel::ScenarioDependent::NO);
-        checkConstraint(model5.getConstraints().at("Level equation"),
+        checkConstraint(model5.Constraints().at("Level equation"),
                         "Level equation",
                         "level - level - efficiency * injection + withdrawal = inflows");
 
         auto& model6 = lib.Models().at("thermal-cluster-dhd");
         BOOST_CHECK_EQUAL(model6.Id(), "thermal-cluster-dhd");
-        BOOST_REQUIRE_EQUAL(model6.getConstraints().size(), 5);
+        BOOST_REQUIRE_EQUAL(model6.Constraints().size(), 5);
         BOOST_REQUIRE_EQUAL(model6.Parameters().size(), 7);
         BOOST_REQUIRE_EQUAL(model6.Variables().size(), 4);
         BOOST_REQUIRE_EQUAL(model6.Ports().size(), 1);
@@ -445,19 +450,19 @@ library:
                       SystemModel::ValueType::FLOAT,
                       SystemModel::TimeDependent::YES,
                       SystemModel::ScenarioDependent::NO);
-        checkConstraint(model6.getConstraints().at("Max generation"),
+        checkConstraint(model6.Constraints().at("Max generation"),
                         "Max generation",
                         "generation <= nb_on * p_max");
-        checkConstraint(model6.getConstraints().at("Min generation"),
+        checkConstraint(model6.Constraints().at("Min generation"),
                         "Min generation",
                         "generation >= nb_on * p_min");
-        checkConstraint(model6.getConstraints().at("Number of units variation"),
+        checkConstraint(model6.Constraints().at("Number of units variation"),
                         "Number of units variation",
                         "nb_on = nb_on + nb_start - nb_stop");
-        checkConstraint(model6.getConstraints().at("Min up time"),
+        checkConstraint(model6.Constraints().at("Min up time"),
                         "Min up time",
                         "t-d_min_up + 1 <= nb_on");
-        checkConstraint(model6.getConstraints().at("Min down time"),
+        checkConstraint(model6.Constraints().at("Min down time"),
                         "Min down time",
                         "t-d_min_down + 1 <= nb_units_max - nb_on");
         BOOST_CHECK_EQUAL(model6.Objective().Value(), "cost * generation");

--- a/src/tests/src/study/system-model/CMakeLists.txt
+++ b/src/tests/src/study/system-model/CMakeLists.txt
@@ -6,6 +6,7 @@ add_boost_test(test-system-model
   test_system.cpp
   test_library.cpp
   LIBS
+  Antares::exception
   Antares::expressions
   Antares::model-converter
   Antares::yml-model

--- a/src/tests/src/study/system-model/test_library.cpp
+++ b/src/tests/src/study/system-model/test_library.cpp
@@ -25,11 +25,120 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "antares/exception/RuntimeError.hpp"
+#include "antares/study/system-model/model.h"
 #include "antares/study/system-model/portType.h"
 
 using namespace Antares::ModelerStudy::SystemModel;
 
 BOOST_AUTO_TEST_SUITE(_ModelerLibrary_)
+
+BOOST_AUTO_TEST_CASE(model_with_same_objects_of_same_id)
+{
+    ModelBuilder model_builder;
+
+    // Two parameters with same ID
+    model_builder.withId("model");
+    BOOST_CHECK_EXCEPTION(
+      model_builder.withParameters({Parameter("param1", TimeDependent::NO, ScenarioDependent::NO),
+                                    Parameter("param1", TimeDependent::NO, ScenarioDependent::NO)}),
+      Antares::Error::RuntimeError,
+      checkMessage("Model \"model\" contains multiple objects with ID \"param1\"."));
+
+    // Two variables with same ID
+    model_builder.withId("model");
+    std::vector<Variable> variables;
+    variables.push_back({"var1", {}, {}, ValueType::FLOAT, {}, {}});
+    variables.push_back({"var1", {}, {}, ValueType::BOOL, {}, {}});
+    BOOST_CHECK_EXCEPTION(model_builder.withVariables(std::move(variables)),
+                          Antares::Error::RuntimeError,
+                          checkMessage(
+                            "Model \"model\" contains multiple objects with ID \"var1\"."));
+
+    // Two constraints with same ID
+    model_builder.withId("model32");
+    std::vector<Constraint> constraints;
+    Constraint ct1("ctt", {});
+    Constraint ct2("ctt", {});
+    constraints.push_back(std::move(ct1));
+    constraints.push_back(std::move(ct2));
+    BOOST_CHECK_EXCEPTION(model_builder.withConstraints(std::move(constraints)),
+                          Antares::Error::RuntimeError,
+                          checkMessage(
+                            "Model \"model32\" contains multiple objects with ID \"ctt\"."));
+
+    // Two ports with same ID
+    model_builder.withId("model");
+    PortField flow("flow");
+    std::vector<PortField> portFields = {flow};
+    PortType portType("some-port-type", std::move(portFields));
+    Port port1("p", portType);
+    Port port2("p", portType);
+    BOOST_CHECK_EXCEPTION(model_builder.withPorts({port1, port2}),
+                          Antares::Error::RuntimeError,
+                          checkMessage("Model \"model\" contains multiple objects with ID \"p\"."));
+
+    // Two extra outputs with same ID
+    model_builder.withId("model312");
+    std::vector<ExtraOutput> outputs;
+    ExtraOutput eo1("output", {});
+    ExtraOutput eo2("output", {});
+    outputs.push_back(std::move(eo1));
+    outputs.push_back(std::move(eo2));
+    BOOST_CHECK_EXCEPTION(model_builder.withExtraOutputs(std::move(outputs)),
+                          Antares::Error::RuntimeError,
+                          checkMessage(
+                            "Model \"model312\" contains multiple objects with ID \"output\"."));
+}
+
+BOOST_AUTO_TEST_CASE(model_with_different_objects_of_same_id)
+{
+    ModelBuilder model_builder;
+
+    // Variable with same ID as parameter
+    model_builder.withId("model");
+    model_builder.withParameters({Parameter("z", TimeDependent::NO, ScenarioDependent::NO)});
+    std::vector<Variable> variables;
+    variables.push_back({"z", {}, {}, ValueType::FLOAT, {}, {}});
+    BOOST_CHECK_EXCEPTION(model_builder.withVariables(std::move(variables)),
+                          Antares::Error::RuntimeError,
+                          checkMessage("Model \"model\" contains multiple objects with ID \"z\"."));
+
+    // Constraint with same id as parameter
+    model_builder.withId("model32");
+    model_builder.withParameters({Parameter("x", TimeDependent::NO, ScenarioDependent::NO)});
+    std::vector<Constraint> constraints;
+    Constraint ct("x", {});
+    constraints.push_back(std::move(ct));
+    BOOST_CHECK_EXCEPTION(model_builder.withConstraints(std::move(constraints)),
+                          Antares::Error::RuntimeError,
+                          checkMessage(
+                            "Model \"model32\" contains multiple objects with ID \"x\"."));
+
+    // Port with same ID as constraint
+    model_builder.withId("model");
+    model_builder.withConstraints(std::move(constraints));
+    PortField flow("flow");
+    std::vector<PortField> portFields = {flow};
+    PortType portType("some-port-type", std::move(portFields));
+    Port port("x", portType);
+    BOOST_CHECK_EXCEPTION(model_builder.withPorts({port}),
+                          Antares::Error::RuntimeError,
+                          checkMessage("Model \"model\" contains multiple objects with ID \"x\"."));
+
+    // Extra output with same ID as variable
+    model_builder.withId("model__");
+    std::vector<Variable> variables2;
+    variables2.push_back({"y", {}, {}, ValueType::FLOAT, {}, {}});
+    model_builder.withVariables(std::move(variables2));
+    std::vector<ExtraOutput> extraOutputs;
+    ExtraOutput eo("y", {});
+    extraOutputs.push_back(std::move(eo));
+    BOOST_CHECK_EXCEPTION(model_builder.withExtraOutputs(std::move(extraOutputs)),
+                          Antares::Error::RuntimeError,
+                          checkMessage(
+                            "Model \"model__\" contains multiple objects with ID \"y\"."));
+}
 
 BOOST_AUTO_TEST_CASE(port_type_basic)
 {


### PR DESCRIPTION
- Added the ability to define "extra-outputs" at the model level (yaml & cpp class), to define extra outputs that will be exported in the output files (actual export will come in an upcooming PR)
- Fixed the ID unicity check: currently, only some unicity checks are made at local scope (eg 2 constraints can't have the same ID). However, we want IDs to be unique across the whole model, so there is no ambiguity when interpreting expressions or output values.