### PR TITLE
6.2c - simplify fixtures

### DIFF
--- a/src/tests/src/solver/optim-model-filler/component-filler-utils/objectives-creators.cpp
+++ b/src/tests/src/solver/optim-model-filler/component-filler-utils/objectives-creators.cpp
@@ -22,20 +22,21 @@ Objective makeObjectiveFromVariable(Registry<Nodes::Node>& nodeRegistry,
     return objective;
 }
 
-std::vector<Objective> NoObjectiveCreator::create()
+std::vector<Objective> NoObjectiveCreator::Create(Registry<Nodes::Node>&)
 {
     return {};
 }
 
-std::vector<Objective> TwoObjsCreator_OneSubPb_OneMaster::create()
+std::vector<Objective> TwoObjsCreator_OneSubPb_OneMaster::Create(
+  Registry<Nodes::Node>& nodeRegistry)
 {
     std::vector<Objective> objectives;
-    auto obj_1 = makeObjectiveFromVariable(nodeRegistry_,
+    auto obj_1 = makeObjectiveFromVariable(nodeRegistry,
                                            "var-1",
                                            0,
                                            "obj-1",
                                            Config::Location::SUBPROBLEMS);
-    auto obj_2 = makeObjectiveFromVariable(nodeRegistry_,
+    auto obj_2 = makeObjectiveFromVariable(nodeRegistry,
                                            "var-2",
                                            1,
                                            "obj-2",
@@ -46,15 +47,15 @@ std::vector<Objective> TwoObjsCreator_OneSubPb_OneMaster::create()
     return objectives;
 }
 
-std::vector<Objective> TwoSubPbObjsCreator::create()
+std::vector<Objective> TwoSubPbObjsCreator::Create(Registry<Nodes::Node>& nodeRegistry)
 {
     std::vector<Objective> objectives;
-    auto obj_1 = makeObjectiveFromVariable(nodeRegistry_,
+    auto obj_1 = makeObjectiveFromVariable(nodeRegistry,
                                            "var-1",
                                            0,
                                            "obj-1",
                                            Config::Location::SUBPROBLEMS);
-    auto obj_2 = makeObjectiveFromVariable(nodeRegistry_,
+    auto obj_2 = makeObjectiveFromVariable(nodeRegistry,
                                            "var-2",
                                            1,
                                            "obj-2",

--- a/src/tests/src/solver/optim-model-filler/component-filler-utils/objectives-creators.h
+++ b/src/tests/src/solver/optim-model-filler/component-filler-utils/objectives-creators.h
@@ -8,40 +8,20 @@
 
 using namespace Antares;
 
-class ObjectivesCreator
+struct NoObjectiveCreator
 {
-public:
-    explicit ObjectivesCreator(Expressions::Registry<Expressions::Nodes::Node>& nodeRegistry):
-        nodeRegistry_(nodeRegistry)
-    {
-    }
-
-    virtual std::vector<ModelerStudy::SystemModel::Objective> create() = 0;
-
-protected:
-    Expressions::Registry<Expressions::Nodes::Node>& nodeRegistry_;
+    static std::vector<ModelerStudy::SystemModel::Objective> Create(
+      Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& registry);
 };
 
-class NoObjectiveCreator: public ObjectivesCreator
+struct TwoObjsCreator_OneSubPb_OneMaster
 {
-    using ObjectivesCreator::ObjectivesCreator;
-
-public:
-    std::vector<ModelerStudy::SystemModel::Objective> create() override;
+    static std::vector<ModelerStudy::SystemModel::Objective> Create(
+      Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& registry);
 };
 
-class TwoObjsCreator_OneSubPb_OneMaster: public ObjectivesCreator
+struct TwoSubPbObjsCreator
 {
-    using ObjectivesCreator::ObjectivesCreator;
-
-public:
-    std::vector<ModelerStudy::SystemModel::Objective> create() override;
-};
-
-class TwoSubPbObjsCreator: public ObjectivesCreator
-{
-    using ObjectivesCreator::ObjectivesCreator;
-
-public:
-    std::vector<ModelerStudy::SystemModel::Objective> create() override;
+    static std::vector<ModelerStudy::SystemModel::Objective> Create(
+      Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& registry);
 };

--- a/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.cpp
+++ b/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.cpp
@@ -11,18 +11,19 @@ Expression createLiteral(std::string name, double value, Registry<Nodes::Node>& 
     return Expression(name, std::move(node_registry));
 }
 
-std::vector<Variable> TwoVarsCreator_OneSubPb_OneMaster::create()
+std::vector<Variable> TwoVarsCreator_OneSubPb_OneMaster::Create(
+  Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& nodeRegistry)
 {
     Variable var_1("var-1",
-                   createLiteral("low-bound", 0., nodeRegistry_),
-                   createLiteral("up-bound", 1., nodeRegistry_),
+                   createLiteral("low-bound", 0., nodeRegistry),
+                   createLiteral("up-bound", 1., nodeRegistry),
                    ValueType::FLOAT,
                    TimeDependent::NO,
                    ScenarioDependent::NO,
                    Config::Location::SUBPROBLEMS);
     Variable var_2("var-2",
-                   createLiteral("low-bound", 0., nodeRegistry_),
-                   createLiteral("up-bound", 1., nodeRegistry_),
+                   createLiteral("low-bound", 0., nodeRegistry),
+                   createLiteral("up-bound", 1., nodeRegistry),
                    ValueType::FLOAT,
                    TimeDependent::NO,
                    ScenarioDependent::NO,
@@ -34,18 +35,19 @@ std::vector<Variable> TwoVarsCreator_OneSubPb_OneMaster::create()
     return variables;
 }
 
-std::vector<Variable> TwoSubPbVarsCreator::create()
+std::vector<Variable> TwoSubPbVarsCreator::Create(
+  Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& nodeRegistry)
 {
     Variable var_1("var-1",
-                   createLiteral("low-bound", 0., nodeRegistry_),
-                   createLiteral("up-bound", 1., nodeRegistry_),
+                   createLiteral("low-bound", 0., nodeRegistry),
+                   createLiteral("up-bound", 1., nodeRegistry),
                    ValueType::FLOAT,
                    TimeDependent::NO,
                    ScenarioDependent::NO,
                    Config::Location::SUBPROBLEMS);
     Variable var_2("var-2",
-                   createLiteral("low-bound", 0., nodeRegistry_),
-                   createLiteral("up-bound", 1., nodeRegistry_),
+                   createLiteral("low-bound", 0., nodeRegistry),
+                   createLiteral("up-bound", 1., nodeRegistry),
                    ValueType::FLOAT,
                    TimeDependent::NO,
                    ScenarioDependent::NO,

--- a/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.cpp
+++ b/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.cpp
@@ -12,7 +12,7 @@ Expression createLiteral(std::string name, double value, Registry<Nodes::Node>& 
 }
 
 std::vector<Variable> TwoVarsCreator_OneSubPb_OneMaster::Create(
-  Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& nodeRegistry)
+  Antares::Expressions::Registry<Node>& nodeRegistry)
 {
     Variable var_1("var-1",
                    createLiteral("low-bound", 0., nodeRegistry),
@@ -36,7 +36,7 @@ std::vector<Variable> TwoVarsCreator_OneSubPb_OneMaster::Create(
 }
 
 std::vector<Variable> TwoSubPbVarsCreator::Create(
-  Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& nodeRegistry)
+  Antares::Expressions::Registry<Node>& nodeRegistry)
 {
     Variable var_1("var-1",
                    createLiteral("low-bound", 0., nodeRegistry),

--- a/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.h
+++ b/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.h
@@ -7,32 +7,14 @@
 
 using namespace Antares;
 
-class VariablesCreator
+struct TwoVarsCreator_OneSubPb_OneMaster
 {
-public:
-    explicit VariablesCreator(Expressions::Registry<Expressions::Nodes::Node>& nodeRegistry):
-        nodeRegistry_(nodeRegistry)
-    {
-    }
-
-    virtual std::vector<ModelerStudy::SystemModel::Variable> create() = 0;
-
-protected:
-    Expressions::Registry<Expressions::Nodes::Node>& nodeRegistry_;
+    static std::vector<ModelerStudy::SystemModel::Variable> Create(
+      Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& registry);
 };
 
-class TwoVarsCreator_OneSubPb_OneMaster: public VariablesCreator
+struct TwoSubPbVarsCreator
 {
-    using VariablesCreator::VariablesCreator;
-
-public:
-    std::vector<ModelerStudy::SystemModel::Variable> create() override;
-};
-
-class TwoSubPbVarsCreator: public VariablesCreator
-{
-    using VariablesCreator::VariablesCreator;
-
-public:
-    std::vector<ModelerStudy::SystemModel::Variable> create() override;
+    static std::vector<ModelerStudy::SystemModel::Variable> Create(
+      Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& registry);
 };

--- a/src/tests/src/solver/optim-model-filler/test-component-filler-to-master-pb.cpp
+++ b/src/tests/src/solver/optim-model-filler/test-component-filler-to-master-pb.cpp
@@ -21,15 +21,15 @@ using namespace Antares::Optimisation::LinearProblemMpsolverImpl;
 using namespace Antares::Optimisation::LinearProblemApi;
 using namespace Antares::Optimisation::LinearProblemDataImpl;
 
-template<class Variables, class Objectives>
+template<class VariablesCreator, class ObjectivesCreator>
 class FactoryFixture
 {
 public:
     FactoryFixture():
         linear_pb(false, "sirius"),
         optimEntityContainer(linear_pb, &dummy_data, &scenario_group_repo),
-        variables(Variables::Create(nodeRegistry)),
-        objectives(Objectives::Create(nodeRegistry))
+        variables(VariablesCreator::Create(nodeRegistry)),
+        objectives(ObjectivesCreator::Create(nodeRegistry))
     {
         createModel();
         createComponent();

--- a/src/tests/src/solver/optim-model-filler/test-component-filler-to-master-pb.cpp
+++ b/src/tests/src/solver/optim-model-filler/test-component-filler-to-master-pb.cpp
@@ -21,31 +21,24 @@ using namespace Antares::Optimisation::LinearProblemMpsolverImpl;
 using namespace Antares::Optimisation::LinearProblemApi;
 using namespace Antares::Optimisation::LinearProblemDataImpl;
 
-struct FactoryFixture
+template<class Variables, class Objectives>
+class FactoryFixture
 {
+public:
     FactoryFixture():
         linear_pb(false, "sirius"),
-        optimEntityContainer(linear_pb, &dummy_data, &scenario_group_repo)
+        optimEntityContainer(linear_pb, &dummy_data, &scenario_group_repo),
+        variables(Variables::Create(nodeRegistry)),
+        objectives(Objectives::Create(nodeRegistry))
     {
-    }
-
-    void initialize(std::unique_ptr<VariablesCreator> varCreator,
-                    std::unique_ptr<ObjectivesCreator> objCreator)
-    {
-        variables = varCreator->create();
-        objectives = objCreator->create();
         createModel();
         createComponent();
         setOptimEntityContainer();
     }
 
-    // Function members
-    void createModel();
-    void createComponent();
-    void setOptimEntityContainer();
-
     // Data members
-    Registry<Node> nodeRegistry; // Storing AST Nodes (to destroy them at end of test)
+    Antares::Expressions::Registry<Node>
+      nodeRegistry; // Storing AST Nodes (to destroy them at end of test)
     std::vector<Variable> variables;
     std::vector<Objective> objectives;
     Model model;
@@ -59,39 +52,46 @@ struct FactoryFixture
     OptimEntityContainer optimEntityContainer;
 
     FillContext time_scenario_ctx = {0, 0, 0, 0, 0};
+
+private:
+    // Function members
+    void createModel()
+    {
+        ModelBuilder model_builder;
+        model_builder.withId("my-model")
+          .withVariables(std::move(variables))
+          .withObjectives(std::move(objectives));
+
+        model = model_builder.build();
+    }
+
+    void createComponent()
+    {
+        ComponentBuilder component_builder;
+        component_builder.withModel(&model).withId("my-component");
+        component = std::make_unique<Component>(component_builder.build());
+    }
+
+    void setOptimEntityContainer()
+    {
+        std::vector<Component> components = {*component};
+        optimEntityContainer.addFromSystemComponents(components);
+    }
 };
 
-void FactoryFixture::createModel()
+namespace Fixtures
 {
-    ModelBuilder model_builder;
-    model_builder.withId("my-model")
-      .withVariables(std::move(variables))
-      .withObjectives(std::move(objectives));
-
-    model = model_builder.build();
-}
-
-void FactoryFixture::createComponent()
-{
-    ComponentBuilder component_builder;
-    component_builder.withModel(&model).withId("my-component");
-    component = std::make_unique<Component>(component_builder.build());
-}
-
-void FactoryFixture::setOptimEntityContainer()
-{
-    std::vector<Component> components = {*component};
-    optimEntityContainer.addFromSystemComponents(components);
-}
+using _1 = FactoryFixture<TwoVarsCreator_OneSubPb_OneMaster, NoObjectiveCreator>;
+using _2 = FactoryFixture<TwoVarsCreator_OneSubPb_OneMaster, NoObjectiveCreator>;
+using _3 = FactoryFixture<TwoSubPbVarsCreator, TwoObjsCreator_OneSubPb_OneMaster>;
+using _4 = FactoryFixture<TwoSubPbVarsCreator, TwoObjsCreator_OneSubPb_OneMaster>;
+} // namespace Fixtures
 
 BOOST_AUTO_TEST_SUITE(add_variables_to_master_linear_problem)
 
 BOOST_FIXTURE_TEST_CASE(adding_variables_to_master_pb_actually_adds_only_master_variables,
-                        FactoryFixture)
+                        Fixtures::_1)
 {
-    // Arrange
-    initialize(std::make_unique<TwoVarsCreator_OneSubPb_OneMaster>(nodeRegistry),
-               std::make_unique<NoObjectiveCreator>(nodeRegistry));
     ComponentFiller componentFiller(*component, optimEntityContainer, scenario_group_repo);
 
     // Act
@@ -104,11 +104,8 @@ BOOST_FIXTURE_TEST_CASE(adding_variables_to_master_pb_actually_adds_only_master_
 }
 
 BOOST_FIXTURE_TEST_CASE(adding_variables_to_pb_actually_adds_only_subproblem_variables,
-                        FactoryFixture)
+                        Fixtures::_2)
 {
-    // Arrange
-    initialize(std::make_unique<TwoVarsCreator_OneSubPb_OneMaster>(nodeRegistry),
-               std::make_unique<NoObjectiveCreator>(nodeRegistry));
     ComponentFiller componentFiller(*component, optimEntityContainer, scenario_group_repo);
 
     // Act
@@ -125,11 +122,8 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(add_constraints_to_master_linear_problem)
 
 BOOST_FIXTURE_TEST_CASE(adding_objectives_to_pb_actually_adds_only_subproblem_objectives,
-                        FactoryFixture)
+                        Fixtures::_3)
 {
-    // Arrange
-    initialize(std::make_unique<TwoSubPbVarsCreator>(nodeRegistry),
-               std::make_unique<TwoObjsCreator_OneSubPb_OneMaster>(nodeRegistry));
     ComponentFiller componentFiller(*component, optimEntityContainer, scenario_group_repo);
 
     // Act
@@ -149,11 +143,8 @@ BOOST_FIXTURE_TEST_CASE(adding_objectives_to_pb_actually_adds_only_subproblem_ob
 }
 
 BOOST_FIXTURE_TEST_CASE(adding_objectives_to_master_pb_actually_adds_only_master_objectives,
-                        FactoryFixture)
+                        Fixtures::_4)
 {
-    // Arrange
-    initialize(std::make_unique<TwoSubPbVarsCreator>(nodeRegistry),
-               std::make_unique<TwoObjsCreator_OneSubPb_OneMaster>(nodeRegistry));
     ComponentFiller componentFiller(*component, optimEntityContainer, scenario_group_repo);
 
     // Act


### PR DESCRIPTION
Use static methods instead of an interface class, remove need for `initialize` and `virtual` functions.