### PR TITLE
Simplify `getVariables` interface

### DIFF
--- a/src/expressions/include/antares/expressions/nodes/VariableNode.h
+++ b/src/expressions/include/antares/expressions/nodes/VariableNode.h
@@ -21,9 +21,11 @@ class VariableNode final: public Leaf<std::string>
 public:
     explicit VariableNode(
       const std::string& value,
-      Optimisation::TimeIndex time_index = Optimisation::TimeIndex::VARYING_IN_TIME_AND_SCENARIO):
+      Optimisation::TimeIndex time_index = Optimisation::TimeIndex::VARYING_IN_TIME_AND_SCENARIO,
+      unsigned int index = 0):
         Leaf<std::string>(value),
-        time_index_(time_index)
+        time_index_(time_index),
+        index_(index)
     {
     }
 
@@ -37,7 +39,15 @@ public:
         return time_index_;
     }
 
+    unsigned int Index() const
+    {
+        return index_;
+    }
+
 private:
-    Optimisation::TimeIndex time_index_;
+    // Is the variable time-dependent / scenario-dependent ?
+    const Optimisation::TimeIndex time_index_;
+    // Local index within the component, starting from 0
+    const unsigned int index_;
 };
 } // namespace Antares::Expressions::Nodes

--- a/src/expressions/include/antares/expressions/nodes/VariableNode.h
+++ b/src/expressions/include/antares/expressions/nodes/VariableNode.h
@@ -21,11 +21,12 @@ class VariableNode final: public Leaf<std::string>
 public:
     explicit VariableNode(
       const std::string& value,
-      Optimisation::TimeIndex time_index = Optimisation::TimeIndex::VARYING_IN_TIME_AND_SCENARIO,
-      unsigned int index = 0):
+      unsigned int index,
+      Optimisation::TimeIndex time_index = Optimisation::TimeIndex::VARYING_IN_TIME_AND_SCENARIO):
         Leaf<std::string>(value),
-        time_index_(time_index),
-        index_(index)
+        index_(index),
+        time_index_(time_index)
+
     {
     }
 
@@ -48,6 +49,6 @@ private:
     // Is the variable time-dependent / scenario-dependent ?
     const Optimisation::TimeIndex time_index_;
     // Local index within the component, starting from 0
-    const unsigned int index_;
+    const unsigned int index_ = 0;
 };
 } // namespace Antares::Expressions::Nodes

--- a/src/expressions/visitors/CloneVisitor.cpp
+++ b/src/expressions/visitors/CloneVisitor.cpp
@@ -81,7 +81,9 @@ Nodes::Node* CloneVisitor::visit(const Nodes::NegationNode* negationNode)
 
 Nodes::Node* CloneVisitor::visit(const Nodes::VariableNode* variableNode)
 {
-    return registry_.create<Nodes::VariableNode>(variableNode->value(), variableNode->timeIndex());
+    return registry_.create<Nodes::VariableNode>(variableNode->value(),
+                                                 variableNode->Index(),
+                                                 variableNode->timeIndex());
 }
 
 Nodes::Node* CloneVisitor::visit(const Nodes::ParameterNode* parameterNode)

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -96,20 +96,22 @@ EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
           Optimization::MCYearAndTime::MCYear{fillContext_.getYear()},
           std::nullopt);
 
-        std::span variables = optimContainer_.getComponentVariable(component_, node->value(), 1);
-        return EvaluationResult(variables[0]->solutionValue());
+        const std::span componentVariables = optimContainer_.getComponentVariable(
+          component_,
+          node->value(),
+          1 /* single timestep*/);
+        return EvaluationResult(componentVariables[0]->solutionValue());
     }
     // VARYING_IN_TIME_ONLY or VARYING_IN_TIME_AND_SCENARIO)
     unsigned nbTimeStep = fillContext_.getLocalLastTimeStep() - fillContext_.getLocalFirstTimeStep()
                           + 1;
     std::vector<double> varValues(nbTimeStep, 0.0);
-
-    std::span variables = optimContainer_.getComponentVariable(component_,
-                                                               node->value(),
-                                                               nbTimeStep);
+    const std::span componentVariables = optimContainer_.getComponentVariable(component_,
+                                                                              node->value(),
+                                                                              nbTimeStep);
     for (unsigned varInd = 0; varInd < nbTimeStep; ++varInd)
     {
-        varValues[varInd] = variables[varInd]->solutionValue();
+        varValues[varInd] = componentVariables[varInd]->solutionValue();
     }
 
     return EvaluationResult{varValues};

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -92,7 +92,7 @@ EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
     {
         const std::span componentVariables = optimContainer_.getComponentVariable(
           component_,
-          node->value(),
+          node->Index(),
           1 /* single timestep*/);
         return EvaluationResult(componentVariables[0]->solutionValue());
     }
@@ -100,7 +100,7 @@ EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
     const unsigned nbTimeStep = fillContext_.getLocalNumberOfTimeSteps();
     std::vector<double> varValues(nbTimeStep, 0.0);
     const std::span componentVariables = optimContainer_.getComponentVariable(component_,
-                                                                              node->value(),
+                                                                              node->Index(),
                                                                               nbTimeStep);
     for (unsigned varInd = 0; varInd < nbTimeStep; ++varInd)
     {

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -90,12 +90,6 @@ EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
     if (node->timeIndex() == Optimisation::TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO
         || node->timeIndex() == Optimisation::TimeIndex::VARYING_IN_SCENARIO_ONLY)
     {
-        std::string varName = Antares::Optimisation::buildVariableName(
-          component_.Id(),
-          node->value(),
-          Optimization::MCYearAndTime::MCYear{fillContext_.getYear()},
-          std::nullopt);
-
         const std::span componentVariables = optimContainer_.getComponentVariable(
           component_,
           node->value(),
@@ -103,8 +97,7 @@ EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
         return EvaluationResult(componentVariables[0]->solutionValue());
     }
     // VARYING_IN_TIME_ONLY or VARYING_IN_TIME_AND_SCENARIO)
-    unsigned nbTimeStep = fillContext_.getLocalLastTimeStep() - fillContext_.getLocalFirstTimeStep()
-                          + 1;
+    const unsigned nbTimeStep = fillContext_.getLocalNumberOfTimeSteps();
     std::vector<double> varValues(nbTimeStep, 0.0);
     const std::span componentVariables = optimContainer_.getComponentVariable(component_,
                                                                               node->value(),

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -87,8 +87,6 @@ EvaluationResult EvalVisitor::visit(const Nodes::GreaterThanOrEqualNode* node)
 
 EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
 {
-    const auto& solverVariables = optimContainer_.getVariables();
-    const auto startColumn = optimContainer_.getVariableStartColumn(component_, node->value());
     if (node->timeIndex() == Optimisation::TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO
         || node->timeIndex() == Optimisation::TimeIndex::VARYING_IN_SCENARIO_ONLY)
     {
@@ -98,7 +96,8 @@ EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
           Optimization::MCYearAndTime::MCYear{fillContext_.getYear()},
           std::nullopt);
 
-        return EvaluationResult(solverVariables[startColumn]->solutionValue());
+        return EvaluationResult(
+          optimContainer_.getVariable(component_, node->value(), 0)->solutionValue());
     }
     // VARYING_IN_TIME_ONLY or VARYING_IN_TIME_AND_SCENARIO)
     unsigned nbTimeStep = fillContext_.getLocalLastTimeStep() - fillContext_.getLocalFirstTimeStep()
@@ -107,7 +106,8 @@ EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
 
     for (unsigned varInd = 0; varInd < nbTimeStep; ++varInd)
     {
-        varValues[varInd] = solverVariables[startColumn + varInd]->solutionValue();
+        auto* variable = optimContainer_.getVariable(component_, node->value(), varInd);
+        varValues[varInd] = variable->solutionValue();
     }
 
     return EvaluationResult{varValues};

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -96,18 +96,20 @@ EvaluationResult EvalVisitor::visit(const Nodes::VariableNode* node)
           Optimization::MCYearAndTime::MCYear{fillContext_.getYear()},
           std::nullopt);
 
-        return EvaluationResult(
-          optimContainer_.getVariable(component_, node->value(), 0)->solutionValue());
+        std::span variables = optimContainer_.getComponentVariable(component_, node->value(), 1);
+        return EvaluationResult(variables[0]->solutionValue());
     }
     // VARYING_IN_TIME_ONLY or VARYING_IN_TIME_AND_SCENARIO)
     unsigned nbTimeStep = fillContext_.getLocalLastTimeStep() - fillContext_.getLocalFirstTimeStep()
                           + 1;
     std::vector<double> varValues(nbTimeStep, 0.0);
 
+    std::span variables = optimContainer_.getComponentVariable(component_,
+                                                               node->value(),
+                                                               nbTimeStep);
     for (unsigned varInd = 0; varInd < nbTimeStep; ++varInd)
     {
-        auto* variable = optimContainer_.getVariable(component_, node->value(), varInd);
-        varValues[varInd] = variable->solutionValue();
+        varValues[varInd] = variables[varInd]->solutionValue();
     }
 
     return EvaluationResult{varValues};

--- a/src/io/inputs/model-converter/convertorVisitor.cpp
+++ b/src/io/inputs/model-converter/convertorVisitor.cpp
@@ -159,9 +159,9 @@ Node* ConvertorVisitor::convertIdentifier(const std::string& identifier) const
         {
             return static_cast<Node*>(
               registry_.create<VariableNode>(var.id,
+                                             index,
                                              convertToTimeIndex(var.time_dependent,
-                                                                var.scenario_dependent),
-                                             index));
+                                                                var.scenario_dependent)));
         }
     }
     throw NoParameterOrVariableWithThisName(identifier);

--- a/src/io/inputs/model-converter/convertorVisitor.cpp
+++ b/src/io/inputs/model-converter/convertorVisitor.cpp
@@ -151,14 +151,17 @@ Node* ConvertorVisitor::convertIdentifier(const std::string& identifier) const
         }
     }
 
-    for (const auto& var: model_.variables)
+    const auto& variables = model_.variables;
+    for (auto index = 0; index < variables.size(); ++index)
     {
+        const auto& var = variables[index];
         if (var.id == identifier)
         {
             return static_cast<Node*>(
               registry_.create<VariableNode>(var.id,
                                              convertToTimeIndex(var.time_dependent,
-                                                                var.scenario_dependent)));
+                                                                var.scenario_dependent),
+                                             index));
         }
     }
     throw NoParameterOrVariableWithThisName(identifier);

--- a/src/io/outputs/SimulationTableGenerator.cpp
+++ b/src/io/outputs/SimulationTableGenerator.cpp
@@ -95,18 +95,12 @@ void addVariableEntries(ISimulationTable& simulationTable,
     const auto& variableStart = optimEntityContainer.getVariableStartColumn();
     const auto& solverVariables = optimEntityContainer.getVariables();
     const auto& optimComponent = optimEntityContainer.getOptimComponent(component.Index());
-    const auto& modelVariablesGlobalIndices = optimComponent.modelVariablesGlobalIndices;
     unsigned variableLocalIndex = 0;
     for (const auto& modelVar: component.getModel()->Variables())
     {
         bool scenDep = modelVar.IsScenarioDependent();
         bool timeDep = modelVar.isTimeDependent();
-        // this is the global Index
-        // auto varGlobalIndex = component.getVariableGlobalIndex(modelVar.Id());
-        // but since model::Variables is a vector, the order never changes, in consequence
-        // component.getVariableGlobalIndex(modelVar.Id()) ==
-        // modelVariablesGlobalIndices.at(variableLocalIndex)
-        auto varGlobalIndex = modelVariablesGlobalIndices.at(variableLocalIndex);
+
         ++variableLocalIndex;
         auto handle = [&](std::optional<unsigned> timeStep, std::optional<unsigned> scenIdx)
         {
@@ -117,7 +111,9 @@ void addVariableEntries(ISimulationTable& simulationTable,
                                     : TimeBlock{.block = currentBlock + 1,
                                                 .blockTimeIndex = std::nullopt,
                                                 .absoluteTimeIndex = std::nullopt};
-            auto* var = solverVariables.at(variableStart.at(varGlobalIndex) + timeStep.value_or(0));
+            auto* var = optimEntityContainer.getVariable(component,
+                                                         modelVar.Id(),
+                                                         timeStep.value_or(0));
             simulationTable.addEntry(
               {.block = tb.block,
                .component = componentId,

--- a/src/io/outputs/SimulationTableGenerator.cpp
+++ b/src/io/outputs/SimulationTableGenerator.cpp
@@ -91,17 +91,16 @@ void addVariableEntries(ISimulationTable& simulationTable,
 {
     const auto& componentId = component.Id();
     const bool isLp = linearProblem.isLP();
-
-    const auto& variableStart = optimEntityContainer.getVariableStartColumn();
-    const auto& solverVariables = optimEntityContainer.getVariables();
     const auto& optimComponent = optimEntityContainer.getOptimComponent(component.Index());
-    unsigned variableLocalIndex = 0;
     for (const auto& modelVar: component.getModel()->Variables())
     {
         bool scenDep = modelVar.IsScenarioDependent();
         bool timeDep = modelVar.isTimeDependent();
+        const std::span componentVariables = optimEntityContainer.getComponentVariable(
+          component,
+          modelVar.Id(),
+          fillContext.getLocalNumberOfTimeSteps());
 
-        ++variableLocalIndex;
         auto handle = [&](std::optional<unsigned> timeStep, std::optional<unsigned> scenIdx)
         {
             TimeBlock tb = timeStep ? convertBlockTimeStepToAbsoluteTimeStep(
@@ -111,9 +110,7 @@ void addVariableEntries(ISimulationTable& simulationTable,
                                     : TimeBlock{.block = currentBlock + 1,
                                                 .blockTimeIndex = std::nullopt,
                                                 .absoluteTimeIndex = std::nullopt};
-            auto* var = optimEntityContainer.getVariable(component,
-                                                         modelVar.Id(),
-                                                         timeStep.value_or(0));
+            auto* var = componentVariables[timeStep.value_or(0)];
             simulationTable.addEntry(
               {.block = tb.block,
                .component = componentId,

--- a/src/io/outputs/SimulationTableGenerator.cpp
+++ b/src/io/outputs/SimulationTableGenerator.cpp
@@ -92,13 +92,15 @@ void addVariableEntries(ISimulationTable& simulationTable,
     const auto& componentId = component.Id();
     const bool isLp = linearProblem.isLP();
     const auto& optimComponent = optimEntityContainer.getOptimComponent(component.Index());
-    for (const auto& modelVar: component.getModel()->Variables())
+    const auto& variables = component.getModel()->Variables();
+    for (auto varIndex = 0; varIndex < variables.size(); ++varIndex)
     {
+        const auto& modelVar = variables[varIndex];
         bool scenDep = modelVar.IsScenarioDependent();
         bool timeDep = modelVar.isTimeDependent();
         const std::span componentVariables = optimEntityContainer.getComponentVariable(
           component,
-          modelVar.Id(),
+          varIndex,
           fillContext.getLocalNumberOfTimeSteps());
 
         auto handle = [&](std::optional<unsigned> timeStep, std::optional<unsigned> scenIdx)

--- a/src/modeler-optimisation-container/OptimEntityContainer.cpp
+++ b/src/modeler-optimisation-container/OptimEntityContainer.cpp
@@ -26,7 +26,7 @@
 namespace Antares::Optimisation
 {
 
-  OptimEntityContainer::OptimEntityContainer(LinearProblemApi::ILinearProblem& linearProblem,
+OptimEntityContainer::OptimEntityContainer(LinearProblemApi::ILinearProblem& linearProblem,
                                            const LinearProblemApi::ILinearProblemData* data,
                                            const ScenarioGroupRepository* scenarioGroupRepository):
     linearProblem_(linearProblem),
@@ -35,32 +35,28 @@ namespace Antares::Optimisation
 {
 }
 
-
-
 void OptimEntityContainer::addFromSystemComponent(
   const Antares::ModelerStudy::SystemModel::Component& component)
 {
     const auto* model = component.getModel();
     const auto& variables = model->Variables();
-    std::vector<unsigned int> modelVariablesGlobalIndices(variables.size(), 0);
     std::unordered_map<std::string, unsigned int> variableIndexMap;
     variableIndexMap.reserve(variables.size());
 
     unsigned int variableLocalIndex = 0;
     for (const auto& variable: variables)
     {
-        modelVariablesGlobalIndices[variableLocalIndex] = variableGlobalIndex_;
         variableIndexMap[variable.Id()] = variableGlobalIndex_; // used in
         // ReadlinearExpressionVisitor
         ++variableGlobalIndex_;
         ++variableLocalIndex;
     }
-    optimComponents_.push_back({.index = component.Index(),
-                                .modelVariablesGlobalIndices = modelVariablesGlobalIndices,
-                                .variableIndexMap = variableIndexMap,
+    optimComponents_.push_back(
+      {.index = component.Index(),
+       .variableIndexMap = variableIndexMap,
        .evaluationContext = Optimisation::EvaluationContext(&component,
                                                             data_,
                                                             &scenarioGroupRepository_->scenario(
-                                                              component.getScenarioGroupId() ) ) });
+                                                              component.getScenarioGroupId()))});
 }
 } // namespace Antares::Optimisation

--- a/src/modeler-optimisation-container/OptimEntityContainer.cpp
+++ b/src/modeler-optimisation-container/OptimEntityContainer.cpp
@@ -40,20 +40,19 @@ void OptimEntityContainer::addFromSystemComponent(
 {
     const auto* model = component.getModel();
     const auto& variables = model->Variables();
-    std::unordered_map<std::string, unsigned int> variableIndexMap;
-    variableIndexMap.reserve(variables.size());
+    std::vector<unsigned int> modelVariableGlobalIndices;
+    modelVariableGlobalIndices.resize(variables.size());
 
-    unsigned int variableLocalIndex = 0;
-    for (const auto& variable: variables)
+    for (auto variableLocalIndex = 0; variableLocalIndex < variables.size(); ++variableLocalIndex)
     {
-        variableIndexMap[variable.Id()] = variableGlobalIndex_; // used in
+        modelVariableGlobalIndices[variableLocalIndex] = variableGlobalIndex_; // used in
         // ReadlinearExpressionVisitor
         ++variableGlobalIndex_;
         ++variableLocalIndex;
     }
     optimComponents_.push_back(
       {.index = component.Index(),
-       .variableIndexMap = variableIndexMap,
+       .modelVariableGlobalIndices = modelVariableGlobalIndices,
        .evaluationContext = Optimisation::EvaluationContext(&component,
                                                             data_,
                                                             &scenarioGroupRepository_->scenario(

--- a/src/modeler-optimisation-container/OptimEntityContainer.cpp
+++ b/src/modeler-optimisation-container/OptimEntityContainer.cpp
@@ -48,7 +48,6 @@ void OptimEntityContainer::addFromSystemComponent(
         modelVariableGlobalIndices[variableLocalIndex] = variableGlobalIndex_; // used in
         // ReadlinearExpressionVisitor
         ++variableGlobalIndex_;
-        ++variableLocalIndex;
     }
     optimComponents_.push_back(
       {.index = component.Index(),

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -110,16 +110,6 @@ public:
         return constraints_;
     }
 
-    [[nodiscard]] size_t variablesSize() const
-    {
-        return variables_.size();
-    }
-
-    [[nodiscard]] size_t constraintsSize() const
-    {
-        return constraints_.size();
-    }
-
     void registerVariable(LinearProblemApi::IMipVariable* variable)
     {
         variables_.push_back(variable);

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -36,7 +36,6 @@ namespace Antares::Optimisation
 struct OptimComponent
 {
     unsigned int index = 0;
-    std::vector<unsigned int> modelVariablesGlobalIndices = {};
     std::unordered_map<std::string, unsigned int> variableIndexMap;
     std::vector<unsigned int> modelConstraintsGlobalIndices = {};
     std::vector<TimeIndex> modelConstraintsTimeIndex = {};
@@ -94,6 +93,15 @@ public:
     [[nodiscard]] const std::vector<LinearProblemApi::IMipVariable*>& getVariables() const
     {
         return variables_;
+    }
+
+    [[nodiscard]] LinearProblemApi::IMipVariable* getVariable(
+      const Antares::ModelerStudy::SystemModel::Component& component,
+      const std::string& varName,
+      int localTimeStep) const
+    {
+        unsigned int startColumn = getVariableStartColumn(component, varName);
+        return variables_[startColumn + localTimeStep];
     }
 
     [[nodiscard]] const std::vector<LinearProblemApi::IMipConstraint*>& getConstraints() const

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -37,7 +37,7 @@ namespace Antares::Optimisation
 struct OptimComponent
 {
     unsigned int index = 0;
-    std::unordered_map<std::string, unsigned int> variableIndexMap;
+    std::vector<unsigned int> modelVariableGlobalIndices;
     std::vector<unsigned int> modelConstraintsGlobalIndices = {};
     std::vector<TimeIndex> modelConstraintsTimeIndex = {};
     EvaluationContext evaluationContext;
@@ -58,10 +58,10 @@ public:
 
     [[nodiscard]] unsigned int getVariableStartColumn(
       const Antares::ModelerStudy::SystemModel::Component& component,
-      const std::string& varName) const
+      unsigned int index) const
     {
         const auto& optimComponent = optimComponents_.at(component.Index());
-        return variableStartColumn_.at(optimComponent.variableIndexMap.at(varName));
+        return variableStartColumn_.at(optimComponent.modelVariableGlobalIndices.at(index));
     }
 
     [[nodiscard]] const EvaluationContext& getEvaluationContext(
@@ -98,10 +98,10 @@ public:
 
     [[nodiscard]] std::span<LinearProblemApi::IMipVariable* const> getComponentVariable(
       const Antares::ModelerStudy::SystemModel::Component& component,
-      const std::string& varName,
+      unsigned int index,
       std::size_t nbTimeSteps) const
     {
-        unsigned int startColumn = getVariableStartColumn(component, varName);
+        unsigned int startColumn = getVariableStartColumn(component, index);
         return {variables_.begin() + startColumn, nbTimeSteps};
     }
 

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -140,12 +140,7 @@ public:
 
     unsigned int ConstraintGLobalIndex() const
     {
-        return constraintGlobalIndex_;
-    }
-
-    void IncrementConstraintGLobalIndex()
-    {
-        ++constraintGlobalIndex_;
+        return static_cast<unsigned int>(constraintStartLine_.size());
     }
 
 private:
@@ -156,7 +151,6 @@ private:
     //---
     std::vector<LinearProblemApi::IMipConstraint*> constraints_;
     std::vector<unsigned int> constraintStartLine_;
-    unsigned int constraintGlobalIndex_ = 0;
     LinearProblemApi::ILinearProblem& linearProblem_;
     const LinearProblemApi::ILinearProblemData* data_;
     const ScenarioGroupRepository* scenarioGroupRepository_;

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -20,6 +20,7 @@
  */
 
 #pragma once
+#include <span>
 #include <vector>
 
 #include <antares/optimisation/linear-problem-api/mipConstraint.h>
@@ -95,13 +96,13 @@ public:
         return variables_;
     }
 
-    [[nodiscard]] LinearProblemApi::IMipVariable* getVariable(
+    [[nodiscard]] std::span<LinearProblemApi::IMipVariable* const> getComponentVariable(
       const Antares::ModelerStudy::SystemModel::Component& component,
       const std::string& varName,
-      int localTimeStep) const
+      std::size_t nbTimeSteps) const
     {
         unsigned int startColumn = getVariableStartColumn(component, varName);
-        return variables_[startColumn + localTimeStep];
+        return {variables_.begin() + startColumn, nbTimeSteps};
     }
 
     [[nodiscard]] const std::vector<LinearProblemApi::IMipConstraint*>& getConstraints() const

--- a/src/solver/optim-model-filler/ComponentFiller.cpp
+++ b/src/solver/optim-model-filler/ComponentFiller.cpp
@@ -72,9 +72,8 @@ void VariablesBulkAddition::addVariable(const std::string& compoId,
     {
         for (const auto t: dim.getTimesteps())
         {
-            auto year = buildOptional<Optimization::MCYearAndTime::MCYear>(
-              dim.isScenarioDependent(),
-              static_cast<Optimization::MCYearAndTime::MCYear>(s));
+            auto year = buildOptional(dim.isScenarioDependent(),
+                                      static_cast<Optimization::MCYearAndTime::MCYear>(s));
             const auto ts = buildOptional(dim.isTimeDependent(), t);
             optimEntityContainer_.registerVariable(
               linear_problem_.addVariable(lb,

--- a/src/solver/optim-model-filler/ComponentFiller.cpp
+++ b/src/solver/optim-model-filler/ComponentFiller.cpp
@@ -337,7 +337,6 @@ void ComponentFiller::addConstraints(const LinearProblemApi::FillContext& ctx)
         const auto timeIndex = getConstraintTimeIndex(root_node, component_);
         optimComponent.modelConstraintsTimeIndex.push_back(timeIndex);
 
-        optimEntityContainer_.IncrementConstraintGLobalIndex();
         optimEntityContainer_.addStartLine();
         if (timeIndex == TimeIndex::VARYING_IN_TIME_ONLY
             || timeIndex == TimeIndex::VARYING_IN_TIME_AND_SCENARIO)

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ComponentFiller.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ComponentFiller.h
@@ -64,8 +64,6 @@ public:
     void addVariables(const Optimisation::LinearProblemApi::FillContext& ctx) override;
 
     void addConstraints(const Optimisation::LinearProblemApi::FillContext& ctx) override;
-    const std::vector<unsigned int>& getVariableStartColumn() const;
-
     void addObjective(const Optimisation::LinearProblemApi::FillContext& ctx) override;
 
 private:

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
@@ -137,7 +137,7 @@ public:
       const Nodes::VariableNode* node) override
     {
         const auto variableStart = optimEntityContainer_.getVariableStartColumn(component_,
-                                                                                node->value());
+                                                                                node->Index());
         if (node->timeIndex() == Antares::Optimisation::TimeIndex::CONSTANT_IN_TIME_AND_SCENARIO)
         {
             Antares::Optimization::LinearExpression out;

--- a/src/tests/end-to-end/modeler/test-modeler.cpp
+++ b/src/tests/end-to-end/modeler/test-modeler.cpp
@@ -110,8 +110,8 @@ public:
 
     Antares::Modeler::Data loadAll() override
     {
-        auto objective = fixture.variable("x");
-        auto var_node = fixture.variable("x");
+        auto objective = fixture.variable("x", 0);
+        auto var_node = fixture.variable("x", 0);
         auto zero = fixture.literal(0);
         auto ct_node = fixture.nodes.template create<
           Antares::Expressions::Nodes::GreaterThanOrEqualNode>(var_node, zero);

--- a/src/tests/inmemory-modeler/include/inmemory-modeler.h
+++ b/src/tests/inmemory-modeler/include/inmemory-modeler.h
@@ -105,6 +105,7 @@ struct LinearProblemBuildingFixture
 
     Antares::Expressions::Nodes::Node* variable(
       const std::string& varId,
+      unsigned int index,
       const Antares::Optimisation::TimeIndex& timeIndex = Antares::Optimisation::TimeIndex::
         CONSTANT_IN_TIME_AND_SCENARIO);
 

--- a/src/tests/inmemory-modeler/inmemory-modeler.cpp
+++ b/src/tests/inmemory-modeler/inmemory-modeler.cpp
@@ -118,9 +118,10 @@ Antares::Expressions::Nodes::Node* LinearProblemBuildingFixture::parameter(
 
 Antares::Expressions::Nodes::Node* LinearProblemBuildingFixture::variable(
   const std::string& varId,
+  unsigned index,
   const Antares::Optimisation::TimeIndex& timeIndex)
 {
-    return nodes.create<Antares::Expressions::Nodes::VariableNode>(varId, timeIndex);
+    return nodes.create<Antares::Expressions::Nodes::VariableNode>(varId, index, timeIndex);
 }
 
 Antares::Expressions::Nodes::Node* LinearProblemBuildingFixture::multiply(

--- a/src/tests/src/expressions/test_AstDOTStyleVisitor.cpp
+++ b/src/tests/src/expressions/test_AstDOTStyleVisitor.cpp
@@ -47,7 +47,7 @@ public:
         Node* parameterNode = registry_.create<ParameterNode>("avogadro_constant");
         Node* multiplicationNode = registry_.create<MultiplicationNode>(negationNode,
                                                                         parameterNode);
-        Node* variableNode = registry_.create<VariableNode>("atoms_count");
+        Node* variableNode = registry_.create<VariableNode>("atoms_count", 56);
         Node* divisionNode = registry_.create<DivisionNode>(variableNode, multiplicationNode);
         Node* portFieldNode = registry_.create<PortFieldNode>("gasStation", "1149");
         Node* portFieldSumNode = registry_.create<PortFieldSumNode>("portfield", "sum");

--- a/src/tests/src/expressions/test_LinearVisitor.cpp
+++ b/src/tests/src/expressions/test_LinearVisitor.cpp
@@ -135,9 +135,9 @@ BOOST_FIXTURE_TEST_CASE(comparison_nodes_variable_variable_is_linear, Registry<N
     PrintVisitor printVisitor;
     LinearityVisitor linearVisitor;
 
-    VariableNode var1("x");
+    VariableNode var1("x", 0);
     // variable
-    VariableNode var2("y");
+    VariableNode var2("y", 1);
     // x==y
     Node* eq = create<EqualNode>(&var1, &var2);
     BOOST_CHECK_EQUAL(printVisitor.dispatch(eq), "x==y");
@@ -157,7 +157,7 @@ BOOST_FIXTURE_TEST_CASE(comparison_nodes_variable_constant_is_linear, Registry<N
     PrintVisitor printVisitor;
     LinearityVisitor linearVisitor;
 
-    VariableNode var1("x");
+    VariableNode var1("x", 0);
     // variable
     LiteralNode literal(21.);
     // x==21
@@ -194,9 +194,9 @@ BOOST_FIXTURE_TEST_CASE(comparison_nodes_non_lin_constant_is_constant, Registry<
     PrintVisitor printVisitor;
     LinearityVisitor linearVisitor;
 
-    VariableNode var1("x");
+    VariableNode var1("x", 0);
     // variable
-    VariableNode var2("y");
+    VariableNode var2("y", 1);
     MultiplicationNode mult(&var1, &var2);
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(&mult), LinearStatus::NON_LINEAR);
 
@@ -208,12 +208,12 @@ BOOST_FIXTURE_TEST_CASE(comparison_nodes_non_lin_constant_is_constant, Registry<
 BOOST_FIXTURE_TEST_CASE(simple_linear, Registry<Node>)
 {
     LiteralNode literalNode1(10.);
-    VariableNode var1("x");
+    VariableNode var1("x", 0);
     // 10.*x
     Node* u = create<MultiplicationNode>(&literalNode1, &var1);
 
     LiteralNode literalNode2(20.);
-    VariableNode var2("id");
+    VariableNode var2("id", 3);
     // 20.*id
     Node* v = create<MultiplicationNode>(&literalNode2, &var2);
     // 10.*x+20.*id
@@ -227,8 +227,8 @@ BOOST_FIXTURE_TEST_CASE(simple_linear, Registry<Node>)
 
 BOOST_FIXTURE_TEST_CASE(simple_not_linear, Registry<Node>)
 {
-    VariableNode var1("x");
-    VariableNode var2("id");
+    VariableNode var1("x", 89);
+    VariableNode var2("id", 782);
     // x*id.y
     Node* expr = create<MultiplicationNode>(&var1, &var2);
 
@@ -240,7 +240,7 @@ BOOST_FIXTURE_TEST_CASE(simple_not_linear, Registry<Node>)
 
 BOOST_FIXTURE_TEST_CASE(simple_linear_division, Registry<Node>)
 {
-    VariableNode var1("x");
+    VariableNode var1("x", 0);
     // constant
     ParameterNode param("y");
     // x/y
@@ -254,9 +254,9 @@ BOOST_FIXTURE_TEST_CASE(simple_linear_division, Registry<Node>)
 
 BOOST_FIXTURE_TEST_CASE(simple_non_linear_division, Registry<Node>)
 {
-    VariableNode var1("x");
+    VariableNode var1("x", 6);
     // variable
-    VariableNode var2("y");
+    VariableNode var2("y", 44);
     // x/y
     Node* expr = create<DivisionNode>(&var1, &var2);
 
@@ -317,7 +317,7 @@ BOOST_FIXTURE_TEST_CASE(CheckTimeShiftOnLiteralLinearity, Registry<Node>)
 BOOST_FIXTURE_TEST_CASE(CheckTimeShiftOnVariableLinearity, Registry<Node>)
 {
     LinearityVisitor linearityVisitor;
-    Node* var1 = create<VariableNode>("variable1");
+    Node* var1 = create<VariableNode>("variable1", 0);
     Node* lit1 = create<LiteralNode>(0);
     Node* expr1 = create<TimeShiftNode>(var1, lit1);
     BOOST_CHECK(linearityVisitor.dispatch(expr1)
@@ -338,7 +338,7 @@ BOOST_FIXTURE_TEST_CASE(CheckTimeSumOnLiteralLinearity, Registry<Node>)
 BOOST_FIXTURE_TEST_CASE(CheckTimeSumOnVariableLinearity, Registry<Node>)
 {
     LinearityVisitor linearityVisitor;
-    Node* var1 = create<VariableNode>("variable1");
+    Node* var1 = create<VariableNode>("variable1", 0);
     Node* from = create<LiteralNode>(0.);
     Node* to = create<LiteralNode>(1.);
     Node* expr1 = create<TimeSumNode>(from, to, var1);
@@ -357,7 +357,7 @@ BOOST_FIXTURE_TEST_CASE(CheckAllTimeSumOnLiteralLinearity, Registry<Node>)
 BOOST_FIXTURE_TEST_CASE(CheckAllTimeSumOnVariableLinearity, Registry<Node>)
 {
     LinearityVisitor linearityVisitor;
-    Node* var1 = create<VariableNode>("variable1");
+    Node* var1 = create<VariableNode>("variable1", 0);
     Node* expr1 = create<AllTimeSumNode>(var1);
     BOOST_CHECK(linearityVisitor.dispatch(expr1)
                 == LinearStatus::CONSTANT); // because var1 is linear
@@ -374,23 +374,23 @@ BOOST_FIXTURE_TEST_CASE(sum_node_cases, Registry<Node>)
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::CONSTANT);
 
     expr = create<SumNode>(
-      create<MultiplicationNode>(create<LiteralNode>(5), create<VariableNode>("a")));
+      create<MultiplicationNode>(create<LiteralNode>(5), create<VariableNode>("a", 0)));
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::LINEAR);
 
     expr = create<SumNode>(create<LiteralNode>(41),
                            create<MultiplicationNode>(create<LiteralNode>(5),
-                                                      create<VariableNode>("b")));
+                                                      create<VariableNode>("b", 0)));
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::LINEAR);
 
     expr = create<SumNode>(
-      create<MultiplicationNode>(create<VariableNode>("c"), create<VariableNode>("d")));
+      create<MultiplicationNode>(create<VariableNode>("c", 658), create<VariableNode>("d", 0)));
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::NON_LINEAR);
 
     expr = create<SumNode>(create<LiteralNode>(41),
                            create<MultiplicationNode>(create<LiteralNode>(5),
-                                                      create<VariableNode>("e")),
-                           create<MultiplicationNode>(create<VariableNode>("f"),
-                                                      create<VariableNode>("g")));
+                                                      create<VariableNode>("e", 0)),
+                           create<MultiplicationNode>(create<VariableNode>("f", 0),
+                                                      create<VariableNode>("g", 0)));
     BOOST_CHECK_EQUAL(linearVisitor.dispatch(expr), LinearStatus::NON_LINEAR);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/expressions/test_nodes.cpp
+++ b/src/tests/src/expressions/test_nodes.cpp
@@ -87,7 +87,7 @@ BOOST_FIXTURE_TEST_CASE(nodes_name, Registry<Node>)
       {create<GreaterThanOrEqualNode>(literalNode, literalNode), "GreaterThanOrEqualNode"},
       {create<NegationNode>(literalNode), "NegationNode"},
       {create<ParameterNode>(literalNode->name()), "ParameterNode"},
-      {create<VariableNode>(literalNode->name()), "VariableNode"},
+      {create<VariableNode>(literalNode->name(), 568), "VariableNode"},
       {create<PortFieldNode>(literalNode->name(), literalNode->name()), "PortFieldNode"},
       {create<PortFieldSumNode>(literalNode->name(), literalNode->name()), "PortFieldSumNode"},
       {create<TimeShiftNode>(literalNode, literalNode), "TimeShiftNode"},

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -283,7 +283,7 @@ ExpressionToNodeConvertorEmptyModel createMediumExpression()
 std::pair<std::string, Nodes::Node*> expected_expression(Registry<Nodes::Node>& registry)
 {
     auto* param = registry.create<Nodes::ParameterNode>("param1");
-    auto* var = registry.create<Nodes::VariableNode>("varP");
+    auto* var = registry.create<Nodes::VariableNode>("varP", 89);
     auto* l3 = registry.create<Nodes::LiteralNode>(3);
     auto* l42 = registry.create<Nodes::LiteralNode>(42);
     auto* l1 = registry.create<Nodes::LiteralNode>(1);


### PR DESCRIPTION
- Remove unused public methods `variablesSize` and `constraintsSize` from class `OptimEntityContainer`
- Remove unused public method `getVariableStartColumn` from `ComponentFiller`
- Remove public method `IncrementConstraintGLobalIndex` from `OptimEntityContainer`, use `constraintStartLine_.size()` instead.
- Add a `getVariables` public method to simplify calling sites. 
- Remove `OptimEntityContainer::modelVariablesGlobalIndices` (becomes unused)