### PR TITLE
Optimization by daily chunk : remove [ANT-2695]

### DIFF
--- a/src/io/outputs/SimulationTableGenerator.cpp
+++ b/src/io/outputs/SimulationTableGenerator.cpp
@@ -31,22 +31,11 @@
 
 using namespace Antares::Optimisation::LinearProblemApi;
 
-TimeBlock convertTimeStepToBlockTimeIndex(unsigned int timeStep, const TimeConversionMode& mode)
+TimeBlock convertTimeStepToBlockTimeIndex(unsigned timeStep, const unsigned timeBlockSize)
 {
-    switch (mode)
-    {
-    case TimeConversionMode::WeeklyBlocks:
-        return {.block = timeStep / 168 + 1,
-                .blockTimeIndex = timeStep % 168 + 1,
-                .absoluteTimeIndex = timeStep + 1};
-    case TimeConversionMode::DailyBlocks:
-        return {.block = timeStep / 24 + 1,
-                .blockTimeIndex = timeStep % 24 + 1,
-                .absoluteTimeIndex = timeStep + 1};
-    case TimeConversionMode::SingleBlock:
-    default:
-        return {.block = 1, .blockTimeIndex = timeStep + 1, .absoluteTimeIndex = timeStep + 1};
-    }
+    return {.block = timeStep / timeBlockSize + 1,
+            .blockTimeIndex = timeStep % timeBlockSize + 1,
+            .absoluteTimeIndex = timeStep + 1};
 }
 
 std::string BuildModelerConstraintName(const std::string& cid,
@@ -78,7 +67,7 @@ void addVariableEntries(ISimulationTable& simulationTable,
                         const FillContext& fillContext,
                         const Antares::ModelerStudy::SystemModel::Component& component,
                         unsigned currentBlock,
-                        const TimeConversionMode& timeConversionMode,
+                        const unsigned timeBlockSize,
                         std::optional<unsigned> scenario)
 {
     const auto& cid = component.Id();
@@ -96,7 +85,7 @@ void addVariableEntries(ISimulationTable& simulationTable,
               timeStep);
             TimeBlock tb = timeStep ? convertTimeStepToBlockTimeIndex(
                                         *timeStep + fillContext.getGlobalFirstTimeStep(),
-                                        timeConversionMode)
+                                        timeBlockSize)
                                     : TimeBlock{.block = currentBlock,
                                                 .blockTimeIndex = std::nullopt,
                                                 .absoluteTimeIndex = std::nullopt};
@@ -146,7 +135,7 @@ void addConstraintEntries(ISimulationTable& simulationTable,
                           const FillContext& fillContext,
                           const Antares::ModelerStudy::SystemModel::Component& component,
                           unsigned currentBlock,
-                          const TimeConversionMode& timeConversionMode,
+                          const unsigned timeBlockSize,
                           std::optional<unsigned> scenario)
 {
     using TI = Antares::Expressions::Visitors::TimeIndex;
@@ -163,7 +152,7 @@ void addConstraintEntries(ISimulationTable& simulationTable,
             const auto* c = linearProblem.lookupConstraint(fullConstName);
             TimeBlock tb = ts ? convertTimeStepToBlockTimeIndex(
                                   *ts + fillContext.getGlobalFirstTimeStep(),
-                                  timeConversionMode)
+                                  timeBlockSize)
                               : TimeBlock{.block = currentBlock,
                                           .blockTimeIndex = std::nullopt,
                                           .absoluteTimeIndex = std::nullopt};
@@ -229,7 +218,7 @@ void FillSimulationTable(
   const std::unordered_map<std::string, Antares::ModelerStudy::SystemModel::Component>& components,
   const FillContext& fillContext,
   unsigned currentBlock,
-  const TimeConversionMode& timeConversionMode)
+  const unsigned timeBlockSize)
 {
     unsigned scenario = fillContext.getYear();
     for (const auto& component: components | std::views::values)
@@ -239,7 +228,7 @@ void FillSimulationTable(
                            fillContext,
                            component,
                            currentBlock,
-                           timeConversionMode,
+                           timeBlockSize,
                            scenario);
 
         addConstraintEntries(simulationTable,
@@ -247,7 +236,7 @@ void FillSimulationTable(
                              fillContext,
                              component,
                              currentBlock,
-                             timeConversionMode,
+                             timeBlockSize,
                              scenario);
     }
     addObjectiveValue(simulationTable, objectiveValue, currentBlock, scenario);

--- a/src/io/outputs/include/antares/io/outputs/SimulationTableGenerator.h
+++ b/src/io/outputs/include/antares/io/outputs/SimulationTableGenerator.h
@@ -54,14 +54,9 @@ struct TimeBlock
     std::optional<int> blockTimeIndex;
     std::optional<int> absoluteTimeIndex;
 };
-enum class TimeConversionMode
-{
-    SingleBlock, // for Modeler
-    DailyBlocks,
-    WeeklyBlocks
-};
 
-TimeBlock convertTimeStepToBlockTimeIndex(unsigned int timeStep, const TimeConversionMode& mode);
+TimeBlock convertTimeStepToBlockTimeIndex(unsigned timeStep,
+                                          const unsigned timeBlockSize = UINT_MAX);
 
 std::string BuildModelerConstraintName(const std::string& cid,
                                        const std::string& cname,
@@ -74,7 +69,7 @@ void addVariableEntries(
   const Antares::Optimisation::LinearProblemApi::FillContext& fillContext,
   const Antares::ModelerStudy::SystemModel::Component& component,
   unsigned currentBlock,
-  const TimeConversionMode& timeConversionMode,
+  const unsigned timeBlockSize,
   std::optional<unsigned> scenario);
 
 void addConstraintEntries(
@@ -83,7 +78,7 @@ void addConstraintEntries(
   const Antares::Optimisation::LinearProblemApi::FillContext& fillContext,
   const Antares::ModelerStudy::SystemModel::Component& component,
   unsigned currentBlock,
-  const TimeConversionMode& timeConversionMode,
+  const unsigned timeBlockSize,
   std::optional<unsigned> scenario);
 
 void FillSimulationTable(
@@ -93,4 +88,4 @@ void FillSimulationTable(
   const std::unordered_map<std::string, Antares::ModelerStudy::SystemModel::Component>& components,
   const Antares::Optimisation::LinearProblemApi::FillContext& fillContext,
   unsigned currentBlock,
-  const TimeConversionMode& timeConversionMode);
+  const unsigned timeBlockSize = UINT_MAX);

--- a/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintsRepository.cpp
@@ -244,28 +244,7 @@ bool BindingConstraintsRepository::loadFromFolder(Study& study,
         }
     }
 
-    // When ran from the solver and if the simplex is in `weekly` mode,
-    // all weekly constraints will become daily ones.
-    if (study.usedByTheSolver && sorDay == study.parameters.simplexOptimizationRange)
-    {
-        changeConstraintsWeeklyToDaily();
-    }
-
     return true;
-}
-
-void BindingConstraintsRepository::changeConstraintsWeeklyToDaily()
-{
-    each(
-      [](BindingConstraint& constraint)
-      {
-          if (constraint.type() == BindingConstraint::typeWeekly)
-          {
-              logs.info() << "  The type of the constraint '" << constraint.name()
-                          << "' is now 'daily'";
-              constraint.setTimeGranularity(BindingConstraint::typeDaily);
-          }
-      });
 }
 
 bool BindingConstraintsRepository::internalSaveToFolder(

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintsRepository.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintsRepository.h
@@ -152,11 +152,6 @@ public:
     bool rename(Data::BindingConstraint* bc, const AnyString& newname);
 
     /*!
-    ** \brief Convert all weekly constraints into daily ones
-    */
-    void changeConstraintsWeeklyToDaily();
-
-    /*!
     ** \brief Invalidate all matrices of all binding constraints
     */
     void forceReload(bool reload = false) const;

--- a/src/modeler/FileWriter.cpp
+++ b/src/modeler/FileWriter.cpp
@@ -66,8 +66,7 @@ void FileWriter::writeSimulationTable(
                             solution.getObjectiveValue(),
                             components,
                             fillContext,
-                            1,
-                            TimeConversionMode::SingleBlock);
+                            1);
         simulationTable.writeHeader();
         simulationTable.write();
     }

--- a/src/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.cpp
@@ -30,7 +30,6 @@ AdqPatchPostProcessList::AdqPatchPostProcessList(const AdqPatchParams& adqPatchP
                                                  uint numSpace,
                                                  AreaList& areas,
                                                  SheddingPolicy sheddingPolicy,
-                                                 SimplexOptimization splxOptimization,
                                                  Calendar& calendar,
                                                  const OptimizationOptions& solverOptions):
     interfacePostProcessList(problemeHebdo, numSpace)

--- a/src/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.cpp
@@ -37,10 +37,8 @@ AdqPatchPostProcessList::AdqPatchPostProcessList(const AdqPatchParams& adqPatchP
     post_process_list.push_back(
       std::make_unique<DispatchableMarginPostProcessCmd>(problemeHebdo_, numSpace_, areas));
     // Here a post process particular to adq patch
-    post_process_list.push_back(std::make_unique<RemixHydroPostProcessCmd>(problemeHebdo_,
-                                                                           areas,
-                                                                           sheddingPolicy,
-                                                                           numSpace));
+    post_process_list.push_back(
+      std::make_unique<RemixHydroPostProcessCmd>(problemeHebdo_, areas, sheddingPolicy, numSpace));
     post_process_list.push_back(std::make_unique<CurtailmentSharingPostProcessCmd>(adqPatchParams,
                                                                                    problemeHebdo_,
                                                                                    areas,

--- a/src/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.cpp
@@ -41,7 +41,6 @@ AdqPatchPostProcessList::AdqPatchPostProcessList(const AdqPatchParams& adqPatchP
     post_process_list.push_back(std::make_unique<RemixHydroPostProcessCmd>(problemeHebdo_,
                                                                            areas,
                                                                            sheddingPolicy,
-                                                                           splxOptimization,
                                                                            numSpace));
     post_process_list.push_back(std::make_unique<CurtailmentSharingPostProcessCmd>(adqPatchParams,
                                                                                    problemeHebdo_,

--- a/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.h
@@ -37,7 +37,6 @@ public:
                             uint numSpace,
                             AreaList& areas,
                             SheddingPolicy sheddingPolicy,
-                            SimplexOptimization splxOptimization,
                             Calendar& calendar,
                             const OptimizationOptions& solverOptions);
 

--- a/src/solver/optimisation/include/antares/solver/optimisation/optim_post_process_list.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/optim_post_process_list.h
@@ -32,7 +32,6 @@ public:
                        uint numSpace,
                        AreaList& areas,
                        SheddingPolicy sheddingPolicy,
-                       SimplexOptimization splxOptimization,
                        Calendar& calendar);
 
     virtual ~OptPostProcessList() = default;

--- a/src/solver/optimisation/include/antares/solver/optimisation/post_process_commands.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/post_process_commands.h
@@ -43,7 +43,6 @@ public:
     RemixHydroPostProcessCmd(PROBLEME_HEBDO* problemeHebdo,
                              AreaList& areas,
                              SheddingPolicy sheddingPolicy,
-                             SimplexOptimization simplexOptimization,
                              unsigned int numSpace);
     void execute(const optRuntimeData& opt_runtime_data) override;
 
@@ -51,7 +50,6 @@ private:
     const AreaList& area_list_;
     unsigned int numSpace_ = 0;
     SheddingPolicy shedding_policy_;
-    SimplexOptimization splx_optimization_;
 };
 
 class UpdateMrgPriceAfterCSRcmd: public basePostProcessCommand

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -130,20 +130,11 @@ FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo, int NumInterva
     unsigned globalFirst, globalLast;
     unsigned localFirst = 0, localLast;
     auto nTsInDay = static_cast<unsigned>(problemeHebdo->NombreDePasDeTempsDUneJournee);
-    if (problemeHebdo->OptimisationAuPasHebdomadaire)
-    {
-        globalFirst = problemeHebdo->weekInTheYear * nTsInDay * problemeHebdo->NombreDeJours;
-        globalLast = globalFirst + nTsInDay * problemeHebdo->NombreDeJours - 1;
-        localLast = nTsInDay * problemeHebdo->NombreDeJours - 1;
-    }
-    else
-    {
-        globalFirst = (problemeHebdo->weekInTheYear * problemeHebdo->NombreDeJours
-                       + static_cast<unsigned>(NumIntervalle))
-                      * nTsInDay;
-        globalLast = globalFirst + nTsInDay - 1;
-        localLast = nTsInDay - 1;
-    }
+
+    globalFirst = problemeHebdo->weekInTheYear * nTsInDay * problemeHebdo->NombreDeJours;
+    globalLast = globalFirst + nTsInDay * problemeHebdo->NombreDeJours - 1;
+    localLast = nTsInDay * problemeHebdo->NombreDeJours - 1;
+
     return {localFirst,
             localLast,
             globalFirst,
@@ -265,19 +256,14 @@ static SimplexResult OPT_TryToCallSimplex(const SingleOptimOptions& options,
 
     if (problemeHebdo->modelerSystem)
     {
-        unsigned currentBlock = problemeHebdo->OptimisationAuPasHebdomadaire
-                                  ? problemeHebdo->weekInTheYear
-                                  : NumIntervalle;
-        TimeConversionMode timeConversionMode = problemeHebdo->OptimisationAuPasHebdomadaire
-                                                  ? TimeConversionMode::WeeklyBlocks
-                                                  : TimeConversionMode::DailyBlocks;
+        unsigned currentWeek = problemeHebdo->weekInTheYear;
         FillSimulationTable(simulationTable,
                             ortoolsProblem,
                             ::getObjectiveValue(solver),
                             problemeHebdo->modelerSystem->Components(),
                             fillCtx,
-                            currentBlock,
-                            timeConversionMode);
+                            currentWeek,
+                            Constants::nbHoursInAWeek);
     }
 
     return {.success = true,

--- a/src/solver/optimisation/optim_post_process_list.cpp
+++ b/src/solver/optimisation/optim_post_process_list.cpp
@@ -29,7 +29,6 @@ OptPostProcessList::OptPostProcessList(PROBLEME_HEBDO* problemeHebdo,
                                        uint numSpace,
                                        AreaList& areas,
                                        SheddingPolicy sheddingPolicy,
-                                       SimplexOptimization splxOptimization,
                                        Calendar& calendar)
 
     :

--- a/src/solver/optimisation/optim_post_process_list.cpp
+++ b/src/solver/optimisation/optim_post_process_list.cpp
@@ -40,7 +40,6 @@ OptPostProcessList::OptPostProcessList(PROBLEME_HEBDO* problemeHebdo,
     post_process_list.push_back(std::make_unique<RemixHydroPostProcessCmd>(problemeHebdo_,
                                                                            areas,
                                                                            sheddingPolicy,
-                                                                           splxOptimization,
                                                                            numSpace));
     post_process_list.push_back(
       std::make_unique<InterpolateWaterValuePostProcessCmd>(problemeHebdo_, areas, calendar));

--- a/src/solver/optimisation/optim_post_process_list.cpp
+++ b/src/solver/optimisation/optim_post_process_list.cpp
@@ -36,10 +36,8 @@ OptPostProcessList::OptPostProcessList(PROBLEME_HEBDO* problemeHebdo,
 {
     post_process_list.push_back(
       std::make_unique<DispatchableMarginPostProcessCmd>(problemeHebdo_, numSpace_, areas));
-    post_process_list.push_back(std::make_unique<RemixHydroPostProcessCmd>(problemeHebdo_,
-                                                                           areas,
-                                                                           sheddingPolicy,
-                                                                           numSpace));
+    post_process_list.push_back(
+      std::make_unique<RemixHydroPostProcessCmd>(problemeHebdo_, areas, sheddingPolicy, numSpace));
     post_process_list.push_back(
       std::make_unique<InterpolateWaterValuePostProcessCmd>(problemeHebdo_, areas, calendar));
     post_process_list.push_back(

--- a/src/solver/optimisation/post_process_commands.cpp
+++ b/src/solver/optimisation/post_process_commands.cpp
@@ -75,13 +75,11 @@ void DispatchableMarginPostProcessCmd::execute(const optRuntimeData& opt_runtime
 RemixHydroPostProcessCmd::RemixHydroPostProcessCmd(PROBLEME_HEBDO* problemeHebdo,
                                                    AreaList& areas,
                                                    SheddingPolicy sheddingPolicy,
-                                                   SimplexOptimization simplexOptimization,
                                                    unsigned int numSpace):
     basePostProcessCommand(problemeHebdo),
     area_list_(areas),
     numSpace_(numSpace),
-    shedding_policy_(sheddingPolicy),
-    splx_optimization_(simplexOptimization)
+    shedding_policy_(sheddingPolicy)
 {
 }
 

--- a/src/solver/optimisation/post_process_commands.cpp
+++ b/src/solver/optimisation/post_process_commands.cpp
@@ -91,7 +91,6 @@ void RemixHydroPostProcessCmd::execute(const optRuntimeData& opt_runtime_data)
     RemixHydroForAllAreas(area_list_,
                           *problemeHebdo_,
                           shedding_policy_,
-                          splx_optimization_,
                           numSpace_,
                           hourInYear);
 }

--- a/src/solver/optimisation/post_process_commands.cpp
+++ b/src/solver/optimisation/post_process_commands.cpp
@@ -86,11 +86,7 @@ RemixHydroPostProcessCmd::RemixHydroPostProcessCmd(PROBLEME_HEBDO* problemeHebdo
 void RemixHydroPostProcessCmd::execute(const optRuntimeData& opt_runtime_data)
 {
     unsigned int hourInYear = opt_runtime_data.hourInTheYear;
-    RemixHydroForAllAreas(area_list_,
-                          *problemeHebdo_,
-                          shedding_policy_,
-                          numSpace_,
-                          hourInYear);
+    RemixHydroForAllAreas(area_list_, *problemeHebdo_, shedding_policy_, numSpace_, hourInYear);
 }
 
 // ----------------------------------

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -229,7 +229,6 @@ bool Adequacy::year(Progression::Task& progression,
                 RemixHydroForAllAreas(study.areas,
                                       currentProblem,
                                       study.parameters.shedding.policy,
-                                      study.parameters.simplexOptimizationRange,
                                       numSpace,
                                       hourInTheYear);
             }

--- a/src/solver/simulation/base_post_process.cpp
+++ b/src/solver/simulation/base_post_process.cpp
@@ -67,7 +67,6 @@ std::unique_ptr<interfacePostProcessList> interfacePostProcessList::create(
                                                     numSpace,
                                                     areas,
                                                     sheddingPolicy,
-                                                    splxOptimization,
                                                     calendar);
     }
 }

--- a/src/solver/simulation/base_post_process.cpp
+++ b/src/solver/simulation/base_post_process.cpp
@@ -46,7 +46,6 @@ std::unique_ptr<interfacePostProcessList> interfacePostProcessList::create(
   uint numSpace,
   AreaList& areas,
   SheddingPolicy sheddingPolicy,
-  SimplexOptimization splxOptimization,
   Calendar& calendar,
   const OptimizationOptions& solverOptions)
 {

--- a/src/solver/simulation/base_post_process.cpp
+++ b/src/solver/simulation/base_post_process.cpp
@@ -57,7 +57,6 @@ std::unique_ptr<interfacePostProcessList> interfacePostProcessList::create(
                                                          numSpace,
                                                          areas,
                                                          sheddingPolicy,
-                                                         splxOptimization,
                                                          calendar,
                                                          solverOptions);
     }

--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -293,7 +293,6 @@ static void RunAccurateShavePeaks(const Data::AreaList& areas,
 void RemixHydroForAllAreas(const Data::AreaList& areas,
                            PROBLEME_HEBDO& problem,
                            Data::SheddingPolicy sheddingPolicy,
-                           Data::SimplexOptimization simplexOptimizationRange,
                            uint numSpace,
                            uint hourInYear)
 {

--- a/src/solver/simulation/common-hydro-remix.cpp
+++ b/src/solver/simulation/common-hydro-remix.cpp
@@ -36,9 +36,7 @@ namespace Antares::Solver::Simulation
 {
 
 const unsigned int HOURS_IN_WEEK = 168;
-const unsigned int HOURS_IN_DAY = 24;
 
-template<uint step>
 static bool Remix(const Data::AreaList& areas,
                   PROBLEME_HEBDO& problem,
                   uint numSpace,
@@ -70,154 +68,147 @@ static bool Remix(const Data::AreaList& areas,
           memset(remix, 0, sizeof(remix));
           memset(G, 0, sizeof(G));
 
-          uint endHour = step;
-          uint offset = 0;
-          for (; offset < HOURS_IN_WEEK; offset += step, endHour += step)
+          double WD = 0.;
+          for (uint h = 0; h != HOURS_IN_WEEK; ++h)
           {
+              WD += D[h];
+          }
+          if (WD < EPSILON)
+          {
+              return;
+          }
+
+          double WH = 0.;
+
+          for (uint h = 0; h != HOURS_IN_WEEK; ++h)
+          {
+              if (S[h] < EPSILON)
               {
-                  double WD = 0.;
-                  for (uint i = offset; i != endHour; ++i)
-                  {
-                      WD += D[i];
-                  }
-                  if (WD < EPSILON)
-                  {
-                      continue;
-                  }
+                  WH += H[h];
               }
+          }
 
-              double WH = 0.;
+          if (WH < EPSILON)
+          {
+              return;
+          }
 
-              for (uint i = offset; i != endHour; ++i)
+          WH = 0.;
+
+          double bottom = std::numeric_limits<double>::max();
+          double top = 0;
+
+          auto* L = area.load.series.getColumn(problem.year);
+
+          const double* M = area.scratchpad[numSpace].dispatchableGenerationMargin;
+
+          for (uint h = 0; h < HOURS_IN_WEEK; ++h)
+          {
+              double h_d = H[h] + D[h];
+              if (h_d > 0. && Utils::isZero(S[h] + M[h]))
               {
-                  if (S[i] < EPSILON)
+                  double Li = L[h + hourInYear];
+
+                  remix[h] = true;
+                  G[h] = Li - h_d;
+
+                  if (G[h] < bottom)
                   {
-                      WH += H[i];
+                      bottom = G[h];
                   }
-              }
-
-              if (WH < EPSILON)
-              {
-                  continue;
-              }
-
-              WH = 0.;
-
-              double bottom = std::numeric_limits<double>::max();
-              double top = 0;
-
-              auto* L = area.load.series.getColumn(problem.year);
-
-              const double* M = area.scratchpad[numSpace].dispatchableGenerationMargin;
-
-              for (uint i = offset; i < endHour; ++i)
-              {
-                  double h_d = H[i] + D[i];
-                  if (h_d > 0. && Utils::isZero(S[i] + M[i]))
+                  if (Li > top)
                   {
-                      double Li = L[i + hourInYear];
+                      top = Li;
+                  }
 
-                      remix[i] = true;
-                      G[i] = Li - h_d;
+                  WH += H[h];
+              }
+          }
 
-                      if (G[i] < bottom)
+          const auto& P = problem.CaracteristiquesHydrauliques[index]
+                            .ContrainteDePmaxHydrauliqueHoraire;
+
+          double ecart = 1.;
+          uint loop = 100;
+          do
+          {
+              double niveau = (top + bottom) * 0.5;
+              double stock = 0.;
+
+              for (uint h = 0; h != HOURS_IN_WEEK; ++h)
+              {
+                  if (remix[h])
+                  {
+                      double HEi;
+                      uint iYear = h + hourInYear;
+                      if (niveau > L[iYear])
                       {
-                          bottom = G[i];
-                      }
-                      if (Li > top)
-                      {
-                          top = Li;
-                      }
-
-                      WH += H[i];
-                  }
-              }
-
-              const auto& P = problem.CaracteristiquesHydrauliques[index]
-                                .ContrainteDePmaxHydrauliqueHoraire;
-
-              double ecart = 1.;
-              uint loop = 100;
-              do
-              {
-                  double niveau = (top + bottom) * 0.5;
-                  double stock = 0.;
-
-                  for (uint i = offset; i != endHour; ++i)
-                  {
-                      if (remix[i])
-                      {
-                          double HEi;
-                          uint iYear = i + hourInYear;
-                          if (niveau > L[iYear])
+                          HEi = H[h] + D[h];
+                          if (HEi > P[h])
                           {
-                              HEi = H[i] + D[i];
-                              if (HEi > P[i])
-                              {
-                                  HEi = P[i];
-                                  DE[i] = H[i] + D[i] - HEi;
-                              }
-                              else
-                              {
-                                  DE[i] = 0;
-                              }
+                              HEi = P[h];
+                              DE[h] = H[h] + D[h] - HEi;
                           }
                           else
                           {
-                              if (G[i] > niveau)
-                              {
-                                  HEi = 0;
-                                  DE[i] = H[i] + D[i];
-                              }
-                              else
-                              {
-                                  HEi = niveau - G[i];
-                                  if (HEi > P[i])
-                                  {
-                                      HEi = P[i];
-                                  }
-                                  DE[i] = H[i] + D[i] - HEi;
-                              }
+                              DE[h] = 0;
                           }
-                          stock += HEi;
-                          HE[i] = HEi;
                       }
                       else
                       {
-                          HE[i] = H[i];
-                          DE[i] = D[i];
+                          if (G[h] > niveau)
+                          {
+                              HEi = 0;
+                              DE[h] = H[h] + D[h];
+                          }
+                          else
+                          {
+                              HEi = niveau - G[h];
+                              if (HEi > P[h])
+                              {
+                                  HEi = P[h];
+                              }
+                              DE[h] = H[h] + D[h] - HEi;
+                          }
                       }
-                  }
-
-                  ecart = WH - stock;
-                  if (ecart > 0.)
-                  {
-                      bottom = niveau;
+                      stock += HEi;
+                      HE[h] = HEi;
                   }
                   else
                   {
-                      top = niveau;
+                      HE[h] = H[h];
+                      DE[h] = D[h];
                   }
-
-                  if (!--loop)
-                  {
-                      status = false;
-                      logs.error() << "hydro remix: " << area.name
-                                   << ": infinite loop detected. please check input data";
-                      break;
-                  }
-              } while (std::abs(ecart) > 0.01);
-
-              for (uint i = offset; i != endHour; ++i)
-              {
-                  H[i] = HE[i];
-                  assert(not std::isnan(HE[i]) && "hydro remix: nan detected");
               }
-              for (uint i = offset; i != endHour; ++i)
+
+              ecart = WH - stock;
+              if (ecart > 0.)
               {
-                  D[i] = DE[i];
-                  assert(not std::isnan(DE[i]) && "hydro remix: nan detected");
+                  bottom = niveau;
               }
+              else
+              {
+                  top = niveau;
+              }
+
+              if (!--loop)
+              {
+                  status = false;
+                  logs.error() << "hydro remix: " << area.name
+                               << ": infinite loop detected. please check input data";
+                  break;
+              }
+          } while (std::abs(ecart) > 0.01);
+
+          for (uint h = 0; h != HOURS_IN_WEEK; ++h)
+          {
+              H[h] = HE[h];
+              assert(not std::isnan(HE[h]) && "hydro remix: nan detected");
+          }
+          for (uint h = 0; h != HOURS_IN_WEEK; ++h)
+          {
+              D[h] = DE[h];
+              assert(not std::isnan(DE[h]) && "hydro remix: nan detected");
           }
       });
 
@@ -310,20 +301,7 @@ void RemixHydroForAllAreas(const Data::AreaList& areas,
     {
         bool result = true;
 
-        switch (simplexOptimizationRange)
-        {
-        case Data::sorWeek:
-            result = Remix<HOURS_IN_WEEK>(areas, problem, numSpace, hourInYear);
-            break;
-        case Data::sorDay:
-            result = Remix<HOURS_IN_DAY>(areas, problem, numSpace, hourInYear);
-            break;
-        case Data::sorUnknown:
-            logs.fatal() << "invalid simplex optimization range";
-            break;
-        }
-
-        if (!result)
+        if (!Remix(areas, problem, numSpace, hourInYear))
         {
             throw Data::AssertionError(
               "Error in simplex optimisation. Check logs for more details.");

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -107,7 +107,6 @@ bool Economy::simulationBegin()
               numSpace,
               study.areas,
               study.parameters.shedding.policy,
-              study.parameters.simplexOptimizationRange,
               study.calendar,
               study.parameters.optOptions);
         }

--- a/src/solver/simulation/include/antares/solver/simulation/base_post_process.h
+++ b/src/solver/simulation/include/antares/solver/simulation/base_post_process.h
@@ -76,7 +76,6 @@ public:
       uint numSpace,
       AreaList& areas,
       SheddingPolicy sheddingPolicy,
-      SimplexOptimization splxOptimization,
       Calendar& calendar,
       const OptimizationOptions& solverOptions);
     void runAll(const optRuntimeData& opt_runtime_data);

--- a/src/solver/simulation/include/antares/solver/simulation/common-eco-adq.h
+++ b/src/solver/simulation/include/antares/solver/simulation/common-eco-adq.h
@@ -92,7 +92,6 @@ void ComputeFlowQuad(Data::Study& study,
 void RemixHydroForAllAreas(const Data::AreaList& areas,
                            PROBLEME_HEBDO& problem,
                            Data::SheddingPolicy sheddingPolicy,
-                           Data::SimplexOptimization splxOptimization,
                            uint numSpace,
                            uint hourInYear);
 

--- a/src/tests/src/io/outputs/testSimulationTable.cpp
+++ b/src/tests/src/io/outputs/testSimulationTable.cpp
@@ -533,20 +533,20 @@ BOOST_AUTO_TEST_CASE(TimeStep_BoundaryValues)
     // Test boundary values for different time conversion modes
 
     // Daily blocks - exactly at day boundary
-    auto result1 = convertTimeStepToBlockTimeIndex(23, TimeConversionMode::DailyBlocks);
-    BOOST_CHECK_EQUAL(result1.block, 1);
-    BOOST_CHECK_EQUAL(*result1.blockTimeIndex, 24);
+    auto timeBlock1 = convertTimeStepToBlockTimeIndex(23, 24);
+    BOOST_CHECK_EQUAL(timeBlock1.block, 1);
+    BOOST_CHECK_EQUAL(*timeBlock1.blockTimeIndex, 24);
 
-    auto result2 = convertTimeStepToBlockTimeIndex(24, TimeConversionMode::DailyBlocks);
-    BOOST_CHECK_EQUAL(result2.block, 2);
-    BOOST_CHECK_EQUAL(*result2.blockTimeIndex, 1);
+    auto timeBlock2 = convertTimeStepToBlockTimeIndex(24, 24);
+    BOOST_CHECK_EQUAL(timeBlock2.block, 2);
+    BOOST_CHECK_EQUAL(*timeBlock2.blockTimeIndex, 1);
 
     // Weekly blocks - exactly at week boundary
-    auto result3 = convertTimeStepToBlockTimeIndex(167, TimeConversionMode::WeeklyBlocks);
-    BOOST_CHECK_EQUAL(result3.block, 1);
-    BOOST_CHECK_EQUAL(*result3.blockTimeIndex, 168);
+    auto timeBlock3 = convertTimeStepToBlockTimeIndex(167, 168);
+    BOOST_CHECK_EQUAL(timeBlock3.block, 1);
+    BOOST_CHECK_EQUAL(*timeBlock3.blockTimeIndex, 168);
 
-    auto result4 = convertTimeStepToBlockTimeIndex(168, TimeConversionMode::WeeklyBlocks);
+    auto result4 = convertTimeStepToBlockTimeIndex(168, 168);
     BOOST_CHECK_EQUAL(result4.block, 2);
     BOOST_CHECK_EQUAL(*result4.blockTimeIndex, 1);
 }
@@ -958,13 +958,7 @@ BOOST_AUTO_TEST_CASE(TemplateFunction_VariableEntries_AllCombinations)
     build();
     const FillContext fillContext(0, 9, 0, 9, 0); // 10 time steps
 
-    addVariableEntries(table,
-                       linearProblem,
-                       fillContext,
-                       components.begin()->second,
-                       1,
-                       TimeConversionMode::SingleBlock,
-                       0);
+    addVariableEntries(table, linearProblem, fillContext, components.begin()->second, 1, 1, 0);
     table.writeHeader();
     table.write();
     std::string buffer = table.buffer();
@@ -1110,13 +1104,8 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_ModelerIntegration)
 
     build(fillContext, &linearProblem);
     MockMipSolution solution;
-    BOOST_CHECK_NO_THROW(FillSimulationTable(table,
-                                             linearProblem,
-                                             45.0,
-                                             components,
-                                             fillContext,
-                                             1,
-                                             TimeConversionMode::SingleBlock););
+    BOOST_CHECK_NO_THROW(
+      FillSimulationTable(table, linearProblem, 45.0, components, fillContext, 1););
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -1255,52 +1244,52 @@ BOOST_AUTO_TEST_SUITE(TimeConversionTests)
 
 BOOST_AUTO_TEST_CASE(ConvertTimeStep_SingleBlock)
 {
-    auto result = convertTimeStepToBlockTimeIndex(42, TimeConversionMode::SingleBlock);
-    BOOST_CHECK_EQUAL(result.block, 1);
-    BOOST_CHECK_EQUAL(*result.blockTimeIndex, 43);    // 42 + 1
-    BOOST_CHECK_EQUAL(*result.absoluteTimeIndex, 43); // 42 + 1
+    auto timeBlock = convertTimeStepToBlockTimeIndex(42);
+    BOOST_CHECK_EQUAL(timeBlock.block, 1);
+    BOOST_CHECK_EQUAL(*timeBlock.blockTimeIndex, 43);    // 42 + 1
+    BOOST_CHECK_EQUAL(*timeBlock.absoluteTimeIndex, 43); // 42 + 1
 }
 
 BOOST_AUTO_TEST_CASE(ConvertTimeStep_DailyBlocks)
 {
     // Test first day
-    auto result1 = convertTimeStepToBlockTimeIndex(0, TimeConversionMode::DailyBlocks);
-    BOOST_CHECK_EQUAL(result1.block, 1);
-    BOOST_CHECK_EQUAL(*result1.blockTimeIndex, 1);
-    BOOST_CHECK_EQUAL(*result1.absoluteTimeIndex, 1);
+    auto timeBlock1 = convertTimeStepToBlockTimeIndex(0, 24);
+    BOOST_CHECK_EQUAL(timeBlock1.block, 1);
+    BOOST_CHECK_EQUAL(*timeBlock1.blockTimeIndex, 1);
+    BOOST_CHECK_EQUAL(*timeBlock1.absoluteTimeIndex, 1);
 
     // Test second day
-    auto result2 = convertTimeStepToBlockTimeIndex(24, TimeConversionMode::DailyBlocks);
-    BOOST_CHECK_EQUAL(result2.block, 2);
-    BOOST_CHECK_EQUAL(*result2.blockTimeIndex, 1);
-    BOOST_CHECK_EQUAL(*result2.absoluteTimeIndex, 25);
+    auto timeBlock2 = convertTimeStepToBlockTimeIndex(24, 24);
+    BOOST_CHECK_EQUAL(timeBlock2.block, 2);
+    BOOST_CHECK_EQUAL(*timeBlock2.blockTimeIndex, 1);
+    BOOST_CHECK_EQUAL(*timeBlock2.absoluteTimeIndex, 25);
 
     // Test middle of day
-    auto result3 = convertTimeStepToBlockTimeIndex(35, TimeConversionMode::DailyBlocks);
-    BOOST_CHECK_EQUAL(result3.block, 2);
-    BOOST_CHECK_EQUAL(*result3.blockTimeIndex, 12); // 35 % 24 + 1
-    BOOST_CHECK_EQUAL(*result3.absoluteTimeIndex, 36);
+    auto timeBlock3 = convertTimeStepToBlockTimeIndex(35, 24);
+    BOOST_CHECK_EQUAL(timeBlock3.block, 2);
+    BOOST_CHECK_EQUAL(*timeBlock3.blockTimeIndex, 12); // 35 % 24 + 1
+    BOOST_CHECK_EQUAL(*timeBlock3.absoluteTimeIndex, 36);
 }
 
 BOOST_AUTO_TEST_CASE(ConvertTimeStep_WeeklyBlocks)
 {
     // Test first week
-    auto result1 = convertTimeStepToBlockTimeIndex(0, TimeConversionMode::WeeklyBlocks);
-    BOOST_CHECK_EQUAL(result1.block, 1);
-    BOOST_CHECK_EQUAL(*result1.blockTimeIndex, 1);
-    BOOST_CHECK_EQUAL(*result1.absoluteTimeIndex, 1);
+    auto timeBlock1 = convertTimeStepToBlockTimeIndex(0, 168);
+    BOOST_CHECK_EQUAL(timeBlock1.block, 1);
+    BOOST_CHECK_EQUAL(*timeBlock1.blockTimeIndex, 1);
+    BOOST_CHECK_EQUAL(*timeBlock1.absoluteTimeIndex, 1);
 
     // Test second week
-    auto result2 = convertTimeStepToBlockTimeIndex(168, TimeConversionMode::WeeklyBlocks);
-    BOOST_CHECK_EQUAL(result2.block, 2);
-    BOOST_CHECK_EQUAL(*result2.blockTimeIndex, 1);
-    BOOST_CHECK_EQUAL(*result2.absoluteTimeIndex, 169);
+    auto timeBlock2 = convertTimeStepToBlockTimeIndex(168, 168);
+    BOOST_CHECK_EQUAL(timeBlock2.block, 2);
+    BOOST_CHECK_EQUAL(*timeBlock2.blockTimeIndex, 1);
+    BOOST_CHECK_EQUAL(*timeBlock2.absoluteTimeIndex, 169);
 
     // Test middle of week
-    auto result3 = convertTimeStepToBlockTimeIndex(100, TimeConversionMode::WeeklyBlocks);
-    BOOST_CHECK_EQUAL(result3.block, 1);
-    BOOST_CHECK_EQUAL(*result3.blockTimeIndex, 101); // 100 % 168 + 1
-    BOOST_CHECK_EQUAL(*result3.absoluteTimeIndex, 101);
+    auto timeBlock3 = convertTimeStepToBlockTimeIndex(100, 168);
+    BOOST_CHECK_EQUAL(timeBlock3.block, 1);
+    BOOST_CHECK_EQUAL(*timeBlock3.blockTimeIndex, 101); // 100 % 168 + 1
+    BOOST_CHECK_EQUAL(*timeBlock3.absoluteTimeIndex, 101);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -1634,33 +1623,18 @@ BOOST_DATA_TEST_CASE(StatusToString_AllStatuses,
     BOOST_CHECK_EQUAL(StatusToString(status), expected_string);
 }
 
-inline std::ostream& operator<<(std::ostream& os, const TimeConversionMode& mode)
-{
-    switch (mode)
-    {
-    case TimeConversionMode::SingleBlock:
-        return os << "SingleBlock";
-    case TimeConversionMode::DailyBlocks:
-        return os << "DailyBlocks";
-    case TimeConversionMode::WeeklyBlocks:
-        return os << "WeeklyBlocks";
-    default:
-        return os << "Unknown";
-    }
-}
-
 struct TimeTestCase
 {
-    unsigned int timeStep;
-    TimeConversionMode mode;
-    unsigned int expectedBlock;
+    unsigned timeStep;
+    unsigned timeBlockSize;
+    unsigned expectedBlock;
     int expectedBlockTime;
     int expectedAbsTime;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const TimeTestCase& tc)
 {
-    return os << "{timeStep=" << tc.timeStep << ", mode=" << tc.mode
+    return os << "{timeStep=" << tc.timeStep << ", blockSize=" << tc.timeBlockSize
               << ", expectedBlock=" << tc.expectedBlock
               << ", expectedBlockTime=" << tc.expectedBlockTime
               << ", expectedAbsTime=" << tc.expectedAbsTime << "}";
@@ -1668,21 +1642,20 @@ inline std::ostream& operator<<(std::ostream& os, const TimeTestCase& tc)
 
 // Test data for time conversion modes
 
-constexpr std::array<TimeTestCase, 8> time_test_data{
-  {{0, TimeConversionMode::SingleBlock, 1, 1, 1},
-   {23, TimeConversionMode::SingleBlock, 1, 24, 24},
-   {0, TimeConversionMode::DailyBlocks, 1, 1, 1},
-   {23, TimeConversionMode::DailyBlocks, 1, 24, 24},
-   {24, TimeConversionMode::DailyBlocks, 2, 1, 25},
-   {0, TimeConversionMode::WeeklyBlocks, 1, 1, 1},
-   {167, TimeConversionMode::WeeklyBlocks, 1, 168, 168},
-   {168, TimeConversionMode::WeeklyBlocks, 2, 1, 169}}};
+constexpr std::array<TimeTestCase, 8> time_test_data{{{0, UINT_MAX, 1, 1, 1},
+                                                      {23, UINT_MAX, 1, 24, 24},
+                                                      {0, 24, 1, 1, 1},
+                                                      {23, 24, 1, 24, 24},
+                                                      {24, 24, 2, 1, 25},
+                                                      {0, 168, 1, 1, 1},
+                                                      {167, 168, 1, 168, 168},
+                                                      {168, 168, 2, 1, 169}}};
 
 BOOST_DATA_TEST_CASE(TimeConversion_ParameterizedTest,
                      boost::unit_test::data::make(time_test_data),
                      testCase)
 {
-    auto result = convertTimeStepToBlockTimeIndex(testCase.timeStep, testCase.mode);
+    auto result = convertTimeStepToBlockTimeIndex(testCase.timeStep, testCase.timeBlockSize);
 
     BOOST_CHECK_EQUAL(result.block, testCase.expectedBlock);
     BOOST_CHECK_EQUAL(*result.blockTimeIndex, testCase.expectedBlockTime);


### PR DESCRIPTION
Fixes a part 2 of [ticket ANT-2965](https://gopro-tickets.rte-france.com/browse/ANT-2965) : 
This PR follows [PR 3048](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/3048), and intends to : 
- make subsequent simplifications
- remove dead code

**What was done** : 
- [x] adapting / simplifying simulation table (modeler)
- [x] adapting / simplifying remix hydro
- [x] binding constraints removing automatic conversion of a weekly BC to daily BC
- [ ] what else ? 