### PR TITLE
Fix logic for map parsing in yaml-cpp

### DIFF
--- a/src/io/inputs/yml-system/decoders.hxx
+++ b/src/io/inputs/yml-system/decoders.hxx
@@ -85,12 +85,13 @@ struct convert<Antares::IO::Inputs::YmlSystem::Connection>
 {
     static bool decode(const Node& node, Antares::IO::Inputs::YmlSystem::Connection& rhs)
     {
-        if (!node.IsMap() && node.size() != 4)
+        if (!node.IsMap() || node.size() != 4)
         {
             return false;
         }
         rhs.firstEntry.componentId = node["component1"].as<std::string>();
         rhs.firstEntry.portId = node["port1"].as<std::string>();
+
         rhs.secondEntry.componentId = node["component2"].as<std::string>();
         rhs.secondEntry.portId = node["port2"].as<std::string>();
         return true;
@@ -102,7 +103,7 @@ struct convert<Antares::IO::Inputs::YmlSystem::AreaConnection>
 {
     static bool decode(const Node& node, Antares::IO::Inputs::YmlSystem::AreaConnection& rhs)
     {
-        if (!node.IsMap() && node.size() != 4)
+        if (!node.IsMap() || node.size() != 3)
         {
             return false;
         }


### PR DESCRIPTION
For model fields `connections` and `area-connections`, the right behavior is
- Check that the node is a map
- Check that the map has the right size

Previously, if the node was a map, the check on the size was skipped because of `&&`. With existing studies, we had this sequence
- `node.IsMap() = true`
- `!node.IsMap() = false`
- `!node.IsMap() && anything = false`
so the `size` condition is skipped whenever `node.IsMap() = true`. 

Also, `Antares::IO::Inputs::YmlSystem::AreaConnection` expects 3 elements, not 4.