### PR TITLE
Remove std::enable_shared_from_this from ThermalCluster

### DIFF
--- a/src/libs/antares/study/include/antares/study/parts/thermal/cluster.h
+++ b/src/libs/antares/study/include/antares/study/parts/thermal/cluster.h
@@ -72,7 +72,7 @@ double computeMarketBidCost(double fuelCost,
 /*!
 ** \brief A single thermal cluster
 */
-class ThermalCluster final: public Cluster, public std::enable_shared_from_this<ThermalCluster>
+class ThermalCluster final: public Cluster
 {
 public:
     Pollutant emissions;


### PR DESCRIPTION
It seems that it's no longer used.