### PR TITLE
Fix lolpCsr spatial aggregate

### DIFF
--- a/src/solver/variable/include/antares/solver/variable/economy/lolpCsr.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/lolpCsr.h
@@ -72,7 +72,7 @@ struct VCardLOLP_CSR
     //! Number of columns used by the variable (One ResultsType per column)
     static constexpr int columnCount = 1;
     //! The Spatial aggregation
-    static constexpr uint8_t spatialAggregate = Category::spatialAggregateSum;
+    static constexpr uint8_t spatialAggregate = Category::spatialAggregateOr;
     static constexpr uint8_t spatialAggregateMode = Category::spatialAggregateEachYear;
     static constexpr uint8_t spatialAggregatePostProcessing = 0;
     //! Intermediate values


### PR DESCRIPTION
This change corrects a typo in the spatialAggregate constant for the LOLP CSR variable. The value was incorrectly set to Category::spatialAggregateSum, which would lead to incoherent results for district-level aggregation (e.g., values outside the [0, 100] range, as summing probabilities doesn't make sense for a failure probability metric).

LOLP represents the probability of failure. For a single area, it's calculated as 100 * (number of scenarios with failure) / (total scenarios). For multiple areas (district), the aggregation should use OR logic: if any area has failure, the district has failure (resulting in 100 if true, 0 otherwise), as implemented in info.h.

The correct value is Category::spatialAggregateOr, ensuring consistent and meaningful output for district-level LOLP CSR.