### PR TITLE
windows-vcpkg workflow - skip CI if commit message contains [skip ci]

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -45,6 +45,7 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     runs-on: windows-2022
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
 
       - uses: actions/checkout@v5


### PR DESCRIPTION
Same behavior as other worfklows (ubuntu, sonarcloud, etc.)