### PR TITLE
[ANT-4049] Fix segfault caused by expression[t]

### DIFF
--- a/src/io/inputs/model-converter/convertorVisitor.cpp
+++ b/src/io/inputs/model-converter/convertorVisitor.cpp
@@ -319,9 +319,17 @@ std::any ConvertorVisitor::visitTimeIndex([[maybe_unused]] ExprParser::TimeIndex
 
 std::any ConvertorVisitor::buildShiftNode(Node* shifted_expr, ExprParser::ShiftContext* context)
 {
-    auto* time_shift = std::any_cast<Node*>(context->shift_expr()->accept(this));
+    Node* shift;
+    if (auto shift_maybe = context->shift_expr()) // [t+1], [t-1], etc.
+    {
+        shift = std::any_cast<Node*>(shift_maybe->accept(this));
+    }
+    else // [t]
+    {
+        shift = registry_.create<LiteralNode>(0); // no shift
+    }
 
-    return static_cast<Node*>(registry_.create<TimeShiftNode>(shifted_expr, time_shift));
+    return static_cast<Node*>(registry_.create<TimeShiftNode>(shifted_expr, shift));
 }
 
 std::any ConvertorVisitor::visitTimeShift([[maybe_unused]] ExprParser::TimeShiftContext* context)

--- a/src/io/inputs/model-converter/convertorVisitor.cpp
+++ b/src/io/inputs/model-converter/convertorVisitor.cpp
@@ -319,17 +319,15 @@ std::any ConvertorVisitor::visitTimeIndex([[maybe_unused]] ExprParser::TimeIndex
 
 std::any ConvertorVisitor::buildShiftNode(Node* shifted_expr, ExprParser::ShiftContext* context)
 {
-    Node* shift;
     if (auto shift_maybe = context->shift_expr()) // [t+1], [t-1], etc.
     {
-        shift = std::any_cast<Node*>(shift_maybe->accept(this));
+        Node* shift = std::any_cast<Node*>(shift_maybe->accept(this));
+        return static_cast<Node*>(registry_.create<TimeShiftNode>(shifted_expr, shift));
     }
     else // [t]
     {
-        shift = registry_.create<LiteralNode>(0); // no shift
+        return shifted_expr; // implicit conversion to std::any
     }
-
-    return static_cast<Node*>(registry_.create<TimeShiftNode>(shifted_expr, shift));
 }
 
 std::any ConvertorVisitor::visitTimeShift([[maybe_unused]] ExprParser::TimeShiftContext* context)


### PR DESCRIPTION
When visiting `expression[t]`, the shifted_expr is optional: if it is absent, ANTLR returns a `nullptr`. This PR handles this case gracefully (no shift).