### PR TITLE
Refactor unique ID check

### DIFF
--- a/src/study/system-model/include/antares/study/system-model/model.h
+++ b/src/study/system-model/include/antares/study/system-model/model.h
@@ -121,6 +121,18 @@ private:
     PortFieldMap portFieldDefinitions_;
 };
 
+// List of IDs used internally to check for uniqueness of IDs at component level
+class UniqueIDChecker
+{
+public:
+    void add(const std::string& id);
+    void check(const std::string& modelId) const;
+    void clear();
+
+private:
+    std::unordered_map<std::string, int> attribute_ids_;
+};
+
 class ModelBuilder
 {
 public:
@@ -132,14 +144,11 @@ public:
     ModelBuilder& withConstraints(std::vector<Constraint>&& constraints);
     ModelBuilder& withPortFieldDefinitions(std::vector<PortFieldDefinition>&& portFieldDefinitions);
     ModelBuilder& withExtraOutputs(std::vector<ExtraOutput>&& extraOutputs);
-    void checkThatIdIsNotUsed(const std::string& id);
     Model build();
 
 private:
     Model model_;
-    // List of IDs used internally to check for uniqueness of IDs at component level
-    std::unordered_set<std::string> attribute_ids_;
-
+    UniqueIDChecker uniqueIdChecker_;
     void reset();
 };
 

--- a/src/study/system-model/model.cpp
+++ b/src/study/system-model/model.cpp
@@ -94,8 +94,15 @@ void UniqueIDChecker::clear()
 Model ModelBuilder::build()
 {
     Model model = std::move(model_);
-    uniqueIdChecker_.check(model_.Id());
-    reset();
+    try
+    {
+        uniqueIdChecker_.check(model.Id());
+    }
+    catch (...)
+    {
+        reset();
+        throw;
+    }
     return model;
 }
 

--- a/src/study/system-model/model.cpp
+++ b/src/study/system-model/model.cpp
@@ -32,14 +32,17 @@
 namespace
 {
 template<class OutT, class InT>
-void fillMapFrom(OutT& out, InT&& in, Antares::ModelerStudy::SystemModel::ModelBuilder& builder)
+void fillMapFrom(OutT& out,
+                 InT&& in,
+                 Antares::ModelerStudy::SystemModel::UniqueIDChecker& uniqueIdChecker)
 {
-    for (const auto& x: in)
+    using InnerT = std::remove_cvref_t<InT>::value_type;
+
+    for (const InnerT& x: in)
     {
-        builder.checkThatIdIsNotUsed(x.Id());
+        uniqueIdChecker.add(x.Id());
     }
 
-    using InnerT = std::remove_cvref_t<InT>::value_type;
     std::transform(in.begin(),
                    in.end(),
                    std::inserter(out, out.end()),
@@ -61,16 +64,26 @@ std::size_t PortFieldKeyHash::operator()(const PortFieldKey& input) const
     return seed;
 }
 
-void ModelBuilder::checkThatIdIsNotUsed(const std::string& id)
+void UniqueIDChecker::add(const std::string& id)
 {
-    if (attribute_ids_.contains(id))
+    attribute_ids_[id]++;
+}
+
+void UniqueIDChecker::check(const std::string& modelId) const
+{
+    for (const auto& [id, count]: attribute_ids_)
     {
-        std::string modelId = model_.id_;
-        reset();
-        throw Error::RuntimeError("Model \"" + modelId + "\" contains multiple objects with ID \""
-                                  + id + "\".");
+        if (count > 1)
+        {
+            throw Error::RuntimeError("Model \"" + modelId
+                                      + "\" contains multiple objects with ID \"" + id + "\".");
+        }
     }
-    attribute_ids_.emplace(id);
+}
+
+void UniqueIDChecker::clear()
+{
+    attribute_ids_.clear();
 }
 
 /**
@@ -81,6 +94,7 @@ void ModelBuilder::checkThatIdIsNotUsed(const std::string& id)
 Model ModelBuilder::build()
 {
     Model model = std::move(model_);
+    uniqueIdChecker_.check(model_.Id());
     reset();
     return model;
 }
@@ -88,7 +102,7 @@ Model ModelBuilder::build()
 void ModelBuilder::reset()
 {
     model_ = Model(); // makes ModelBuilder re-usable
-    attribute_ids_.clear();
+    uniqueIdChecker_.clear();
 }
 
 /**
@@ -125,7 +139,7 @@ ModelBuilder& ModelBuilder::withObjective(Expression&& objective)
  */
 ModelBuilder& ModelBuilder::withParameters(std::vector<Parameter>&& parameters)
 {
-    fillMapFrom(model_.parameters_, parameters, *this);
+    fillMapFrom(model_.parameters_, parameters, uniqueIdChecker_);
     return *this;
 }
 
@@ -139,7 +153,7 @@ ModelBuilder& ModelBuilder::withParameters(std::vector<Parameter>&& parameters)
  */
 ModelBuilder& ModelBuilder::withVariables(std::vector<Variable>&& variables)
 {
-    fillMapFrom(model_.variables_, variables, *this);
+    fillMapFrom(model_.variables_, variables, uniqueIdChecker_);
     return *this;
 }
 
@@ -153,7 +167,7 @@ ModelBuilder& ModelBuilder::withVariables(std::vector<Variable>&& variables)
  */
 ModelBuilder& ModelBuilder::withPorts(std::vector<Port>&& ports)
 {
-    fillMapFrom(model_.ports_, ports, *this);
+    fillMapFrom(model_.ports_, ports, uniqueIdChecker_);
     return *this;
 }
 
@@ -167,7 +181,7 @@ ModelBuilder& ModelBuilder::withPorts(std::vector<Port>&& ports)
  */
 ModelBuilder& ModelBuilder::withConstraints(std::vector<Constraint>&& constraints)
 {
-    fillMapFrom(model_.constraints_, constraints, *this);
+    fillMapFrom(model_.constraints_, constraints, uniqueIdChecker_);
     return *this;
 }
 
@@ -205,7 +219,7 @@ ModelBuilder& ModelBuilder::withPortFieldDefinitions(
  */
 ModelBuilder& ModelBuilder::withExtraOutputs(std::vector<ExtraOutput>&& extraOutputs)
 {
-    fillMapFrom(model_.extraOutputs_, extraOutputs, *this);
+    fillMapFrom(model_.extraOutputs_, extraOutputs, uniqueIdChecker_);
     return *this;
 }
 

--- a/src/study/system-model/model.cpp
+++ b/src/study/system-model/model.cpp
@@ -103,6 +103,7 @@ Model ModelBuilder::build()
         reset();
         throw;
     }
+    reset();
     return model;
 }
 

--- a/src/tests/src/solver/optim-model-filler/test_readLinExprVisitor_sum_connections.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_readLinExprVisitor_sum_connections.cpp
@@ -103,7 +103,7 @@ BOOST_FIXTURE_TEST_CASE(sum_conections_connects_2_components_with_a_port_field,
 
     std::vector<SystemModel::Constraint> constraints;
     constraints.push_back(std::move(balance_constraint));
-    modelBuilder.reset();
+
     auto nodeModel = modelBuilder.withId("node")
                        .withPorts({injection_port})
                        .withConstraints(std::move(constraints))

--- a/src/tests/src/solver/optim-model-filler/test_readLinExprVisitor_sum_connections.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_readLinExprVisitor_sum_connections.cpp
@@ -103,7 +103,7 @@ BOOST_FIXTURE_TEST_CASE(sum_conections_connects_2_components_with_a_port_field,
 
     std::vector<SystemModel::Constraint> constraints;
     constraints.push_back(std::move(balance_constraint));
-
+    modelBuilder.reset();
     auto nodeModel = modelBuilder.withId("node")
                        .withPorts({injection_port})
                        .withConstraints(std::move(constraints))

--- a/src/tests/src/study/system-model/test_library.cpp
+++ b/src/tests/src/study/system-model/test_library.cpp
@@ -39,18 +39,20 @@ BOOST_AUTO_TEST_CASE(model_with_same_objects_of_same_id)
 
     // Two parameters with same ID
     model_builder.withId("model");
-    BOOST_CHECK_EXCEPTION(
-      model_builder.withParameters({Parameter("param1", TimeDependent::NO, ScenarioDependent::NO),
-                                    Parameter("param1", TimeDependent::NO, ScenarioDependent::NO)}),
-      Antares::Error::RuntimeError,
-      checkMessage("Model \"model\" contains multiple objects with ID \"param1\"."));
+    model_builder.withParameters({Parameter("param1", TimeDependent::NO, ScenarioDependent::NO),
+                                  Parameter("param1", TimeDependent::NO, ScenarioDependent::NO)});
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
+                          Antares::Error::RuntimeError,
+                          checkMessage(
+                            "Model \"model\" contains multiple objects with ID \"param1\"."));
 
     // Two variables with same ID
     model_builder.withId("model");
     std::vector<Variable> variables;
     variables.push_back({"var1", {}, {}, ValueType::FLOAT, {}, {}});
     variables.push_back({"var1", {}, {}, ValueType::BOOL, {}, {}});
-    BOOST_CHECK_EXCEPTION(model_builder.withVariables(std::move(variables)),
+    model_builder.withVariables(std::move(variables));
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
                           Antares::Error::RuntimeError,
                           checkMessage(
                             "Model \"model\" contains multiple objects with ID \"var1\"."));
@@ -62,7 +64,9 @@ BOOST_AUTO_TEST_CASE(model_with_same_objects_of_same_id)
     Constraint ct2("ctt", {});
     constraints.push_back(std::move(ct1));
     constraints.push_back(std::move(ct2));
-    BOOST_CHECK_EXCEPTION(model_builder.withConstraints(std::move(constraints)),
+
+    model_builder.withConstraints(std::move(constraints));
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
                           Antares::Error::RuntimeError,
                           checkMessage(
                             "Model \"model32\" contains multiple objects with ID \"ctt\"."));
@@ -74,7 +78,8 @@ BOOST_AUTO_TEST_CASE(model_with_same_objects_of_same_id)
     PortType portType("some-port-type", std::move(portFields));
     Port port1("p", portType);
     Port port2("p", portType);
-    BOOST_CHECK_EXCEPTION(model_builder.withPorts({port1, port2}),
+    model_builder.withPorts({port1, port2});
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
                           Antares::Error::RuntimeError,
                           checkMessage("Model \"model\" contains multiple objects with ID \"p\"."));
 
@@ -85,7 +90,9 @@ BOOST_AUTO_TEST_CASE(model_with_same_objects_of_same_id)
     ExtraOutput eo2("output", {});
     outputs.push_back(std::move(eo1));
     outputs.push_back(std::move(eo2));
-    BOOST_CHECK_EXCEPTION(model_builder.withExtraOutputs(std::move(outputs)),
+
+    model_builder.withExtraOutputs(std::move(outputs));
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
                           Antares::Error::RuntimeError,
                           checkMessage(
                             "Model \"model312\" contains multiple objects with ID \"output\"."));
@@ -100,7 +107,8 @@ BOOST_AUTO_TEST_CASE(model_with_different_objects_of_same_id)
     model_builder.withParameters({Parameter("z", TimeDependent::NO, ScenarioDependent::NO)});
     std::vector<Variable> variables;
     variables.push_back({"z", {}, {}, ValueType::FLOAT, {}, {}});
-    BOOST_CHECK_EXCEPTION(model_builder.withVariables(std::move(variables)),
+    model_builder.withVariables(std::move(variables));
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
                           Antares::Error::RuntimeError,
                           checkMessage("Model \"model\" contains multiple objects with ID \"z\"."));
 
@@ -110,19 +118,31 @@ BOOST_AUTO_TEST_CASE(model_with_different_objects_of_same_id)
     std::vector<Constraint> constraints;
     Constraint ct("x", {});
     constraints.push_back(std::move(ct));
-    BOOST_CHECK_EXCEPTION(model_builder.withConstraints(std::move(constraints)),
+    model_builder.withConstraints(std::move(constraints));
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
                           Antares::Error::RuntimeError,
                           checkMessage(
                             "Model \"model32\" contains multiple objects with ID \"x\"."));
+}
+
+BOOST_AUTO_TEST_CASE(model_with_port_ct_same_id)
+{
+    ModelBuilder model_builder;
 
     // Port with same ID as constraint
     model_builder.withId("model");
-    model_builder.withConstraints(std::move(constraints));
     PortField flow("flow");
     std::vector<PortField> portFields = {flow};
     PortType portType("some-port-type", std::move(portFields));
     Port port("x", portType);
-    BOOST_CHECK_EXCEPTION(model_builder.withPorts({port}),
+    model_builder.withPorts({port});
+
+    std::vector<Constraint> constraints;
+    Constraint ct("x", {});
+    constraints.push_back(std::move(ct));
+    model_builder.withConstraints(std::move(constraints));
+
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
                           Antares::Error::RuntimeError,
                           checkMessage("Model \"model\" contains multiple objects with ID \"x\"."));
 
@@ -134,7 +154,8 @@ BOOST_AUTO_TEST_CASE(model_with_different_objects_of_same_id)
     std::vector<ExtraOutput> extraOutputs;
     ExtraOutput eo("y", {});
     extraOutputs.push_back(std::move(eo));
-    BOOST_CHECK_EXCEPTION(model_builder.withExtraOutputs(std::move(extraOutputs)),
+    model_builder.withExtraOutputs(std::move(extraOutputs));
+    BOOST_CHECK_EXCEPTION(model_builder.build(),
                           Antares::Error::RuntimeError,
                           checkMessage(
                             "Model \"model__\" contains multiple objects with ID \"y\"."));


### PR DESCRIPTION
- Check uniqueness when calling `ModelBuilder::build`, instead of each time we import an ID-bearing object.
- Use a dedicated `UniqueIDChecker` class to better split responsabilities