### PR TITLE
[ANT-3989] Publish log-capture util to test_utils_unit

### DIFF
--- a/src/tests/src/libs/antares/study/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/CMakeLists.txt
@@ -22,5 +22,6 @@ add_boost_test(test-study
 add_boost_test(test-duplicates
   SRC test_duplicates.cpp
   LIBS
+  test_utils_unit
   Antares::study
   Antares::exception)

--- a/src/tests/src/libs/antares/study/test_duplicates.cpp
+++ b/src/tests/src/libs/antares/study/test_duplicates.cpp
@@ -21,6 +21,8 @@
 
 #define BOOST_TEST_MODULE study
 #define WIN32_LEAN_AND_MEAN
+#include <unit_test_utils.h>
+
 #include <boost/test/unit_test.hpp>
 
 #include <antares/exception/LoadingError.hpp>
@@ -37,28 +39,8 @@ using namespace Antares::Data::ShortTermStorage;
 
 BOOST_AUTO_TEST_SUITE(study_duplicates)
 
-struct DuplicateFixture: public Yuni::IEventObserver<DuplicateFixture, Yuni::Policy::SingleThreaded>
+struct DuplicateFixture: public Antares::UnitTests::CaptureAntaresLogs
 {
-    DuplicateFixture()
-    {
-        logs.callback.connect(this, &DuplicateFixture::onLogMessage);
-    }
-
-    void onLogMessage(int level, const std::string& message)
-    {
-        if (level == Yuni::Logs::Verbosity::Error::level)
-        {
-            errors.insert(message);
-        }
-    }
-
-    ~DuplicateFixture()
-    {
-        logs.callback.clear();
-        destroyBoundEvents();
-    }
-
-    std::set<std::string> errors;
     std::unique_ptr<Study> study = std::make_unique<Study>();
     Data::Area* areaA = study->areaAdd("A");
     Data::Area* areaB = study->areaAdd("B");
@@ -93,7 +75,7 @@ void addShortTermStorage(Data::Area* area, const std::string& name)
 BOOST_FIXTURE_TEST_CASE(empty_study, DuplicateFixture)
 {
     BOOST_CHECK(checkForDuplicates(*study));
-    BOOST_REQUIRE(errors.empty());
+    BOOST_REQUIRE(getErrors().empty());
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_two_duplicate_thermal_clusters, DuplicateFixture)
@@ -102,8 +84,8 @@ BOOST_FIXTURE_TEST_CASE(single_area_two_duplicate_thermal_clusters, DuplicateFix
     addThermalCluster(areaA, "cluster");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 1);
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `cluster` found in area `a`"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 1);
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `cluster` found in area `a`"));
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_four_duplicate_thermal_clusters, DuplicateFixture)
@@ -115,9 +97,9 @@ BOOST_FIXTURE_TEST_CASE(single_area_four_duplicate_thermal_clusters, DuplicateFi
     addThermalCluster(areaA, "cluster_2");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 2); // Stops after first error
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `cluster` found in area `a`"));
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `cluster_2` found in area `a`"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 2); // Stops after first error
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `cluster` found in area `a`"));
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `cluster_2` found in area `a`"));
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_two_thermal_clusters, DuplicateFixture)
@@ -126,7 +108,7 @@ BOOST_FIXTURE_TEST_CASE(single_area_two_thermal_clusters, DuplicateFixture)
     addThermalCluster(areaA, "cluster_2");
 
     BOOST_CHECK(checkForDuplicates(*study));
-    BOOST_REQUIRE(errors.empty());
+    BOOST_REQUIRE(getErrors().empty());
 }
 
 BOOST_FIXTURE_TEST_CASE(two_areas_two_duplicate_thermal_clusters, DuplicateFixture)
@@ -135,8 +117,8 @@ BOOST_FIXTURE_TEST_CASE(two_areas_two_duplicate_thermal_clusters, DuplicateFixtu
     addThermalCluster(areaB, "cluster");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 1);
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `cluster` found in area `b`"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 1);
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `cluster` found in area `b`"));
 }
 
 BOOST_FIXTURE_TEST_CASE(two_areas_two_thermal_clusters, DuplicateFixture)
@@ -145,7 +127,7 @@ BOOST_FIXTURE_TEST_CASE(two_areas_two_thermal_clusters, DuplicateFixture)
     addThermalCluster(areaA, "cluster_2");
 
     BOOST_CHECK(checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 0);
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 0);
 }
 
 BOOST_FIXTURE_TEST_CASE(two_areas_four_thermal_clusters, DuplicateFixture)
@@ -156,7 +138,7 @@ BOOST_FIXTURE_TEST_CASE(two_areas_four_thermal_clusters, DuplicateFixture)
     addThermalCluster(areaB, "cluster_2");
 
     BOOST_CHECK(checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 0);
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 0);
 }
 
 BOOST_FIXTURE_TEST_CASE(two_areas_eight_duplicates_thermal_clusters, DuplicateFixture)
@@ -170,11 +152,11 @@ BOOST_FIXTURE_TEST_CASE(two_areas_eight_duplicates_thermal_clusters, DuplicateFi
     }
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 4);
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `cluster_1` found in area `a`"));
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `cluster_2` found in area `a`"));
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `cluster_1` found in area `b`"));
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `cluster_2` found in area `b`"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 4);
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `cluster_1` found in area `a`"));
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `cluster_2` found in area `a`"));
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `cluster_1` found in area `b`"));
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `cluster_2` found in area `b`"));
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_two_duplicate_renewable_clusters, DuplicateFixture)
@@ -183,8 +165,8 @@ BOOST_FIXTURE_TEST_CASE(single_area_two_duplicate_renewable_clusters, DuplicateF
     addRenewableCluster(areaA, "cluster");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 1);
-    BOOST_CHECK(errors.contains("Duplicate renewable cluster `cluster` found in area `a`"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 1);
+    BOOST_CHECK(getErrors().contains("Duplicate renewable cluster `cluster` found in area `a`"));
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_four_duplicate_renewable_clusters, DuplicateFixture)
@@ -196,9 +178,9 @@ BOOST_FIXTURE_TEST_CASE(single_area_four_duplicate_renewable_clusters, Duplicate
     addRenewableCluster(areaA, "cluster_2");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 2);
-    BOOST_CHECK(errors.contains("Duplicate renewable cluster `cluster` found in area `a`"));
-    BOOST_CHECK(errors.contains("Duplicate renewable cluster `cluster_2` found in area `a`"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 2);
+    BOOST_CHECK(getErrors().contains("Duplicate renewable cluster `cluster` found in area `a`"));
+    BOOST_CHECK(getErrors().contains("Duplicate renewable cluster `cluster_2` found in area `a`"));
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_two_renewable_clusters, DuplicateFixture)
@@ -207,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(single_area_two_renewable_clusters, DuplicateFixture)
     addRenewableCluster(areaA, "cluster_2");
 
     BOOST_CHECK(checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 0);
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 0);
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_two_duplicate_STS_clusters, DuplicateFixture)
@@ -216,8 +198,8 @@ BOOST_FIXTURE_TEST_CASE(single_area_two_duplicate_STS_clusters, DuplicateFixture
     addShortTermStorage(areaA, "cluster");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 1);
-    BOOST_CHECK(errors.contains("Duplicate short term storage `cluster` found in area `a`"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 1);
+    BOOST_CHECK(getErrors().contains("Duplicate short term storage `cluster` found in area `a`"));
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_four_duplicate_STS_clusters, DuplicateFixture)
@@ -229,9 +211,9 @@ BOOST_FIXTURE_TEST_CASE(single_area_four_duplicate_STS_clusters, DuplicateFixtur
     addShortTermStorage(areaA, "cluster_2");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 2);
-    BOOST_CHECK(errors.contains("Duplicate short term storage `cluster` found in area `a`"));
-    BOOST_CHECK(errors.contains("Duplicate short term storage `cluster_2` found in area `a`"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 2);
+    BOOST_CHECK(getErrors().contains("Duplicate short term storage `cluster` found in area `a`"));
+    BOOST_CHECK(getErrors().contains("Duplicate short term storage `cluster_2` found in area `a`"));
 }
 
 BOOST_FIXTURE_TEST_CASE(single_area_two_STS_clusters, DuplicateFixture)
@@ -240,7 +222,7 @@ BOOST_FIXTURE_TEST_CASE(single_area_two_STS_clusters, DuplicateFixture)
     addShortTermStorage(areaA, "cluster_2");
 
     BOOST_CHECK(checkForDuplicates(*study));
-    BOOST_REQUIRE(errors.empty());
+    BOOST_REQUIRE(getErrors().empty());
 }
 
 BOOST_FIXTURE_TEST_CASE(detection_of_duplicate_constraints, DuplicateFixture)
@@ -249,8 +231,8 @@ BOOST_FIXTURE_TEST_CASE(detection_of_duplicate_constraints, DuplicateFixture)
     addBindingConstraint("dummy");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 1);
-    BOOST_CHECK(errors.contains("Duplicate binding constraint `dummy` found in study"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 1);
+    BOOST_CHECK(getErrors().contains("Duplicate binding constraint `dummy` found in study"));
 }
 
 BOOST_FIXTURE_TEST_CASE(detection_of_more_duplicate_constraints, DuplicateFixture)
@@ -262,9 +244,9 @@ BOOST_FIXTURE_TEST_CASE(detection_of_more_duplicate_constraints, DuplicateFixtur
     addBindingConstraint("dummy_2");
 
     BOOST_CHECK(!checkForDuplicates(*study));
-    BOOST_REQUIRE_EQUAL(errors.size(), 2);
-    BOOST_CHECK(errors.contains("Duplicate binding constraint `dummy` found in study"));
-    BOOST_CHECK(errors.contains("Duplicate binding constraint `dummy_2` found in study"));
+    BOOST_REQUIRE_EQUAL(getErrors().size(), 2);
+    BOOST_CHECK(getErrors().contains("Duplicate binding constraint `dummy` found in study"));
+    BOOST_CHECK(getErrors().contains("Duplicate binding constraint `dummy_2` found in study"));
 }
 
 BOOST_FIXTURE_TEST_CASE(detection_of_non_duplicate_constraints, DuplicateFixture)
@@ -273,7 +255,7 @@ BOOST_FIXTURE_TEST_CASE(detection_of_non_duplicate_constraints, DuplicateFixture
     addBindingConstraint("dummy_2");
 
     BOOST_CHECK(checkForDuplicates(*study));
-    BOOST_REQUIRE(errors.empty());
+    BOOST_REQUIRE(getErrors().empty());
 }
 
 BOOST_FIXTURE_TEST_CASE(many_duplicates, DuplicateFixture)
@@ -287,12 +269,12 @@ BOOST_FIXTURE_TEST_CASE(many_duplicates, DuplicateFixture)
     }
     BOOST_CHECK(!checkForDuplicates(*study));
     // Check logs
-    BOOST_CHECK_EQUAL(errors.size(), 4);
-    BOOST_CHECK(errors.contains("Duplicate renewable cluster `renewable` found in area `a`"));
-    BOOST_CHECK(errors.contains("Duplicate thermal cluster `thermal` found in area `b`"));
-    BOOST_CHECK(errors.contains("Duplicate short term storage `storage` found in area `a`"));
+    BOOST_CHECK_EQUAL(getErrors().size(), 4);
+    BOOST_CHECK(getErrors().contains("Duplicate renewable cluster `renewable` found in area `a`"));
+    BOOST_CHECK(getErrors().contains("Duplicate thermal cluster `thermal` found in area `b`"));
+    BOOST_CHECK(getErrors().contains("Duplicate short term storage `storage` found in area `a`"));
     BOOST_CHECK(
-      errors.contains("Duplicate binding constraint `binding_constraint` found in study"));
+      getErrors().contains("Duplicate binding constraint `binding_constraint` found in study"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/utils/CMakeLists.txt
+++ b/src/tests/src/utils/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(test_utils_unit
         )
 
 target_link_libraries(test_utils_unit
+       PUBLIC
+       Antares::logs
        PRIVATE
        Boost::unit_test_framework)
 

--- a/src/tests/src/utils/unit_test_utils.cpp
+++ b/src/tests/src/utils/unit_test_utils.cpp
@@ -3,6 +3,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <boost/test/unit_test.hpp>
 
+#include <antares/logs/logs.h>
+
 std::function<bool(const std::exception&)> checkMessage(std::string expected_message)
 {
     return [expected_message](const std::exception& e)
@@ -21,3 +23,58 @@ std::function<bool(const std::exception&)> containsMessage(std::string expected_
         return true;
     };
 }
+
+namespace Antares::UnitTests
+{
+CaptureAntaresLogs::CaptureAntaresLogs()
+{
+    logs.callback.connect(this, &CaptureAntaresLogs::onLogMessage);
+}
+
+CaptureAntaresLogs::~CaptureAntaresLogs()
+{
+    logs.callback.clear();
+    destroyBoundEvents();
+}
+
+void CaptureAntaresLogs::onLogMessage(int level, const std::string& message)
+{
+    switch (level)
+    {
+        using namespace Yuni::Logs::Verbosity;
+    case Warning::level:
+        warnings_.insert(message);
+        break;
+    case Error::level:
+        errors_.insert(message);
+        break;
+    case Fatal::level:
+        fatals_.insert(message);
+        break;
+    case Info::level:
+        infos_.insert(message);
+    default:
+        break;
+    }
+}
+
+const std::set<std::string>& CaptureAntaresLogs::getFatals() const
+{
+    return fatals_;
+}
+
+const std::set<std::string>& CaptureAntaresLogs::getErrors() const
+{
+    return errors_;
+}
+
+const std::set<std::string>& CaptureAntaresLogs::getWarnings() const
+{
+    return warnings_;
+}
+
+const std::set<std::string>& CaptureAntaresLogs::getInfos() const
+{
+    return infos_;
+}
+} // namespace Antares::UnitTests

--- a/src/tests/src/utils/unit_test_utils.h
+++ b/src/tests/src/utils/unit_test_utils.h
@@ -31,9 +31,10 @@ std::function<bool(const std::exception&)> containsMessage(std::string expected_
 
 namespace Antares::UnitTests
 {
-struct CaptureAntaresLogs
+class CaptureAntaresLogs
     : public Yuni::IEventObserver<CaptureAntaresLogs, Yuni::Policy::SingleThreaded>
 {
+public:
     CaptureAntaresLogs();
     ~CaptureAntaresLogs();
 

--- a/src/tests/src/utils/unit_test_utils.h
+++ b/src/tests/src/utils/unit_test_utils.h
@@ -20,9 +20,34 @@
  */
 
 #pragma once
-
 #include <functional>
+#include <set>
 #include <string>
+
+#include <antares/logs/logs.h>
 
 std::function<bool(const std::exception&)> checkMessage(std::string expected_message);
 std::function<bool(const std::exception&)> containsMessage(std::string expected_message);
+
+namespace Antares::UnitTests
+{
+struct CaptureAntaresLogs
+    : public Yuni::IEventObserver<CaptureAntaresLogs, Yuni::Policy::SingleThreaded>
+{
+    CaptureAntaresLogs();
+    ~CaptureAntaresLogs();
+
+    const std::set<std::string>& getFatals() const;
+    const std::set<std::string>& getErrors() const;
+    const std::set<std::string>& getWarnings() const;
+    const std::set<std::string>& getInfos() const;
+
+private:
+    void onLogMessage(int level, const std::string& message);
+
+    std::set<std::string> fatals_;
+    std::set<std::string> errors_;
+    std::set<std::string> warnings_;
+    std::set<std::string> infos_;
+};
+} // namespace Antares::UnitTests


### PR DESCRIPTION
### Summary
Make it easier to capture & test logs by publishing an existing mechanism. Previously it gave access to errors, but now also `info`, `warning`, `fatal`.

### Usage
```cpp
class Fixture : Antares::UnitTests::CaptureAntaresLogs
{
};

BOOST_FIXTURE_TEST_CASE(check_logs, Fixture)
{
    doStuff();
    BOOST_REQUIRE_EQUAL(getErrors().size(), 1);
    BOOST_CHECK(getErrors().contains("This is the expected error message"));
}
```