### PR TITLE
Fix clang Wunused-local-typedef

### DIFF
--- a/src/ext/yuni/src/yuni/core/logs/handler/file.hxx
+++ b/src/ext/yuni/src/yuni/core/logs/handler/file.hxx
@@ -1,5 +1,26 @@
 
 /*
+ * Copyright 2007-2025, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
+
+/*
 ** This file is part of libyuni, a cross-platform C++ framework (http://libyuni.org).
 **
 ** This Source Code Form is subject to the terms of the Mozilla Public License
@@ -60,7 +81,9 @@ void File<NextHandler>::internalDecoratorWriteWL(LoggerT& logger, const AnyStrin
 {
     if (pFile.opened())
     {
+#if defined(__GNUC__) && !defined(__clang__)
         using DecoratorsType = typename LoggerT::DecoratorsType;
+#endif
         // Append the message to the file
         logger.DecoratorsType::template internalDecoratorAddPrefix<File, VerbosityType>(pFile, s);
 

--- a/src/ext/yuni/src/yuni/core/logs/handler/stdcout.h
+++ b/src/ext/yuni/src/yuni/core/logs/handler/stdcout.h
@@ -1,5 +1,26 @@
 
 /*
+ * Copyright 2007-2025, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
+
+/*
 ** This file is part of libyuni, a cross-platform C++ framework (http://libyuni.org).
 **
 ** This Source Code Form is subject to the terms of the Mozilla Public License
@@ -37,7 +58,10 @@ public:
     template<class LoggerT, class VerbosityType>
     void internalDecoratorWriteWL(LoggerT& logger, const AnyString& s) const
     {
+#if defined(__GNUC__) && !defined(__clang__)
         using DecoratorsType = typename LoggerT::DecoratorsType;
+#endif
+
         // Write the message to the std::cout/cerr
         if (VerbosityType::shouldUsesStdCerr)
         {


### PR DESCRIPTION
It seems Clang is right on this and it's a bug on GCC.

Using a macro that does nothing for clang to erase the warning