### PR TITLE
Remove study dependency in exception

### DIFF
--- a/src/expressions/CMakeLists.txt
+++ b/src/expressions/CMakeLists.txt
@@ -90,7 +90,7 @@ target_link_libraries(expressions
         Antares::exception
 )
 
-if (msvc)
+if (MSVC)
     target_compile_options(expressions PRIVATE /utf-8)
 endif ()
 
@@ -106,4 +106,3 @@ target_link_libraries(expressions-iterators PRIVATE expressions)
 install(DIRECTORY include/antares
         DESTINATION "include"
 )
-

--- a/src/expressions/CMakeLists.txt
+++ b/src/expressions/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(expressions
         #TODO i need LinearProblemData
         linear-problem-api
         Antares::modeler-optimisation-container
+        Antares::optim-model-filler
         PRIVATE
         Antares::antares-study-system-model
         Antares::exception

--- a/src/expressions/CMakeLists.txt
+++ b/src/expressions/CMakeLists.txt
@@ -90,6 +90,10 @@ target_link_libraries(expressions
         Antares::exception
 )
 
+if (msvc)
+    target_compile_options(expressions PRIVATE /utf-8)
+endif ()
+
 
 add_library(expressions-iterators
         iterators/pre-order.cpp

--- a/src/io/outputs/CMakeLists.txt
+++ b/src/io/outputs/CMakeLists.txt
@@ -28,6 +28,8 @@ target_link_libraries(modeler-simulation-table
         Antares::optim-model-filler
         Antares::antares-study-system-model
         Antares::utils
+        PRIVATE
+        Antares::modeler-lib
 )
 
 install(DIRECTORY include/antares

--- a/src/io/outputs/SimulationTableGenerator.cpp
+++ b/src/io/outputs/SimulationTableGenerator.cpp
@@ -28,7 +28,6 @@
 #include "antares/expressions/visitors/EvalVisitor.h"
 #include "antares/expressions/visitors/TimeIndexVisitor.h"
 #include "antares/logs/logs.h"
-#include "antares/optimisation/linear-problem-api/IScenario.h"
 #include "antares/optimisation/linear-problem-api/linearProblem.h"
 #include "antares/optimisation/linear-problem-api/mipConstraint.h"
 #include "antares/solver/modeler/data.h"

--- a/src/libs/antares/checks/CMakeLists.txt
+++ b/src/libs/antares/checks/CMakeLists.txt
@@ -17,6 +17,8 @@ target_include_directories(checks
 )
 
 target_link_libraries(checks
+        PUBLIC
+        Antares::exception
         PRIVATE
         logs
         yuni-static-core

--- a/src/libs/antares/checks/checkLoadedInputData.cpp
+++ b/src/libs/antares/checks/checkLoadedInputData.cpp
@@ -77,7 +77,7 @@ void checkSimplexRangeHydroHeuristic(Antares::Data::SimplexOptimization optRange
             const auto& area = *(areas.byIndex[i]);
             if (!area.hydro.useHeuristicTarget)
             {
-                throw Error::IncompatibleDailyOptHeuristicForArea(area.name);
+                throw IncompatibleDailyOptHeuristicForArea(area.name);
             }
         }
     }
@@ -117,7 +117,7 @@ void checkMinStablePower(bool tsGenThermal, const Antares::Data::AreaList& areas
         std::map<int, YString> areaClusterNames;
         if (!(areasThermalClustersMinStablePowerValidity(areas, areaClusterNames)))
         {
-            throw Error::InvalidParametersForThermalClusters(areaClusterNames);
+            throw InvalidParametersForThermalClusters(areaClusterNames);
         }
     }
     else
@@ -174,4 +174,35 @@ void checkCO2CostColumnNumber(const Antares::Data::AreaList& areas)
       &Antares::Data::EconomicInputData::co2cost);
 }
 
+IncompatibleDailyOptHeuristicForArea::IncompatibleDailyOptHeuristicForArea(
+  const Antares::Data::AreaName& name):
+    LoadingError(
+      std::string("Area ") + name.c_str()
+      + " : simplex daily optimization and use heuristic target == no are not compatible")
+{
+}
+
+std::string InvalidParametersForThermalClusters::buildMessage(
+  const std::map<int, Yuni::String>& clusterNames) const
+{
+    const std::string startMessage("Conflict between Min Stable Power, Pnom, spinning and capacity "
+                                   "modulation for the following clusters : ");
+    std::string clusters;
+    for (const auto& it: clusterNames)
+    {
+        clusters += it.second.c_str();
+        clusters += ";";
+    }
+    if (!clusters.empty())
+    {
+        clusters.pop_back(); // Remove final semicolon
+    }
+    return startMessage + clusters;
+}
+
+InvalidParametersForThermalClusters::InvalidParametersForThermalClusters(
+  const std::map<int, Yuni::String>& clusterNames):
+    LoadingError(buildMessage(clusterNames))
+{
+}
 } // namespace Antares::Check

--- a/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
+++ b/src/libs/antares/checks/include/antares/checks/checkLoadedInputData.h
@@ -19,6 +19,7 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 #include <antares/study/version.h>
+#include "antares/exception/LoadingError.hpp"
 #include "antares/study/fwd.h"
 
 namespace Antares::Check
@@ -39,4 +40,18 @@ void checkMinStablePower(bool tsGenThermal, const Antares::Data::AreaList& areas
 void checkFuelCostColumnNumber(const Antares::Data::AreaList& areas);
 void checkCO2CostColumnNumber(const Antares::Data::AreaList& areas);
 
+class IncompatibleDailyOptHeuristicForArea final: public Error::LoadingError
+{
+public:
+    explicit IncompatibleDailyOptHeuristicForArea(const Antares::Data::AreaName& name);
+};
+
+class InvalidParametersForThermalClusters final: public Error::LoadingError
+{
+public:
+    explicit InvalidParametersForThermalClusters(const std::map<int, Yuni::String>& clusterNames);
+
+private:
+    std::string buildMessage(const std::map<int, Yuni::String>& clusterNames) const;
+};
 } // namespace Antares::Check

--- a/src/libs/antares/exception/CMakeLists.txt
+++ b/src/libs/antares/exception/CMakeLists.txt
@@ -16,14 +16,12 @@ add_library(${PROJ} ${SRC_PROJ})
 add_library(Antares::${PROJ} ALIAS ${PROJ})
 
 target_link_libraries(${PROJ}
-        PUBLIC
-        Antares::study
         PRIVATE
         yuni-static-core
 )
 
 target_include_directories(${PROJ}
-                PUBLIC
+        PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 

--- a/src/libs/antares/exception/LoadingError.cpp
+++ b/src/libs/antares/exception/LoadingError.cpp
@@ -145,38 +145,6 @@ IncompatibleOptRangeUCMode::IncompatibleOptRangeUCMode():
 {
 }
 
-IncompatibleDailyOptHeuristicForArea::IncompatibleDailyOptHeuristicForArea(
-  const Antares::Data::AreaName& name):
-    LoadingError(
-      std::string("Area ") + name.c_str()
-      + " : simplex daily optimization and use heuristic target == no are not compatible")
-{
-}
-
-std::string InvalidParametersForThermalClusters::buildMessage(
-  const std::map<int, Yuni::String>& clusterNames) const
-{
-    const std::string startMessage("Conflict between Min Stable Power, Pnom, spinning and capacity "
-                                   "modulation for the following clusters : ");
-    std::string clusters;
-    for (const auto& it: clusterNames)
-    {
-        clusters += it.second.c_str();
-        clusters += ";";
-    }
-    if (!clusters.empty())
-    {
-        clusters.pop_back(); // Remove final semicolon
-    }
-    return startMessage + clusters;
-}
-
-InvalidParametersForThermalClusters::InvalidParametersForThermalClusters(
-  const std::map<int, Yuni::String>& clusterNames):
-    LoadingError(buildMessage(clusterNames))
-{
-}
-
 CommandLineArguments::CommandLineArguments(uint errors):
     LoadingError("Invalid command-line arguments provided : " + std::to_string(errors)
                  + " error(s) found")

--- a/src/libs/antares/exception/LoadingError.cpp
+++ b/src/libs/antares/exception/LoadingError.cpp
@@ -145,7 +145,7 @@ IncompatibleOptRangeUCMode::IncompatibleOptRangeUCMode():
 {
 }
 
-CommandLineArguments::CommandLineArguments(uint errors):
+CommandLineArguments::CommandLineArguments(unsigned int errors):
     LoadingError("Invalid command-line arguments provided : " + std::to_string(errors)
                  + " error(s) found")
 {

--- a/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
@@ -156,7 +156,7 @@ public:
 class CommandLineArguments final: public LoadingError
 {
 public:
-    explicit CommandLineArguments(uint errors);
+    explicit CommandLineArguments(unsigned int errors);
 };
 
 class IncompatibleOutputOptions final: public LoadingError

--- a/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
+++ b/src/libs/antares/exception/include/antares/exception/LoadingError.hpp
@@ -21,14 +21,8 @@
 
 #pragma once
 
-#include <list>
 #include <map>
 #include <stdexcept>
-
-#include <yuni/yuni.h>
-#include <yuni/string.h>
-
-#include "antares/study/fwd.h"
 
 namespace Antares::Error
 {
@@ -157,21 +151,6 @@ class InvalidVersion final: public LoadingError
 {
 public:
     InvalidVersion(const std::string& version, const std::string& latest);
-};
-
-class IncompatibleDailyOptHeuristicForArea final: public LoadingError
-{
-public:
-    explicit IncompatibleDailyOptHeuristicForArea(const Antares::Data::AreaName& name);
-};
-
-class InvalidParametersForThermalClusters final: public LoadingError
-{
-public:
-    explicit InvalidParametersForThermalClusters(const std::map<int, Yuni::String>& clusterNames);
-
-private:
-    std::string buildMessage(const std::map<int, Yuni::String>& clusterNames) const;
 };
 
 class CommandLineArguments final: public LoadingError

--- a/src/tests/inmemory-modeler/CMakeLists.txt
+++ b/src/tests/inmemory-modeler/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(inmemory-modeler)
 add_library(Antares::tests::inmemory-modeler ALIAS inmemory-modeler)
 target_sources(inmemory-modeler
         PRIVATE
-    inmemory-modeler.cpp
-    include/inmemory-modeler.h
+        inmemory-modeler.cpp
+        include/inmemory-modeler.h
 )
 
 target_include_directories(inmemory-modeler
@@ -12,9 +12,10 @@ target_include_directories(inmemory-modeler
 )
 
 target_link_libraries(inmemory-modeler
+        PUBLIC
+        Antares::linear-problem-mpsolver-impl
         PRIVATE
         antares-study-system-model
-        Antares::linear-problem-mpsolver-impl
         Antares::optim-model-filler
         Antares::linear-problem-data-impl
         Antares::expressions

--- a/src/tests/src/optimisation/linear-problem-data/CMakeLists.txt
+++ b/src/tests/src/optimisation/linear-problem-data/CMakeLists.txt
@@ -11,4 +11,5 @@ add_boost_test(unit-tests-for-modeler-data-series
         linear-problem-data-impl
         test_utils_unit
         Antares::optim-model-filler
+        Antares::modeler-optimisation-container
 )


### PR DESCRIPTION
- Remove study dependency in Antares::exception in order to avoid cyclical dependencies
- Fix missing dependencies
- Add compile option /utf-8 for windows to fix the following error

>  D:\a\Antares_Simulator\Antares_Simulator\_build\vcpkg_installed\x64-windows-release\include\fmt\base.h(458,28): error C2338: static_assert failed: 'Unicode support requires compiling with /utf-8' [D:\a\Antares_Simulator\Antares_Simulator\_build\expressions\expressions.vcxproj]
  (compiling source file '../../src/expressions/visitors/EvalVisitor.cpp')
>  
>  EvalVisitor.cpp
D:\a\Antares_Simulator\Antares_Simulator\_build\vcpkg_installed\x64-windows-release\include\fmt\base.h(458,28): error C2338: static_assert failed: 'Unicode support requires compiling with /utf-8' [D:\a\Antares_Simulator\Antares_Simulator\_build\expressions\expressions.vcxproj]
  TimeIndexVisitor.cpp
D:\a\Antares_Simulator\Antares_Simulator\_build\vcpkg_installed\x64-windows-release\include\fmt\base.h(458,28): error C2338: static_assert failed: 'Unicode support requires compiling with /utf-8' [D:\a\Antares_Simulator\Antares_Simulator\_build\expressions\expressions.vcxproj]
  (compiling source file '../../src/expressions/visitors/AstDOTStyleVisitor.cpp')
>  
>  AstDOTStyleVisitor.cpp
D:\a\Antares_Simulator\Antares_Simulator\_build\vcpkg_installed\x64-windows-release\include\fmt\base.h(458,28): error C2338: static_assert failed: 'Unicode support requires compiling with /utf-8' [D:\a\Antares_Simulator\Antares_Simulator\_build\expressions\expressions.vcxproj]