### PR TITLE
ANT-3697 : fix contraint on weekly hydro generation amount (ANT-3697)

### DIFF
--- a/src/libs/antares/study/area/scratchpad.cpp
+++ b/src/libs/antares/study/area/scratchpad.cpp
@@ -54,8 +54,8 @@ void CalculateDailyMeanPower(const Matrix<double>::ColumnType& hourlyColumn,
     {
         dailyColumn[day] = std::accumulate(hourlyColumn + day * HOURS_PER_DAY,
                                            hourlyColumn + day * HOURS_PER_DAY + HOURS_PER_DAY,
-                                           0)
-                           / 24.;
+                                           0.)
+                           / 24;
     }
 }
 


### PR DESCRIPTION
Fixes [ticket ANT-3697](https://gopro-tickets.rte-france.com/browse/ANT-3697)

**Cause** : 
```c++
std::vector<double> v = {1, 1, 1, 1, 0.5};

double sum = std::accumulate(v.begin(), v.end(), 0);
std::cout << "sum = " << sum << std::endl;

sum = std::accumulate(v.begin(), v.end(), 0.);
std::cout << "sum = " << sum << std::endl;
```
**Output** 
> sum = 4
> sum = 4.5

In algorithm **std::accumulate**, type of init value (here **0** [int] or **0.** [double]) impacts return type, and an unwanted conversion into int occur. 
