### PR TITLE
Extract random number handling from templated class ISimulation (technical preriquisite) [ANT-2334]

### DIFF
--- a/src/solver/simulation/CMakeLists.txt
+++ b/src/solver/simulation/CMakeLists.txt
@@ -15,9 +15,9 @@ set(SRC_SIMULATION
         include/antares/solver/simulation/simulation.h
         include/antares/solver/simulation/solver.h
         include/antares/solver/simulation/solver.hxx
-	include/antares/solver/simulation/numspace_manager.h
-	include/antares/solver/simulation/random.h
-	numspace_manager.cpp
+        include/antares/solver/simulation/numspace_manager.h
+        include/antares/solver/simulation/random.h
+        numspace_manager.cpp
         include/antares/solver/simulation/timeseries-numbers.h
         sim_alloc_probleme_hebdo.cpp
         sim_binding_constraints_rhs.cpp
@@ -50,7 +50,7 @@ set(SRC_SIMULATION
         TimeSeriesNumbersWriter.cpp
         include/antares/solver/simulation/BindingConstraintsTimeSeriesNumbersWriter.h
         include/antares/solver/simulation/ISimulationObserver.h
-	random.cpp
+        random.cpp
 )
 source_group("simulation" FILES ${SRC_SIMULATION})
 

--- a/src/solver/simulation/CMakeLists.txt
+++ b/src/solver/simulation/CMakeLists.txt
@@ -15,8 +15,9 @@ set(SRC_SIMULATION
         include/antares/solver/simulation/simulation.h
         include/antares/solver/simulation/solver.h
         include/antares/solver/simulation/solver.hxx
-		include/antares/solver/simulation/numspace_manager.h
-		numspace_manager.cpp
+	include/antares/solver/simulation/numspace_manager.h
+	include/antares/solver/simulation/random.h
+	numspace_manager.cpp
         include/antares/solver/simulation/timeseries-numbers.h
         sim_alloc_probleme_hebdo.cpp
         sim_binding_constraints_rhs.cpp
@@ -49,6 +50,7 @@ set(SRC_SIMULATION
         TimeSeriesNumbersWriter.cpp
         include/antares/solver/simulation/BindingConstraintsTimeSeriesNumbersWriter.h
         include/antares/solver/simulation/ISimulationObserver.h
+	random.cpp
 )
 source_group("simulation" FILES ${SRC_SIMULATION})
 

--- a/src/solver/simulation/include/antares/solver/simulation/random.h
+++ b/src/solver/simulation/include/antares/solver/simulation/random.h
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2007-2025, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
+
 #pragma once
 
 #include <antares/mersenne-twister/mersenne-twister.h>

--- a/src/solver/simulation/include/antares/solver/simulation/random.h
+++ b/src/solver/simulation/include/antares/solver/simulation/random.h
@@ -30,30 +30,15 @@ namespace Antares::Solver::Simulation
 class randomNumbers
 {
 public:
-    randomNumbers(uint maxNbPerformedYearsInAset, Data::PowerFluctuations powerFluctuations):
-        pMaxNbPerformedYears(maxNbPerformedYearsInAset)
-    {
-        // Allocate a table of parallel years structures
-        pYears.resize(maxNbPerformedYearsInAset);
-
-        // Tells these structures their power fluctuations mode
-        for (uint y = 0; y < maxNbPerformedYearsInAset; ++y)
-        {
-            pYears[y].setPowerFluctuations(powerFluctuations);
-        }
-    }
-
+    randomNumbers(uint maxNbPerformedYearsInAset, Data::PowerFluctuations powerFluctuations);
     ~randomNumbers() = default;
 
-    void reset()
-    {
-        for (uint i = 0; i < pMaxNbPerformedYears; i++)
-        {
-            pYears[i].reset();
-        }
-
-        yearNumberToIndex.clear();
-    }
+    void allocate(const Antares::Data::Study& study);
+    void compute(Antares::Data::Study& study,
+                 unsigned years,
+                 std::map<unsigned int, bool>& isYearPerformed,
+                 MersenneTwister& randomHydro);
+    void reset();
 
     uint pMaxNbPerformedYears;
     std::vector<yearRandomNumbers> pYears;
@@ -64,13 +49,4 @@ public:
     //..., max nb of parallel years - 1)
     std::map<uint, uint> yearNumberToIndex;
 };
-
-void allocateMemoryForRandomNumbers(const Antares::Data::Study& study,
-                                    randomNumbers& randomForParallelYears);
-
-void computeRandomNumbers(Antares::Data::Study& study,
-                          randomNumbers& randomForYears,
-                          unsigned years,
-                          std::map<unsigned int, bool>& isYearPerformed,
-                          MersenneTwister& randomHydro);
 } // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/include/antares/solver/simulation/random.h
+++ b/src/solver/simulation/include/antares/solver/simulation/random.h
@@ -27,6 +27,44 @@
 
 namespace Antares::Solver::Simulation
 {
+class randomNumbers
+{
+public:
+    randomNumbers(uint maxNbPerformedYearsInAset, Data::PowerFluctuations powerFluctuations):
+        pMaxNbPerformedYears(maxNbPerformedYearsInAset)
+    {
+        // Allocate a table of parallel years structures
+        pYears.resize(maxNbPerformedYearsInAset);
+
+        // Tells these structures their power fluctuations mode
+        for (uint y = 0; y < maxNbPerformedYearsInAset; ++y)
+        {
+            pYears[y].setPowerFluctuations(powerFluctuations);
+        }
+    }
+
+    ~randomNumbers() = default;
+
+    void reset()
+    {
+        for (uint i = 0; i < pMaxNbPerformedYears; i++)
+        {
+            pYears[i].reset();
+        }
+
+        yearNumberToIndex.clear();
+    }
+
+    uint pMaxNbPerformedYears;
+    std::vector<yearRandomNumbers> pYears;
+
+    // Associates :
+    //		year number (0, ..., total nb of years to compute - 1) --> index of the year's space
+    //(0,
+    //..., max nb of parallel years - 1)
+    std::map<uint, uint> yearNumberToIndex;
+};
+
 void allocateMemoryForRandomNumbers(const Antares::Data::Study& study,
                                     randomNumbers& randomForParallelYears);
 

--- a/src/solver/simulation/include/antares/solver/simulation/random.h
+++ b/src/solver/simulation/include/antares/solver/simulation/random.h
@@ -40,7 +40,6 @@ public:
                  MersenneTwister& randomHydro);
     void reset();
 
-    uint pMaxNbPerformedYears;
     std::vector<yearRandomNumbers> pYears;
 
     // Associates :
@@ -48,5 +47,8 @@ public:
     //(0,
     //..., max nb of parallel years - 1)
     std::map<uint, uint> yearNumberToIndex;
+
+private:
+    uint pMaxNbPerformedYears;
 };
 } // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/include/antares/solver/simulation/random.h
+++ b/src/solver/simulation/include/antares/solver/simulation/random.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <antares/mersenne-twister/mersenne-twister.h>
+#include <antares/solver/simulation/solver_utils.h>
+#include <antares/study/study.h>
+
+namespace Antares::Solver::Simulation
+{
+void allocateMemoryForRandomNumbers(const Antares::Data::Study& study,
+                                    randomNumbers& randomForParallelYears);
+
+void computeRandomNumbers(Antares::Data::Study& study,
+                          randomNumbers& randomForYears,
+                          unsigned years,
+                          std::map<unsigned int, bool>& isYearPerformed,
+                          MersenneTwister& randomHydro);
+} // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/include/antares/solver/simulation/solver.h
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.h
@@ -39,7 +39,6 @@ class OptimisationsSimulationTable;
 
 namespace Antares::Solver::Simulation
 {
-
 template<class Impl>
 class yearJob;
 
@@ -98,24 +97,6 @@ private:
     uint buildSetsOfParallelYears(uint firstYear,
                                   uint endYear,
                                   std::vector<setOfParallelYears>& setsOfParallelYears);
-
-    /*!
-    ** \brief Allocate storage for random numbers of parallel years
-    **
-    ** \param	randomParallelYears	... to be finished ...
-    */
-    void allocateMemoryForRandomNumbers(randomNumbers& randomForParallelYears);
-
-    /*!
-    ** \brief Computes random numbers for each years of a list
-    **
-    ** \param	randomForYears	Storage for random numbers for years in the list
-    ** \param	years			List of years
-    */
-    void computeRandomNumbers(randomNumbers& randomForYears,
-                              unsigned years,
-                              std::map<unsigned int, bool>& isYearPerformed,
-                              MersenneTwister& randomHydro);
 
     /*!
     ** \brief Computes statistics on annual (system and solution) costs, to be printed in output

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -21,8 +21,6 @@
 #ifndef __SOLVER_SIMULATION_SOLVER_HXX__
 #define __SOLVER_SIMULATION_SOLVER_HXX__
 
-// #include <yuni/io/io.h>
-
 #include <antares/antares/fatal-error.h>
 #include <antares/date/date.h>
 #include <antares/exception/InitializationError.hpp>

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -21,7 +21,7 @@
 #ifndef __SOLVER_SIMULATION_SOLVER_HXX__
 #define __SOLVER_SIMULATION_SOLVER_HXX__
 
-#include <yuni/io/io.h>
+// #include <yuni/io/io.h>
 
 #include <antares/antares/fatal-error.h>
 #include <antares/date/date.h>
@@ -33,6 +33,7 @@
 #include "antares/solver/hydro/management/management.h"
 #include "antares/solver/simulation/numspace_manager.h"
 #include "antares/solver/simulation/opt_time_writer.h"
+#include "antares/solver/simulation/random.h"
 #include "antares/solver/simulation/timeseries-numbers.h"
 #include "antares/solver/ts-generator/generator.h"
 #include "antares/solver/variable/print.h"
@@ -473,296 +474,6 @@ void ISimulation<ImplementationType>::regenerateTimeSeries()
 }
 
 template<class ImplementationType>
-void ISimulation<ImplementationType>::allocateMemoryForRandomNumbers(
-  randomNumbers& randomForParallelYears)
-{
-    uint maxNbPerformedYears = randomForParallelYears.pMaxNbPerformedYears;
-    uint nbAreas = study.areas.size();
-
-    for (uint y = 0; y < maxNbPerformedYears; y++)
-    {
-        // General :
-        randomForParallelYears.pYears[y].setNbAreas(nbAreas);
-        randomForParallelYears.pYears[y].pNbClustersByArea.resize(nbAreas);
-
-        // Thermal noises :
-        randomForParallelYears.pYears[y].pThermalNoisesByArea.resize(nbAreas);
-
-        for (uint a = 0; a != nbAreas; ++a)
-        {
-            // logs.info() << "   area : " << a << " :";
-            auto& area = *(study.areas.byIndex[a]);
-            size_t nbClusters = area.thermal.list.allClustersCount();
-            randomForParallelYears.pYears[y].pThermalNoisesByArea[a].resize(nbClusters);
-            randomForParallelYears.pYears[y].pNbClustersByArea[a] = nbClusters;
-        }
-
-        // Reservoir levels
-        randomForParallelYears.pYears[y].pReservoirLevels.resize(nbAreas);
-
-        // Noises on unsupplied and spilled energy
-        randomForParallelYears.pYears[y].pUnsuppliedEnergy.resize(nbAreas);
-        randomForParallelYears.pYears[y].pSpilledEnergy.resize(nbAreas);
-
-        // Hydro costs noises
-        switch (study.parameters.power.fluctuations)
-        {
-        case Data::lssFreeModulations:
-        {
-            randomForParallelYears.pYears[y].pHydroCostsByArea_freeMod.resize(nbAreas);
-            for (uint a = 0; a != nbAreas; ++a)
-            {
-                randomForParallelYears.pYears[y].pHydroCostsByArea_freeMod[a].resize(8784);
-            }
-            break;
-        }
-        case Data::lssMinimizeRamping:
-        case Data::lssMinimizeExcursions:
-        {
-            randomForParallelYears.pYears[y].pHydroCosts_rampingOrExcursion.resize(nbAreas);
-            break;
-        }
-        case Data::lssUnknown:
-        {
-            logs.error() << "Power fluctuation unknown";
-            break;
-        }
-        }
-    } // End loop over years
-}
-
-template<class ImplementationType>
-void ISimulation<ImplementationType>::computeRandomNumbers(
-  randomNumbers& randomForYears,
-  unsigned nbYears,
-  std::map<unsigned int, bool>& isYearPerformed,
-  MersenneTwister& randomHydroGenerator)
-{
-    uint indexYear = 0;
-
-    for (unsigned y = 0; y < nbYears; ++y)
-    {
-        bool isPerformed = isYearPerformed[y];
-        if (isPerformed)
-        {
-            randomForYears.yearNumberToIndex[y] = indexYear;
-        }
-
-        // General
-        const unsigned int nbAreas = study.areas.size();
-
-        // ... Thermal noise ...
-        for (unsigned int a = 0; a != nbAreas; ++a)
-        {
-            const auto& area = *(study.areas.byIndex[a]);
-
-            for (auto& cluster: area.thermal.list.all())
-            {
-                uint clusterIndex = cluster->areaWideIndex;
-                double thermalNoise = study.runtime.random[Data::seedThermalCosts].next();
-                if (isPerformed)
-                {
-                    randomForYears.pYears[indexYear].pThermalNoisesByArea[a][clusterIndex]
-                      = thermalNoise;
-                }
-            }
-        }
-
-        // ... Reservoir levels ...
-        uint areaIndex = 0;
-        study.areas.each(
-          [&areaIndex, &indexYear, &randomForYears, &randomHydroGenerator, &y, &isPerformed, this](
-            Data::Area& area)
-          {
-              // looking for the initial reservoir level (begining of the year)
-              auto& min = area.hydro.reservoirLevel[Data::PartHydro::minimum];
-              auto& avg = area.hydro.reservoirLevel[Data::PartHydro::average];
-              auto& max = area.hydro.reservoirLevel[Data::PartHydro::maximum];
-
-              // Month the reservoir level is initialized according to.
-              // This month number is given in the civil calendar, from january to december (0 is
-              // january).
-              int initResLevelOnMonth = area.hydro.initializeReservoirLevelDate;
-
-              // Conversion of the previous month into simulation calendar
-              int initResLevelOnSimMonth = study.calendar.mapping.months[initResLevelOnMonth];
-
-              // Previous month's first day in the year
-              int firstDayOfMonth = study.calendar.months[initResLevelOnSimMonth].daysYear.first;
-
-              double randomLevel = randomReservoirLevel(min[firstDayOfMonth],
-                                                        avg[firstDayOfMonth],
-                                                        max[firstDayOfMonth],
-                                                        randomHydroGenerator);
-
-              // Possibly update the intial level from scenario builder
-              if (study.parameters.useCustomScenario)
-              {
-                  double levelFromScenarioBuilder = study.scenarioInitialHydroLevels[areaIndex][y];
-                  if (levelFromScenarioBuilder >= 0.)
-                  {
-                      randomLevel = levelFromScenarioBuilder;
-                  }
-              }
-
-              // Current area's hydro starting (or initial) level computation
-              // (no matter if the year is performed or not, we always draw a random initial
-              // reservoir level to ensure the same results)
-              if (isPerformed)
-              {
-                  randomForYears.pYears[indexYear].pReservoirLevels[areaIndex] = randomLevel;
-              }
-
-              areaIndex++;
-          }); // each area
-
-        // ... Unsupplied and spilled energy costs noises (french : bruits sur la defaillance
-        // positive et negatives) ... references to the random number generators
-        auto& randomUnsupplied = study.runtime.random[Data::seedUnsuppliedEnergyCosts];
-        auto& randomSpilled = study.runtime.random[Data::seedSpilledEnergyCosts];
-
-        int currentSpilledEnergySeed = study.parameters.seed[Data::seedSpilledEnergyCosts];
-        int defaultSpilledEnergySeed = Data::antaresSeedDefaultValue
-                                       + Data::seedSpilledEnergyCosts * Data::antaresSeedIncrement;
-        bool SpilledEnergySeedIsDefault = (currentSpilledEnergySeed == defaultSpilledEnergySeed);
-        areaIndex = 0;
-        study.areas.each(
-          [&isPerformed,
-           &areaIndex,
-           &randomUnsupplied,
-           &randomSpilled,
-           &randomForYears,
-           &indexYear,
-           &SpilledEnergySeedIsDefault](Data::Area& area)
-          {
-              (void)area; // Avoiding warnings at compilation (unused variable) on linux
-              if (isPerformed)
-              {
-                  double randomNumber = randomUnsupplied();
-                  randomForYears.pYears[indexYear].pUnsuppliedEnergy[areaIndex] = randomNumber;
-                  randomForYears.pYears[indexYear].pSpilledEnergy[areaIndex] = randomNumber;
-                  if (!SpilledEnergySeedIsDefault)
-                  {
-                      randomForYears.pYears[indexYear].pSpilledEnergy[areaIndex] = randomSpilled();
-                  }
-              }
-              else
-              {
-                  randomUnsupplied();
-                  if (!SpilledEnergySeedIsDefault)
-                  {
-                      randomSpilled();
-                  }
-              }
-
-              areaIndex++;
-          }); // each area
-
-        // ... Hydro costs noises ...
-        auto& randomHydro = study.runtime.random[Data::seedHydroCosts];
-
-        Data::PowerFluctuations powerFluctuations = study.parameters.power.fluctuations;
-        switch (powerFluctuations)
-        {
-        case Data::lssFreeModulations:
-        {
-            areaIndex = 0;
-            auto end = study.areas.end();
-
-            // Computing hourly hydro costs noises so that they are homogeneously spread into :
-            // [-1.e-3, -5*1.e-4] U [+5*1.e-4, +1.e-3]
-            if (isPerformed)
-            {
-                for (auto i = study.areas.begin(); i != end; ++i)
-                {
-                    auto& noise = randomForYears.pYears[indexYear]
-                                    .pHydroCostsByArea_freeMod[areaIndex];
-                    std::set<hydroCostNoise, compareHydroCostsNoises> setHydroCostsNoises;
-                    for (uint j = 0; j != 8784; ++j)
-                    {
-                        noise[j] = randomHydro();
-                        noise[j] -= 0.5; // Now we have : -0.5 < noise[j] < +0.5
-
-                        // This std::set naturally sorts the hydro costs noises into increasing
-                        // absolute values order
-                        setHydroCostsNoises.insert(hydroCostNoise(noise[j], j));
-                    }
-
-                    uint rank = 0;
-                    std::set<hydroCostNoise, compareHydroCostsNoises>::iterator it;
-                    for (it = setHydroCostsNoises.begin(); it != setHydroCostsNoises.end(); it++)
-                    {
-                        uint index = it->getIndex();
-                        double value = it->getValue();
-
-                        if (value < 0.)
-                        {
-                            noise[index] = -5 * 1.e-4 * (1 + rank / 8784.);
-                        }
-                        else
-                        {
-                            noise[index] = 5 * 1.e-4 * (1 + rank / 8784.);
-                        }
-
-                        rank++;
-                    }
-
-                    areaIndex++;
-                }
-            }
-            else
-            {
-                for (auto i = study.areas.begin(); i != end; ++i)
-                {
-                    for (uint j = 0; j != 8784; ++j)
-                    {
-                        randomHydro();
-                    }
-                }
-            }
-
-            break;
-        }
-
-        case Data::lssMinimizeRamping:
-        case Data::lssMinimizeExcursions:
-        {
-            areaIndex = 0;
-            auto end = study.areas.end();
-            for (auto i = study.areas.begin(); i != end; ++i)
-            {
-                if (isPerformed)
-                {
-                    randomForYears.pYears[indexYear].pHydroCosts_rampingOrExcursion[areaIndex]
-                      = randomHydro();
-                }
-                else
-                {
-                    randomHydro();
-                }
-
-                areaIndex++;
-            }
-            break;
-        }
-
-        case Data::lssUnknown:
-        {
-            logs.error() << "Power fluctuation unknown";
-            break;
-        }
-
-        } // end of switch
-
-        if (isPerformed)
-        {
-            indexYear++;
-        }
-
-    } // End loop over years
-} // End function
-
-template<class ImplementationType>
 void ISimulation<ImplementationType>::computeAnnualCostsStatistics(Variable::State s)
 {
     pAnnualStatistics.systemCost.addCost(s.annualSystemCost);
@@ -828,8 +539,12 @@ void ISimulation<ImplementationType>::loopThroughYears(uint firstYear,
     randomNumbers randomForParallelYears(pNbYearsReallyPerformed,
                                          study.parameters.power.fluctuations);
 
-    allocateMemoryForRandomNumbers(randomForParallelYears);
-    computeRandomNumbers(randomForParallelYears, endYear, isYearPerformed, randomHydroGenerator);
+    allocateMemoryForRandomNumbers(study, randomForParallelYears);
+    computeRandomNumbers(study,
+                         randomForParallelYears,
+                         endYear,
+                         isYearPerformed,
+                         randomHydroGenerator);
 
     // hydro checks
     for (uint year = firstYear; year < endYear; ++year)

--- a/src/solver/simulation/include/antares/solver/simulation/solver.hxx
+++ b/src/solver/simulation/include/antares/solver/simulation/solver.hxx
@@ -537,12 +537,8 @@ void ISimulation<ImplementationType>::loopThroughYears(uint firstYear,
     randomNumbers randomForParallelYears(pNbYearsReallyPerformed,
                                          study.parameters.power.fluctuations);
 
-    allocateMemoryForRandomNumbers(study, randomForParallelYears);
-    computeRandomNumbers(study,
-                         randomForParallelYears,
-                         endYear,
-                         isYearPerformed,
-                         randomHydroGenerator);
+    randomForParallelYears.allocate(study);
+    randomForParallelYears.compute(study, endYear, isYearPerformed, randomHydroGenerator);
 
     // hydro checks
     for (uint year = firstYear; year < endYear; ++year)

--- a/src/solver/simulation/include/antares/solver/simulation/solver_utils.h
+++ b/src/solver/simulation/include/antares/solver/simulation/solver_utils.h
@@ -183,44 +183,6 @@ public:
     std::vector<double> pHydroCosts_rampingOrExcursion;
 };
 
-class randomNumbers
-{
-public:
-    randomNumbers(uint maxNbPerformedYearsInAset, Data::PowerFluctuations powerFluctuations):
-        pMaxNbPerformedYears(maxNbPerformedYearsInAset)
-    {
-        // Allocate a table of parallel years structures
-        pYears.resize(maxNbPerformedYearsInAset);
-
-        // Tells these structures their power fluctuations mode
-        for (uint y = 0; y < maxNbPerformedYearsInAset; ++y)
-        {
-            pYears[y].setPowerFluctuations(powerFluctuations);
-        }
-    }
-
-    ~randomNumbers() = default;
-
-    void reset()
-    {
-        for (uint i = 0; i < pMaxNbPerformedYears; i++)
-        {
-            pYears[i].reset();
-        }
-
-        yearNumberToIndex.clear();
-    }
-
-    uint pMaxNbPerformedYears;
-    std::vector<yearRandomNumbers> pYears;
-
-    // Associates :
-    //		year number (0, ..., total nb of years to compute - 1) --> index of the year's space
-    //(0,
-    //..., max nb of parallel years - 1)
-    std::map<uint, uint> yearNumberToIndex;
-};
-
 // Class representing a hydro cost noise.
 // This class allows sorting hydro costs noises into increasing absolute values order
 // when instances are contained in a :

--- a/src/solver/simulation/random.cpp
+++ b/src/solver/simulation/random.cpp
@@ -25,53 +25,75 @@
 
 namespace Antares::Solver::Simulation
 {
-void allocateMemoryForRandomNumbers(const Antares::Data::Study& study,
-                                    randomNumbers& randomForParallelYears)
+randomNumbers::randomNumbers(uint maxNbPerformedYearsInAset,
+                             Data::PowerFluctuations powerFluctuations):
+    pMaxNbPerformedYears(maxNbPerformedYearsInAset)
 {
-    uint maxNbPerformedYears = randomForParallelYears.pMaxNbPerformedYears;
+    // Allocate a table of parallel years structures
+    pYears.resize(maxNbPerformedYearsInAset);
+
+    // Tells these structures their power fluctuations mode
+    for (uint y = 0; y < maxNbPerformedYearsInAset; ++y)
+    {
+        pYears[y].setPowerFluctuations(powerFluctuations);
+    }
+}
+
+void randomNumbers::reset()
+{
+    for (uint i = 0; i < pMaxNbPerformedYears; i++)
+    {
+        pYears[i].reset();
+    }
+
+    yearNumberToIndex.clear();
+}
+
+void randomNumbers::allocate(const Antares::Data::Study& study)
+{
     uint nbAreas = study.areas.size();
 
-    for (uint y = 0; y < maxNbPerformedYears; y++)
+    for (uint y = 0; y < pMaxNbPerformedYears; y++)
     {
         // General :
-        randomForParallelYears.pYears[y].setNbAreas(nbAreas);
-        randomForParallelYears.pYears[y].pNbClustersByArea.resize(nbAreas);
+        pYears[y].setNbAreas(nbAreas);
+        pYears[y].pNbClustersByArea.resize(nbAreas);
 
         // Thermal noises :
-        randomForParallelYears.pYears[y].pThermalNoisesByArea.resize(nbAreas);
+        pYears[y].pThermalNoisesByArea.resize(nbAreas);
 
         for (uint a = 0; a != nbAreas; ++a)
         {
             // logs.info() << "   area : " << a << " :";
             auto& area = *(study.areas.byIndex[a]);
             size_t nbClusters = area.thermal.list.allClustersCount();
-            randomForParallelYears.pYears[y].pThermalNoisesByArea[a].resize(nbClusters);
-            randomForParallelYears.pYears[y].pNbClustersByArea[a] = nbClusters;
+            pYears[y].pThermalNoisesByArea[a].resize(nbClusters);
+            pYears[y].pNbClustersByArea[a] = nbClusters;
         }
 
         // Reservoir levels
-        randomForParallelYears.pYears[y].pReservoirLevels.resize(nbAreas);
+        pYears[y].pReservoirLevels.resize(nbAreas);
 
         // Noises on unsupplied and spilled energy
-        randomForParallelYears.pYears[y].pUnsuppliedEnergy.resize(nbAreas);
-        randomForParallelYears.pYears[y].pSpilledEnergy.resize(nbAreas);
+        pYears[y].pUnsuppliedEnergy.resize(nbAreas);
+        pYears[y].pSpilledEnergy.resize(nbAreas);
 
         // Hydro costs noises
         switch (study.parameters.power.fluctuations)
         {
         case Data::lssFreeModulations:
         {
-            randomForParallelYears.pYears[y].pHydroCostsByArea_freeMod.resize(nbAreas);
+            pYears[y].pHydroCostsByArea_freeMod.resize(nbAreas);
             for (uint a = 0; a != nbAreas; ++a)
             {
-                randomForParallelYears.pYears[y].pHydroCostsByArea_freeMod[a].resize(8784);
+                pYears[y].pHydroCostsByArea_freeMod[a].resize(8784);
             }
             break;
         }
         case Data::lssMinimizeRamping:
         case Data::lssMinimizeExcursions:
         {
-            randomForParallelYears.pYears[y].pHydroCosts_rampingOrExcursion.resize(nbAreas);
+            pYears[y].pHydroCosts_rampingOrExcursion.resize(nbAreas);
             break;
         }
         case Data::lssUnknown:
@@ -83,11 +105,10 @@ void allocateMemoryForRandomNumbers(const Antares::Data::Study& study,
     } // End loop over years
 }
 
-void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has non-const methods
-                          randomNumbers& randomForYears,
-                          unsigned nbYears,
-                          std::map<unsigned int, bool>& isYearPerformed,
-                          MersenneTwister& randomHydroGenerator)
+void randomNumbers::compute(Antares::Data::Study& study, // Mersenne-Twister has non-const methods
+                            unsigned nbYears,
+                            std::map<unsigned int, bool>& isYearPerformed,
+                            MersenneTwister& randomHydroGenerator)
 {
     uint indexYear = 0;
 
@@ -96,7 +117,7 @@ void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has n
         bool isPerformed = isYearPerformed[y];
         if (isPerformed)
         {
-            randomForYears.yearNumberToIndex[y] = indexYear;
+            yearNumberToIndex[y] = indexYear;
         }
 
         // General
@@ -113,8 +134,7 @@ void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has n
                 double thermalNoise = study.runtime.random[Data::seedThermalCosts].next();
                 if (isPerformed)
                 {
-                    randomForYears.pYears[indexYear].pThermalNoisesByArea[a][clusterIndex]
-                      = thermalNoise;
+                    pYears[indexYear].pThermalNoisesByArea[a][clusterIndex] = thermalNoise;
                 }
             }
         }
@@ -122,13 +142,8 @@ void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has n
         // ... Reservoir levels ...
         uint areaIndex = 0;
         study.areas.each(
-          [&areaIndex,
-           &indexYear,
-           &randomForYears,
-           &randomHydroGenerator,
-           &y,
-           &isPerformed,
-           &study](Data::Area& area)
+          [&areaIndex, &indexYear, &randomHydroGenerator, &y, &isPerformed, &study, this](
+            Data::Area& area)
           {
               // looking for the initial reservoir level (begining of the year)
               auto& min = area.hydro.reservoirLevel[Data::PartHydro::minimum];
@@ -166,7 +181,7 @@ void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has n
               // reservoir level to ensure the same results)
               if (isPerformed)
               {
-                  randomForYears.pYears[indexYear].pReservoirLevels[areaIndex] = randomLevel;
+                  pYears[indexYear].pReservoirLevels[areaIndex] = randomLevel;
               }
 
               areaIndex++;
@@ -187,19 +202,19 @@ void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has n
            &areaIndex,
            &randomUnsupplied,
            &randomSpilled,
-           &randomForYears,
            &indexYear,
-           &SpilledEnergySeedIsDefault](Data::Area& area)
+           &SpilledEnergySeedIsDefault,
+           this](Data::Area& area)
           {
               (void)area; // Avoiding warnings at compilation (unused variable) on linux
               if (isPerformed)
               {
                   double randomNumber = randomUnsupplied();
-                  randomForYears.pYears[indexYear].pUnsuppliedEnergy[areaIndex] = randomNumber;
-                  randomForYears.pYears[indexYear].pSpilledEnergy[areaIndex] = randomNumber;
+                  pYears[indexYear].pUnsuppliedEnergy[areaIndex] = randomNumber;
+                  pYears[indexYear].pSpilledEnergy[areaIndex] = randomNumber;
                   if (!SpilledEnergySeedIsDefault)
                   {
-                      randomForYears.pYears[indexYear].pSpilledEnergy[areaIndex] = randomSpilled();
+                      pYears[indexYear].pSpilledEnergy[areaIndex] = randomSpilled();
                   }
               }
               else
@@ -231,8 +246,7 @@ void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has n
             {
                 for (auto i = study.areas.begin(); i != end; ++i)
                 {
-                    auto& noise = randomForYears.pYears[indexYear]
-                                    .pHydroCostsByArea_freeMod[areaIndex];
+                    auto& noise = pYears[indexYear].pHydroCostsByArea_freeMod[areaIndex];
                     std::set<hydroCostNoise, compareHydroCostsNoises> setHydroCostsNoises;
                     for (uint j = 0; j != 8784; ++j)
                     {
@@ -289,8 +303,7 @@ void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has n
             {
                 if (isPerformed)
                 {
-                    randomForYears.pYears[indexYear].pHydroCosts_rampingOrExcursion[areaIndex]
-                      = randomHydro();
+                    pYears[indexYear].pHydroCosts_rampingOrExcursion[areaIndex] = randomHydro();
                 }
                 else
                 {

--- a/src/solver/simulation/random.cpp
+++ b/src/solver/simulation/random.cpp
@@ -1,0 +1,299 @@
+#include "antares/solver/simulation/random.h"
+
+#include "antares/solver/hydro/management/management.h"
+
+namespace Antares::Solver::Simulation
+{
+void allocateMemoryForRandomNumbers(const Antares::Data::Study& study,
+                                    randomNumbers& randomForParallelYears)
+{
+    uint maxNbPerformedYears = randomForParallelYears.pMaxNbPerformedYears;
+    uint nbAreas = study.areas.size();
+
+    for (uint y = 0; y < maxNbPerformedYears; y++)
+    {
+        // General :
+        randomForParallelYears.pYears[y].setNbAreas(nbAreas);
+        randomForParallelYears.pYears[y].pNbClustersByArea.resize(nbAreas);
+
+        // Thermal noises :
+        randomForParallelYears.pYears[y].pThermalNoisesByArea.resize(nbAreas);
+
+        for (uint a = 0; a != nbAreas; ++a)
+        {
+            // logs.info() << "   area : " << a << " :";
+            auto& area = *(study.areas.byIndex[a]);
+            size_t nbClusters = area.thermal.list.allClustersCount();
+            randomForParallelYears.pYears[y].pThermalNoisesByArea[a].resize(nbClusters);
+            randomForParallelYears.pYears[y].pNbClustersByArea[a] = nbClusters;
+        }
+
+        // Reservoir levels
+        randomForParallelYears.pYears[y].pReservoirLevels.resize(nbAreas);
+
+        // Noises on unsupplied and spilled energy
+        randomForParallelYears.pYears[y].pUnsuppliedEnergy.resize(nbAreas);
+        randomForParallelYears.pYears[y].pSpilledEnergy.resize(nbAreas);
+
+        // Hydro costs noises
+        switch (study.parameters.power.fluctuations)
+        {
+        case Data::lssFreeModulations:
+        {
+            randomForParallelYears.pYears[y].pHydroCostsByArea_freeMod.resize(nbAreas);
+            for (uint a = 0; a != nbAreas; ++a)
+            {
+                randomForParallelYears.pYears[y].pHydroCostsByArea_freeMod[a].resize(8784);
+            }
+            break;
+        }
+        case Data::lssMinimizeRamping:
+        case Data::lssMinimizeExcursions:
+        {
+            randomForParallelYears.pYears[y].pHydroCosts_rampingOrExcursion.resize(nbAreas);
+            break;
+        }
+        case Data::lssUnknown:
+        {
+            logs.error() << "Power fluctuation unknown";
+            break;
+        }
+        }
+    } // End loop over years
+}
+
+void computeRandomNumbers(Antares::Data::Study& study, // Mersenne-Twister has non-const methods
+                          randomNumbers& randomForYears,
+                          unsigned nbYears,
+                          std::map<unsigned int, bool>& isYearPerformed,
+                          MersenneTwister& randomHydroGenerator)
+{
+    uint indexYear = 0;
+
+    for (unsigned y = 0; y < nbYears; ++y)
+    {
+        bool isPerformed = isYearPerformed[y];
+        if (isPerformed)
+        {
+            randomForYears.yearNumberToIndex[y] = indexYear;
+        }
+
+        // General
+        const unsigned int nbAreas = study.areas.size();
+
+        // ... Thermal noise ...
+        for (unsigned int a = 0; a != nbAreas; ++a)
+        {
+            const auto& area = *(study.areas.byIndex[a]);
+
+            for (auto& cluster: area.thermal.list.all())
+            {
+                uint clusterIndex = cluster->areaWideIndex;
+                double thermalNoise = study.runtime.random[Data::seedThermalCosts].next();
+                if (isPerformed)
+                {
+                    randomForYears.pYears[indexYear].pThermalNoisesByArea[a][clusterIndex]
+                      = thermalNoise;
+                }
+            }
+        }
+
+        // ... Reservoir levels ...
+        uint areaIndex = 0;
+        study.areas.each(
+          [&areaIndex,
+           &indexYear,
+           &randomForYears,
+           &randomHydroGenerator,
+           &y,
+           &isPerformed,
+           &study](Data::Area& area)
+          {
+              // looking for the initial reservoir level (begining of the year)
+              auto& min = area.hydro.reservoirLevel[Data::PartHydro::minimum];
+              auto& avg = area.hydro.reservoirLevel[Data::PartHydro::average];
+              auto& max = area.hydro.reservoirLevel[Data::PartHydro::maximum];
+
+              // Month the reservoir level is initialized according to.
+              // This month number is given in the civil calendar, from january to december (0 is
+              // january).
+              int initResLevelOnMonth = area.hydro.initializeReservoirLevelDate;
+
+              // Conversion of the previous month into simulation calendar
+              int initResLevelOnSimMonth = study.calendar.mapping.months[initResLevelOnMonth];
+
+              // Previous month's first day in the year
+              int firstDayOfMonth = study.calendar.months[initResLevelOnSimMonth].daysYear.first;
+
+              double randomLevel = randomReservoirLevel(min[firstDayOfMonth],
+                                                        avg[firstDayOfMonth],
+                                                        max[firstDayOfMonth],
+                                                        randomHydroGenerator);
+
+              // Possibly update the intial level from scenario builder
+              if (study.parameters.useCustomScenario)
+              {
+                  double levelFromScenarioBuilder = study.scenarioInitialHydroLevels[areaIndex][y];
+                  if (levelFromScenarioBuilder >= 0.)
+                  {
+                      randomLevel = levelFromScenarioBuilder;
+                  }
+              }
+
+              // Current area's hydro starting (or initial) level computation
+              // (no matter if the year is performed or not, we always draw a random initial
+              // reservoir level to ensure the same results)
+              if (isPerformed)
+              {
+                  randomForYears.pYears[indexYear].pReservoirLevels[areaIndex] = randomLevel;
+              }
+
+              areaIndex++;
+          }); // each area
+
+        // ... Unsupplied and spilled energy costs noises (french : bruits sur la defaillance
+        // positive et negatives) ... references to the random number generators
+        auto& randomUnsupplied = study.runtime.random[Data::seedUnsuppliedEnergyCosts];
+        auto& randomSpilled = study.runtime.random[Data::seedSpilledEnergyCosts];
+
+        int currentSpilledEnergySeed = study.parameters.seed[Data::seedSpilledEnergyCosts];
+        int defaultSpilledEnergySeed = Data::antaresSeedDefaultValue
+                                       + Data::seedSpilledEnergyCosts * Data::antaresSeedIncrement;
+        bool SpilledEnergySeedIsDefault = (currentSpilledEnergySeed == defaultSpilledEnergySeed);
+        areaIndex = 0;
+        study.areas.each(
+          [&isPerformed,
+           &areaIndex,
+           &randomUnsupplied,
+           &randomSpilled,
+           &randomForYears,
+           &indexYear,
+           &SpilledEnergySeedIsDefault](Data::Area& area)
+          {
+              (void)area; // Avoiding warnings at compilation (unused variable) on linux
+              if (isPerformed)
+              {
+                  double randomNumber = randomUnsupplied();
+                  randomForYears.pYears[indexYear].pUnsuppliedEnergy[areaIndex] = randomNumber;
+                  randomForYears.pYears[indexYear].pSpilledEnergy[areaIndex] = randomNumber;
+                  if (!SpilledEnergySeedIsDefault)
+                  {
+                      randomForYears.pYears[indexYear].pSpilledEnergy[areaIndex] = randomSpilled();
+                  }
+              }
+              else
+              {
+                  randomUnsupplied();
+                  if (!SpilledEnergySeedIsDefault)
+                  {
+                      randomSpilled();
+                  }
+              }
+
+              areaIndex++;
+          }); // each area
+
+        // ... Hydro costs noises ...
+        auto& randomHydro = study.runtime.random[Data::seedHydroCosts];
+
+        Data::PowerFluctuations powerFluctuations = study.parameters.power.fluctuations;
+        switch (powerFluctuations)
+        {
+        case Data::lssFreeModulations:
+        {
+            areaIndex = 0;
+            auto end = study.areas.end();
+
+            // Computing hourly hydro costs noises so that they are homogeneously spread into :
+            // [-1.e-3, -5*1.e-4] U [+5*1.e-4, +1.e-3]
+            if (isPerformed)
+            {
+                for (auto i = study.areas.begin(); i != end; ++i)
+                {
+                    auto& noise = randomForYears.pYears[indexYear]
+                                    .pHydroCostsByArea_freeMod[areaIndex];
+                    std::set<hydroCostNoise, compareHydroCostsNoises> setHydroCostsNoises;
+                    for (uint j = 0; j != 8784; ++j)
+                    {
+                        noise[j] = randomHydro();
+                        noise[j] -= 0.5; // Now we have : -0.5 < noise[j] < +0.5
+
+                        // This std::set naturally sorts the hydro costs noises into increasing
+                        // absolute values order
+                        setHydroCostsNoises.insert(hydroCostNoise(noise[j], j));
+                    }
+
+                    uint rank = 0;
+                    std::set<hydroCostNoise, compareHydroCostsNoises>::iterator it;
+                    for (it = setHydroCostsNoises.begin(); it != setHydroCostsNoises.end(); it++)
+                    {
+                        uint index = it->getIndex();
+                        double value = it->getValue();
+
+                        if (value < 0.)
+                        {
+                            noise[index] = -5 * 1.e-4 * (1 + rank / 8784.);
+                        }
+                        else
+                        {
+                            noise[index] = 5 * 1.e-4 * (1 + rank / 8784.);
+                        }
+
+                        rank++;
+                    }
+
+                    areaIndex++;
+                }
+            }
+            else
+            {
+                for (auto i = study.areas.begin(); i != end; ++i)
+                {
+                    for (uint j = 0; j != 8784; ++j)
+                    {
+                        randomHydro();
+                    }
+                }
+            }
+
+            break;
+        }
+
+        case Data::lssMinimizeRamping:
+        case Data::lssMinimizeExcursions:
+        {
+            areaIndex = 0;
+            auto end = study.areas.end();
+            for (auto i = study.areas.begin(); i != end; ++i)
+            {
+                if (isPerformed)
+                {
+                    randomForYears.pYears[indexYear].pHydroCosts_rampingOrExcursion[areaIndex]
+                      = randomHydro();
+                }
+                else
+                {
+                    randomHydro();
+                }
+
+                areaIndex++;
+            }
+            break;
+        }
+
+        case Data::lssUnknown:
+        {
+            logs.error() << "Power fluctuation unknown";
+            break;
+        }
+
+        } // end of switch
+
+        if (isPerformed)
+        {
+            indexYear++;
+        }
+
+    } // End loop over years
+} // End function
+} // namespace Antares::Solver::Simulation

--- a/src/solver/simulation/random.cpp
+++ b/src/solver/simulation/random.cpp
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2007-2025, RTE (https://www.rte-france.com)
+ * See AUTHORS.txt
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of Antares-Simulator,
+ * Adequacy and Performance assessment for interconnected energy networks.
+ *
+ * Antares_Simulator is free software: you can redistribute it and/or modify
+ * it under the terms of the Mozilla Public Licence 2.0 as published by
+ * the Mozilla Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Antares_Simulator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Mozilla Public Licence 2.0 for more details.
+ *
+ * You should have received a copy of the Mozilla Public Licence 2.0
+ * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
+ */
+
 #include "antares/solver/simulation/random.h"
 
 #include "antares/solver/hydro/management/management.h"


### PR DESCRIPTION
Extracting random number handling is necessary for the new `getProblem(year, week)` API since we need these functions that are private members of the `ISimulation<>` class.