### PR TITLE
Add `final` keyword for final classes

### DIFF
--- a/docs/developer-guide/6-Contributing.md
+++ b/docs/developer-guide/6-Contributing.md
@@ -255,7 +255,6 @@ v = w * (x + z);
 
 // Space after double dash. And full sentences in comments.
 ```
-
 ## Tips and Hints
 
 - If you see outdated code which can be improved, DO IT NOW (but in a separate pull request or commit)!
@@ -276,3 +275,13 @@ v = w * (x + z);
   - `logs.warning() << msg`: indicates undesired behavior that is not an error, and that does not interrupt processing or the application. Use if for issues that do not interrupt simulation (obsolete parameter ignored, input data ignored, etc.).
   - `logs.info() << msg`: information message explaining how the simulator works, intended for the person or application using it
   - `logs.debug() << msg`: information message to facilitate debugging, intended for developers
+
+## A final word about `final`
+Please use the `final` keyword for classes that won't be derived. It can avoid unintended overrides (fewer bugs) and save vtable lookups/improve compiler inlining (fewer CPU cycles).
+
+```cpp
+class WillNotBeDerived final
+{
+
+};
+```

--- a/src/expressions/include/antares/expressions/NodeRegistry.h
+++ b/src/expressions/include/antares/expressions/NodeRegistry.h
@@ -5,7 +5,7 @@
 
 namespace Antares::Expressions
 {
-class NodeRegistry
+class NodeRegistry final
 {
 public:
     NodeRegistry() = default;

--- a/src/expressions/include/antares/expressions/expression.h
+++ b/src/expressions/include/antares/expressions/expression.h
@@ -33,7 +33,7 @@ namespace Antares::ModelerStudy::SystemModel
 {
 
 // TODO: add unit tests for this class
-class Expression
+class Expression final
 {
 public:
     Expression() = default;

--- a/src/expressions/include/antares/expressions/nodes/DivisionNode.h
+++ b/src/expressions/include/antares/expressions/nodes/DivisionNode.h
@@ -27,7 +27,7 @@ namespace Antares::Expressions::Nodes
 /**
  * @brief Represents a division node in a syntax tree.
  */
-class DivisionNode: public BinaryNode
+class DivisionNode final: public BinaryNode
 {
 public:
     using BinaryNode::BinaryNode;

--- a/src/expressions/include/antares/expressions/nodes/EqualNode.h
+++ b/src/expressions/include/antares/expressions/nodes/EqualNode.h
@@ -27,7 +27,7 @@ namespace Antares::Expressions::Nodes
 /**
  * @brief Represents an equality comparison node in a syntax tree.
  */
-class EqualNode: public ComparisonNode
+class EqualNode final: public ComparisonNode
 {
 public:
     using ComparisonNode::ComparisonNode;

--- a/src/expressions/include/antares/expressions/nodes/GreaterThanOrEqualNode.h
+++ b/src/expressions/include/antares/expressions/nodes/GreaterThanOrEqualNode.h
@@ -27,7 +27,7 @@ namespace Antares::Expressions::Nodes
 /**
  * @brief Represents a greater than or equal comparison node in a syntax tree.
  */
-class GreaterThanOrEqualNode: public ComparisonNode
+class GreaterThanOrEqualNode final: public ComparisonNode
 {
 public:
     using ComparisonNode::ComparisonNode;

--- a/src/expressions/include/antares/expressions/nodes/LiteralNode.h
+++ b/src/expressions/include/antares/expressions/nodes/LiteralNode.h
@@ -7,7 +7,7 @@ namespace Antares::Expressions::Nodes
 /**
  * @brief Represents a literal node in a syntax tree, storing a double value.
  */
-class LiteralNode: public Leaf<double>
+class LiteralNode final: public Leaf<double>
 {
 public:
     using Leaf<double>::Leaf;

--- a/src/expressions/include/antares/expressions/nodes/MultiplicationNode.h
+++ b/src/expressions/include/antares/expressions/nodes/MultiplicationNode.h
@@ -27,7 +27,7 @@ namespace Antares::Expressions::Nodes
 /**
  * @brief Represents a multiplication node in a syntax tree.
  */
-class MultiplicationNode: public BinaryNode
+class MultiplicationNode final: public BinaryNode
 {
 public:
     using BinaryNode::BinaryNode;

--- a/src/expressions/include/antares/expressions/nodes/PortFieldSumNode.h
+++ b/src/expressions/include/antares/expressions/nodes/PortFieldSumNode.h
@@ -29,7 +29,7 @@ namespace Antares::Expressions::Nodes
 /**
  * @brief Represents a port field node where the expression is a sum.
  */
-class PortFieldSumNode: public Node, public Hashable
+class PortFieldSumNode final: public Node, public Hashable
 {
 public:
     /**

--- a/src/expressions/include/antares/expressions/nodes/SubtractionNode.h
+++ b/src/expressions/include/antares/expressions/nodes/SubtractionNode.h
@@ -27,7 +27,7 @@ namespace Antares::Expressions::Nodes
 /**
  * @brief Represents a subtraction node in a syntax tree.
  */
-class SubtractionNode: public BinaryNode
+class SubtractionNode final: public BinaryNode
 {
 public:
     using BinaryNode::BinaryNode;

--- a/src/expressions/include/antares/expressions/nodes/SumNode.h
+++ b/src/expressions/include/antares/expressions/nodes/SumNode.h
@@ -25,7 +25,7 @@
 namespace Antares::Expressions::Nodes
 {
 
-class SumNode: public ParentNode
+class SumNode final: public ParentNode
 {
 public:
     using ParentNode::ParentNode;

--- a/src/expressions/include/antares/expressions/nodes/TimeIndexNode.h
+++ b/src/expressions/include/antares/expressions/nodes/TimeIndexNode.h
@@ -24,7 +24,7 @@
 
 namespace Antares::Expressions::Nodes
 {
-class TimeIndexNode: public BinaryNode
+class TimeIndexNode final: public BinaryNode
 {
 public:
     using BinaryNode::BinaryNode;

--- a/src/expressions/include/antares/expressions/nodes/TimeShiftNode.h
+++ b/src/expressions/include/antares/expressions/nodes/TimeShiftNode.h
@@ -25,7 +25,7 @@
 namespace Antares::Expressions::Nodes
 {
 
-class TimeShiftNode: public BinaryNode
+class TimeShiftNode final: public BinaryNode
 {
 public:
     using BinaryNode::BinaryNode;

--- a/src/expressions/include/antares/expressions/nodes/TimeSumNode.h
+++ b/src/expressions/include/antares/expressions/nodes/TimeSumNode.h
@@ -24,7 +24,7 @@
 
 namespace Antares::Expressions::Nodes
 {
-class TimeSumNode: public ParentNode
+class TimeSumNode final: public ParentNode
 {
 public:
     /**

--- a/src/io/include/antares/io/statistics.h
+++ b/src/io/include/antares/io/statistics.h
@@ -95,7 +95,7 @@ void Reset();
 */
 void DumpToLogs();
 
-class Updater
+class Updater final
 {
 public:
     Updater()
@@ -109,7 +109,7 @@ public:
     }
 };
 
-class LogsDumper
+class LogsDumper final
 {
 public:
     LogsDumper()

--- a/src/io/inputs/data-series-csv-importer/include/antares/io/inputs/data-series-csv-importer/DataSeriesRepoImporter.h
+++ b/src/io/inputs/data-series-csv-importer/include/antares/io/inputs/data-series-csv-importer/DataSeriesRepoImporter.h
@@ -30,7 +30,7 @@
  */
 namespace Antares::IO::Inputs::DataSeriesCsvImporter
 {
-class DataSeriesRepoImporter
+class DataSeriesRepoImporter final
 {
 public:
     DataSeriesRepoImporter() = delete; // must not be used

--- a/src/io/inputs/model-converter/convertorVisitor.cpp
+++ b/src/io/inputs/model-converter/convertorVisitor.cpp
@@ -34,7 +34,7 @@ namespace Antares::IO::Inputs::ModelConverter
 using namespace Antares::Expressions::Nodes;
 
 /// Visitor to convert ANTLR expressions to Antares::Expressions::Nodes
-class ConvertorVisitor: public ExprVisitor
+class ConvertorVisitor final: public ExprVisitor
 {
 public:
     ConvertorVisitor(Expressions::Registry<Node>& registry, const YmlModel::Model& model);
@@ -116,7 +116,7 @@ std::any ConvertorVisitor::visit(antlr4::tree::ParseTree* tree)
     return tree->accept(this);
 }
 
-class NoParameterOrVariableWithThisName: public std::runtime_error
+class NoParameterOrVariableWithThisName final: public std::runtime_error
 {
 public:
     explicit NoParameterOrVariableWithThisName(const std::string& name):
@@ -225,7 +225,7 @@ std::any ConvertorVisitor::visitAddsub(ExprParser::AddsubContext* context)
                        : static_cast<Node*>(registry_.create<SubtractionNode>(left, right));
 }
 
-class NotImplemented: public std::runtime_error
+class NotImplemented final: public std::runtime_error
 {
 public:
     using std::runtime_error::runtime_error;

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/modelConverter.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/modelConverter.h
@@ -48,55 +48,55 @@ namespace Antares::IO::Inputs::ModelConverter
 ModelerStudy::SystemModel::Library convert(const YmlModel::Library& library);
 
 // EXCEPTIONS
-class UnknownTypeException: public std::runtime_error
+class UnknownTypeException final: public std::runtime_error
 {
 public:
     explicit UnknownTypeException(const std::string& type);
 };
 
-class PortWithThisIdAlreadyExists: public std::runtime_error
+class PortWithThisIdAlreadyExists final: public std::runtime_error
 {
 public:
     explicit PortWithThisIdAlreadyExists(const std::string& id);
 };
 
-class PortTypeWithThisIdAlreadyExists: public std::runtime_error
+class PortTypeWithThisIdAlreadyExists final: public std::runtime_error
 {
 public:
     explicit PortTypeWithThisIdAlreadyExists(const std::string& id);
 };
 
-class ConstraintWithThisIdAlreadyExists: public std::runtime_error
+class ConstraintWithThisIdAlreadyExists final: public std::runtime_error
 {
 public:
     explicit ConstraintWithThisIdAlreadyExists(const std::string& id);
 };
 
-class PortTypeDoesntContainsFields: public std::runtime_error
+class PortTypeDoesntContainsFields final: public std::runtime_error
 {
 public:
     explicit PortTypeDoesntContainsFields(const std::string& id);
 };
 
-class PortTypeNotFound: public std::runtime_error
+class PortTypeNotFound final: public std::runtime_error
 {
 public:
     explicit PortTypeNotFound(const std::string& portId, const std::string& portTypeId);
 };
 
-class PortNotFoundForDefinition: public std::runtime_error
+class PortNotFoundForDefinition final: public std::runtime_error
 {
 public:
     explicit PortNotFoundForDefinition(const std::string& portId);
 };
 
-class FieldNotFoundForDefinition: public std::runtime_error
+class FieldNotFoundForDefinition final: public std::runtime_error
 {
 public:
     explicit FieldNotFoundForDefinition(const std::string& portId, const std::string& fieldId);
 };
 
-class PortInDefinition: public std::runtime_error
+class PortInDefinition final: public std::runtime_error
 {
 public:
     explicit PortInDefinition(const std::string& portId, const std::string& portInDefId);

--- a/src/io/inputs/yml-model/include/antares/io/inputs/yml-model/parser.h
+++ b/src/io/inputs/yml-model/include/antares/io/inputs/yml-model/parser.h
@@ -25,7 +25,7 @@
 
 namespace Antares::IO::Inputs::YmlModel
 {
-class Parser
+class Parser final
 {
 public:
     Parser() = default;

--- a/src/io/inputs/yml-system/converter.cpp
+++ b/src/io/inputs/yml-system/converter.cpp
@@ -35,7 +35,7 @@ using namespace Antares::ModelerStudy::SystemModel; // Mainly for type Connexion
 namespace Antares::IO::Inputs::SystemConverter
 {
 
-class ErrorWhileSplittingLibraryAndModel: public std::runtime_error
+class ErrorWhileSplittingLibraryAndModel final: public std::runtime_error
 {
 public:
     explicit ErrorWhileSplittingLibraryAndModel(const std::string& s):
@@ -44,7 +44,7 @@ public:
     }
 };
 
-class LibraryNotFound: public std::runtime_error
+class LibraryNotFound final: public std::runtime_error
 {
 public:
     explicit LibraryNotFound(const std::string& s):
@@ -53,7 +53,7 @@ public:
     }
 };
 
-class ModelNotFound: public std::runtime_error
+class ModelNotFound final: public std::runtime_error
 {
 public:
     explicit ModelNotFound(const std::string& s):

--- a/src/io/inputs/yml-system/include/antares/io/inputs/yml-system/parser.h
+++ b/src/io/inputs/yml-system/include/antares/io/inputs/yml-system/parser.h
@@ -24,7 +24,7 @@
 
 namespace Antares::IO::Inputs::YmlSystem
 {
-class Parser
+class Parser final
 {
 public:
     System parse(const std::string& content);

--- a/src/io/outputs/include/antares/io/outputs/SimulationTableCsvFile.h
+++ b/src/io/outputs/include/antares/io/outputs/SimulationTableCsvFile.h
@@ -24,7 +24,7 @@
 
 #include "SimulationTableCsv.h"
 
-class SimulationTableCsvFile: public SimulationTableCsv
+class SimulationTableCsvFile final: public SimulationTableCsv
 {
 public:
     SimulationTableCsvFile(const std::filesystem::path& outputFolder,

--- a/src/io/outputs/include/antares/io/outputs/columns.h
+++ b/src/io/outputs/include/antares/io/outputs/columns.h
@@ -83,7 +83,7 @@ static std::string FormatValue(const U& v)
 }
 
 template<typename T>
-class TypedColumn: public IColumn
+class TypedColumn final: public IColumn
 {
 public:
     TypedColumn() = default;

--- a/src/libs/antares/InfoCollection/include/antares/infoCollection/StudyInfoCollector.h
+++ b/src/libs/antares/InfoCollection/include/antares/infoCollection/StudyInfoCollector.h
@@ -30,7 +30,7 @@ namespace Benchmarking
 {
 class FileContent;
 
-class StudyInfoCollector
+class StudyInfoCollector final
 {
 public:
     StudyInfoCollector(const Antares::Data::Study& study):
@@ -63,7 +63,7 @@ struct OptimizationInfo
     unsigned int nbConstraints = 0;
 };
 
-class SimulationInfoCollector
+class SimulationInfoCollector final
 {
 public:
     SimulationInfoCollector(const OptimizationInfo& optInfo):

--- a/src/libs/antares/args/include/antares/args/args_to_utf8.h
+++ b/src/libs/antares/args/include/antares/args/args_to_utf8.h
@@ -22,7 +22,7 @@
 
 #include <utility>
 
-class IntoUTF8ArgsTranslator
+class IntoUTF8ArgsTranslator final
 {
 public:
     IntoUTF8ArgsTranslator(int argc, const char** argv);

--- a/src/libs/antares/benchmarking/include/antares/benchmarking/DurationCollector.h
+++ b/src/libs/antares/benchmarking/include/antares/benchmarking/DurationCollector.h
@@ -32,7 +32,7 @@
 namespace Benchmarking
 {
 
-class DurationCollector
+class DurationCollector final
 {
 public:
     void toFileContent(FileContent& file_content);

--- a/src/libs/antares/benchmarking/include/antares/benchmarking/file_content.h
+++ b/src/libs/antares/benchmarking/include/antares/benchmarking/file_content.h
@@ -26,7 +26,7 @@
 
 namespace Benchmarking
 {
-class FileContent
+class FileContent final
 {
 public:
     FileContent() = default;

--- a/src/libs/antares/benchmarking/include/antares/benchmarking/timer.h
+++ b/src/libs/antares/benchmarking/include/antares/benchmarking/timer.h
@@ -25,7 +25,7 @@
 
 namespace Benchmarking
 {
-class Timer
+class Timer final
 {
 public:
     Timer();

--- a/src/libs/antares/concurrency/concurrency.cpp
+++ b/src/libs/antares/concurrency/concurrency.cpp
@@ -33,7 +33,7 @@ namespace
 /*!
  * Just wraps an arbitrary task as a yuni job, and allows to retrieve the corresponding future.
  */
-class PackagedJob: public Yuni::Job::IJob
+class PackagedJob final: public Yuni::Job::IJob
 {
 public:
     PackagedJob(const Task& task):

--- a/src/libs/antares/date/include/antares/date/date.h
+++ b/src/libs/antares/date/include/antares/date/date.h
@@ -176,7 +176,7 @@ struct DayInterval
     }
 }; // class DayInterval
 
-class Calendar
+class Calendar final
 {
 public:
     //! Short string representation with maximum 42 characters

--- a/src/libs/antares/exception/include/antares/exception/AssertionError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/AssertionError.hpp
@@ -25,7 +25,7 @@
 
 namespace Antares::Data
 {
-class AssertionError: public std::runtime_error
+class AssertionError final: public std::runtime_error
 {
 public:
     explicit AssertionError(const std::string& message);

--- a/src/libs/antares/exception/include/antares/exception/InitializationError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/InitializationError.hpp
@@ -25,7 +25,7 @@
 
 namespace Antares::Solver::Initialization::Error
 {
-class NoQueueService: public std::runtime_error
+class NoQueueService final: public std::runtime_error
 {
 public:
     NoQueueService():

--- a/src/libs/antares/exception/include/antares/exception/InvalidArgumentError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/InvalidArgumentError.hpp
@@ -25,7 +25,7 @@
 
 namespace Antares::Error
 {
-class InvalidArgumentError: public std::invalid_argument
+class InvalidArgumentError final: public std::invalid_argument
 {
 public:
     using std::invalid_argument::invalid_argument;

--- a/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
@@ -38,140 +38,140 @@ public:
     using std::runtime_error::runtime_error;
 };
 
-class StudyFolderDoesNotExist: public LoadingError
+class StudyFolderDoesNotExist final: public LoadingError
 {
 public:
     explicit StudyFolderDoesNotExist(const std::string& folder);
 };
 
-class StudyFolderContainsNonASCIIchars: public LoadingError
+class StudyFolderContainsNonASCIIchars final: public LoadingError
 {
 public:
     explicit StudyFolderContainsNonASCIIchars(const std::string& folder);
 };
 
-class ReadingStudy: public LoadingError
+class ReadingStudy final: public LoadingError
 {
 public:
     ReadingStudy();
 };
 
-class NoAreas: public LoadingError
+class NoAreas final: public LoadingError
 {
 public:
     NoAreas();
 };
 
-class Duplicates: public LoadingError
+class Duplicates final: public LoadingError
 {
 public:
     Duplicates();
 };
 
-class InvalidFileName: public LoadingError
+class InvalidFileName final: public LoadingError
 {
 public:
     InvalidFileName();
 };
 
-class RuntimeInfoInitialization: public LoadingError
+class RuntimeInfoInitialization final: public LoadingError
 {
 public:
     RuntimeInfoInitialization();
 };
 
-class WritingPID: public LoadingError
+class WritingPID final: public LoadingError
 {
 public:
     explicit WritingPID(const std::string& filePath);
 };
 
-class IncompatibleParallelOptions: public LoadingError
+class IncompatibleParallelOptions final: public LoadingError
 {
 public:
     IncompatibleParallelOptions();
 };
 
-class IncompatibleMILPOrtoolsSolver: public LoadingError
+class IncompatibleMILPOrtoolsSolver final: public LoadingError
 {
 public:
     IncompatibleMILPOrtoolsSolver();
 };
 
-class UseMILPsolverWithWrongOptions: public LoadingError
+class UseMILPsolverWithWrongOptions final: public LoadingError
 {
 public:
     UseMILPsolverWithWrongOptions();
 };
 
-class IncompatibleOptRangeHydroPricing: public LoadingError
+class IncompatibleOptRangeHydroPricing final: public LoadingError
 {
 public:
     IncompatibleOptRangeHydroPricing();
 };
 
-class IncompatibleOptRangeUCMode: public LoadingError
+class IncompatibleOptRangeUCMode final: public LoadingError
 {
 public:
     IncompatibleOptRangeUCMode();
 };
 
-class InvalidOptimizationRange: public LoadingError
+class InvalidOptimizationRange final: public LoadingError
 {
 public:
     InvalidOptimizationRange();
 };
 
-class InvalidSimulationMode: public LoadingError
+class InvalidSimulationMode final: public LoadingError
 {
 public:
     InvalidSimulationMode();
 };
 
-class InvalidSolver: public LoadingError
+class InvalidSolver final: public LoadingError
 {
 public:
     explicit InvalidSolver(const std::string& solver, const std::string& availableSolverList);
 };
 
-class InvalidSolverSpecificParameters: public LoadingError
+class InvalidSolverSpecificParameters final: public LoadingError
 {
 public:
     explicit InvalidSolverSpecificParameters(const std::string& solver,
                                              const std::string& specificParameters);
 };
 
-class IncompatibleLinearSolverParameters: public LoadingError
+class IncompatibleLinearSolverParameters final: public LoadingError
 {
 public:
     IncompatibleLinearSolverParameters();
 };
 
-class InvalidStudy: public LoadingError
+class InvalidStudy final: public LoadingError
 {
 public:
     explicit InvalidStudy(const std::string& study);
 };
 
-class NoStudyProvided: public LoadingError
+class NoStudyProvided final: public LoadingError
 {
 public:
     NoStudyProvided();
 };
 
-class InvalidVersion: public LoadingError
+class InvalidVersion final: public LoadingError
 {
 public:
     InvalidVersion(const std::string& version, const std::string& latest);
 };
 
-class IncompatibleDailyOptHeuristicForArea: public LoadingError
+class IncompatibleDailyOptHeuristicForArea final: public LoadingError
 {
 public:
     explicit IncompatibleDailyOptHeuristicForArea(const Antares::Data::AreaName& name);
 };
 
-class InvalidParametersForThermalClusters: public LoadingError
+class InvalidParametersForThermalClusters final: public LoadingError
 {
 public:
     explicit InvalidParametersForThermalClusters(const std::map<int, Yuni::String>& clusterNames);
@@ -180,43 +180,43 @@ private:
     std::string buildMessage(const std::map<int, Yuni::String>& clusterNames) const;
 };
 
-class CommandLineArguments: public LoadingError
+class CommandLineArguments final: public LoadingError
 {
 public:
     explicit CommandLineArguments(uint errors);
 };
 
-class IncompatibleSimulationModeForAdqPatch: public LoadingError
+class IncompatibleSimulationModeForAdqPatch final: public LoadingError
 {
 public:
     IncompatibleSimulationModeForAdqPatch();
 };
 
-class NoAreaInsideAdqPatchMode: public LoadingError
+class NoAreaInsideAdqPatchMode final: public LoadingError
 {
 public:
     NoAreaInsideAdqPatchMode();
 };
 
-class IncompatibleHurdleCostCSR: public LoadingError
+class IncompatibleHurdleCostCSR final: public LoadingError
 {
 public:
     IncompatibleHurdleCostCSR();
 };
 
-class IncompatibleOutputOptions: public LoadingError
+class IncompatibleOutputOptions final: public LoadingError
 {
 public:
     explicit IncompatibleOutputOptions(const std::string& text);
 };
 
-class IncompatibleCO2CostColumns: public LoadingError
+class IncompatibleCO2CostColumns final: public LoadingError
 {
 public:
     IncompatibleCO2CostColumns();
 };
 
-class IncompatibleFuelCostColumns: public LoadingError
+class IncompatibleFuelCostColumns final: public LoadingError
 {
 public:
     IncompatibleFuelCostColumns();

--- a/src/libs/antares/exception/include/antares/exception/RuntimeError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/RuntimeError.hpp
@@ -25,7 +25,7 @@
 
 namespace Antares::Error
 {
-class RuntimeError: public std::runtime_error
+class RuntimeError final: public std::runtime_error
 {
 public:
     using std::runtime_error::runtime_error;

--- a/src/libs/antares/exception/include/antares/exception/UnfeasibleProblemError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/UnfeasibleProblemError.hpp
@@ -25,7 +25,7 @@
 
 namespace Antares::Data
 {
-class UnfeasibleProblemError: public std::runtime_error
+class UnfeasibleProblemError final: public std::runtime_error
 {
 public:
     explicit UnfeasibleProblemError(const std::string& message);

--- a/src/libs/antares/include/antares/antares/fatal-error.h
+++ b/src/libs/antares/include/antares/antares/fatal-error.h
@@ -28,7 +28,7 @@ namespace Antares
 /*!
 ** \brief A generic exception for errors that should end the program.
 */
-class FatalError: public std::runtime_error
+class FatalError final: public std::runtime_error
 {
 public:
     using std::runtime_error::runtime_error;

--- a/src/libs/antares/optimization-options/include/antares/optimization-options/options.h
+++ b/src/libs/antares/optimization-options/include/antares/optimization-options/options.h
@@ -50,7 +50,7 @@ struct CmdLineOptimOptions
     bool solverLogs = false;
 };
 
-class OptimizationOptions
+class OptimizationOptions final
 {
 public:
     void initializeWith(const CmdLineOptimOptions& cmdLineOptimOptions);

--- a/src/libs/antares/paths/include/antares/paths/list.h
+++ b/src/libs/antares/paths/include/antares/paths/list.h
@@ -44,7 +44,7 @@ enum PathListOption
 /*!
 ** \brief Path list structure
 */
-class PathList
+class PathList final
 {
 public:
     struct FileInfo

--- a/src/libs/antares/paths/list.cpp
+++ b/src/libs/antares/paths/list.cpp
@@ -115,7 +115,7 @@ uint PathList::internalDeleteAllFiles()
     return count;
 }
 
-class PathListIterator: public IO::Directory::IIterator<true>
+class PathListIterator final: public IO::Directory::IIterator<true>
 {
 public:
     using IteratorType = IO::Directory::IIterator<true>;

--- a/src/libs/antares/scenarioGroupParser/ScenarioGroupParser.cpp
+++ b/src/libs/antares/scenarioGroupParser/ScenarioGroupParser.cpp
@@ -30,7 +30,7 @@
 
 namespace Antares
 {
-class ScenarioBuilderImplVisitor: public ScenarioBuilderBaseVisitor
+class ScenarioBuilderImplVisitor final: public ScenarioBuilderBaseVisitor
 {
 public:
     std::any visitRules(ScenarioBuilderParser::RulesContext* ctx) override

--- a/src/libs/antares/scenarioGroupParser/include/antares/scenarioGroupParser/ScenarioGroupParser.h
+++ b/src/libs/antares/scenarioGroupParser/include/antares/scenarioGroupParser/ScenarioGroupParser.h
@@ -24,7 +24,7 @@
 
 namespace Antares
 {
-class ScenarioGroupParser
+class ScenarioGroupParser final
 {
 public:
     struct Line

--- a/src/libs/antares/series/include/antares/series/series.h
+++ b/src/libs/antares/series/include/antares/series/series.h
@@ -38,7 +38,7 @@ namespace Antares::Data
  */
 class TimeSeries;
 
-class TimeSeriesNumbers
+class TimeSeriesNumbers final
 {
 public:
     void registerSeries(const TimeSeries* s, std::string label);
@@ -61,7 +61,7 @@ private:
     std::map<std::string, const TimeSeries*> series;
 };
 
-class TimeSeries
+class TimeSeries final
 {
 public:
     using TS = Matrix<double>;

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintGroup.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintGroup.h
@@ -32,7 +32,7 @@
 namespace Antares::Data
 {
 
-class BindingConstraintGroup
+class BindingConstraintGroup final
 {
 public:
     explicit BindingConstraintGroup(std::string name);

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintGroupRepository.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintGroupRepository.h
@@ -37,7 +37,7 @@
 namespace Antares::Data
 {
 
-class BindingConstraintGroupRepository
+class BindingConstraintGroupRepository final
 {
 public:
     [[nodiscard]] unsigned size() const;

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintLoader.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintLoader.h
@@ -37,7 +37,7 @@ namespace Antares::Data
 
 class BindingConstraint;
 
-class BindingConstraintLoader
+class BindingConstraintLoader final
 {
 public:
     std::vector<std::shared_ptr<BindingConstraint>> load(EnvForLoading env);

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintSaver.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintSaver.h
@@ -30,7 +30,7 @@
 
 namespace Antares::Data
 {
-class BindingConstraintSaver
+class BindingConstraintSaver final
 {
 public:
     class EnvForSaving final

--- a/src/libs/antares/study/include/antares/study/finder/finder.h
+++ b/src/libs/antares/study/include/antares/study/finder/finder.h
@@ -36,7 +36,7 @@ namespace Antares::Data
 /*!
 ** \brief Look for study folders asynchronously
 */
-class StudyFinder final
+class StudyFinder
 {
 public:
     enum

--- a/src/libs/antares/study/include/antares/study/finder/finder.h
+++ b/src/libs/antares/study/include/antares/study/finder/finder.h
@@ -36,7 +36,7 @@ namespace Antares::Data
 /*!
 ** \brief Look for study folders asynchronously
 */
-class StudyFinder
+class StudyFinder final
 {
 public:
     enum

--- a/src/libs/antares/study/include/antares/study/load-options.h
+++ b/src/libs/antares/study/include/antares/study/load-options.h
@@ -30,7 +30,7 @@
 
 namespace Antares::Data
 {
-class StudyLoadOptions
+class StudyLoadOptions final
 {
 public:
     //! \name Constructor

--- a/src/libs/antares/study/include/antares/study/parameters/adq-patch-params.h
+++ b/src/libs/antares/study/include/antares/study/parameters/adq-patch-params.h
@@ -62,7 +62,7 @@ enum class AdqPatchPTO
 
 }; // enum AdqPatchPTO
 
-class CurtailmentSharing
+class CurtailmentSharing final
 {
 public:
     //! PTO (Price Taking Order) for adequacy patch. User can choose between DENS and Load.

--- a/src/libs/antares/study/include/antares/study/parts/hydro/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/container.h
@@ -82,7 +82,7 @@ struct AreaDependantHydroManagementData
 /*!
 ** \brief Hydro for a single area
 */
-class PartHydro
+class PartHydro final
 {
 public:
     enum

--- a/src/libs/antares/study/include/antares/study/parts/hydro/prepro.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/prepro.h
@@ -31,7 +31,7 @@ namespace Antares::Data
 ** \brief Data for the hydro preprocessor
 ** \ingroup hydroprepro
 */
-class PreproHydro
+class PreproHydro final
 {
 public:
     enum

--- a/src/libs/antares/study/include/antares/study/parts/hydro/series.h
+++ b/src/libs/antares/study/include/antares/study/parts/hydro/series.h
@@ -34,7 +34,7 @@ namespace Antares::Data
 /*!
 ** \brief Data series (Hydro)
 */
-class DataSeriesHydro
+class DataSeriesHydro final
 {
 public:
     //! \name Constructor

--- a/src/libs/antares/study/include/antares/study/parts/load/prepro.h
+++ b/src/libs/antares/study/include/antares/study/parts/load/prepro.h
@@ -28,7 +28,7 @@ namespace Antares::Data::Load
 /*!
 ** \brief Prepro Load
 */
-class Prepro
+class Prepro final
 {
 public:
     //! \name Constructor & Destructor

--- a/src/libs/antares/study/include/antares/study/parts/renewable/cluster_list.h
+++ b/src/libs/antares/study/include/antares/study/parts/renewable/cluster_list.h
@@ -34,7 +34,7 @@ namespace Antares::Data
 ** \brief List of renewable clusters
 ** \ingroup renewableclusters
 */
-class RenewableClusterList: public ClusterList<RenewableCluster>
+class RenewableClusterList final: public ClusterList<RenewableCluster>
 {
 public:
     std::string typeID() const override;

--- a/src/libs/antares/study/include/antares/study/parts/renewable/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/renewable/container.h
@@ -29,7 +29,7 @@
 
 namespace Antares::Data
 {
-class PartRenewable
+class PartRenewable final
 {
 public:
     //! \name Constructor

--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/cluster.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/cluster.h
@@ -34,7 +34,7 @@
 
 namespace Antares::Data::ShortTermStorage
 {
-class STStorageCluster
+class STStorageCluster final
 {
 public:
     bool enabled() const;

--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/container.h
@@ -29,7 +29,7 @@
 
 namespace Antares::Data::ShortTermStorage
 {
-class STStorageInput
+class STStorageInput final
 {
 public:
     bool validate(StudyVersion studyVersion) const;

--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/makeGroupsOfHoursFromString.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/makeGroupsOfHoursFromString.h
@@ -38,7 +38,7 @@ struct ShortTermStorageAdditionalConstraintsError final: std::invalid_argument
     using std::invalid_argument::invalid_argument;
 };
 
-class CustomErrorListener: public antlr4::BaseErrorListener
+class CustomErrorListener final: public antlr4::BaseErrorListener
 {
 public:
     void syntaxError(antlr4::Recognizer* recognizer,

--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/properties.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/properties.h
@@ -27,7 +27,7 @@
 
 namespace Antares::Data::ShortTermStorage
 {
-class Properties
+class Properties final
 {
 public:
     bool validate();

--- a/src/libs/antares/study/include/antares/study/parts/solar/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/solar/container.h
@@ -27,7 +27,7 @@ namespace Antares::Data::Solar
 {
 class Prepro;
 
-class Container
+class Container final
 {
 public:
     //! \name Constructor & Destructor

--- a/src/libs/antares/study/include/antares/study/parts/solar/prepro.h
+++ b/src/libs/antares/study/include/antares/study/parts/solar/prepro.h
@@ -28,7 +28,7 @@ namespace Antares::Data::Solar
 /*!
 ** \brief Prepro Solar
 */
-class Prepro
+class Prepro final
 {
 public:
     //! \name Constructor & Destructor

--- a/src/libs/antares/study/include/antares/study/parts/thermal/cluster_list.h
+++ b/src/libs/antares/study/include/antares/study/parts/thermal/cluster_list.h
@@ -32,7 +32,7 @@ namespace Antares::Data
 ** \brief List of clusters
 ** \ingroup thermalclusters
 */
-class ThermalClusterList: public ClusterList<ThermalCluster>
+class ThermalClusterList final: public ClusterList<ThermalCluster>
 {
 public:
     std::string typeID() const override;

--- a/src/libs/antares/study/include/antares/study/parts/thermal/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/thermal/container.h
@@ -27,7 +27,7 @@
 
 namespace Antares::Data
 {
-class PartThermal
+class PartThermal final
 {
 public:
     //! \name Constructor

--- a/src/libs/antares/study/include/antares/study/parts/thermal/cost_provider.h
+++ b/src/libs/antares/study/include/antares/study/parts/thermal/cost_provider.h
@@ -37,7 +37,7 @@ public:
 
 class ThermalCluster;
 
-class ConstantCostProvider: public CostProvider
+class ConstantCostProvider final: public CostProvider
 {
 public:
     explicit ConstantCostProvider(const ThermalCluster& cluster);
@@ -50,7 +50,7 @@ private:
     const ThermalCluster& cluster;
 };
 
-class ScenarizedCostProvider: public CostProvider
+class ScenarizedCostProvider final: public CostProvider
 {
 public:
     explicit ScenarizedCostProvider(const ThermalCluster& cluster);

--- a/src/libs/antares/study/include/antares/study/parts/thermal/ecoInput.h
+++ b/src/libs/antares/study/include/antares/study/parts/thermal/ecoInput.h
@@ -32,7 +32,7 @@ namespace Antares::Data
 /*!
 ** \brief Thermal
 */
-class EconomicInputData
+class EconomicInputData final
 {
 public:
     //! \name Constructor

--- a/src/libs/antares/study/include/antares/study/parts/thermal/pollutant.h
+++ b/src/libs/antares/study/include/antares/study/parts/thermal/pollutant.h
@@ -28,7 +28,7 @@
 namespace Antares::Data
 {
 
-class Pollutant
+class Pollutant final
 {
 public:
     enum PollutantEnum

--- a/src/libs/antares/study/include/antares/study/scenario-builder/BindingConstraintsTSNumbersData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/BindingConstraintsTSNumbersData.h
@@ -28,7 +28,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-class BindingConstraintsTSNumberData: public TSNumberData
+class BindingConstraintsTSNumberData final: public TSNumberData
 {
 public:
     BindingConstraintsTSNumberData() = default;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/HydroTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/HydroTSNumberData.h
@@ -25,7 +25,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-class hydroTSNumberData: public TSNumberData
+class hydroTSNumberData final: public TSNumberData
 {
 public:
     bool apply(Study& study) override;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/NTCTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/NTCTSNumberData.h
@@ -27,7 +27,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-class ntcTSNumberData: public TSNumberData
+class ntcTSNumberData final: public TSNumberData
 {
 public:
     ntcTSNumberData() = default;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/RenewableTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/RenewableTSNumberData.h
@@ -28,7 +28,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-class renewableTSNumberData: public TSNumberData
+class renewableTSNumberData final: public TSNumberData
 {
 public:
     renewableTSNumberData() = default;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/ShortTermAdditionalConstraintsTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/ShortTermAdditionalConstraintsTSNumberData.h
@@ -30,7 +30,7 @@ class AdditionalConstraints;
 
 namespace Antares::Data::ScenarioBuilder
 {
-class ShortTermAdditionalConstraintsTSNumberData: public TSNumberData
+class ShortTermAdditionalConstraintsTSNumberData final: public TSNumberData
 {
 public:
     bool apply(Study& study) override;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/ShortTermInflowsTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/ShortTermInflowsTSNumberData.h
@@ -30,7 +30,7 @@ class STStorageCluster;
 
 namespace Antares::Data::ScenarioBuilder
 {
-class ShortTermInflowsTSNumberData: public TSNumberData
+class ShortTermInflowsTSNumberData final: public TSNumberData
 {
 public:
     bool apply(Study& study) override;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/ThermalTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/ThermalTSNumberData.h
@@ -28,7 +28,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-class thermalTSNumberData: public TSNumberData
+class thermalTSNumberData final: public TSNumberData
 {
 public:
     thermalTSNumberData() = default;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/WindTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/WindTSNumberData.h
@@ -25,7 +25,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-class windTSNumberData: public TSNumberData
+class windTSNumberData final: public TSNumberData
 {
 public:
     bool apply(Study& study) override;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/solarTSNumberData.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/solarTSNumberData.h
@@ -29,7 +29,7 @@
 
 namespace Antares::Data::ScenarioBuilder
 {
-class solarTSNumberData: public TSNumberData
+class solarTSNumberData final: public TSNumberData
 {
 public:
     bool apply(Study& study) override;

--- a/src/libs/antares/study/include/antares/study/scenario-builder/updater.hxx
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/updater.hxx
@@ -33,7 +33,7 @@ namespace Antares
 {
 namespace // anonymous
 {
-class ScenarioBuilderUpdater
+class ScenarioBuilderUpdater final
 {
 public:
     ScenarioBuilderUpdater(Data::Study& study):

--- a/src/libs/antares/study/include/antares/study/sets.h
+++ b/src/libs/antares/study/include/antares/study/sets.h
@@ -258,7 +258,7 @@ private:
     mutable bool pModified = false;
 }; // class Sets
 
-class SetHandlerAreas
+class SetHandlerAreas final
 {
 public:
     explicit SetHandlerAreas(AreaList& areas);

--- a/src/libs/antares/study/include/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/include/antares/study/variable-print-info.h
@@ -34,7 +34,7 @@ namespace Antares::Data
 {
 // Represents an output variable (wears the same name) and mainly answers the question :
 // Is the real variable printed in all output reports ? Or is it not printed in any report ?
-class VariablePrintInfo
+class VariablePrintInfo final
 {
 public:
     VariablePrintInfo(uint dataLvl, uint fileLvl);
@@ -78,7 +78,7 @@ private:
 
 class AllVariablesPrintInfo;
 
-class variablePrintInfoCollector
+class variablePrintInfoCollector final
 {
 public:
     variablePrintInfoCollector(AllVariablesPrintInfo* allvarsprintinfo);
@@ -91,7 +91,7 @@ private:
 // Variables print info collection. Mainly a vector of pointers to print info.
 // This collection is filled with as many print info as we can find output variables in the output
 // variables Antares's static list.
-class AllVariablesPrintInfo
+class AllVariablesPrintInfo final
 {
 public:
     // Public methods

--- a/src/libs/antares/study/include/antares/study/version.h
+++ b/src/libs/antares/study/include/antares/study/version.h
@@ -32,7 +32,7 @@ namespace Antares::Data
 ** \ingroup study
 ** \see CHANGELOG.txt
 */
-class StudyVersion
+class StudyVersion final
 {
 public:
     /// allows automatic members comparison

--- a/src/libs/antares/study/output.cpp
+++ b/src/libs/antares/study/output.cpp
@@ -37,7 +37,7 @@ namespace // anonymous
 {
 
 // TODO VP: remove with GUI
-class OutputFolderIterator: public IO::Directory::IIterator<true>
+class OutputFolderIterator final: public IO::Directory::IIterator<true>
 {
 public:
     using IteratorType = IO::Directory::IIterator<true>;

--- a/src/libs/antares/study/parts/short-term-storage/makeGroupsOfHoursFromString.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/makeGroupsOfHoursFromString.cpp
@@ -45,7 +45,7 @@ void CustomErrorListener::syntaxError(antlr4::Recognizer*,
     throw ShortTermStorageAdditionalConstraintsError(os.str());
 }
 
-class GroupsHours
+class GroupsHours final
 {
 public:
     explicit GroupsHours(const std::string& hoursField):

--- a/src/libs/antares/utils/include/antares/utils/utils.h
+++ b/src/libs/antares/utils/include/antares/utils/utils.h
@@ -67,7 +67,7 @@ std::map<std::string, unsigned> giveNumbersToStrings(const std::vector<std::stri
 bool checkAllElementsIdenticalOrOne(std::vector<unsigned> w);
 bool checkAllElementsIdenticalOrOne(std::vector<std::pair<unsigned, std::string>>& p);
 
-class TimeMeasurement
+class TimeMeasurement final
 {
     using clock = std::chrono::steady_clock;
 

--- a/src/libs/antares/writer/include/antares/writer/in_memory_writer.h
+++ b/src/libs/antares/writer/include/antares/writer/in_memory_writer.h
@@ -31,7 +31,7 @@
 
 namespace Antares::Solver
 {
-class InMemoryWriter: public IResultWriter
+class InMemoryWriter final: public IResultWriter
 {
 public:
     using MapType = std::map<std::string, std::string, std::less<>>;

--- a/src/libs/antares/writer/private/ensure_queue_started.h
+++ b/src/libs/antares/writer/private/ensure_queue_started.h
@@ -25,7 +25,7 @@
 
 namespace Antares::Solver
 {
-class EnsureQueueStartedIfNeeded
+class EnsureQueueStartedIfNeeded final
 {
 public:
     explicit EnsureQueueStartedIfNeeded(IResultWriter* writer,

--- a/src/libs/antares/writer/private/immediate_file_writer.h
+++ b/src/libs/antares/writer/private/immediate_file_writer.h
@@ -29,7 +29,7 @@
 
 namespace Antares::Solver
 {
-class ImmediateFileResultWriter: public IResultWriter
+class ImmediateFileResultWriter final: public IResultWriter
 {
 public:
     ImmediateFileResultWriter(const std::filesystem::path& folderOutput);

--- a/src/libs/antares/writer/private/zip_writer.h
+++ b/src/libs/antares/writer/private/zip_writer.h
@@ -45,7 +45,7 @@ class ZipWriter;
  * May be used as a function object.
  */
 template<class ContentT>
-class ZipWriteJob
+class ZipWriteJob final
 {
 public:
     ZipWriteJob(ZipWriter& writer,
@@ -74,7 +74,7 @@ private:
     Benchmarking::DurationCollector& pDurationCollector;
 };
 
-class ZipWriter: public IResultWriter
+class ZipWriter final: public IResultWriter
 {
 public:
     ZipWriter(std::shared_ptr<Yuni::Job::QueueService> qs,

--- a/src/libs/fswalker/filejob.inc.hxx
+++ b/src/libs/fswalker/filejob.inc.hxx
@@ -27,7 +27,7 @@ using namespace Yuni;
 
 namespace FSWalker
 {
-class FileJob: public IJob
+class FileJob final: public IJob
 {
 public:
     FileJob(EventsRegistry& events):

--- a/src/libs/fswalker/statistics.h
+++ b/src/libs/fswalker/statistics.h
@@ -25,7 +25,7 @@
 
 namespace FSWalker
 {
-class Statistics
+class Statistics final
 {
 public:
     Statistics():

--- a/src/modeler/loadFiles/include/antares/solver/modeler/loadFiles/Fileloader.h
+++ b/src/modeler/loadFiles/include/antares/solver/modeler/loadFiles/Fileloader.h
@@ -25,7 +25,7 @@
 
 namespace Antares::Solver::LoadFiles
 {
-class FileLoader: public ILoader
+class FileLoader final: public ILoader
 {
 public:
     explicit FileLoader(std::filesystem::path studyPath);

--- a/src/modeler/loadFiles/include/antares/solver/modeler/loadFiles/loadFiles.h
+++ b/src/modeler/loadFiles/include/antares/solver/modeler/loadFiles/loadFiles.h
@@ -55,7 +55,7 @@ Optimisation::ScenarioGroupRepository loadScenarioGroupRepository(
 void handleYamlError(const YAML::Exception& e, const std::string& context);
 
 /// Generic error class for all loading errors to catch in the main
-class ErrorLoadingYaml: public std::runtime_error
+class ErrorLoadingYaml final: public std::runtime_error
 {
 public:
     explicit ErrorLoadingYaml(const std::string& s):

--- a/src/modeler/modeler/Modeler.cpp
+++ b/src/modeler/modeler/Modeler.cpp
@@ -49,7 +49,7 @@ Modeler::Modeler(ILoader& loader, IWriter& writer):
 {
 }
 
-class SystemLinearProblemBuilder
+class SystemLinearProblemBuilder final
 {
 public:
     explicit SystemLinearProblemBuilder(const ModelerStudy::SystemModel::System* system):

--- a/src/modeler/modeler/include/antares/solver/modeler/Modeler.h
+++ b/src/modeler/modeler/include/antares/solver/modeler/Modeler.h
@@ -25,7 +25,7 @@ namespace Antares::Solver
 class ILoader;
 class IWriter;
 
-class Modeler
+class Modeler final
 {
 public:
     Modeler(ILoader& loader, IWriter& writer);

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/ILinearProblemData.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/ILinearProblemData.h
@@ -30,7 +30,7 @@ namespace Antares::Optimisation::LinearProblemApi
 /** \brief Context for filling linear problem data.
  * Contains temporal information
  */
-class FillContext
+class FillContext final
 {
 public:
     FillContext(unsigned localFirstTimeStep,

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/IScenario.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/IScenario.h
@@ -61,7 +61,7 @@ private:
  * Provide a default implementation of IScenario that returns 0 for any year for a group named
  * "empty"
  */
-class EmptyScenario: public IScenario
+class EmptyScenario final: public IScenario
 {
 public:
     EmptyScenario():

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/linearProblemBuilder.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/linearProblemBuilder.h
@@ -28,7 +28,7 @@
 namespace Antares::Optimisation::LinearProblemApi
 {
 
-class LinearProblemBuilder
+class LinearProblemBuilder final
 {
 public:
     explicit LinearProblemBuilder(std::vector<std::unique_ptr<LinearProblemFiller>>& fillers);

--- a/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/Scenario.h
+++ b/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/Scenario.h
@@ -25,7 +25,7 @@
 
 namespace Antares::Optimisation::LinearProblemDataImpl
 {
-class Scenario: public LinearProblemApi::IScenario
+class Scenario final: public LinearProblemApi::IScenario
 {
 public:
     using IScenario::IScenario;
@@ -34,13 +34,13 @@ public:
 
     void setTimeSerieNumber(Year year, TimeSeriesNumber timeSeriesNumber);
 
-    class AlreadyExists: public std::invalid_argument
+    class AlreadyExists final: public std::invalid_argument
     {
     public:
         explicit AlreadyExists(const std::string& groupId);
     };
 
-    class ScenarioNotExist: public std::invalid_argument
+    class ScenarioNotExist final: public std::invalid_argument
     {
     public:
         explicit ScenarioNotExist(const std::string& groupId, Year year);

--- a/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/timeSeriesSet.h
+++ b/src/optimisation/linear-problem-data-impl/include/antares/optimisation/linear-problem-data-impl/timeSeriesSet.h
@@ -39,7 +39,7 @@ private:
     std::vector<std::vector<double>> tsSet_;
 
 public:
-    class AddTSofWrongSize: public std::invalid_argument
+    class AddTSofWrongSize final: public std::invalid_argument
     {
     public:
         explicit AddTSofWrongSize(const std::string& name,
@@ -47,19 +47,19 @@ public:
                                   const unsigned& height);
     };
 
-    class Empty: public std::invalid_argument
+    class Empty final: public std::invalid_argument
     {
     public:
         explicit Empty(const std::string& name);
     };
 
-    class RankTooBig: public std::invalid_argument
+    class RankTooBig final: public std::invalid_argument
     {
     public:
         explicit RankTooBig(const std::string& name, unsigned rank, unsigned tsSetSize);
     };
 
-    class HourTooBig: public std::invalid_argument
+    class HourTooBig final: public std::invalid_argument
     {
     public:
         explicit HourTooBig(const std::string& name, unsigned hour);

--- a/src/solver/hydro/include/antares/solver/hydro/daily2/h2o2_j_donnees_optimisation.h
+++ b/src/solver/hydro/include/antares/solver/hydro/daily2/h2o2_j_donnees_optimisation.h
@@ -145,7 +145,7 @@ constexpr double noiseAmplitude = 1e-3;
 constexpr unsigned int seed = 0x79683264; // "hyd2" in hexa
 } // namespace Antares::Constants
 
-class Hydro_problem_costs
+class Hydro_problem_costs final
 {
 public:
     Hydro_problem_costs(const Data::Parameters& parameters);

--- a/src/solver/hydro/include/antares/solver/hydro/management/HydroErrorsCollector.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/HydroErrorsCollector.h
@@ -28,10 +28,10 @@
 namespace Antares
 {
 
-class HydroErrorsCollector
+class HydroErrorsCollector final
 {
 public:
-    class AreaReference
+    class AreaReference final
     {
     public:
         AreaReference(HydroErrorsCollector* collector, const std::string& name);

--- a/src/solver/hydro/include/antares/solver/hydro/management/HydroInputsChecker.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/HydroInputsChecker.h
@@ -29,7 +29,7 @@
 namespace Antares
 {
 
-class HydroInputsChecker
+class HydroInputsChecker final
 {
 public:
     explicit HydroInputsChecker(Antares::Data::Study& study);

--- a/src/solver/hydro/include/antares/solver/hydro/management/MinGenerationScaling.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/MinGenerationScaling.h
@@ -27,7 +27,7 @@ namespace Antares
 {
 
 //! Prepare minimum generation scaling for each area
-class MinGenerationScaling
+class MinGenerationScaling final
 {
 public:
     MinGenerationScaling(Data::AreaList& areas, const Date::Calendar& calendar);

--- a/src/solver/hydro/include/antares/solver/hydro/management/finalLevelValidator.h
+++ b/src/solver/hydro/include/antares/solver/hydro/management/finalLevelValidator.h
@@ -38,7 +38,7 @@ class PartHydro;
 
 namespace Solver
 {
-class FinalLevelValidator
+class FinalLevelValidator final
 {
 public:
     FinalLevelValidator(const Antares::Data::PartHydro& hydro,

--- a/src/solver/lps/include/antares/solver/lps/LpsFromAntares.h
+++ b/src/solver/lps/include/antares/solver/lps/LpsFromAntares.h
@@ -112,7 +112,7 @@ using WeeklyDataByYearWeek = std::map<WeeklyProblemId, WeeklyDataFromAntares>;
  * @brief The LpsFromAntares class is used to manage the constant and weekly data for Antares
  * problems.
  */
-class LpsFromAntares
+class LpsFromAntares final
 {
 public:
     /*

--- a/src/solver/misc/include/antares/solver/misc/options.h
+++ b/src/solver/misc/include/antares/solver/misc/options.h
@@ -32,7 +32,7 @@
 /*!
 ** \brief Command line settings for launching the simulation
 */
-class Settings
+class Settings final
 {
 public:
     void reset();

--- a/src/solver/misc/include/antares/solver/misc/system-memory.h
+++ b/src/solver/misc/include/antares/solver/misc/system-memory.h
@@ -24,7 +24,7 @@
 #include <yuni/yuni.h>
 #include <yuni/thread/timer.h>
 
-class SystemMemoryLogger: public Yuni::Thread::Timer
+class SystemMemoryLogger final: public Yuni::Thread::Timer
 {
 public:
     SystemMemoryLogger();

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/EvaluationContextProvider.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/EvaluationContextProvider.h
@@ -28,7 +28,7 @@
 
 namespace Antares::Optimisation
 {
-class EvaluationContextProvider: public Expressions::IEvaluationContextProvider
+class EvaluationContextProvider final: public Expressions::IEvaluationContextProvider
 {
 public:
     explicit EvaluationContextProvider(const LinearProblemApi::ILinearProblemData& data,

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/FullKey.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/FullKey.h
@@ -40,7 +40,7 @@ struct boost::hash<Antares::Optimization::PartialKey>
 namespace Antares::Optimization
 {
 
-class FullKey
+class FullKey final
 {
 public:
     FullKey(const std::string& component, const std::string& variable);
@@ -68,7 +68,7 @@ private:
     std::optional<unsigned int> timestep;
 };
 
-class FullKeyHash
+class FullKeyHash final
 {
 public:
     std::size_t operator()(const FullKey& p) const;

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/LinearExpression.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/LinearExpression.h
@@ -133,7 +133,7 @@ using RawTerm = std::pair<FullKey, double>;
  * - the non-zero coefficients of the variables
  * - a scalar offset
  */
-class LinearExpression
+class LinearExpression final
 {
 public:
     /// Build a linear expression with zero offset and zero coefficients

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/PartialKey.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/PartialKey.h
@@ -25,7 +25,7 @@
 
 namespace Antares::Optimization
 {
-class PartialKey
+class PartialKey final
 {
 public:
     PartialKey(const std::string& component_id, const std::string& variable_id);
@@ -41,7 +41,7 @@ private:
     std::string variable_id;
 };
 
-class PartialKeyHash
+class PartialKeyHash final
 {
 public:
     std::size_t operator()(const PartialKey& p) const;

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearConstraintVisitor.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearConstraintVisitor.h
@@ -51,7 +51,7 @@ struct LinearConstraint
     unsigned int timeStep = 0;
 };
 
-class ReadLinearConstraintVisitor
+class ReadLinearConstraintVisitor final
     : public Expressions::Visitors::NodeVisitor<std::vector<LinearConstraint>>
 {
 public:

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
@@ -40,7 +40,7 @@
 namespace Antares::Optimization
 {
 
-class ReadLinearExpressionVisitor
+class ReadLinearExpressionVisitor final
     : public Expressions::Visitors::NodeVisitor<TimeDependentLinearExpression>
 {
 public:

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
@@ -31,7 +31,7 @@ namespace Antares::Optimization
 using LinearExpressionMap = std::map<unsigned int, LinearExpression>;
 
 // time dependent parameter
-class TimeDependentLinearExpression
+class TimeDependentLinearExpression final
 {
 public:
     explicit TimeDependentLinearExpression(

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/VariableDictionary.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/VariableDictionary.h
@@ -44,7 +44,7 @@ struct IntegerInterval
     unsigned int initialTime = 0;
     unsigned int finalTime = 0;
 
-    class Iterator
+    class Iterator final
     {
     public:
         explicit Iterator(unsigned int current);
@@ -72,7 +72,7 @@ struct IntegerInterval
     }
 };
 
-class Dimensions
+class Dimensions final
 {
 public:
     Dimensions() = default;
@@ -89,11 +89,11 @@ private:
     std::optional<IntegerInterval> timeInterval;
 };
 
-class VariableDictionary
+class VariableDictionary final
 {
     using Value = Optimisation::LinearProblemApi::IMipVariable*;
 
-    class VectorWithOffset
+    class VectorWithOffset final
     {
     public:
         VectorWithOffset() = default;

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/scenarioGroupRepo.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/scenarioGroupRepo.h
@@ -8,7 +8,7 @@
 
 namespace Antares::Optimisation
 {
-class ScenarioGroupRepository
+class ScenarioGroupRepository final
 {
 public:
     void addScenario(const std::string& groupId,
@@ -20,13 +20,13 @@ private:
     std::map<std::string, std::unique_ptr<LinearProblemApi::IScenario>> scenarioGroups_;
 
 public:
-    class AlreadyExists: public std::invalid_argument
+    class AlreadyExists final: public std::invalid_argument
     {
     public:
         explicit AlreadyExists(const std::string& groupId);
     };
 
-    class DoesNotExist: public std::invalid_argument
+    class DoesNotExist final: public std::invalid_argument
     {
     public:
         explicit DoesNotExist(const std::string& groupId);

--- a/src/solver/optim-model-filler/scenarioGroupRepo.cpp
+++ b/src/solver/optim-model-filler/scenarioGroupRepo.cpp
@@ -37,7 +37,7 @@ void ScenarioGroupRepository::addScenario(const std::string& groupId,
     scenarioGroups_[gId] = std::move(scenario);
 }
 
-class DefaultScenario: public Optimisation::LinearProblemApi::IScenario
+class DefaultScenario final: public Optimisation::LinearProblemApi::IScenario
 {
 public:
     using IScenario::IScenario;

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -104,7 +104,7 @@ void ComponentToAreaConnectionFiller::addExpressionToConstraint(
 }
 
 // TODO remove and use proper scenario
-class DefaultScenario: public IScenario
+class DefaultScenario final: public IScenario
 {
 public:
     using IScenario::IScenario;

--- a/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
@@ -38,7 +38,8 @@ namespace Antares::Optimization
  * This class is responsible for adding variables, constraints, and objectives to the linear problem
  * based on the connections between components and areas in the Antares study.
  */
-class ComponentToAreaConnectionFiller: public Optimisation::LinearProblemApi::LinearProblemFiller
+class ComponentToAreaConnectionFiller final
+    : public Optimisation::LinearProblemApi::LinearProblemFiller
 {
 public:
     explicit ComponentToAreaConnectionFiller(

--- a/src/solver/optimisation/include/antares/solver/optimisation/HebdoProblemToLpsTranslator.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/HebdoProblemToLpsTranslator.h
@@ -35,7 +35,7 @@ namespace Antares::Solver
  * This class is a custom exception class that is thrown when an error occurs during the translation
  * of a weekly problem.
  */
-class WeeklyProblemTranslationException: public std::runtime_error
+class WeeklyProblemTranslationException final: public std::runtime_error
 {
 public:
     explicit WeeklyProblemTranslationException(const std::string& string) noexcept;
@@ -47,7 +47,7 @@ public:
  *
  * This class is responsible for translating a weekly problem to a linear programming problem.
  */
-class HebdoProblemToLpsTranslator
+class HebdoProblemToLpsTranslator final
 {
 public:
     /**

--- a/src/solver/optimisation/include/antares/solver/optimisation/LegacyFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/LegacyFiller.h
@@ -7,7 +7,7 @@
 
 namespace Antares::Optimization
 {
-class LegacyFiller: public Optimisation::LinearProblemApi::LinearProblemFiller
+class LegacyFiller final: public Optimisation::LinearProblemApi::LinearProblemFiller
 {
 public:
     explicit LegacyFiller(const PROBLEME_HEBDO* problemeHebdo, bool namedProblems);

--- a/src/solver/optimisation/include/antares/solver/optimisation/LinearProblemMatrix.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/LinearProblemMatrix.h
@@ -37,7 +37,7 @@
 
 using namespace Antares::Data;
 
-class LinearProblemMatrix: public ProblemMatrixEssential
+class LinearProblemMatrix final: public ProblemMatrixEssential
 {
 public:
     explicit LinearProblemMatrix(PROBLEME_HEBDO* problemeHebdo, ConstraintBuilder& builder);

--- a/src/solver/optimisation/include/antares/solver/optimisation/LinearProblemMatrixStartUpCosts.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/LinearProblemMatrixStartUpCosts.h
@@ -33,7 +33,7 @@
 
 using namespace Antares::Data;
 
-class LinearProblemMatrixStartUpCosts: public ProblemMatrixEssential
+class LinearProblemMatrixStartUpCosts final: public ProblemMatrixEssential
 {
 public:
     explicit LinearProblemMatrixStartUpCosts(PROBLEME_HEBDO* problemeHebdo,

--- a/src/solver/optimisation/include/antares/solver/optimisation/QuadraticProblemMatrix.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/QuadraticProblemMatrix.h
@@ -26,7 +26,7 @@
 #include "ProblemMatrixEssential.h"
 #include "constraints/ExchangeBalanceGroup.h"
 
-class QuadraticProblemMatrix: public ProblemMatrixEssential
+class QuadraticProblemMatrix final: public ProblemMatrixEssential
 {
 public:
     QuadraticProblemMatrix(PROBLEME_HEBDO* problem_hebdo, ConstraintBuilder& builder):

--- a/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/adq_patch_post_process_list.h
@@ -27,7 +27,7 @@
 namespace Antares::Solver::Simulation
 {
 
-class AdqPatchPostProcessList: public interfacePostProcessList
+class AdqPatchPostProcessList final: public interfacePostProcessList
 {
     using AdqPatchParams = Antares::Data::AdequacyPatch::AdqPatchParams;
 

--- a/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/constraints/CsrAreaBalance.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/constraints/CsrAreaBalance.h
@@ -39,7 +39,7 @@ struct CsrAreaBalanceData
     const uint32_t NombreDePays;
 };
 
-class CsrAreaBalance: private ConstraintFactory
+class CsrAreaBalance final: private ConstraintFactory
 {
 public:
     CsrAreaBalance(ConstraintBuilder& builder, CsrAreaBalanceData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/constraints/CsrBindingConstraintHour.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/constraints/CsrBindingConstraintHour.h
@@ -31,7 +31,7 @@ struct CsrBindingConstraintHourData
     std::map<int, int>& numberOfConstraintCsrHourlyBinding;
 };
 
-class CsrBindingConstraintHour: private ConstraintFactory
+class CsrBindingConstraintHour final: private ConstraintFactory
 {
 public:
     CsrBindingConstraintHour(ConstraintBuilder& builder, CsrBindingConstraintHourData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/constraints/CsrFlowDissociation.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/constraints/CsrFlowDissociation.h
@@ -35,7 +35,7 @@ struct CsrFlowDissociationData
     const int hour;
 };
 
-class CsrFlowDissociation: private ConstraintFactory
+class CsrFlowDissociation final: private ConstraintFactory
 {
 public:
     CsrFlowDissociation(ConstraintBuilder& builder, CsrFlowDissociationData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/csr_quadratic_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/csr_quadratic_problem.h
@@ -27,7 +27,7 @@ class HourlyCSRProblem;
 namespace Antares::Solver::Optimization
 {
 
-class CsrQuadraticProblem
+class CsrQuadraticProblem final
 {
 public:
     CsrQuadraticProblem(PROBLEME_HEBDO* p,

--- a/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/hourly_csr_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/adequacy_patch_csr/hourly_csr_problem.h
@@ -65,7 +65,7 @@ struct LinkVariable
 
 struct PROBLEME_HEBDO;
 
-class HourlyCSRProblem
+class HourlyCSRProblem final
 {
     using AdqPatchParams = Antares::Data::AdequacyPatch::AdqPatchParams;
 

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/AreaBalance.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/AreaBalance.h
@@ -36,7 +36,7 @@ struct AreaBalanceData
  * represent 'Area Balance' constraint type
  */
 
-class AreaBalance: public ConstraintFactory
+class AreaBalance final: public ConstraintFactory
 {
 public:
     AreaBalance(ConstraintBuilder& builder, AreaBalanceData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/AreaHydroLevel.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/AreaHydroLevel.h
@@ -32,7 +32,7 @@ struct AreaHydroLevelData
  * represent 'Area Hydraulic Level' constraint type
  */
 
-class AreaHydroLevel: private ConstraintFactory
+class AreaHydroLevel final: private ConstraintFactory
 {
 public:
     AreaHydroLevel(ConstraintBuilder& builder, AreaHydroLevelData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/AreaHydroLevelGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/AreaHydroLevelGroup.h
@@ -23,7 +23,7 @@
 #include "AreaHydroLevel.h"
 #include "ConstraintGroup.h"
 
-class AreaHydroLevelGroup: public ConstraintGroup
+class AreaHydroLevelGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintDay.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintDay.h
@@ -35,7 +35,7 @@ struct BindingConstraintDayData
  * represent 'Daily Binding Constraint' type
  */
 
-class BindingConstraintDay: private ConstraintFactory
+class BindingConstraintDay final: private ConstraintFactory
 {
 public:
     BindingConstraintDay(ConstraintBuilder& builder, BindingConstraintDayData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintDayGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintDayGroup.h
@@ -23,7 +23,7 @@
 #include "BindingConstraintDay.h"
 #include "ConstraintGroup.h"
 
-class BindingConstraintDayGroup: public ConstraintGroup
+class BindingConstraintDayGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintHour.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintHour.h
@@ -32,7 +32,7 @@ struct BindingConstraintHourData
 /*!
  * represent 'Hourly Binding Constraint' type
  */
-class BindingConstraintHour: private ConstraintFactory
+class BindingConstraintHour final: private ConstraintFactory
 {
 public:
     BindingConstraintHour(ConstraintBuilder& builder, BindingConstraintHourData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintWeek.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintWeek.h
@@ -33,7 +33,7 @@ struct BindingConstraintWeekData
  * represent 'Hourly Binding Constraint' type
  */
 
-class BindingConstraintWeek: private ConstraintFactory
+class BindingConstraintWeek final: private ConstraintFactory
 {
 public:
     BindingConstraintWeek(ConstraintBuilder& builder, BindingConstraintWeekData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintWeekGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/BindingConstraintWeekGroup.h
@@ -23,7 +23,7 @@
 #include "BindingConstraintWeek.h"
 #include "ConstraintGroup.h"
 
-class BindingConstraintWeekGroup: public ConstraintGroup
+class BindingConstraintWeekGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ConsistenceNumberOfDispatchableUnits.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ConsistenceNumberOfDispatchableUnits.h
@@ -25,7 +25,7 @@
 /*!
  * represent 'Consistence Number Of Dispatchable Units Constraint' type
  */
-class ConsistenceNumberOfDispatchableUnits: private ConstraintFactory
+class ConsistenceNumberOfDispatchableUnits final: private ConstraintFactory
 {
 public:
     ConsistenceNumberOfDispatchableUnits(ConstraintBuilder& builder, StartUpCostsData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ConsistenceNumberOfDispatchableUnitsGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ConsistenceNumberOfDispatchableUnitsGroup.h
@@ -28,7 +28,7 @@
  *
  */
 
-class ConsistenceNumberOfDispatchableUnitsGroup: public AbstractStartUpCostsGroup
+class ConsistenceNumberOfDispatchableUnitsGroup final: public AbstractStartUpCostsGroup
 {
 public:
     using AbstractStartUpCostsGroup::AbstractStartUpCostsGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ConstraintBuilder.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ConstraintBuilder.h
@@ -31,7 +31,7 @@
 #include "../variables/VariableManagement.h"
 
 // TODO God struct should be decomposed
-class ConstraintBuilderData
+class ConstraintBuilderData final
 {
 public:
     std::vector<double>& Pi;
@@ -66,7 +66,7 @@ ex: calling NTCDirect() implies adding Direct NTC Variable to the current Constr
 finally the build() method gather all variables and put them into the matrix
 \endverbatim
 */
-class ConstraintBuilder
+class ConstraintBuilder final
 {
 public:
     ConstraintBuilder() = delete;
@@ -164,7 +164,7 @@ public:
 
     //@}
 
-    class ConstraintBuilderInvalidOperator: public std::runtime_error
+    class ConstraintBuilderInvalidOperator final: public std::runtime_error
     {
     public:
         using std::runtime_error::runtime_error;
@@ -280,7 +280,7 @@ inline void ExportPaliers(const PALIERS_THERMIQUES& PaliersThermiquesDuPays,
     }
 }
 
-class BindingConstraintData
+class BindingConstraintData final
 {
 public:
     const char& TypeDeContrainteCouplante;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ExchangeBalance.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ExchangeBalance.h
@@ -32,7 +32,7 @@ struct ExchangeBalanceData
     std::vector<int>& NumeroDeContrainteDeSoldeDEchange;
 };
 
-class ExchangeBalance: private ConstraintFactory
+class ExchangeBalance final: private ConstraintFactory
 {
 public:
     ExchangeBalance(ConstraintBuilder& builder, ExchangeBalanceData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ExchangeBalanceGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ExchangeBalanceGroup.h
@@ -23,7 +23,7 @@
 #include "ConstraintGroup.h"
 #include "ExchangeBalance.h"
 
-class ExchangeBalanceGroup: public ConstraintGroup
+class ExchangeBalanceGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/FictitiousLoad.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/FictitiousLoad.h
@@ -33,7 +33,7 @@ struct FictitiousLoadData
 /*!
  * represent 'Fictitious Load' constraint type
  */
-class FictitiousLoad: private ConstraintFactory
+class FictitiousLoad final: private ConstraintFactory
 {
 public:
     FictitiousLoad(ConstraintBuilder& builder, FictitiousLoadData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/FinalStockEquivalent.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/FinalStockEquivalent.h
@@ -31,7 +31,7 @@ struct FinalStockEquivalentData
 /*!
  * represent 'Final Stock Equivalent' constraint type
  */
-class FinalStockEquivalent: private ConstraintFactory
+class FinalStockEquivalent final: private ConstraintFactory
 {
 public:
     FinalStockEquivalent(ConstraintBuilder& builder, FinalStockEquivalentData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/FinalStockExpression.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/FinalStockExpression.h
@@ -32,7 +32,7 @@ struct FinalStockExpressionData
 /*!
  * represent 'Final Stock Expression' constraint type
  */
-class FinalStockExpression: private ConstraintFactory
+class FinalStockExpression final: private ConstraintFactory
 {
 public:
     FinalStockExpression(ConstraintBuilder& builder, FinalStockExpressionData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/FinalStockGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/FinalStockGroup.h
@@ -24,7 +24,7 @@
 #include "FinalStockEquivalent.h"
 #include "FinalStockExpression.h"
 
-class FinalStockGroup: public ConstraintGroup
+class FinalStockGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/FlowDissociation.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/FlowDissociation.h
@@ -34,7 +34,7 @@ struct FlowDissociationData
  * represent 'Flow Dissociation' constraint type
  */
 
-class FlowDissociation: private ConstraintFactory
+class FlowDissociation final: private ConstraintFactory
 {
 public:
     FlowDissociation(ConstraintBuilder& builder, FlowDissociationData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/Group1.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/Group1.h
@@ -27,7 +27,7 @@
 #include "FlowDissociation.h"
 #include "ShortTermStorageLevel.h"
 
-class Group1: public ConstraintGroup
+class Group1 final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydraulicSmoothingGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydraulicSmoothingGroup.h
@@ -22,7 +22,7 @@
 #pragma once
 #include "ConstraintGroup.h"
 
-class HydraulicSmoothingGroup: public ConstraintGroup
+class HydraulicSmoothingGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPower.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPower.h
@@ -33,7 +33,7 @@ struct HydroPowerData
  * represent 'Hydraulic Power' constraint type
  */
 
-class HydroPower: private ConstraintFactory
+class HydroPower final: private ConstraintFactory
 {
 public:
     HydroPower(ConstraintBuilder& builder, HydroPowerData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPowerGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPowerGroup.h
@@ -23,7 +23,7 @@
 #include "ConstraintGroup.h"
 #include "HydroPower.h"
 
-class HydroPowerGroup: public ConstraintGroup
+class HydroPowerGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPowerSmoothingUsingVariationMaxDown.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPowerSmoothingUsingVariationMaxDown.h
@@ -26,7 +26,7 @@
  * represent 'Hydraulic Power Smoothing Using Variation Max Down' constraint type
  */
 
-class HydroPowerSmoothingUsingVariationMaxDown: private ConstraintFactory
+class HydroPowerSmoothingUsingVariationMaxDown final: private ConstraintFactory
 {
 public:
     using ConstraintFactory::ConstraintFactory;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPowerSmoothingUsingVariationMaxUp.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPowerSmoothingUsingVariationMaxUp.h
@@ -25,7 +25,7 @@
 /*!
  * represent 'Hydraulic Power Smoothing Using Variation Max Up' constraint type
  */
-class HydroPowerSmoothingUsingVariationMaxUp: private ConstraintFactory
+class HydroPowerSmoothingUsingVariationMaxUp final: private ConstraintFactory
 {
 public:
     using ConstraintFactory::ConstraintFactory;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPowerSmoothingUsingVariationSum.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/HydroPowerSmoothingUsingVariationSum.h
@@ -27,7 +27,7 @@
  * represent 'Hydraulic Power Smoothing Using Variation Sum' constraint type
  */
 
-class HydroPowerSmoothingUsingVariationSum: private ConstraintFactory
+class HydroPowerSmoothingUsingVariationSum final: private ConstraintFactory
 {
 public:
     using ConstraintFactory::ConstraintFactory;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxHydroPower.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxHydroPower.h
@@ -32,7 +32,7 @@ struct MaxHydroPowerData
 /*!
  * represent 'Max Hydraulic Power' constraint type
  */
-class MaxHydroPower: private ConstraintFactory
+class MaxHydroPower final: private ConstraintFactory
 {
 public:
     MaxHydroPower(ConstraintBuilder& builder, MaxHydroPowerData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxPumping.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxPumping.h
@@ -32,7 +32,7 @@ struct MaxPumpingData
  * represent 'Max Pumping' constraint type
  */
 
-class MaxPumping: private ConstraintFactory
+class MaxPumping final: private ConstraintFactory
 {
 public:
     MaxPumping(ConstraintBuilder& builder, MaxPumpingData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxPumpingGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxPumpingGroup.h
@@ -23,7 +23,7 @@
 #include "ConstraintGroup.h"
 #include "MaxPumping.h"
 
-class MaxPumpingGroup: public ConstraintGroup
+class MaxPumpingGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MinDownTime.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MinDownTime.h
@@ -32,7 +32,7 @@ struct MinDownTimeData
 /*!
  * represent 'MinDownTime' Constraint type
  */
-class MinDownTime: private ConstraintFactory
+class MinDownTime final: private ConstraintFactory
 {
 public:
     MinDownTime(ConstraintBuilder& builder, MinDownTimeData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MinDownTimeGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MinDownTimeGroup.h
@@ -29,7 +29,7 @@
  *
  */
 
-class MinDownTimeGroup: public AbstractStartUpCostsGroup
+class MinDownTimeGroup final: public AbstractStartUpCostsGroup
 {
 public:
     using AbstractStartUpCostsGroup::AbstractStartUpCostsGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MinHydroPower.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MinHydroPower.h
@@ -33,7 +33,7 @@ struct MinHydroPowerData
  * represent 'Min Hydraulic Power' constraint type
  */
 
-class MinHydroPower: private ConstraintFactory
+class MinHydroPower final: private ConstraintFactory
 {
 public:
     MinHydroPower(ConstraintBuilder& builder, MinHydroPowerData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MinMaxHydroPowerGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MinMaxHydroPowerGroup.h
@@ -24,7 +24,7 @@
 #include "MaxHydroPower.h"
 #include "MinHydroPower.h"
 
-class MinMaxHydroPowerGroup: public ConstraintGroup
+class MinMaxHydroPowerGroup final: public ConstraintGroup
 {
 public:
     using ConstraintGroup::ConstraintGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/NbDispUnitsMinBoundSinceMinUpTime.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/NbDispUnitsMinBoundSinceMinUpTime.h
@@ -31,7 +31,7 @@ struct NbDispUnitsMinBoundSinceMinUpTimeData
 /*!
  * represent 'Number of Dispatchable Units Min Bound Since Min Up Time' type
  */
-class NbDispUnitsMinBoundSinceMinUpTime: private ConstraintFactory
+class NbDispUnitsMinBoundSinceMinUpTime final: private ConstraintFactory
 {
 public:
     NbDispUnitsMinBoundSinceMinUpTime(ConstraintBuilder& builder,

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/NbDispUnitsMinBoundSinceMinUpTimeGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/NbDispUnitsMinBoundSinceMinUpTimeGroup.h
@@ -29,7 +29,7 @@
  *
  */
 
-class NbDispUnitsMinBoundSinceMinUpTimeGroup: public AbstractStartUpCostsGroup
+class NbDispUnitsMinBoundSinceMinUpTimeGroup final: public AbstractStartUpCostsGroup
 {
 public:
     using AbstractStartUpCostsGroup::AbstractStartUpCostsGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/NbUnitsOutageLessThanNbUnitsStop.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/NbUnitsOutageLessThanNbUnitsStop.h
@@ -31,7 +31,7 @@ struct NbUnitsOutageLessThanNbUnitsStopData
 /*!
  * represent 'NbUnitsOutageLessThanNbUnitsStop' type
  */
-class NbUnitsOutageLessThanNbUnitsStop: private ConstraintFactory
+class NbUnitsOutageLessThanNbUnitsStop final: private ConstraintFactory
 {
 public:
     NbUnitsOutageLessThanNbUnitsStop(ConstraintBuilder& builder,

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/NbUnitsOutageLessThanNbUnitsStopGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/NbUnitsOutageLessThanNbUnitsStopGroup.h
@@ -29,7 +29,7 @@
  *
  */
 
-class NbUnitsOutageLessThanNbUnitsStopGroup: public AbstractStartUpCostsGroup
+class NbUnitsOutageLessThanNbUnitsStopGroup final: public AbstractStartUpCostsGroup
 {
 public:
     using AbstractStartUpCostsGroup::AbstractStartUpCostsGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/PMaxDispatchableGeneration.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/PMaxDispatchableGeneration.h
@@ -25,7 +25,7 @@
 /*!
  * represent 'PMaxDispatchableGeneration' Constraint type
  */
-class PMaxDispatchableGeneration: private ConstraintFactory
+class PMaxDispatchableGeneration final: private ConstraintFactory
 {
 public:
     PMaxDispatchableGeneration(ConstraintBuilder& builder, StartUpCostsData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/PMinDispatchableGeneration.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/PMinDispatchableGeneration.h
@@ -25,7 +25,7 @@
 /*!
  * represent 'PMinDispatchableGeneration' Constraint type
  */
-class PMinDispatchableGeneration: private ConstraintFactory
+class PMinDispatchableGeneration final: private ConstraintFactory
 {
 public:
     PMinDispatchableGeneration(ConstraintBuilder& builder, StartUpCostsData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/PMinMaxDispatchableGenerationGroup.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/PMinMaxDispatchableGenerationGroup.h
@@ -29,7 +29,7 @@
  * @brief Group of Pmin/PmaxDispatchableGenerationGroup constraints
  *
  */
-class PMinMaxDispatchableGenerationGroup: public AbstractStartUpCostsGroup
+class PMinMaxDispatchableGenerationGroup final: public AbstractStartUpCostsGroup
 {
 public:
     using AbstractStartUpCostsGroup::AbstractStartUpCostsGroup;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ShortTermStorageCostVariation.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ShortTermStorageCostVariation.h
@@ -45,7 +45,7 @@ protected:
     void addStorageConstraint(const std::string& constraintName, int pdt, int pays);
 };
 
-class ShortTermStorageCostVariationInjectionBackward: ShortTermStorageCostVariation
+class ShortTermStorageCostVariationInjectionBackward final: ShortTermStorageCostVariation
 {
 public:
     using ShortTermStorageCostVariation::ShortTermStorageCostVariation;
@@ -59,7 +59,7 @@ public:
     void buildConstraint(int index) override;
 };
 
-class ShortTermStorageCostVariationInjectionForward: ShortTermStorageCostVariation
+class ShortTermStorageCostVariationInjectionForward final: ShortTermStorageCostVariation
 {
 public:
     using ShortTermStorageCostVariation::ShortTermStorageCostVariation;
@@ -73,7 +73,7 @@ public:
     void buildConstraint(int index) override;
 };
 
-class ShortTermStorageCostVariationWithdrawalBackward: ShortTermStorageCostVariation
+class ShortTermStorageCostVariationWithdrawalBackward final: ShortTermStorageCostVariation
 {
 public:
     using ShortTermStorageCostVariation::ShortTermStorageCostVariation;
@@ -87,7 +87,7 @@ public:
     void buildConstraint(int index) override;
 };
 
-class ShortTermStorageCostVariationWithdrawalForward: ShortTermStorageCostVariation
+class ShortTermStorageCostVariationWithdrawalForward final: ShortTermStorageCostVariation
 {
 public:
     using ShortTermStorageCostVariation::ShortTermStorageCostVariation;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ShortTermStorageCumulation.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ShortTermStorageCumulation.h
@@ -22,7 +22,7 @@
 #pragma once
 #include "ConstraintBuilder.h"
 
-class ShortTermStorageCumulation: ConstraintFactory
+class ShortTermStorageCumulation final: ConstraintFactory
 {
 public:
     ShortTermStorageCumulation(ConstraintBuilder& builder,

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ShortTermStorageLevel.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ShortTermStorageLevel.h
@@ -22,7 +22,7 @@
 #pragma once
 #include "ConstraintBuilder.h"
 
-class ShortTermStorageLevel: private ConstraintFactory
+class ShortTermStorageLevel final: private ConstraintFactory
 {
 public:
     ShortTermStorageLevel(ConstraintBuilder& builder, ShortTermStorageData& data):

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_structure_probleme_a_resoudre.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_structure_probleme_a_resoudre.h
@@ -34,7 +34,7 @@ class MPSolver;
 /*--------------------------------------------------------------------------------------*/
 
 /* Le probleme a resoudre */
-class PROBLEME_ANTARES_A_RESOUDRE
+class PROBLEME_ANTARES_A_RESOUDRE final
 {
 public:
     /* La matrice des contraintes */

--- a/src/solver/optimisation/include/antares/solver/optimisation/optim_post_process_list.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/optim_post_process_list.h
@@ -25,7 +25,7 @@
 
 namespace Antares::Solver::Simulation
 {
-class OptPostProcessList: public interfacePostProcessList
+class OptPostProcessList final: public interfacePostProcessList
 {
 public:
     OptPostProcessList(PROBLEME_HEBDO* problemeHebdo,

--- a/src/solver/optimisation/include/antares/solver/optimisation/post_process_commands.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/post_process_commands.h
@@ -24,7 +24,7 @@
 
 namespace Antares::Solver::Simulation
 {
-class DispatchableMarginPostProcessCmd: public basePostProcessCommand
+class DispatchableMarginPostProcessCmd final: public basePostProcessCommand
 {
 public:
     DispatchableMarginPostProcessCmd(PROBLEME_HEBDO* problemeHebdo,
@@ -37,7 +37,7 @@ private:
     const AreaList& area_list_;
 };
 
-class RemixHydroPostProcessCmd: public basePostProcessCommand
+class RemixHydroPostProcessCmd final: public basePostProcessCommand
 {
 public:
     RemixHydroPostProcessCmd(PROBLEME_HEBDO* problemeHebdo,
@@ -52,7 +52,7 @@ private:
     const Data::Parameters& params_;
 };
 
-class UpdateMrgPriceAfterCSRcmd: public basePostProcessCommand
+class UpdateMrgPriceAfterCSRcmd final: public basePostProcessCommand
 {
 public:
     UpdateMrgPriceAfterCSRcmd(PROBLEME_HEBDO* problemeHebdo,
@@ -65,7 +65,7 @@ private:
     unsigned int numSpace_ = 0;
 };
 
-class DTGnettingAfterCSRcmd: public basePostProcessCommand
+class DTGnettingAfterCSRcmd final: public basePostProcessCommand
 {
 public:
     DTGnettingAfterCSRcmd(PROBLEME_HEBDO* problemeHebdo, AreaList& areas, unsigned int numSpace);
@@ -76,7 +76,7 @@ private:
     unsigned int numSpace_ = 0;
 };
 
-class InterpolateWaterValuePostProcessCmd: public basePostProcessCommand
+class InterpolateWaterValuePostProcessCmd final: public basePostProcessCommand
 {
 public:
     InterpolateWaterValuePostProcessCmd(PROBLEME_HEBDO* problemeHebdo,
@@ -90,7 +90,7 @@ private:
     const Date::Calendar& calendar_;
 };
 
-class HydroLevelsFinalUpdatePostProcessCmd: public basePostProcessCommand
+class HydroLevelsFinalUpdatePostProcessCmd final: public basePostProcessCommand
 {
 public:
     HydroLevelsFinalUpdatePostProcessCmd(PROBLEME_HEBDO* problemeHebdo, AreaList& areas);
@@ -101,7 +101,7 @@ private:
     const AreaList& area_list_;
 };
 
-class CurtailmentSharingPostProcessCmd: public basePostProcessCommand
+class CurtailmentSharingPostProcessCmd final: public basePostProcessCommand
 {
 public:
     CurtailmentSharingPostProcessCmd(const AdqPatchParams& adqPatchParams,

--- a/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
@@ -29,7 +29,7 @@ class OptimisationsSimulationTable;
 namespace Antares::Solver::Optimization
 {
 
-class WeeklyOptimization
+class WeeklyOptimization final
 {
 public:
     WeeklyOptimization(const OptimizationOptions& options,

--- a/src/solver/optimisation/variables/VariableManagement.h
+++ b/src/solver/optimisation/variables/VariableManagement.h
@@ -8,7 +8,7 @@ namespace VariableManagement
 /*!
 Factory class that hold variables indices
 */
-class VariableManager
+class VariableManager final
 {
 public:
     VariableManager(std::vector<CORRESPONDANCES_DES_VARIABLES>& CorrespondanceVarNativesVarOptim,

--- a/src/solver/simulation/include/antares/solver/simulation/BindingConstraintsTimeSeriesNumbersWriter.h
+++ b/src/solver/simulation/include/antares/solver/simulation/BindingConstraintsTimeSeriesNumbersWriter.h
@@ -28,7 +28,7 @@
 
 namespace Antares::Solver::Simulation
 {
-class BindingConstraintsTimeSeriesNumbersWriter: public ITimeSeriesNumbersWriter
+class BindingConstraintsTimeSeriesNumbersWriter final: public ITimeSeriesNumbersWriter
 {
 public:
     explicit BindingConstraintsTimeSeriesNumbersWriter(IResultWriter& resultWriter);

--- a/src/solver/simulation/include/antares/solver/simulation/numspace_manager.h
+++ b/src/solver/simulation/include/antares/solver/simulation/numspace_manager.h
@@ -26,7 +26,7 @@
 
 namespace Antares::Solver::Simulation
 {
-class NumSpaceManager
+class NumSpaceManager final
 {
 public:
     explicit NumSpaceManager(unsigned N);

--- a/src/solver/simulation/include/antares/solver/simulation/opt_time_writer.h
+++ b/src/solver/simulation/include/antares/solver/simulation/opt_time_writer.h
@@ -26,7 +26,7 @@
 
 #include "simulation.h"
 
-class OptimizationStatisticsWriter
+class OptimizationStatisticsWriter final
 {
 public:
     void addTime(uint week, const TIME_MEASURES& timeMeasure);

--- a/src/solver/simulation/include/antares/solver/simulation/remix-storage/remix-utils.h
+++ b/src/solver/simulation/include/antares/solver/simulation/remix-storage/remix-utils.h
@@ -82,7 +82,7 @@ inline double min_on_subrange(std::vector<double>&& v, unsigned h, unsigned H)
 }
 
 template<typename T>
-class CyclicIterator
+class CyclicIterator final
 {
 public:
     CyclicIterator(std::vector<T>& v);

--- a/src/solver/simulation/include/antares/solver/simulation/remix-storage/storage-for-remix-interface.h
+++ b/src/solver/simulation/include/antares/solver/simulation/remix-storage/storage-for-remix-interface.h
@@ -41,7 +41,7 @@ private:
 
 using ListStorageForRemix = std::vector<std::shared_ptr<IStorageForRemix>>;
 
-class StorageListSort
+class StorageListSort final
 {
 public:
     void add(const double capacity, const std::shared_ptr<IStorageForRemix> sts);

--- a/src/solver/simulation/timeseries-numbers.cpp
+++ b/src/solver/simulation/timeseries-numbers.cpp
@@ -175,7 +175,7 @@ public:
     }
 };
 
-class IntraModalConsistencyChecker
+class IntraModalConsistencyChecker final
 {
 public:
     IntraModalConsistencyChecker(const TimeSeriesType ts,

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/generator.h
@@ -69,7 +69,7 @@ struct LinkTSgenerationParams
     bool hasValidData = true;
 };
 
-class AvailabilityTSGeneratorData
+class AvailabilityTSGeneratorData final
 {
 public:
     explicit AvailabilityTSGeneratorData(Data::ThermalCluster*);

--- a/src/solver/utils/basis_status_impl.h
+++ b/src/solver/utils/basis_status_impl.h
@@ -32,7 +32,7 @@ class BasisStatus;
 
 namespace Antares::Optimization
 {
-class BasisStatusImpl
+class BasisStatusImpl final
 {
 private:
     friend class BasisStatus;

--- a/src/solver/utils/include/antares/solver/utils/optimization_statistics.h
+++ b/src/solver/utils/include/antares/solver/utils/optimization_statistics.h
@@ -25,7 +25,7 @@
 #include <cmath>
 #include <string>
 
-class OptimizationStatistics
+class OptimizationStatistics final
 {
 private:
     std::atomic<long long> totalSolveTime;

--- a/src/solver/utils/include/antares/solver/utils/ortools_utils.h
+++ b/src/solver/utils/include/antares/solver/utils/ortools_utils.h
@@ -84,7 +84,7 @@ MPSolver* MPSolverFactory(const bool isMip, const std::string& solverName);
 std::string generateTempPath(const std::string& filename);
 void removeTemporaryFile(const std::string& tmpPath);
 
-class OrtoolsUtils
+class OrtoolsUtils final
 {
 public:
     struct SolverNames

--- a/src/study/system-model/include/antares/study/system-model/component.h
+++ b/src/study/system-model/include/antares/study/system-model/component.h
@@ -36,7 +36,7 @@ namespace Antares::ModelerStudy::SystemModel
  * Defines the attributes of the Component class
  * Made into a struct to avoid duplication in ComponentBuilder
  */
-class ComponentData
+class ComponentData final
 {
 public:
     std::string id;
@@ -56,7 +56,7 @@ public:
 /**
  * Defines an actual component of the simulated system.
  */
-class Component
+class Component final
 {
 public:
     // Only allowing one private constructor (see below) to forbid empty Components
@@ -116,7 +116,7 @@ protected:
     ComponentData data_;
 };
 
-class ComponentBuilder
+class ComponentBuilder final
 {
 public:
     ComponentBuilder& withId(std::string_view id);

--- a/src/study/system-model/include/antares/study/system-model/connection.h
+++ b/src/study/system-model/include/antares/study/system-model/connection.h
@@ -44,7 +44,7 @@ using PortFieldsRole = std::map<PortField, FieldRole>;
 
 class Component;
 
-class ConnectionEnd
+class ConnectionEnd final
 {
 public:
     ConnectionEnd(Component* component, const Port* port);

--- a/src/study/system-model/include/antares/study/system-model/constraint.h
+++ b/src/study/system-model/include/antares/study/system-model/constraint.h
@@ -36,7 +36,7 @@ namespace Antares::ModelerStudy::SystemModel
 {
 
 /// A constraint linking variables and parameters of a model together
-class Constraint
+class Constraint final
 {
 public:
     Constraint(std::string id, Expression expression):

--- a/src/study/system-model/include/antares/study/system-model/extraOutput.h
+++ b/src/study/system-model/include/antares/study/system-model/extraOutput.h
@@ -28,7 +28,7 @@ namespace Antares::ModelerStudy::SystemModel
 {
 
 /// An extra output expression
-class ExtraOutput
+class ExtraOutput final
 {
 public:
     ExtraOutput(std::string id, Expression expression):

--- a/src/study/system-model/include/antares/study/system-model/library.h
+++ b/src/study/system-model/include/antares/study/system-model/library.h
@@ -30,7 +30,7 @@ namespace Antares::ModelerStudy::SystemModel
 {
 
 /// A library is a collection of models
-class Library
+class Library final
 {
 public:
     Library() = default;
@@ -72,7 +72,7 @@ private:
  * Follow builder pattern:
  * builder.Library().withId("id").withDescription("description").withPortTypes(portList).withModels(modelList).build();
  */
-class LibraryBuilder
+class LibraryBuilder final
 {
 public:
     LibraryBuilder& withId(const std::string& id);

--- a/src/study/system-model/include/antares/study/system-model/model.h
+++ b/src/study/system-model/include/antares/study/system-model/model.h
@@ -42,7 +42,7 @@ struct PortFieldKey
     auto operator<=>(const PortFieldKey&) const = default;
 };
 
-class PortFieldKeyHash
+class PortFieldKeyHash final
 {
 public:
     std::size_t operator()(const PortFieldKey& input) const;
@@ -55,7 +55,7 @@ using PortFieldMap = std::unordered_map<PortFieldKey, PortFieldDefinition, PortF
  * A model defines the behaviour of those components.
  */
 // TODO: add unit tests for this class
-class Model
+class Model final
 {
 public:
     Model() = default;
@@ -122,7 +122,7 @@ private:
 };
 
 // List of IDs used internally to check for uniqueness of IDs at component level
-class UniqueIDChecker
+class UniqueIDChecker final
 {
 public:
     void add(const std::string& id);
@@ -133,7 +133,7 @@ private:
     std::unordered_map<std::string, int> attribute_ids_;
 };
 
-class ModelBuilder
+class ModelBuilder final
 {
 public:
     ModelBuilder& withId(std::string_view id);

--- a/src/study/system-model/include/antares/study/system-model/parameter.h
+++ b/src/study/system-model/include/antares/study/system-model/parameter.h
@@ -33,7 +33,7 @@ namespace Antares::ModelerStudy::SystemModel
  * When the model is instantiated as a component, a value must be provided for
  * parameters, either as constant values or timeseries-based values.
  */
-class Parameter
+class Parameter final
 {
 public:
     explicit Parameter(std::string id,

--- a/src/study/system-model/include/antares/study/system-model/port.h
+++ b/src/study/system-model/include/antares/study/system-model/port.h
@@ -27,7 +27,7 @@
 namespace Antares::ModelerStudy::SystemModel
 {
 
-class Port
+class Port final
 {
 public:
     Port(const std::string& id, const PortType& type):

--- a/src/study/system-model/include/antares/study/system-model/portFieldDefinition.h
+++ b/src/study/system-model/include/antares/study/system-model/portFieldDefinition.h
@@ -26,7 +26,7 @@
 namespace Antares::ModelerStudy::SystemModel
 {
 
-class PortFieldDefinition
+class PortFieldDefinition final
 {
 public:
     PortFieldDefinition(Port port, PortField field, Expression definition):

--- a/src/study/system-model/include/antares/study/system-model/portType.h
+++ b/src/study/system-model/include/antares/study/system-model/portType.h
@@ -31,7 +31,7 @@
 namespace Antares::ModelerStudy::SystemModel
 {
 
-class PortType
+class PortType final
 {
 public:
     PortType(const std::string& id,

--- a/src/study/system-model/include/antares/study/system-model/system.h
+++ b/src/study/system-model/include/antares/study/system-model/system.h
@@ -29,7 +29,7 @@ namespace Antares::ModelerStudy::SystemModel
 /**
  * Defines the simulated system.
  */
-class System
+class System final
 {
 public:
     // Only allowing one private constructor (see below) to forbid empty Systems
@@ -55,7 +55,7 @@ private:
     std::unordered_map<std::string, Component> components_;
 };
 
-class SystemBuilder
+class SystemBuilder final
 {
 public:
     SystemBuilder& withId(std::string_view id);

--- a/src/study/system-model/include/antares/study/system-model/variable.h
+++ b/src/study/system-model/include/antares/study/system-model/variable.h
@@ -31,7 +31,7 @@ namespace Antares::ModelerStudy::SystemModel
 {
 
 /// A decision variable of the model
-class Variable
+class Variable final
 {
 public:
     Variable(std::string id,

--- a/src/tests/end-to-end/modeler/test-modeler.cpp
+++ b/src/tests/end-to-end/modeler/test-modeler.cpp
@@ -52,7 +52,7 @@ private:
     double value_{0.};
 };
 
-class EmptyDataSeries: public ConstantDataSeries
+class EmptyDataSeries final: public ConstantDataSeries
 {
 public:
     EmptyDataSeries():
@@ -74,7 +74,7 @@ Antares::ModelerStudy::SystemModel::Component copyComponent(
       .build();
 }
 
-class DefaultScenario: public Antares::Optimisation::LinearProblemApi::IScenario
+class DefaultScenario final: public Antares::Optimisation::LinearProblemApi::IScenario
 {
 public:
     using IScenario::IScenario;
@@ -88,7 +88,7 @@ public:
 using Models = std::unordered_map<std::string, Antares::ModelerStudy::SystemModel::Model>;
 
 template<class Fixture>
-class InMemoryLoader: public Antares::Solver::ILoader
+class InMemoryLoader final: public Antares::Solver::ILoader
 {
 public:
     Antares::Solver::ModelerParameters loadParameters() override
@@ -197,7 +197,7 @@ struct Solution
     double objectiveValue{0.0};
 };
 
-class InMemoryWriter: public Antares::Solver::IWriter
+class InMemoryWriter final: public Antares::Solver::IWriter
 {
 public:
     mutable Solution solution_{};

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -37,7 +37,7 @@ using namespace Antares::Data::ScenarioBuilder;
 void initializeStudy(Data::Study* study);
 void configureLinkCapacities(AreaLink* link);
 
-class TimeSeriesConfigurer
+class TimeSeriesConfigurer final
 {
 public:
     TimeSeriesConfigurer() = default;
@@ -60,7 +60,7 @@ private:
     Matrix<>* ts_ = nullptr;
 };
 
-class ThermalClusterConfig
+class ThermalClusterConfig final
 {
 public:
     ThermalClusterConfig() = delete;
@@ -76,7 +76,7 @@ private:
     TimeSeriesConfigurer tsAvailablePowerConfig_;
 };
 
-class ShortTermStorageAddConstraintConfig
+class ShortTermStorageAddConstraintConfig final
 {
 public:
     ShortTermStorageAddConstraintConfig() = delete;
@@ -128,7 +128,7 @@ private:
     std::shared_ptr<Antares::Data::ShortTermStorage::AdditionalConstraints> constraint;
 };
 
-class ShortTermStorageConfig
+class ShortTermStorageConfig final
 
 {
 public:
@@ -169,7 +169,7 @@ void addScratchpadToEachArea(Data::Study& study);
 // -------------------------------
 // Simulation results retrieval
 // -------------------------------
-class averageResults
+class averageResults final
 {
 public:
     averageResults(Variable::R::AllYears::AverageData& averageResults):
@@ -211,7 +211,7 @@ private:
     Variable::R::AllYears::AverageData& averageResults_;
 };
 
-class OutputRetriever
+class OutputRetriever final
 {
 public:
     OutputRetriever(ISimulation<Economy>& simulation):
@@ -267,7 +267,7 @@ typename Variable::Storage<VCard>::ResultsType* OutputRetriever::retrieveResults
     return result;
 }
 
-class ScenarioBuilderRule
+class ScenarioBuilderRule final
 {
 public:
     ScenarioBuilderRule(Data::Study& study);
@@ -301,7 +301,7 @@ private:
 // Simulation handler
 // =====================
 
-class TestingSimulationObserver: public Solver::Simulation::ISimulationObserver
+class TestingSimulationObserver final: public Solver::Simulation::ISimulationObserver
 {
 public:
     struct Variable
@@ -336,7 +336,7 @@ public:
                             std::string_view name) override;
 };
 
-class SimulationHandler
+class SimulationHandler final
 {
 public:
     SimulationHandler(Data::Study& study):

--- a/src/tests/src/api_internal/test_api.cpp
+++ b/src/tests/src/api_internal/test_api.cpp
@@ -32,7 +32,7 @@
 #include "API.h"
 #include "in-memory-study.h"
 
-class InMemoryStudyLoader: public IStudyLoader
+class InMemoryStudyLoader final: public IStudyLoader
 {
 public:
     explicit InMemoryStudyLoader(bool success = true):

--- a/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
+++ b/src/tests/src/libs/antares/concurrency/test_concurrency.cpp
@@ -51,7 +51,7 @@ Task failingTask()
     return []() { throw Exc(); };
 }
 
-class TestException
+class TestException final
 {
 };
 
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(test_future_set)
 }
 
 template<int N>
-class TestExceptionN
+class TestExceptionN final
 {
 };
 

--- a/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-area-optimization-ini.cpp
@@ -64,7 +64,7 @@ struct Fixture
     Yuni::Clob path_to_generated_file;
 };
 
-class referenceIniFile
+class referenceIniFile final
 {
 public:
     referenceIniFile();

--- a/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
+++ b/src/tests/src/libs/antares/study/area/test-save-link-properties.cpp
@@ -42,7 +42,7 @@ namespace fs = std::filesystem;
 const string generatedIniFileName = "properties.ini";
 const string referenceIniFileName = "properties-reference.ini";
 
-class referenceIniFile
+class referenceIniFile final
 {
 public:
     referenceIniFile();

--- a/src/tests/src/libs/antares/study/constraint/test_group.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_group.cpp
@@ -35,7 +35,7 @@
 using namespace Antares::Data;
 namespace fs = std::filesystem;
 
-class PublicStudy: public Study
+class PublicStudy final: public Study
 {
 public:
     bool internalLoadBindingConstraints(const StudyLoadOptions& options) override

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -41,7 +41,7 @@ const string referenceScBuilderFileName = "scenariobuilder-reference.dat";
 // ===========================================
 // Reference scenario builder file handler
 // ===========================================
-class referenceScBuilderFile
+class referenceScBuilderFile final
 {
 public:
     referenceScBuilderFile() = default;
@@ -123,7 +123,7 @@ std::shared_ptr<ClusterType> addClusterToArea(Area* area, const std::string& clu
 // ======================================
 // Scenario builder common fixture
 // ======================================
-struct commonFixture
+struct commonFixture final
 {
     commonFixture(const commonFixture& f) = delete;
     commonFixture(const commonFixture&& f) = delete;

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-save.cpp
@@ -123,7 +123,7 @@ std::shared_ptr<ClusterType> addClusterToArea(Area* area, const std::string& clu
 // ======================================
 // Scenario builder common fixture
 // ======================================
-struct commonFixture final
+struct commonFixture
 {
     commonFixture(const commonFixture& f) = delete;
     commonFixture(const commonFixture&& f) = delete;

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/FillerContext.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/FillerContext.h
@@ -5,7 +5,7 @@
 namespace Antares::Optimisation::LinearProblemApi
 {
 
-class VarFillerContext: public LinearProblemFiller
+class VarFillerContext final: public LinearProblemFiller
 {
 public:
     explicit VarFillerContext() = default;

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/OneConstraintFiller.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/OneConstraintFiller.h
@@ -5,7 +5,7 @@
 namespace Antares::Optimisation::LinearProblemApi
 {
 
-class OneConstraintFiller: public LinearProblemFiller
+class OneConstraintFiller final: public LinearProblemFiller
 {
 public:
     explicit OneConstraintFiller() = default;

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/OneVarFiller.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/OneVarFiller.h
@@ -5,7 +5,7 @@
 namespace Antares::Optimisation::LinearProblemApi
 {
 
-class OneVarFiller: public LinearProblemFiller
+class OneVarFiller final: public LinearProblemFiller
 {
 public:
     explicit OneVarFiller() = default;

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/TwoVarsTwoConstraintsFiller.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/TwoVarsTwoConstraintsFiller.h
@@ -5,7 +5,7 @@
 namespace Antares::Optimisation::LinearProblemApi
 {
 
-class TwoVarsTwoConstraintsFiller: public LinearProblemFiller
+class TwoVarsTwoConstraintsFiller final: public LinearProblemFiller
 {
 public:
     explicit TwoVarsTwoConstraintsFiller() = default;

--- a/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
+++ b/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
@@ -341,7 +341,7 @@ struct DummyOptPeriodStringGenerator: OptPeriodStringGenerator
     }
 };
 
-struct NullWriterExtension: Solver::NullResultWriter
+struct NullWriterExtension final: Solver::NullResultWriter
 {
     // hack to read variables and constraints names
     void addEntryFromFile(const std::filesystem::path& entryPath,

--- a/src/tests/src/solver/optim-model-filler/test_componentFiller.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_componentFiller.cpp
@@ -747,7 +747,7 @@ BOOST_AUTO_TEST_CASE(offset_in_objective__throws_exception)
 }
 
 // Mock classes
-class MockMipVariable: public IMipVariable
+class MockMipVariable final: public IMipVariable
 {
 public:
     MockMipVariable(double lb, double ub, bool integer, const std::string& name):
@@ -811,7 +811,7 @@ private:
     std::string name_;
 };
 
-class MockLinearProblem: public ILinearProblem
+class MockLinearProblem final: public ILinearProblem
 {
 public:
     std::vector<std::unique_ptr<MockMipVariable>> variables_;

--- a/src/tests/src/solver/optimisation/translator/test_translator.cpp
+++ b/src/tests/src/solver/optimisation/translator/test_translator.cpp
@@ -31,7 +31,7 @@
 
 using namespace Antares::Solver;
 
-class StubOptPeriodStringGenerator: public OptPeriodStringGenerator
+class StubOptPeriodStringGenerator final: public OptPeriodStringGenerator
 {
 public:
     std::string to_string() const override

--- a/src/tools/vacuum/antares-study.h
+++ b/src/tools/vacuum/antares-study.h
@@ -24,7 +24,7 @@
 #include <fswalker/fswalker.h>
 #include <mutex>
 
-class AntaresStudy: public FSWalker::IExtension
+class AntaresStudy final: public FSWalker::IExtension
 {
 public:
     AntaresStudy(int64_t dateLimit);


### PR DESCRIPTION
This pull request introduces the use of the C++ `final` keyword throughout the codebase to prevent further inheritance from certain classes, which can help catch bugs from unintended overrides and enable compiler optimizations. The changes affect core expression node classes, utility and IO classes, and exception types. Additionally, a documentation update explains the rationale behind using `final`.

**Documentation:**

* Added a section in `docs/developer-guide/6-Contributing.md` explaining the benefits of using the `final` keyword for classes that are not intended to be derived.

**Core logic and expression nodes:**

* Marked key expression-related classes as `final`, including `NodeRegistry`, `Expression`, and various node types such as `DivisionNode`, `MultiplicationNode`, `SubtractionNode`, `SumNode`, `TimeIndexNode`, `TimeShiftNode`, `TimeSumNode`, `PortFieldSumNode`, `LiteralNode`, `EqualNode`, `GreaterThanOrEqualNode`. This change enforces non-inheritability and may improve performance. [[1]](diffhunk://#diff-99f16efec9d40afb0e4e79d628030b860593e4a01b4207c65fe4804e00ead21cL8-R8) [[2]](diffhunk://#diff-ccd0ec629d8cf2017eb68e4ff3617c49cdb65f24221b0f2d32893b1b464aedbeL36-R36) [[3]](diffhunk://#diff-48e2f6c984afbc50248559a4685a7b0b5af4f975b580275816cbd0eca3f11304L30-R30) [[4]](diffhunk://#diff-8af4cb7c80a407eee0f49cbaa3be08098b79c37d6c85bed35ca96a6c71c4ee1aL30-R30) [[5]](diffhunk://#diff-3a5c738f906de6b625f65d3d6eb3f3d102f9f3a85d36c51b0d29900d094d4ab4L30-R30) [[6]](diffhunk://#diff-1373dd1b9385d1e28e3afd8155e2187d08403abb0c9fadb39e1e6b6b8a07f36fL28-R28) [[7]](diffhunk://#diff-9b3015307420ef05930bc2c7589f8025d558a596c9b8018a49284f390d424025L27-R27) [[8]](diffhunk://#diff-f0cf243cd82096eca81d11da390526fc247cefdc3d73838cf90fb966e0b5c202L28-R28) [[9]](diffhunk://#diff-df7ca90cf4c243fdb48c78f1fefe843302da92adf5f84c09e8340067429801fcL27-R27) [[10]](diffhunk://#diff-388d2e819b0c7d99e0cad84cb344ee1540556a65ffd77336c2bcec4f80f0be93L32-R32) [[11]](diffhunk://#diff-736279cc7c665c34c16993c7d9721561c8f47e67dfa87ff5234c7e25ba828ce8L10-R10) [[12]](diffhunk://#diff-bf1d8334d21cbe18445398b6c19e3c5574af3eb45124d563b249d8c2ccf2e631L30-R30) [[13]](diffhunk://#diff-84c7b20e18b119d962d91889e79fe8f6d27453f214bd5ffd5e59d38ada0577baL30-R30)

**Utility, IO, and parser classes:**

* Marked utility and IO classes such as `Updater`, `LogsDumper`, `DataSeriesRepoImporter`, and `Parser` as `final` to prevent unintended subclassing. [[1]](diffhunk://#diff-623d222a149091b4289748f58bb0c1340d26f8085094bffa0b948eb8604341bdL98-R98) [[2]](diffhunk://#diff-623d222a149091b4289748f58bb0c1340d26f8085094bffa0b948eb8604341bdL112-R112) [[3]](diffhunk://#diff-407cc9abceeb44cb8297234df7a82fd01fcdb16a3890019620cca66c69ce7ff0L33-R33) [[4]](diffhunk://#diff-bfc21a00216cd8beac1dd9dfa71b467f1f03cd9cf17d1dac51847bbfc957531bL28-R28)

**Model conversion and visitor classes:**

* Marked the `ConvertorVisitor` class and several exception types in model conversion code as `final` to enforce intended usage and inheritance constraints. [[1]](diffhunk://#diff-c3fe1a1fce2e74b352c4259df485d8f87914b492895c3faa4efae3c1b63631b9L37-R37) [[2]](diffhunk://#diff-c3fe1a1fce2e74b352c4259df485d8f87914b492895c3faa4efae3c1b63631b9L119-R119) [[3]](diffhunk://#diff-c3fe1a1fce2e74b352c4259df485d8f87914b492895c3faa4efae3c1b63631b9L228-R228) [[4]](diffhunk://#diff-75496c96eb567eab0e091590664bd552c6e77126f0e55033beee5f0539093d7dL51-R99)

**YML system and model exceptions:**

* Marked exception classes in `yml-system/converter.cpp` as `final`, such as `ErrorWhileSplittingLibraryAndModel`, `LibraryNotFound`, and `ModelNotFound`. [[1]](diffhunk://#diff-226d9be4321d689174fe53dbd4054a1448714a6c7e5254d992edac00dcc1b019L38-R38) [[2]](diffhunk://#diff-226d9be4321d689174fe53dbd4054a1448714a6c7e5254d992edac00dcc1b019L47-R47) [[3]](diffhunk://#diff-226d9be4321d689174fe53dbd4054a1448714a6c7e5254d992edac00dcc1b019L56-R56)