### PR TITLE
Improve behave's error message for simulation tables

### DIFF
--- a/src/tests/cucumber/features/steps/common_steps/modeler_output_handler.py
+++ b/src/tests/cucumber/features/steps/common_steps/modeler_output_handler.py
@@ -31,7 +31,7 @@ class modeler_output_handler:
         else:
             df = df[df["scenario_index"] == scenario]
         if len(df) != 1:
-            raise LookupError(f"Simulation table does not contain exactly 1 row for component '{component}', output '{output}', block '{block}', timestep '{timestep}', scenario '{scenario}'")
+            raise LookupError(f"Simulation table contains {len(df)} row(s) (expected 1) for component '{component}', output '{output}', block '{block}', timestep '{timestep}', scenario '{scenario}'")
         return df["value"].iloc[0]
 
     def get_objective_value(self):


### PR DESCRIPTION
# Before
> LookupError: Simulation table does not contain exactly 1 row for component 'load1', output 'consumption.flow_field', block '0', timestep 'nan', scenario '0'

# After
> LookupError: Simulation table contains 0 row(s) (expected 1) for component 'load1', output 'consumption.flow_field', block '0', timestep 'nan', scenario '0'
