### PR TITLE
Update ccache properly

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -100,6 +100,7 @@ jobs:
       run: sudo apt-get install -y ccache
 
     - name: Restore ccache cache
+      id: cache
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/.ccache
@@ -171,9 +172,19 @@ jobs:
     - name: Display ccache statistics
       run: ccache -s
 
+    # Delete the old cache on hit to emulate a cache update. See
+    # https://github.com/actions/cache/issues/342.
+    - name: Delete old cache
+      env:
+        GH_TOKEN: ${{ github.token }}
+      if: steps.cache.outputs.cache-hit
+      # Using `--repo` makes it so that this step doesn't require checking out the
+      # repo first.
+      run: gh cache delete --repo ${{ github.repository }} ${{ steps.cache.outputs.cache-primary-key }}
+
     - name: Save ccache cache
       uses: actions/cache/save@v4
       with:
         path: ${{ github.workspace }}/.ccache
-        key: centos7-on-${{ runner.os }}-${{ github.ref_name }}
+        key: ${{ steps.cache.outputs.cache-primary-key }}
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -248,10 +248,5 @@ jobs:
     - name: Display ccache statistics
       run: ccache -s
 
-    - name: Save ccache cache
-      if: ${{ !cancelled() }}
-      uses: actions/cache/save@v4
-      with:
-        path: ${{ github.workspace }}/.ccache
-        key: ${{ matrix.os }}-${{ github.event.pull_request.head.ref }}
+    #Don't save cache to avoid race condition with ubuntu workflow
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -68,6 +68,7 @@ jobs:
       run: sudo apt-get install -y ccache
 
     - name: Restore ccache cache
+      id: cache
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/.ccache_ubuntu
@@ -427,9 +428,19 @@ jobs:
     - name: Display ccache statistics
       run: ccache -s
 
+    # Delete the old cache on hit to emulate a cache update. See
+    # https://github.com/actions/cache/issues/342.
+    - name: Delete old cache
+      env:
+        GH_TOKEN: ${{ github.token }}
+      if: steps.cache.outputs.cache-hit
+      # Using `--repo` makes it so that this step doesn't require checking out the
+      # repo first.
+      run: gh cache delete --repo ${{ github.repository }} ${{ steps.cache.outputs.cache-primary-key }}
+
     - name: Save ccache cache
       if: ${{ !cancelled() }}
       uses: actions/cache/save@v4
       with:
         path: ${{ github.workspace }}/.ccache_ubuntu
-        key: ${{ env.os }}-${{ github.ref_name }}
+        key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -433,7 +433,7 @@ jobs:
     - name: Delete old cache
       env:
         GH_TOKEN: ${{ github.token }}
-      if: steps.cache.outputs.cache-hit
+      if: ${{ !cancelled() && steps.cache.outputs.cache-hit }}
       # Using `--repo` makes it so that this step doesn't require checking out the
       # repo first.
       run: gh cache delete --repo ${{ github.repository }} ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -432,7 +432,7 @@ jobs:
     - name: Delete old cache
       env:
         GH_TOKEN: ${{ github.token }}
-      if: steps.cache.outputs.cache-hit
+      if: ${{ !cancelled() && steps.cache.outputs.cache-hit }}
       # Using `--repo` makes it so that this step doesn't require checking out the
       # repo first.
       run: gh cache delete --repo ${{ github.repository }} ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -74,6 +74,7 @@ jobs:
 
 
     - name: Restore ccache cache
+      id: cache
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/.ccache_windows
@@ -426,9 +427,19 @@ jobs:
     - name: Display ccache statistics
       run: ccache -s
 
+    # Delete the old cache on hit to emulate a cache update. See
+    # https://github.com/actions/cache/issues/342.
+    - name: Delete old cache
+      env:
+        GH_TOKEN: ${{ github.token }}
+      if: steps.cache.outputs.cache-hit
+      # Using `--repo` makes it so that this step doesn't require checking out the
+      # repo first.
+      run: gh cache delete --repo ${{ github.repository }} ${{ steps.cache.outputs.cache-primary-key }}
+
     - name: Save ccache cache
       if: ${{ !cancelled() }}
       uses: actions/cache/save@v4
       with:
         path: ${{ github.workspace }}/.ccache_windows
-        key: ${{ env.os }}-${{ github.ref_name }}
+        key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
It is not possible to update a cache by saving a new cache with an existing key.
This means lot's of cache miss on develop and new branches. Currently only 20% cache hit
The workaround is to delete the old cache entry before saving the new cache.

Also remove saving cache for sonar to avoid race condition with ubuntu job

https://github.com/actions/cache/issues/342#issuecomment-2773231159