### PR TITLE
Use branch name for cache key

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/.ccache
-        key: ${{ matrix.os }}-${{ github.ref_name }}
+        key: ${{ matrix.os }}-${{ github.event.pull_request.head.ref }}
         restore-keys: |
           ${{ matrix.os }}- 
 
@@ -253,5 +253,5 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ${{ github.workspace }}/.ccache
-        key: ${{ matrix.os }}-${{ github.ref_name }}
+        key: ${{ matrix.os }}-${{ github.event.pull_request.head.ref }}
 


### PR DESCRIPTION
For PR event, ${{ github.ref_name }} is #number/merge.
We want the branch name to use the same cache as ubuntu workflows

<img width="1080" height="394" alt="image" src="https://github.com/user-attachments/assets/4a661c86-739f-4f70-a99a-787a1a1a47e1" />
