### PR TITLE
Fix: sonar hit ccache properly

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -143,9 +143,6 @@ jobs:
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -DPython3_EXECUTABLE='${{ steps.setup-python.outputs.python-path }}'
 
-    - name: Install Build Wrapper
-      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6.0.0
-
     - name: Build
       run: |
         build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build _build --config Release -j$(nproc)

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,8 +21,8 @@ jobs:
       # Caching strategy of VCPKG dependencies
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
       BUILD_WRAPPER_OUT_DIR: ${{ github.workspace }}/_build/output # Directory where build-wrapper output will be placed
+      #config in env to be accessible at each step
       CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_LOGFILE: ${{ github.workspace }}/ccache.log
       CCACHE_COMPILERCHECK: content
       CCACHE_BASEDIR: ${{ github.workspace }}
       CCACHE_SLOPPINESS: time_macros,include_file_mtime
@@ -76,23 +76,11 @@ jobs:
     - name: Configure ccache
       run: |
         # Ensure directory exists and point ccache at it
-        export CCACHE_DIR=${{ github.workspace }}/.ccache
-        mkdir -p "$CCACHE_DIR"
+        mkdir -p ${{ env.CCACHE_DIR }}
         # Increase size to reduce evictions; adjust to suit your CI quota
-        ccache --set-config=cache_dir="$CCACHE_DIR"
         ccache --set-config=max_size=5G
         ccache --set-config=compression=true
-        # Normalize absolute paths to improve hits when workspace paths differ
-        ccache --set-config=base_dir=${{ github.workspace }}
-        # Be tolerant to compiler binary path changes; check by content
-        export CCACHE_COMPILERCHECK=content
-        # IMPORTANT: tolerate file/time macros (e.g. __DATE__/__TIME__) and include mtime differences
-        # This reduces misses caused by headers injecting dates/hours different between build.
-        ccache --set-config=sloppiness=time_macros,include_file_mtime
-        echo "CCACHE_DIR=${CCACHE_DIR}" >> $GITHUB_ENV
-        echo "CCACHE_COMPILERCHECK=${CCACHE_COMPILERCHECK}" >> $GITHUB_ENV
         ccache --show-config || true
-        # show compact stats & config to help debug (do NOT reset stats here)
         ccache -p
       shell: bash
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -69,7 +69,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/.ccache
-        key: sonar-${{ matrix.os }}-v1-${{ github.event.pull_request.head.ref }}
+        key: sonar-${{ matrix.os }}-v1-${{ github.event.pull_request.head.ref || github.ref_name }}
         restore-keys: |
           ${{ matrix.os }}-v1
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,6 +21,11 @@ jobs:
       # Caching strategy of VCPKG dependencies
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
       BUILD_WRAPPER_OUT_DIR: ${{ github.workspace }}/_build/output # Directory where build-wrapper output will be placed
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_LOGFILE: ${{ github.workspace }}/ccache.log
+      CCACHE_COMPILERCHECK: content
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_SLOPPINESS: time_macros,include_file_mtime
 
     steps:
     # Disk space on / is insufficient, leading to errors
@@ -58,21 +63,41 @@ jobs:
     - name: Install ccache
       run: sudo apt-get install -y ccache
 
+    # Can't use ubuntu cache. Cache hit is only single digit %
     - name: Restore ccache cache
+      id: cache
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/.ccache
-        key: ${{ matrix.os }}-${{ github.event.pull_request.head.ref }}
+        key: sonar-${{ matrix.os }}-v1-${{ github.event.pull_request.head.ref }}
         restore-keys: |
-          ${{ matrix.os }}- 
+          ${{ matrix.os }}-v1
 
     - name: Configure ccache
       run: |
-        ccache --set-config=cache_dir=${{ github.workspace }}/.ccache
-        ccache --set-config=max_size=500M
+        # Ensure directory exists and point ccache at it
+        export CCACHE_DIR=${{ github.workspace }}/.ccache
+        mkdir -p "$CCACHE_DIR"
+        # Increase size to reduce evictions; adjust to suit your CI quota
+        ccache --set-config=cache_dir="$CCACHE_DIR"
+        ccache --set-config=max_size=5G
         ccache --set-config=compression=true
+        # Normalize absolute paths to improve hits when workspace paths differ
+        ccache --set-config=base_dir=${{ github.workspace }}
+        # Be tolerant to compiler binary path changes; check by content
+        export CCACHE_COMPILERCHECK=content
+        # IMPORTANT: tolerate file/time macros (e.g. __DATE__/__TIME__) and include mtime differences
+        # This reduces misses caused by headers injecting dates/hours different between build.
+        ccache --set-config=sloppiness=time_macros,include_file_mtime
+        echo "CCACHE_DIR=${CCACHE_DIR}" >> $GITHUB_ENV
+        echo "CCACHE_COMPILERCHECK=${CCACHE_COMPILERCHECK}" >> $GITHUB_ENV
+        ccache --show-config || true
+        # show compact stats & config to help debug (do NOT reset stats here)
         ccache -p
-        ccache -z
+      shell: bash
+
+    - name: Install Build Wrapper
+      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6.0.0
 
     - name: Install libraries
       run: |
@@ -246,7 +271,25 @@ jobs:
         key: vcpkg-cache-ubuntu-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}
 
     - name: Display ccache statistics
+      if: always()
       run: ccache -s
 
-    #Don't save cache to avoid race condition with ubuntu workflow
+    # Delete the old cache on hit to emulate a cache update. See
+    # https://github.com/actions/cache/issues/342.
+    - name: Delete old cache
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_DEBUG: api gh cache delete
+      if: ${{ !cancelled() && steps.cache.outputs.cache-hit }}
+      # Using `--repo` makes it so that this step doesn't require checking out the
+      # repo first.
+      run: gh cache delete --repo ${{ github.repository }} ${{ steps.cache.outputs.cache-primary-key }}
+
+    - name: Save ccache cache
+      if: ${{ !cancelled() }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ steps.cache.outputs.cache-primary-key }}
 


### PR DESCRIPTION
CCache wasn't hit properly. A mix of file timestamp and file being injected with __DATE__ and __TIME__ macros.
Using ccache slopiness allow to ignore those parameters as criteria for file matching.