### PR TITLE
Fix inconsistent LOLD for districts [ANT-3408]

### DIFF
--- a/src/solver/variable/include/antares/solver/variable/commons/spatial-aggregate.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/spatial-aggregate.h
@@ -443,7 +443,6 @@ private:
                 // This means that, here :
                 // - for OverallCost, we sum the hourly values of var OverallCost for each
                 //   district's areas.
-                // - for LOLD, we sum the hourly values of var UNSP. ENRG for each district's areas
                 allVars.template computeSpatialAggregateWith<
                   typename VCardType::VCardForSpatialAggregate>(pValuesForTheCurrentYear[numSpace],
                                                                 *i /* the current area */,
@@ -460,8 +459,6 @@ private:
             if (VCardType::VCardOrigin::spatialAggregate
                 & Category::spatialAggregateSumThen1IfPositive)
             {
-                // This case applies (for instance) if VarT is LOLD : if any area in the district
-                // has any unsupplied E (even tiny), LOLD of district is 1.
                 VariableAccessorType::SetTo1IfPositive(pValuesForTheCurrentYear[numSpace]);
             }
             if (VCardType::VCardOrigin::spatialAggregate & Category::spatialAggregateOr)

--- a/src/solver/variable/include/antares/solver/variable/economy/lold.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/lold.h
@@ -21,7 +21,6 @@
 #ifndef __SOLVER_VARIABLE_ECONOMY_LOLD_H__
 #define __SOLVER_VARIABLE_ECONOMY_LOLD_H__
 
-#include "antares/solver/variable/economy/unsupliedEnergy.h"
 #include "antares/solver/variable/variable.h"
 
 namespace Antares::Solver::Variable::Economy
@@ -55,7 +54,7 @@ struct VCardLOLD
       ResultsType;
 
     //! The VCard to look for for calculating spatial aggregates
-    typedef VCardUnsupliedEnergy VCardForSpatialAggregate;
+    typedef VCardLOLD VCardForSpatialAggregate;
 
     //! Data Level
     static constexpr uint8_t categoryDataLevel = Category::DataLevel::area;


### PR DESCRIPTION
### Before
LOLD for a district was 1 if and only if sum(UNSP ENRG) > 0 for all areas of the district
### Now
 LOLD for a district is 1 if and only if at least LOLD=1 for any area within the district