### PR TITLE
Simplify ShortTermStorageCumulation.cpp

### DIFF
--- a/src/solver/optimisation/constraints/ShortTermStorageCumulation.cpp
+++ b/src/solver/optimisation/constraints/ShortTermStorageCumulation.cpp
@@ -21,111 +21,41 @@
 
 #include "antares/solver/optimisation/constraints/ShortTermStorageCumulation.h"
 
+#include <functional>
 #include <memory>
 #include <stdexcept>
 
-class CumulationConstraint
+struct CumulationConstraint
 {
-public:
-    virtual void build(unsigned int index) const = 0;
-
-    virtual std::string name() const = 0;
-    virtual ~CumulationConstraint() = default;
+    const std::string name;
+    const std::function<void(unsigned int)> build;
 };
 
-class WithdrawalCumulationConstraint: public CumulationConstraint
-{
-public:
-    WithdrawalCumulationConstraint(ConstraintBuilder& builder):
-        builder(builder)
-    {
-    }
-
-    void build(unsigned int index) const override
-    {
-        builder.ShortTermStorageWithdrawal(index, 1.0);
-    }
-
-    std::string name() const override
-    {
-        return "WithdrawalSum";
-    }
-
-    ~WithdrawalCumulationConstraint() override = default;
-
-    ConstraintBuilder& builder;
-};
-
-class InjectionCumulationConstraint: public CumulationConstraint
-{
-public:
-    InjectionCumulationConstraint(ConstraintBuilder& builder):
-        builder(builder)
-    {
-    }
-
-    void build(unsigned int index) const override
-    {
-        builder.ShortTermStorageInjection(index, 1.0);
-    }
-
-    std::string name() const override
-    {
-        return "InjectionSum";
-    }
-
-    ~InjectionCumulationConstraint() override = default;
-
-    ConstraintBuilder& builder;
-};
-
-class NettingCumulationConstraint: public CumulationConstraint
-{
-public:
-    NettingCumulationConstraint(
-      ConstraintBuilder& builder,
-      const ::ShortTermStorage::PROPERTIES& short_term_storage_properties):
-        builder(builder),
-        short_term_storage_properties(short_term_storage_properties)
-    {
-    }
-
-    void build(unsigned int index) const override
-    {
-        builder.ShortTermStorageInjection(index, short_term_storage_properties.injectionEfficiency)
-          .ShortTermStorageWithdrawal(index, -short_term_storage_properties.withdrawalEfficiency);
-    }
-
-    std::string name() const override
-    {
-        return "NettingSum";
-    }
-
-    ~NettingCumulationConstraint() override = default;
-
-    ConstraintBuilder& builder;
-    const ShortTermStorage::PROPERTIES& short_term_storage_properties;
-};
-
-std::unique_ptr<CumulationConstraint> cumulationConstraintFactory(
-  const std::string& variable,
-  ConstraintBuilder& builder,
-  const ShortTermStorage::PROPERTIES& short_term_storage_properties)
+CumulationConstraint makeCumulationConstraint(const std::string& variable,
+                                              ConstraintBuilder& builder,
+                                              const ShortTermStorage::PROPERTIES& props)
 {
     if (variable == "withdrawal")
     {
-        return std::make_unique<WithdrawalCumulationConstraint>(builder);
+        return {"WithdrawalSum",
+                [&builder](unsigned int idx) { builder.ShortTermStorageWithdrawal(idx, 1.0); }};
     }
     else if (variable == "injection")
     {
-        return std::make_unique<InjectionCumulationConstraint>(builder);
+        return {"InjectionSum",
+                [&builder](unsigned int idx) { builder.ShortTermStorageInjection(idx, 1.0); }};
     }
     else if (variable == "netting")
     {
-        return std::make_unique<NettingCumulationConstraint>(builder,
-                                                             short_term_storage_properties);
+        return {"NettingSum",
+                [&builder, &props](unsigned int idx)
+                {
+                    builder.ShortTermStorageInjection(idx, props.injectionEfficiency)
+                      .ShortTermStorageWithdrawal(idx, -props.withdrawalEfficiency);
+                }};
     }
-    throw std::invalid_argument("Invalid cumulation constraint type");
+
+    throw std::invalid_argument("Invalid cumulation constraint type: " + variable);
 }
 
 char ConvertSense(const std::string& sense)
@@ -134,14 +64,11 @@ char ConvertSense(const std::string& sense)
     {
         return '>';
     }
-    else if (sense == "less")
+    if (sense == "less")
     {
         return '<';
     }
-    else
-    {
-        return '=';
-    }
+    return '=';
 }
 
 void ShortTermStorageCumulation::add(int pays)
@@ -153,20 +80,18 @@ void ShortTermStorageCumulation::add(int pays)
     {
         for (const auto& additionalConstraints: storage.additionalConstraints)
         {
-            // sum (var[h]) sign rhs, h in list provided by user where:
-            // var = injection for InjectionCumulationConstraint
-            // var = withdrawal for WithdrawalCumulationConstraint
-            // var = injectionEfficiency * injection - withdrawalEfficiency * withdrawal for Netting
-            auto cumulationConstraint = cumulationConstraintFactory(additionalConstraints->variable,
-                                                                    builder,
-                                                                    storage);
+            auto cumulationConstraint = makeCumulationConstraint(additionalConstraints->variable,
+                                                                 builder,
+                                                                 storage);
+
             for (const auto& [hours, globalIndex, localIndex]: additionalConstraints->constraints)
             {
-                namer.ShortTermStorageCumulation(cumulationConstraint->name(),
+                namer.ShortTermStorageCumulation(cumulationConstraint.name,
                                                  builder.data.nombreDeContraintes,
                                                  storage.name,
                                                  additionalConstraints->id + "_"
                                                    + std::to_string(localIndex));
+
                 const auto index = storage.clusterGlobalIndex;
                 data.CorrespondanceCntNativesCntOptimHebdomadaires
                   .ShortTermStorageCumulation[globalIndex]
@@ -175,7 +100,7 @@ void ShortTermStorageCumulation::add(int pays)
                 for (const auto& hour: hours)
                 {
                     builder.updateHourWithinWeek(hour - 1);
-                    cumulationConstraint->build(index);
+                    cumulationConstraint.build(index);
                 }
                 builder.SetOperator(ConvertSense(additionalConstraints->operatorType)).build();
             }

--- a/src/solver/optimisation/constraints/ShortTermStorageCumulation.cpp
+++ b/src/solver/optimisation/constraints/ShortTermStorageCumulation.cpp
@@ -80,9 +80,10 @@ void ShortTermStorageCumulation::add(int pays)
     {
         for (const auto& additionalConstraints: storage.additionalConstraints)
         {
-            auto cumulationConstraint = makeCumulationConstraint(additionalConstraints->variable,
-                                                                 builder,
-                                                                 storage);
+            const CumulationConstraint cumulationConstraint = makeCumulationConstraint(
+              additionalConstraints->variable,
+              builder,
+              storage);
 
             for (const auto& [hours, globalIndex, localIndex]: additionalConstraints->constraints)
             {


### PR DESCRIPTION
Remove `std::unique_ptr`, factory method and pure-virtual functions. Use lambda functions instead.