### PR TITLE
Allocate [Adequacy|Economy]::AllVariables

### DIFF
--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -339,7 +339,7 @@ bool Adequacy::year(Progression::Task& progression,
 
         updatingWeeklyFinalHydroLevel(study.areas, currentProblem);
 
-        variables.weekBegin(state);
+        variables->weekBegin(state);
         uint previousHourInTheYear = state.hourInTheYear;
 
         for (uint hw = 0; hw != nbHoursInAWeek;
@@ -349,16 +349,16 @@ bool Adequacy::year(Progression::Task& progression,
 
             state.ntc = currentProblem.ValeursDeNTC[hw];
 
-            variables.hourBegin(state.hourInTheYear);
+            variables->hourBegin(state.hourInTheYear);
 
-            variables.hourForEachArea(state, numSpace);
+            variables->hourForEachArea(state, numSpace);
 
-            variables.hourEnd(state, state.hourInTheYear);
+            variables->hourEnd(state, state.hourInTheYear);
         }
 
         state.hourInTheYear = previousHourInTheYear;
-        variables.weekForEachArea(state, numSpace);
-        variables.weekEnd(state);
+        variables->weekForEachArea(state, numSpace);
+        variables->weekEnd(state);
 
         hourInTheYear += nbHoursInAWeek;
         optWriter.addTime(w, currentProblem.timeMeasure);
@@ -400,7 +400,7 @@ void Adequacy::simulationEnd()
 {
     if (!preproOnly && study.runtime.interconnectionsCount() > 0)
     {
-        auto balance = retrieveBalance(study, variables);
+        auto balance = retrieveBalance(study, *variables);
         ComputeFlowQuad(study,
                         pProblemesHebdo[0],
                         balance,

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -175,7 +175,7 @@ bool Economy::year(Progression::Task& progression,
             optRuntimeData opt_runtime_data(state.year, w, hourInTheYear);
             postProcessesList_[numSpace]->runAll(opt_runtime_data);
 
-            variables.weekBegin(state);
+            variables->weekBegin(state);
             uint previousHourInTheYear = state.hourInTheYear;
 
             for (uint hw = 0; hw != nbHoursInAWeek;
@@ -185,16 +185,16 @@ bool Economy::year(Progression::Task& progression,
 
                 state.ntc = currentProblem.ValeursDeNTC[hw];
 
-                variables.hourBegin(state.hourInTheYear);
+                variables->hourBegin(state.hourInTheYear);
 
-                variables.hourForEachArea(state, numSpace);
+                variables->hourForEachArea(state, numSpace);
 
-                variables.hourEnd(state, state.hourInTheYear);
+                variables->hourEnd(state, state.hourInTheYear);
             }
 
             state.hourInTheYear = previousHourInTheYear;
-            variables.weekForEachArea(state, numSpace);
-            variables.weekEnd(state);
+            variables->weekForEachArea(state, numSpace);
+            variables->weekEnd(state);
 
             for (int opt = 0; opt < 7; opt++)
             {
@@ -268,7 +268,7 @@ void Economy::simulationEnd()
 {
     if (!preproOnly && study.runtime.interconnectionsCount() > 0)
     {
-        auto balance = retrieveBalance(study, variables);
+        auto balance = retrieveBalance(study, *variables);
         ComputeFlowQuad(study,
                         pProblemesHebdo[0],
                         balance,

--- a/src/solver/simulation/include/antares/solver/simulation/adequacy.h
+++ b/src/solver/simulation/include/antares/solver/simulation/adequacy.h
@@ -55,8 +55,13 @@ public:
     Adequacy(Data::Study& study,
              IResultWriter& resultWriter,
              Simulation::ISimulationObserver& simulationObserver);
+
     //! Destructor
-    ~Adequacy() = default;
+    ~Adequacy()
+    {
+        delete variables;
+    }
+
     //@}
 
     Benchmarking::OptimizationInfo getOptimizationInfo() const;
@@ -64,7 +69,8 @@ public:
     //! Current study
     Data::Study& study;
     //! All variables
-    Solver::Variable::Adequacy::AllVariables variables;
+    Solver::Variable::Adequacy::AllVariables* variables = new Solver::Variable::Adequacy::
+      AllVariables();
     //! Prepro only
     bool preproOnly = false;
 

--- a/src/solver/simulation/include/antares/solver/simulation/economy.h
+++ b/src/solver/simulation/include/antares/solver/simulation/economy.h
@@ -54,8 +54,13 @@ public:
     Economy(Data::Study& study,
             IResultWriter& resultWriter,
             Simulation::ISimulationObserver& simulationObserver);
+
     //! Destructor
-    ~Economy() = default;
+    ~Economy()
+    {
+        delete variables;
+    }
+
     //@}
 
     Benchmarking::OptimizationInfo getOptimizationInfo() const;
@@ -64,7 +69,8 @@ public:
     //! Current study
     Data::Study& study;
     //! All variables
-    Solver::Variable::Economy::AllVariables variables;
+    Solver::Variable::Economy::AllVariables* variables = new Solver::Variable::Economy::
+      AllVariables();
     //! Prepro only
     bool preproOnly;
 

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -158,7 +158,7 @@ public:
         state.year = y;
 
         // 5 - Resetting all variables for the output
-        simulation_->variables.yearBegin(y, numSpace);
+        simulation_->variables->yearBegin(y, numSpace);
 
         // 6 - The Solver itself
         std::list<uint> failedWeekList;
@@ -182,17 +182,17 @@ public:
         // Log failing weeks
         logFailedWeek(y, study, failedWeekList);
 
-        simulation_->variables.yearEndBuild(state, y, numSpace);
+        simulation_->variables->yearEndBuild(state, y, numSpace);
 
         // 7 - End of the year, this is the last stade where the variables can retrieve
         // their data for this year.
-        simulation_->variables.yearEnd(y, numSpace);
+        simulation_->variables->yearEnd(y, numSpace);
 
         // 8 - Spatial clusters
         // Notifying all variables to perform spatial aggregates.
         // This must be done only when all variables have finished to compute their
         // data for the year.
-        simulation_->variables.yearEndSpatialAggregates(simulation_->variables, y, numSpace);
+        simulation_->variables->yearEndSpatialAggregates(simulation_->variables, y, numSpace);
 
         // 9 - Write results for the current year
         if (yearByYear)
@@ -200,7 +200,7 @@ public:
             pDurationCollector("yby_export") << [this, &numSpace]
             {
                 // Before writing, some variable may require minor modifications
-                simulation_->variables.beforeYearByYearExport(y, numSpace);
+                simulation_->variables->beforeYearByYearExport(y, numSpace);
                 // writing the results for the current year into the output
                 simulation_->writeResults(false, y, numSpace); // false for synthesis
             };
@@ -212,10 +212,12 @@ public:
         aggregationMutex.lock();
         yearsFailed[y] = yearFailed;
 
-        simulation_->variables.computeSummary(y, numSpace);
+        simulation_->variables->computeSummary(y, numSpace);
 
         // Computing summary of spatial aggregations
-        simulation_->variables.computeSpatialAggregatesSummary(simulation_->variables, y, numSpace);
+        simulation_->variables->computeSpatialAggregatesSummary(simulation_->variables,
+                                                                y,
+                                                                numSpace);
 
         // Computes statistics on annual (system and solution) costs, to be printed in output
         // into separate files
@@ -282,7 +284,7 @@ void ISimulation<ImplementationType>::run()
     pNbMaxPerformedYearsInParallel = study.maxNbYearsInParallel;
 
     // Initialize all data
-    ImplementationType::variables.initializeFromStudy(study);
+    ImplementationType::variables->initializeFromStudy(study);
     // Computing the max number columns a report of any kind can contain.
     study.parameters.variablesPrintInfo.computeMaxColumnsCountInReports();
 
@@ -291,7 +293,7 @@ void ISimulation<ImplementationType>::run()
     // Memory usage
     {
         Variable::PrintInfosStdCout c;
-        ImplementationType::variables.template provideInformations<Variable::PrintInfosStdCout>(c);
+        ImplementationType::variables->template provideInformations<Variable::PrintInfosStdCout>(c);
     }
 
     ImplementationType::setNbPerformedYearsInParallel(pNbMaxPerformedYearsInParallel);
@@ -319,7 +321,7 @@ void ISimulation<ImplementationType>::run()
             return;
         }
         // Allocating the memory
-        ImplementationType::variables.simulationBegin();
+        ImplementationType::variables->simulationBegin();
 
         // For beauty
         logs.info();
@@ -349,13 +351,14 @@ void ISimulation<ImplementationType>::run()
         // Post operations
         pDurationCollector("post_processing") << [this] { ImplementationType::simulationEnd(); };
 
-        ImplementationType::variables.simulationEnd();
+        ImplementationType::variables->simulationEnd();
 
         // Spatial clusters
         // Notifying all variables to perform the final spatial clusters.
         // This must be done only when all variables have finished to compute their
         // own data.
-        ImplementationType::variables.simulationEndSpatialAggregates(ImplementationType::variables);
+        ImplementationType::variables->simulationEndSpatialAggregates(
+          ImplementationType::variables);
     }
 }
 
@@ -405,10 +408,10 @@ void ISimulation<ImplementationType>::writeResults(bool synthesis, uint year, ui
         }
 
         // Dumping
-        ImplementationType::variables.exportSurveyResults(synthesis,
-                                                          newPath,
-                                                          numSpace,
-                                                          pResultWriter);
+        ImplementationType::variables->exportSurveyResults(synthesis,
+                                                           newPath,
+                                                           numSpace,
+                                                           pResultWriter);
     }
 }
 

--- a/src/solver/variable/include/antares/solver/variable/commons/spatial-aggregate.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/spatial-aggregate.h
@@ -380,7 +380,7 @@ private:
             auto end = set.end();
             for (auto i = set.begin(); i != end; ++i)
             {
-                allVars.template computeSpatialAggregateWith<
+                allVars->template computeSpatialAggregateWith<
                   typename VCardType::VCardForSpatialAggregate> //<typename VCardType::VCardOrigin>
                   (pValuesForTheCurrentYear[0], *i /* the current area */, 0);
             }
@@ -427,7 +427,7 @@ private:
             auto end = set.end();
             for (auto i = set.begin(); i != end; ++i)
             {
-                allVars.template computeSpatialAggregateWith<
+                allVars->template computeSpatialAggregateWith<
                   typename VCardType::VCardForSpatialAggregate> //<typename VCardType::VCardOrigin>
                   (pValuesForTheCurrentYear[numSpace], *i /* the current area */, numSpace);
             }

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -246,7 +246,7 @@ template<class VCard>
 typename Variable::Storage<VCard>::ResultsType* OutputRetriever::retrieveAreaResults(Area* area)
 {
     typename Variable::Storage<VCard>::ResultsType* result = nullptr;
-    simulation_.variables.retrieveResultsForArea<VCard>(&result, area);
+    simulation_.variables->retrieveResultsForArea<VCard>(&result, area);
     return result;
 }
 
@@ -254,7 +254,7 @@ template<class VCard>
 typename Variable::Storage<VCard>::ResultsType* OutputRetriever::retrieveLinkResults(AreaLink* link)
 {
     typename Variable::Storage<VCard>::ResultsType* result = nullptr;
-    simulation_.variables.retrieveResultsForLink<VCard>(&result, link);
+    simulation_.variables->retrieveResultsForLink<VCard>(&result, link);
     return result;
 }
 
@@ -263,7 +263,7 @@ typename Variable::Storage<VCard>::ResultsType* OutputRetriever::retrieveResults
   ThermalCluster* cluster)
 {
     typename Variable::Storage<VCard>::ResultsType* result = nullptr;
-    simulation_.variables.retrieveResultsForThermalCluster<VCard>(&result, cluster);
+    simulation_.variables->retrieveResultsForThermalCluster<VCard>(&result, cluster);
     return result;
 }
 


### PR DESCRIPTION
The goal of this PR is to demonstrate the possibility of not allocating memory for output variables if not necessary.