### PR TITLE
Bump install-build-wrapper@v5.3.1 to fix vulnerability in 5.3.0

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -134,7 +134,7 @@ jobs:
         -DPython3_EXECUTABLE='${{ steps.setup-python.outputs.python-path }}'
 
     - name: Install Build Wrapper
-      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5.3.0
+      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5.3.1
 
     - name: Build
       run: |


### PR DESCRIPTION
See https://community.sonarsource.com/t/security-advisory-sonarqube-scanner-github-action/147696