### PR TITLE
Remove #ifdef __cplusplus, __CPLUSPLUS, unused #define

### DIFF
--- a/src/libs/antares/logs/include/antares/logs/logs.h
+++ b/src/libs/antares/logs/include/antares/logs/logs.h
@@ -57,7 +57,6 @@
 /*! Inform the GUI that the solver has properly ended */
 #define LOG_UI_SOLVER_DONE "[UI] Quitting the solver gracefully"
 
-#ifdef __cplusplus
 // This section is only dedicated to includes from a c++ file
 #include <yuni/core/logs.h>
 #include <yuni/core/logs/decorators/applicationname.h>
@@ -82,13 +81,6 @@ using LoggingDecorators = Yuni::Logs::Time< // Date/Time when the entry log is a
 extern Yuni::Logs::Logger<LoggingHandlers, LoggingDecorators> logs;
 
 } // namespace Antares
-
-#endif
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
 
 /*!
 ** \brief Levels for logging
@@ -118,9 +110,5 @@ int LogCompatibility(const char format[], ...);
 ** \brief Display informations about encountered errors
 */
 void LogDisplayErrorInfos(uint errors, uint warnings, const char* message, bool printError = true);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* __ANTARES_LIBS_LOGS_LOGS_H__ */

--- a/src/solver/hydro/daily/h2o_j_construire_les_variables.cpp
+++ b/src/solver/hydro/daily/h2o_j_construire_les_variables.cpp
@@ -19,19 +19,10 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#ifdef __CPLUSPLUS
-extern "C"
-{
-#endif
-
-#include "spx_constantes_externes.h"
-
-#ifdef __CPLUSPLUS
-}
-#endif
-
 #include "antares/solver/hydro/daily/h2o_j_donnees_mensuelles.h"
 #include "antares/solver/hydro/daily/h2o_j_fonctions.h"
+
+#include "spx_constantes_externes.h"
 
 namespace DoneesOptimisationJournaliere
 {

--- a/src/solver/hydro/daily2/h2o2_j_construire_les_variables.cpp
+++ b/src/solver/hydro/daily2/h2o2_j_construire_les_variables.cpp
@@ -19,18 +19,9 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#ifdef __CPLUSPLUS
-extern "C"
-{
-#endif
+#include "antares/solver/hydro/daily2/h2o2_j_donnees_mensuelles.h"
 
 #include "spx_constantes_externes.h"
-
-#ifdef __CPLUSPLUS
-}
-#endif
-
-#include "antares/solver/hydro/daily2/h2o2_j_donnees_mensuelles.h"
 
 void H2O2_j_ConstruireLesVariables(
   int NbPdt,

--- a/src/solver/hydro/include/antares/solver/hydro/daily/h2o_j_donnees_optimisation.h
+++ b/src/solver/hydro/include/antares/solver/hydro/daily/h2o_j_donnees_optimisation.h
@@ -26,24 +26,9 @@
 
 #include <antares/solver/hydro/probleme_spx_wrapper.h>
 
-#ifdef __CPLUSPLUS
-extern "C"
-{
-#endif
-
 #include "spx_definition_arguments.h"
 
-#ifdef __CPLUSPLUS
-}
-#endif
-
 #define LINFINI 1.e+80
-
-#define JOURS_28 28
-#define JOURS_29 29
-#define JOURS_30 30
-#define JOURS_31 31
-#define NOMBRE_DE_TYPE_DE_MOIS 4
 
 namespace DoneesOptimisationJournaliere
 {

--- a/src/solver/hydro/include/antares/solver/hydro/daily2/h2o2_j_donnees_optimisation.h
+++ b/src/solver/hydro/include/antares/solver/hydro/daily2/h2o2_j_donnees_optimisation.h
@@ -21,29 +21,13 @@
 #ifndef __SOLVER_H2O2_J_STRUCTURE_INTERNE__
 #define __SOLVER_H2O2_J_STRUCTURE_INTERNE__
 
-#ifdef __CPLUSPLUS
-extern "C"
-{
-#endif
-
-#include "spx_definition_arguments.h"
-
-#ifdef __CPLUSPLUS
-}
-
-#endif
 #include <antares/mersenne-twister/mersenne-twister.h>
 #include <antares/study/study.h>
 
 #include "../daily/h2o_j_donnees_optimisation.h"
+#include "spx_definition_arguments.h"
 
 #define LINFINI 1.e+80
-
-#define JOURS_28 28
-#define JOURS_29 29
-#define JOURS_30 30
-#define JOURS_31 31
-#define NOMBRE_DE_TYPE_DE_MOIS 4
 
 /*--------------------------------------------------------------------------------------*/
 /* Matrice des contraintes: il y aura une seule instance pour tous les reservoirs */

--- a/src/solver/hydro/include/antares/solver/hydro/monthly/h2o_m_donnees_optimisation.h
+++ b/src/solver/hydro/include/antares/solver/hydro/monthly/h2o_m_donnees_optimisation.h
@@ -24,16 +24,7 @@
 
 #include <antares/solver/hydro/probleme_spx_wrapper.h>
 
-#ifdef __CPLUSPLUS
-extern "C"
-{
-#endif
-
 #include "spx_definition_arguments.h"
-
-#ifdef __CPLUSPLUS
-}
-#endif
 
 #define LINFINI 1.e+80
 

--- a/src/solver/hydro/monthly/h2o_m_construire_les_variables.cpp
+++ b/src/solver/hydro/monthly/h2o_m_construire_les_variables.cpp
@@ -19,19 +19,10 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-#include "spx_constantes_externes.h"
-
-#ifdef __cplusplus
-}
-#endif
-
 #include "antares/solver/hydro/monthly/h2o_m_donnees_annuelles.h"
 #include "antares/solver/hydro/monthly/h2o_m_fonctions.h"
+
+#include "spx_constantes_externes.h"
 
 namespace DonneesOptimisationMensuelle
 {


### PR DESCRIPTION
- The headers are **always** compiled as C++
- `__CPLUSPLUS` does not exist (never defined)
- Remove some unused `#define` declarations