### PR TITLE
Clean & simplify class OptimEntityContainer

### DIFF
--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -88,8 +88,7 @@ EvaluationResult EvalVisitor::visit(const Nodes::GreaterThanOrEqualNode* node)
 EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
 {
     const auto& solverVariables = optimContainer_.getVariables();
-    const auto startColumn = optimContainer_.getVariableStartColumn(component_.Index(),
-                                                                    node->value());
+    const auto startColumn = optimContainer_.getVariableStartColumn(component_, node->value());
     if (node->timeIndex() == Optimisation::TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO
         || node->timeIndex() == Optimisation::TimeIndex::VARYING_IN_SCENARIO_ONLY)
     {

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -39,7 +39,7 @@ EvalVisitor::EvalVisitor(const Optimisation::OptimEntityContainer& optimContaine
     // Plus it is mandatory to visit Variables & PortFieldSums
     // Else, create a PostOptimEvalVisitor that inherits from EvalVisitor & has a different ctor
     optimContainer_(optimContainer),
-    context_(optimContainer.getOptimComponent(component.Index()).evaluationContext),
+    context_(optimContainer.getEvaluationContext(component)),
     fillContext_(fillContext),
     component_(component)
 {

--- a/src/expressions/visitors/TimeIndexVisitor.cpp
+++ b/src/expressions/visitors/TimeIndexVisitor.cpp
@@ -145,7 +145,7 @@ TimeIndexVisitor::TimeIndexVisitor(const Optimisation::OptimEntityContainer& opt
                                    const ModelerStudy::SystemModel::Component& component):
     optimEntityContainer_(optimEntityContainer),
     component_(component),
-    context_(optimEntityContainer.getOptimComponent(component.Index()).evaluationContext)
+    context_(optimEntityContainer.getEvaluationContext(component))
 {
 }
 

--- a/src/io/outputs/SimulationTableGenerator.cpp
+++ b/src/io/outputs/SimulationTableGenerator.cpp
@@ -313,8 +313,7 @@ void addPortEntries(ISimulationTable& simulationTable,
                     bool forceExportForScenarioIndex)
 {
     const auto& cid = component.Id();
-    const auto& evalContext = optimEntityContainer.getOptimComponent(component.Index())
-                                .evaluationContext;
+    const auto& evalContext = optimEntityContainer.getEvaluationContext(component);
 
     for (const auto& [portFieldKey, portFieldDef]: component.getModel()->PortFieldDefinitions())
     {

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -64,6 +64,13 @@ public:
         return variableStartColumn_.at(optimComponent.variableIndexMap.at(varName));
     }
 
+    [[nodiscard]] const EvaluationContext& getEvaluationContext(
+      const Antares::ModelerStudy::SystemModel::Component& component) const
+    {
+        const auto& optimComponent = optimComponents_.at(component.Index());
+        return optimComponent.evaluationContext;
+    }
+
     [[nodiscard]] const std::vector<unsigned int>& getConstraintStartLine() const
     {
         return constraintStartLine_;

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -50,16 +50,18 @@ public:
                          const LinearProblemApi::ILinearProblemData* data,
                          const ScenarioGroupRepository* scenarioGroupRepository);
 
+    // TODO REMOVE
     [[nodiscard]] const std::vector<unsigned int>& getVariableStartColumn() const
     {
         return variableStartColumn_;
     }
 
-    [[nodiscard]] unsigned int getVariableStartColumn(size_t compoIndex,
-                                                      const std::string& varName) const
+    [[nodiscard]] unsigned int getVariableStartColumn(
+      const Antares::ModelerStudy::SystemModel::Component& component,
+      const std::string& varName) const
     {
-        const auto& optimComponent = optimComponents_[compoIndex];
-        return variableStartColumn_[optimComponent.variableIndexMap.at(varName)];
+        const auto& optimComponent = optimComponents_.at(component.Index());
+        return variableStartColumn_.at(optimComponent.variableIndexMap.at(varName));
     }
 
     [[nodiscard]] const std::vector<unsigned int>& getConstraintStartLine() const
@@ -129,20 +131,10 @@ public:
 
     void addFromSystemComponent(const Antares::ModelerStudy::SystemModel::Component& component);
 
-    // unsigned int VariableGLobalIndex() const
-    // {
-    //     return variableGlobalIndex_;
-    // }
-
     unsigned int ConstraintGLobalIndex() const
     {
         return constraintGlobalIndex_;
     }
-
-    // void IncrementVariableGLobalIndex()
-    // {
-    //     ++variableGlobalIndex_;
-    // }
 
     void IncrementConstraintGLobalIndex()
     {

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
@@ -57,7 +57,7 @@ public:
         component_(component),
         nbtimeSteps_(fillContext.getLocalNumberOfTimeSteps()),
         fillContext_(fillContext),
-        evalContext_(optimEntityContainer.getOptimComponent(component.Index()).evaluationContext),
+        evalContext_(optimEntityContainer.getEvaluationContext(component)),
         evalVisitor_(optimEntityContainer, fillContext, component)
     {
     }

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
@@ -136,23 +136,14 @@ public:
     Antares::Optimization::TimeDependentLinearExpression visit(
       const Nodes::VariableNode* node) override
     {
-        const auto& optimComponent = optimEntityContainer_.getOptimComponent(component_.Index());
-        const auto globalIndex = optimComponent.variableIndexMap.at(
-          node->value()); // the only time we search in a map
-        const auto& variableStartColumn = optimEntityContainer_.getVariableStartColumn();
-        const auto variableStart = variableStartColumn.at(globalIndex);
-        const auto variableEnd = variableStart == *variableStartColumn.rbegin()
-                                   ? optimEntityContainer_.variablesSize()
-                                   : variableStartColumn.at(globalIndex + 1);
-
+        const auto variableStart = optimEntityContainer_.getVariableStartColumn(component_,
+                                                                                node->value());
         if (node->timeIndex() == Antares::Optimisation::TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO)
         {
             Antares::Optimization::LinearExpression out;
             out.addVariable(variableStart, 1);
             return Antares::Optimization::TimeDependentLinearExpression(std::move(out));
         }
-        // else time-dep only hanled    //  check if var is time-dep then nbTimeStep == variableEnd
-        // - variableStart+1
         if (node->timeIndex() == Antares::Optimisation::TimeIndex::VARYING_IN_TIME_ONLY
             || node->timeIndex()
                  == Antares::Optimisation::TimeIndex::VARYING_IN_TIME_AND_SCENARIO) /* scenario not


### PR DESCRIPTION
- Remove commented code
- Add method `getEvaluationContext`, used in 4 locations
- Use `getVariableStartColumn` in 1 location