### PR TITLE
Remove unused methods `getOptimalValue` and `getOptimalValues`

### DIFF
--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipSolution.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/mipSolution.h
@@ -49,14 +49,6 @@ public:
     virtual ~IMipSolution() = default;
 
     [[nodiscard]] virtual MipStatus getStatus() const = 0;
-
     [[nodiscard]] virtual double getObjectiveValue() const = 0;
-
-    [[nodiscard]] virtual double getOptimalValue(const IMipVariable* var) const = 0;
-
-    [[nodiscard]] virtual std::vector<double>
-    getOptimalValues(const std::vector<IMipVariable*>& vars) const = 0;
-
-    [[nodiscard]] virtual const std::map<std::string, double>& getOptimalValues() const = 0;
 };
 } // namespace Antares::Optimisation::LinearProblemApi

--- a/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/mipSolution.h
+++ b/src/optimisation/linear-problem-mpsolver-impl/include/antares/optimisation/linear-problem-mpsolver-impl/mipSolution.h
@@ -41,10 +41,6 @@ public:
 
     [[nodiscard]] LinearProblemApi::MipStatus getStatus() const override;
     [[nodiscard]] double getObjectiveValue() const override;
-    [[nodiscard]] double getOptimalValue(const LinearProblemApi::IMipVariable* var) const override;
-    [[nodiscard]] std::vector<double> getOptimalValues(
-      const std::vector<LinearProblemApi::IMipVariable*>& vars) const override;
-    [[nodiscard]] const std::map<std::string, double>& getOptimalValues() const override;
 
 private:
     operations_research::MPSolver::ResultStatus status_;

--- a/src/optimisation/linear-problem-mpsolver-impl/mipSolution.cpp
+++ b/src/optimisation/linear-problem-mpsolver-impl/mipSolution.cpp
@@ -60,43 +60,4 @@ double OrtoolsMipSolution::getObjectiveValue() const
 {
     return ::getObjectiveValue(mpSolver_);
 }
-
-double OrtoolsMipSolution::getOptimalValue(const LinearProblemApi::IMipVariable* var) const
-{
-    if (!var)
-    {
-        return 0;
-    }
-
-    try
-    {
-        return solution_.at(var->getName());
-    }
-    catch (const std::out_of_range& ex)
-    {
-        logs.warning() << ex.what();
-        logs.warning() << "Solution not found for variable: " << var->getName();
-    }
-    return 0;
-}
-
-std::vector<double> OrtoolsMipSolution::getOptimalValues(
-  const std::vector<LinearProblemApi::IMipVariable*>& vars) const
-{
-    std::vector<double> solution;
-    solution.reserve(vars.size());
-
-    for (const auto* var: vars)
-    {
-        solution.push_back(getOptimalValue(var));
-    }
-
-    return solution;
-}
-
-const std::map<std::string, double>& OrtoolsMipSolution::getOptimalValues() const
-{
-    return solution_;
-}
-
 } // namespace Antares::Optimisation::LinearProblemMpsolverImpl

--- a/src/tests/src/io/outputs/testSimulationTable.cpp
+++ b/src/tests/src/io/outputs/testSimulationTable.cpp
@@ -738,22 +738,6 @@ struct MockMipSolution: IMipSolution
     {
         return 11.18;
     }
-
-    [[nodiscard]] double getOptimalValue(const IMipVariable* var) const override
-    {
-        return 11.18;
-    }
-
-    [[nodiscard]] std::vector<double> getOptimalValues(
-      const std::vector<IMipVariable*>& vars) const override
-    {
-        return std::vector(vars.size(), 11.18);
-    }
-
-    [[nodiscard]] const std::map<std::string, double>& getOptimalValues() const override
-    {
-        return {};
-    }
 };
 
 struct BasicProblemFixture: Test::Modeler::LinearProblemBuildingFixture

--- a/src/tests/src/optimisation/linear-problem/testLinearProblemMpsolverImpl.cpp
+++ b/src/tests/src/optimisation/linear-problem/testLinearProblemMpsolverImpl.cpp
@@ -235,7 +235,7 @@ BOOST_FIXTURE_TEST_CASE(solve_infeasible_problem___check_any_var_is_zero, Fixtur
 
     auto* var = pb->lookupVariable("var");
     BOOST_CHECK(var); // searched variable is known by problem
-    BOOST_CHECK_EQUAL(solution->getOptimalValue(var), 0);
+    BOOST_CHECK_EQUAL(var->solutionValue(), 0);
 }
 
 BOOST_FIXTURE_TEST_CASE(solve_feasible_problem___check_status_is_optimal, FixtureFeasibleProblem)
@@ -256,14 +256,7 @@ BOOST_FIXTURE_TEST_CASE(solve_problem_then_add_new_var___new_var_optimal_value_i
 {
     auto* solution = pb->solve(false);
     auto* newVar = pb->addNumVariable(0, 1, "new var");
-    BOOST_CHECK_EQUAL(solution->getOptimalValue(newVar), 0);
-}
-
-BOOST_FIXTURE_TEST_CASE(solve_problem___check_optimal_value_of_null_var_is_zero,
-                        FixtureFeasibleProblem)
-{
-    auto* solution = pb->solve(false);
-    BOOST_CHECK_EQUAL(solution->getOptimalValue(nullptr), 0);
+    BOOST_CHECK_EQUAL(newVar->solutionValue(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
They were only used in unit tests, and can easily be replaced by `IMipVariable::solutionValue`.