### PR TITLE
Optimization by daily chunk : forbid [ANT-2965]

### DIFF
--- a/src/libs/antares/checks/checkLoadedInputData.cpp
+++ b/src/libs/antares/checks/checkLoadedInputData.cpp
@@ -41,48 +41,6 @@ void checkStudyVersion(const Data::StudyVersion& version, const AnyString& Study
     }
 }
 
-// CHECK incompatible de choix simultané des options « simplex range= daily » et « hydro-pricing
-// = MILP ».
-void checkSimplexRangeHydroPricing(Antares::Data::SimplexOptimization optRange,
-                                   Antares::Data::HydroPricingMode hpMode)
-{
-    using namespace Antares::Data;
-    if (optRange == SimplexOptimization::sorDay && hpMode == HydroPricingMode::hpMILP)
-    {
-        throw Error::IncompatibleOptRangeHydroPricing();
-    }
-}
-
-// CHECK incompatible de choix simultané des options « simplex range= daily » et «
-// unit-commitment = MILP ».
-void checkSimplexRangeUnitCommitmentMode(Antares::Data::SimplexOptimization optRange,
-                                         Antares::Data::UnitCommitmentMode ucMode)
-{
-    if (optRange == Antares::Data::SimplexOptimization::sorDay
-        && ucMode == Antares::Data::UnitCommitmentMode::ucMILP)
-    {
-        throw Error::IncompatibleOptRangeUCMode();
-    }
-}
-
-// Daily simplex optimisation and any area's use heurictic target turned to "No" are not
-// compatible.
-void checkSimplexRangeHydroHeuristic(Antares::Data::SimplexOptimization optRange,
-                                     const Antares::Data::AreaList& areas)
-{
-    if (optRange == Antares::Data::SimplexOptimization::sorDay)
-    {
-        for (uint i = 0; i < areas.size(); ++i)
-        {
-            const auto& area = *(areas.byIndex[i]);
-            if (!area.hydro.useHeuristicTarget)
-            {
-                throw Error::IncompatibleDailyOptHeuristicForArea(area.name);
-            }
-        }
-    }
-}
-
 bool areasThermalClustersMinStablePowerValidity(const Antares::Data::AreaList& areas,
                                                 std::map<int, YString>& areaClusterNames)
 {

--- a/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
+++ b/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
@@ -25,15 +25,6 @@ namespace Antares::Check
 {
 void checkStudyVersion(const Data::StudyVersion& version, const AnyString& StudyFolder);
 
-void checkSimplexRangeHydroPricing(Antares::Data::SimplexOptimization optRange,
-                                   Antares::Data::HydroPricingMode hpMode);
-
-void checkSimplexRangeUnitCommitmentMode(Antares::Data::SimplexOptimization optRange,
-                                         Antares::Data::UnitCommitmentMode ucMode);
-
-void checkSimplexRangeHydroHeuristic(Antares::Data::SimplexOptimization optRange,
-                                     const Antares::Data::AreaList& areas);
-
 void checkMinStablePower(bool tsGenThermal, const Antares::Data::AreaList& areas);
 
 void checkFuelCostColumnNumber(const Antares::Data::AreaList& areas);

--- a/src/libs/antares/exception/LoadingError.cpp
+++ b/src/libs/antares/exception/LoadingError.cpp
@@ -142,24 +142,6 @@ UseMILPsolverWithWrongOptions::UseMILPsolverWithWrongOptions():
 {
 }
 
-IncompatibleOptRangeHydroPricing::IncompatibleOptRangeHydroPricing():
-    LoadingError("Simplex optimization range and hydro pricing mode : values are not compatible ")
-{
-}
-
-IncompatibleOptRangeUCMode::IncompatibleOptRangeUCMode():
-    LoadingError("Simplexe optimization range and unit commitment mode : values are not compatible")
-{
-}
-
-IncompatibleDailyOptHeuristicForArea::IncompatibleDailyOptHeuristicForArea(
-  const Antares::Data::AreaName& name):
-    LoadingError(
-      std::string("Area ") + name.c_str()
-      + " : simplex daily optimization and use heuristic target == no are not compatible")
-{
-}
-
 std::string InvalidParametersForThermalClusters::buildMessage(
   const std::map<int, Yuni::String>& clusterNames) const
 {

--- a/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
@@ -112,18 +112,6 @@ public:
     UseMILPsolverWithWrongOptions();
 };
 
-class IncompatibleOptRangeHydroPricing: public LoadingError
-{
-public:
-    IncompatibleOptRangeHydroPricing();
-};
-
-class IncompatibleOptRangeUCMode: public LoadingError
-{
-public:
-    IncompatibleOptRangeUCMode();
-};
-
 class InvalidOptimizationRange: public LoadingError
 {
 public:
@@ -171,12 +159,6 @@ class InvalidVersion: public LoadingError
 {
 public:
     InvalidVersion(const std::string& version, const std::string& latest);
-};
-
-class IncompatibleDailyOptHeuristicForArea: public LoadingError
-{
-public:
-    explicit IncompatibleDailyOptHeuristicForArea(const Antares::Data::AreaName& name);
 };
 
 class InvalidParametersForThermalClusters: public LoadingError

--- a/src/libs/antares/study/include/antares/study/load-options.h
+++ b/src/libs/antares/study/include/antares/study/load-options.h
@@ -60,8 +60,6 @@ public:
     // This option might be useful for running old studies without upgrading
     bool noTimeseriesImportIntoInput;
 
-    //! Simplex optimization range
-    SimplexOptimization simplexOptimizationRange;
     //! Mps files export asked
     bool mpsToExport;
     //! named problems

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -438,7 +438,7 @@ public:
     //! Transmission capacities
     GlobalTransmissionCapacities transmissionCapacities;
     //! Simplex optimization range (day/week)
-    SimplexOptimization simplexOptimizationRange;
+    SimplexOptimization simplexOptimizationRange = sorWeek;
     //@}
 
     AdequacyPatch::AdqPatchParams adqPatchParams;

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -437,6 +437,8 @@ public:
 
     //! Transmission capacities
     GlobalTransmissionCapacities transmissionCapacities;
+    //! Simplex optimization range (day/week)
+    const SimplexOptimization simplexOptimizationRange = sorWeek;
     //@}
 
     AdequacyPatch::AdqPatchParams adqPatchParams;

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -437,8 +437,6 @@ public:
 
     //! Transmission capacities
     GlobalTransmissionCapacities transmissionCapacities;
-    //! Simplex optimization range (day/week)
-    const SimplexOptimization simplexOptimizationRange = sorWeek;
     //@}
 
     AdequacyPatch::AdqPatchParams adqPatchParams;

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -438,7 +438,7 @@ public:
     //! Transmission capacities
     GlobalTransmissionCapacities transmissionCapacities;
     //! Simplex optimization range (day/week)
-    SimplexOptimization simplexOptimizationRange = sorWeek;
+    const SimplexOptimization simplexOptimizationRange = sorWeek;
     //@}
 
     AdequacyPatch::AdqPatchParams adqPatchParams;

--- a/src/libs/antares/study/load-options.cpp
+++ b/src/libs/antares/study/load-options.cpp
@@ -33,7 +33,6 @@ StudyLoadOptions::StudyLoadOptions():
     forceYearByYear(false),
     forceDerated(false),
     noTimeseriesImportIntoInput(false),
-    simplexOptimizationRange(sorUnknown),
     mpsToExport(false),
     ignoreConstraints(false),
     forceMode(SimulationMode::Unknown),

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -350,7 +350,6 @@ void Parameters::reset()
     include.reserve.strategic = true;
     include.reserve.spinning = true;
     include.reserve.primary = true;
-    simplexOptimizationRange = sorWeek;
 
     include.exportMPS = mpsExportStatus::NO_EXPORT;
     include.exportStructure = false;
@@ -714,9 +713,11 @@ static bool SGDIntLoadFamily_Optimization(Parameters& d,
         return result;
     }
 
+    // deprecated
     if (key == "simplex-range")
     {
-        d.simplexOptimizationRange = sorWeek;
+        // Parameter 'simplex-range' ignored :
+        // simplexOptimizationRange == sorWeek always 
         return true;
     }
 

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -716,8 +716,11 @@ static bool SGDIntLoadFamily_Optimization(Parameters& d,
     // deprecated
     if (key == "simplex-range")
     {
-        // Parameter 'simplex-range' ignored :
-        // simplexOptimizationRange == sorWeek always 
+        if (value == "day")
+        {
+            logs.error("simplex-range : value 'day' is deprecated");
+            return false;
+        }
         return true;
     }
 

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -716,7 +716,7 @@ static bool SGDIntLoadFamily_Optimization(Parameters& d,
 
     if (key == "simplex-range")
     {
-        d.simplexOptimizationRange = (!value.ifind("day")) ? sorDay : sorWeek;
+        d.simplexOptimizationRange = sorWeek;
         return true;
     }
 
@@ -1437,17 +1437,7 @@ void Parameters::prepareForSimulation(const StudyLoadOptions& options)
     horizon.clear();
 
     // Simplex optimization range
-    switch (simplexOptimizationRange)
-    {
-    case sorDay:
-        logs.info() << "  simplex optimization range: day";
-        break;
-    case sorWeek:
-        logs.info() << "  simplex optimization range: week";
-        break;
-    case sorUnknown:
-        break;
-    }
+    logs.info() << "  simplex optimization range: week";
 
     if (derated && userPlaylist)
     {
@@ -1752,17 +1742,8 @@ void Parameters::saveToINI(IniFile& ini) const
     // Optimization
     {
         auto* section = ini.addSection("optimization");
-        switch (simplexOptimizationRange)
-        {
-        case sorDay:
-            section->add("simplex-range", "day");
-            break;
-        case sorWeek:
-            section->add("simplex-range", "week");
-            break;
-        case sorUnknown:
-            break;
-        }
+        section->add("simplex-range", "week");
+
         // Optimization preferences
         section->add("transmission-capacities",
                      GlobalTransmissionCapacitiesToString(transmissionCapacities));

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -285,16 +285,6 @@ void Application::readStudy_makeChecks_and_printThings(Data::StudyLoadOptions& o
 
 void Application::postParametersChecks() const
 {
-    // Some more checks require the existence of pParameters, hence of a study.
-    // Their execution is delayed up to this point.
-    checkSimplexRangeHydroPricing(pParameters->simplexOptimizationRange,
-                                  pParameters->hydroPricing.hpMode);
-
-    checkSimplexRangeUnitCommitmentMode(pParameters->simplexOptimizationRange,
-                                        pParameters->unitCommitment.ucMode);
-
-    checkSimplexRangeHydroHeuristic(pParameters->simplexOptimizationRange, pStudy->areas);
-
     if (pParameters->adqPatchParams.enabled)
     {
         pParameters->adqPatchParams.checkAdqPatchParams(pParameters->mode,

--- a/src/solver/misc/include/antares/solver/misc/options.h
+++ b/src/solver/misc/include/antares/solver/misc/options.h
@@ -44,9 +44,6 @@ public:
     //! Comment file
     std::string commentFile;
 
-    //! Simplex optimizatio range
-    Yuni::CString<32, false> simplexOptimRange;
-
     //! Ignore error/warnings
     int ignoreWarningsErrors = 0;
     //! Ignore constraints

--- a/src/solver/misc/options.cpp
+++ b/src/solver/misc/options.cpp
@@ -175,12 +175,6 @@ std::unique_ptr<Yuni::GetOpt::Parser> CreateParser(Settings& settings, StudyLoad
                 " for XPRESS or \"parallel/maxnthreads 8\" for SCIP. "
                 "Syntax is solver-dependent.");
 
-    // --optimization-range
-    parser->addFlag(settings.simplexOptimRange,
-                    ' ',
-                    "optimization-range",
-                    "Force the simplex optimization range ('day' or 'week')");
-
     // --no-constraints
     parser->addFlag(settings.ignoreConstraints, ' ', "no-constraints", "Ignore all constraints");
 
@@ -266,27 +260,6 @@ void checkAndCorrectSettingsAndOptions(Settings& settings, Data::StudyLoadOption
     if (options.enableParallel && options.forceParallel)
     {
         throw Error::IncompatibleParallelOptions();
-    }
-
-    if (!settings.simplexOptimRange.empty())
-    {
-        settings.simplexOptimRange.trim(" \t");
-        settings.simplexOptimRange.toLower();
-        if (settings.simplexOptimRange == "week")
-        {
-            options.simplexOptimizationRange = Data::sorWeek;
-        }
-        else
-        {
-            if (settings.simplexOptimRange == "day")
-            {
-                options.simplexOptimizationRange = Data::sorDay;
-            }
-            else
-            {
-                throw Error::InvalidOptimizationRange();
-            }
-        }
     }
 
     options.checkForceSimulationMode();

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -139,7 +139,7 @@ void SIM_InitialisationProblemeHebdo(Study& study,
     problem.OptimisationAvecVariablesEntieres = (study.parameters.unitCommitment.ucMode
                                                  == Antares::Data::UnitCommitmentMode::ucMILP);
 
-    problem.OptimisationAuPasHebdomadaire = (parameters.simplexOptimizationRange == Data::sorWeek);
+    problem.OptimisationAuPasHebdomadaire = true;
 
     switch (parameters.power.fluctuations)
     {

--- a/src/tests/src/libs/antares/checks/tests-checks.cpp
+++ b/src/tests/src/libs/antares/checks/tests-checks.cpp
@@ -32,33 +32,3 @@ BOOST_AUTO_TEST_CASE(study_version_is_too_high___exception_raised)
                           containsMessage(err_msg));
 }
 BOOST_AUTO_TEST_SUITE_END()
-
-BOOST_AUTO_TEST_SUITE(check_simplex_range_and_hydro_pricing)
-
-BOOST_AUTO_TEST_CASE(splx_optim_range_and_hydro_pricing_are_incompatible___exception_raised)
-{
-    SimplexOptimization splxOptimRange = SimplexOptimization::sorDay;
-    HydroPricingMode hydroPricingMode = HydroPricingMode::hpMILP;
-    std::string err_msg = "Simplex optimization range and hydro pricing mode : values are not "
-                          "compatible ";
-    BOOST_CHECK_EXCEPTION(checkSimplexRangeHydroPricing(splxOptimRange, hydroPricingMode),
-                          std::runtime_error,
-                          checkMessage(err_msg));
-}
-
-BOOST_AUTO_TEST_SUITE_END()
-
-BOOST_AUTO_TEST_SUITE(check_simplex_range_and_unit_commitment)
-
-BOOST_AUTO_TEST_CASE(splx_optim_range_and_unit_commitment_are_incompatible___exception_raised)
-{
-    SimplexOptimization splxOptimRange = SimplexOptimization::sorDay;
-    UnitCommitmentMode ucMode = UnitCommitmentMode::ucMILP;
-    std::string err_msg = "Simplexe optimization range and unit commitment mode : values are not "
-                          "compatible";
-    BOOST_CHECK_EXCEPTION(checkSimplexRangeUnitCommitmentMode(splxOptimRange, ucMode),
-                          std::runtime_error,
-                          checkMessage(err_msg));
-}
-
-BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/misc/tests-options.cpp
+++ b/src/tests/src/solver/misc/tests-options.cpp
@@ -150,30 +150,6 @@ BOOST_AUTO_TEST_CASE(parallel_optione_incompatible)
                           checkMessage(err_msg));
 }
 
-BOOST_AUTO_TEST_CASE(optimization_range_set_to_unknown___exception_raised)
-{
-    settings.simplexOptimRange = "unknown_opt_range";
-    std::string err_msg = "Invalid command line value for --optimization-range ('day' or 'week' "
-                          "expected)";
-    BOOST_CHECK_EXCEPTION(checkAndCorrectSettingsAndOptions(settings, options),
-                          std::runtime_error,
-                          checkMessage(err_msg));
-}
-
-BOOST_AUTO_TEST_CASE(optimization_range_set_to_day)
-{
-    settings.simplexOptimRange = "DAy"; // Whatever the case, will be downcased
-    checkAndCorrectSettingsAndOptions(settings, options);
-    BOOST_CHECK_EQUAL(options.simplexOptimizationRange, sorDay);
-}
-
-BOOST_AUTO_TEST_CASE(optimization_range_set_to_week)
-{
-    settings.simplexOptimRange = "wEeK"; // Whatever the case, will be downcased
-    checkAndCorrectSettingsAndOptions(settings, options);
-    BOOST_CHECK_EQUAL(options.simplexOptimizationRange, sorWeek);
-}
-
 // settings.noOutput && settings.forceZipOutput
 BOOST_AUTO_TEST_CASE(output_settings_are_incompatible___exception_raised)
 {

--- a/src/ui/simulator/windows/options/optimization/optimization.cpp
+++ b/src/ui/simulator/windows/options/optimization/optimization.cpp
@@ -395,7 +395,7 @@ void Optimization::onResetToDefault(void*)
             study.parameters.include.reserve.primary = true;
             study.parameters.include.reserve.spinning = true;
             study.parameters.include.exportMPS = Data::mpsExportStatus::NO_EXPORT;
-            study.parameters.simplexOptimizationRange = Data::sorWeek;
+            // study.parameters.simplexOptimizationRange = Data::sorWeek;
             study.parameters.include.unfeasibleProblemBehavior
               = Data::UnfeasibleProblemBehavior::ERROR_MPS;
 
@@ -448,6 +448,7 @@ void Optimization::refresh()
       Data::getDisplayName(study.parameters.include.unfeasibleProblemBehavior));
 
     // Simplex Optimization Range
+    /*
     if (Data::sorDay == study.parameters.simplexOptimizationRange)
     {
         pBtnSimplexOptimizationRange->image("images/16x16/calendar_day.png");
@@ -458,6 +459,9 @@ void Optimization::refresh()
         pBtnSimplexOptimizationRange->image("images/16x16/calendar_week.png");
         pBtnSimplexOptimizationRange->caption(wxT("Week"));
     }
+    */
+    pBtnSimplexOptimizationRange->image("images/16x16/calendar_week.png");
+    pBtnSimplexOptimizationRange->caption(wxT("Week"));
 }
 
 void Optimization::onPopupMenu(Component::Button&, wxMenu& menu, void*, const PopupInfo& info)
@@ -623,12 +627,14 @@ void Optimization::onSelectSimplexDay(wxCommandEvent&)
     auto study = GetCurrentStudy();
     if (!(!study))
     {
+        /*
         if (study->parameters.simplexOptimizationRange != Data::sorDay)
         {
             study->parameters.simplexOptimizationRange = Data::sorDay;
             refresh();
             MarkTheStudyAsModified();
         }
+        */
     }
 }
 
@@ -637,12 +643,14 @@ void Optimization::onSelectSimplexWeek(wxCommandEvent&)
     auto study = GetCurrentStudy();
     if (!(!study))
     {
+        /*
         if (study->parameters.simplexOptimizationRange != Data::sorWeek)
         {
             study->parameters.simplexOptimizationRange = Data::sorWeek;
             refresh();
             MarkTheStudyAsModified();
         }
+        */
     }
 }
 


### PR DESCRIPTION
This PR fixes part 1 of ticket [ANT-2965](https://gopro-tickets.rte-france.com/browse/ANT-2965).
It intends to set optimization's simplex range setting to **day** impossible.
 
- [x] genaldata.ini : having **simplex-range = day** causes an error
- [x] Antares solver **optimization-range** option no longer available
- [ ] **GUI** : removing all about the optimization's simplex range setting