### PR TITLE
Add disabled test case for SumNode conversion with more than two operands

### DIFF
--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -30,6 +30,7 @@
 
 using namespace Antares::Expressions;
 using namespace Antares::IO::Inputs;
+namespace utf = boost::unit_test;
 
 class ExpressionToNodeConvertorEmptyModel
 {
@@ -126,7 +127,20 @@ BOOST_AUTO_TEST_CASE(identifierNotFound)
                           expectedMessage);
 }
 
-BOOST_FIXTURE_TEST_CASE(addThreeLiterals, ExpressionToNodeConvertorEmptyModel)
+BOOST_FIXTURE_TEST_CASE(addTwoLiterals, ExpressionToNodeConvertorEmptyModel)
+{
+    const std::string expression = "1 + 2";
+    auto expr = run(expression);
+    BOOST_CHECK_EQUAL(expr.node->name(), "SumNode");
+
+    auto* nodeSum = dynamic_cast<Nodes::SumNode*>(expr.node);
+    BOOST_REQUIRE(nodeSum);
+    const auto& operands = nodeSum->getOperands();
+    BOOST_CHECK_EQUAL(toLiteral(operands[0])->value(), 1);
+    BOOST_CHECK_EQUAL(toLiteral(operands[1])->value(), 2);
+}
+
+BOOST_FIXTURE_TEST_CASE(addThreeLiterals, ExpressionToNodeConvertorEmptyModel, *utf::disabled())
 {
     const std::string expression = "1 + 2 + 3";
     auto expr = run(expression);

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -140,6 +140,13 @@ BOOST_FIXTURE_TEST_CASE(addTwoLiterals, ExpressionToNodeConvertorEmptyModel)
     BOOST_CHECK_EQUAL(toLiteral(operands[1])->value(), 2);
 }
 
+/*
+  /!\ This test is disabled.
+  Current behavior
+  "1+2+3" -> SumNode(SumNode(1,2), 3)
+  Desired behavior
+  "1+2+3" -> SumNode(1,2,3)
+*/
 BOOST_FIXTURE_TEST_CASE(addThreeLiterals, ExpressionToNodeConvertorEmptyModel, *utf::disabled())
 {
     const std::string expression = "1 + 2 + 3";

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -126,17 +126,17 @@ BOOST_AUTO_TEST_CASE(identifierNotFound)
                           expectedMessage);
 }
 
-BOOST_FIXTURE_TEST_CASE(addTwoLiterals, ExpressionToNodeConvertorEmptyModel)
+BOOST_FIXTURE_TEST_CASE(addThreeLiterals, ExpressionToNodeConvertorEmptyModel)
 {
-    const std::string expression = "1 + 2";
+    const std::string expression = "1 + 2 + 3";
     auto expr = run(expression);
-    BOOST_CHECK_EQUAL(expr.node->name(), "SumNode");
 
     auto* nodeSum = dynamic_cast<Nodes::SumNode*>(expr.node);
     BOOST_REQUIRE(nodeSum);
     const auto& operands = nodeSum->getOperands();
     BOOST_CHECK_EQUAL(toLiteral(operands[0])->value(), 1);
     BOOST_CHECK_EQUAL(toLiteral(operands[1])->value(), 2);
+    BOOST_CHECK_EQUAL(toLiteral(operands[1])->value(), 3);
 }
 
 BOOST_FIXTURE_TEST_CASE(subtractTwoLiterals, ExpressionToNodeConvertorEmptyModel)

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -134,9 +134,10 @@ BOOST_FIXTURE_TEST_CASE(addThreeLiterals, ExpressionToNodeConvertorEmptyModel)
     auto* nodeSum = dynamic_cast<Nodes::SumNode*>(expr.node);
     BOOST_REQUIRE(nodeSum);
     const auto& operands = nodeSum->getOperands();
+    BOOST_REQUIRE_EQUAL(operands.size(), 3);
     BOOST_CHECK_EQUAL(toLiteral(operands[0])->value(), 1);
     BOOST_CHECK_EQUAL(toLiteral(operands[1])->value(), 2);
-    BOOST_CHECK_EQUAL(toLiteral(operands[1])->value(), 3);
+    BOOST_CHECK_EQUAL(toLiteral(operands[2])->value(), 3);
 }
 
 BOOST_FIXTURE_TEST_CASE(subtractTwoLiterals, ExpressionToNodeConvertorEmptyModel)


### PR DESCRIPTION
The conversion rule should be
> "1+2+3" -> SumNode(1,2,3)

is actually
> "1+2+3" -> SumNode(SumNode(1,2), 3)

If / when we decide to apply the "single SumNode" rule, this test will be here. It also serves as a reminder to do it.