### PR TITLE
Add test coverage for variable & objective decomposition

### DIFF
--- a/src/io/inputs/yml-optim-config/converter.cpp
+++ b/src/io/inputs/yml-optim-config/converter.cpp
@@ -90,7 +90,7 @@ SystemModel::Model& findSystemModel(const YmlOptimConfig::Model& ymlModel,
     return getModel(libraries, libraryId, modelId);
 }
 
-SystemModel::Variable& findSystemVariable(const std::string var_id, SystemModel::Model& sysModel)
+SystemModel::Variable& findSystemVariable(const std::string& var_id, SystemModel::Model& sysModel)
 {
     auto filter = [&var_id](const SystemModel::Variable& v) { return v.Id() == var_id; };
     auto& sysVariables = sysModel.Variables();
@@ -102,7 +102,7 @@ SystemModel::Variable& findSystemVariable(const std::string var_id, SystemModel:
     return *sysVar;
 }
 
-SystemModel::Objective& findSystemObjective(const std::string obj_id, SystemModel::Model& sysModel)
+SystemModel::Objective& findSystemObjective(const std::string& obj_id, SystemModel::Model& sysModel)
 {
     auto filter = [&obj_id](const SystemModel::Objective& obj) { return obj.Id() == obj_id; };
     auto& sysObjectives = sysModel.Objectives();

--- a/src/io/inputs/yml-optim-config/decoders.hxx
+++ b/src/io/inputs/yml-optim-config/decoders.hxx
@@ -30,6 +30,13 @@
 namespace YAML
 {
 
+// TODO this function is defined at least 3 times, deduplicate
+template<typename T>
+inline T as_fallback_default(const Node& n)
+{
+    return n.as<T>(T());
+}
+
 template<>
 struct convert<Antares::IO::Inputs::YmlOptimConfig::Variable>
 {
@@ -68,11 +75,13 @@ struct convert<Antares::IO::Inputs::YmlOptimConfig::Model>
     {
         rhs.id = node["id"].as<std::string>();
         const auto& modelDecompositionNode = node["model-decomposition"];
-        rhs.variables = modelDecompositionNode["variables"]
-                          .as<std::vector<Antares::IO::Inputs::YmlOptimConfig::Variable>>();
+        rhs.variables = as_fallback_default<
+          std::vector<Antares::IO::Inputs::YmlOptimConfig::Variable>>(
+          modelDecompositionNode["variables"]);
 
-        rhs.objectives = modelDecompositionNode["objective-contributions"]
-                           .as<std::vector<Antares::IO::Inputs::YmlOptimConfig::Objective>>();
+        rhs.objectives = as_fallback_default<
+          std::vector<Antares::IO::Inputs::YmlOptimConfig::Objective>>(
+          modelDecompositionNode["objective-contributions"]);
 
         return true;
     }

--- a/src/tests/src/io/yml-importers/testYmlOptimConfig.cpp
+++ b/src/tests/src/io/yml-importers/testYmlOptimConfig.cpp
@@ -44,7 +44,7 @@ models:
           location: master
         - id: pmax_cluster
           location: master-and-subproblems
-      objectives:
+      objective-contributions:
         - id: invest_objective
           location: master
         - id: operational_objective
@@ -54,7 +54,7 @@ models:
       variables:
         - id: var1
           location: subproblems
-      objectives:
+      objective-contributions:
         - id: obj1
           location: master
 )";
@@ -98,7 +98,7 @@ models:
       variables:
         - id: single_var
           location: master
-      objectives:
+      objective-contributions:
         - id: single_obj
           location: subproblems
 )";
@@ -133,7 +133,7 @@ models:
   - id: model_no_vars
     model-decomposition:
       variables: []
-      objectives:
+      objective-contributions:
         - id: obj1
           location: master
 )";
@@ -155,7 +155,7 @@ models:
       variables:
         - id: var1
           location: master
-      objectives: []
+      objective-contributions: []
 )";
 
     Parser parser;
@@ -179,7 +179,7 @@ models:
           location: subproblems
         - id: var_both
           location: master-and-subproblems
-      objectives:
+      objective-contributions:
         - id: obj_master
           location: master
         - id: obj_sub
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(parse_missing_id_throws)
 models:
   - model-decomposition:
       variables: []
-      objectives: []
+      objective-contributions: []
 )";
 
     Parser parser;
@@ -246,7 +246,7 @@ models:
     model-decomposition:
       variables:
         - location: master
-      objectives: []
+      objective-contributions: []
 )";
 
     Parser parser;
@@ -261,7 +261,7 @@ models:
     model-decomposition:
       variables:
         - id: var1
-      objectives: []
+      objective-contributions: []
 )";
 
     Parser parser;
@@ -275,7 +275,7 @@ models:
   - id: model1
     model-decomposition:
       variables: []
-      objectives:
+      objective-contributions:
         - location: master
 )";
 
@@ -290,7 +290,7 @@ models:
   - id: model1
     model-decomposition:
       variables: []
-      objectives:
+      objective-contributions:
         - id: obj1
 )";
 
@@ -307,7 +307,7 @@ models:
       variables:
         - id: var1
           location: master
-      objectives: [
+      objective-contributions: [
 )";
 
     Parser parser;
@@ -333,7 +333,7 @@ models:
           location: master
         - id: v2
           location: subproblems
-      objectives:
+      objective-contributions:
         - id: o1
           location: master
   - id: model2
@@ -341,7 +341,7 @@ models:
       variables:
         - id: v3
           location: master-and-subproblems
-      objectives:
+      objective-contributions:
         - id: o2
           location: subproblems
         - id: o3
@@ -349,7 +349,7 @@ models:
   - id: model3
     model-decomposition:
       variables: []
-      objectives: []
+      objective-contributions: []
 )";
 
     Parser parser;

--- a/src/tests/src/study/system-model/CMakeLists.txt
+++ b/src/tests/src/study/system-model/CMakeLists.txt
@@ -13,4 +13,6 @@ add_boost_test(test-system-model
   Antares::yml-system
   Antares::antares-study-system-model
   Antares::antlr-interface
+  Antares::load-modeler-files
+  Antares::modeler-lib # TODO dependency of Antares::load-modeler-files
   test_utils_unit)

--- a/src/tests/src/study/system-model/test_library.cpp
+++ b/src/tests/src/study/system-model/test_library.cpp
@@ -21,11 +21,14 @@
 
 #define WIN32_LEAN_AND_MEAN
 
+#include <filesystem>
+#include <fstream>
 #include <unit_test_utils.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include "antares/exception/RuntimeError.hpp"
+#include "antares/solver/modeler/loadFiles/loadFiles.h"
 #include "antares/study/system-model/model.h"
 #include "antares/study/system-model/portType.h"
 
@@ -200,6 +203,41 @@ BOOST_AUTO_TEST_CASE(port_type_with_area_connection_error)
                           std::invalid_argument,
                           checkMessage("Field \"secondField\" selected for area connections was "
                                        "not defined in PortType \"portTypeId\"."));
+}
+
+// NOTE The design should be improved. We shouldn't have to rely on files to test the "join" feature
+BOOST_AUTO_TEST_CASE(variable_decomposition)
+{
+    // Model
+    ModelBuilder model_builder;
+    model_builder.withId("model");
+    std::vector<Variable> variables;
+    variables.push_back({"y", {}, {}, ValueType::FLOAT, {}, {}});
+    model_builder.withVariables(std::move(variables));
+    auto model = model_builder.build();
+    std::vector<Model> models;
+    models.emplace_back(std::move(model));
+
+    // Library
+    LibraryBuilder library_builder;
+    Library lib = library_builder.withId("library").withModels(std::move(models)).build();
+    std::vector<Library> libraries{lib};
+
+    // optim-config's YAML
+    const auto folder = std::filesystem::temp_directory_path();
+
+    const auto yamlPath = folder / "optim-config.yml";
+    std::ofstream outfile(yamlPath);
+    outfile << R"(models:
+  - id: library.model
+    model-decomposition:
+      variables:
+        - id: y
+          location: master-and-subproblems)";
+
+    Antares::Solver::LoadFiles::loadOptimConfig(folder, libraries);
+    BOOST_CHECK(libraries[0].Models()["model"].Variables()[0].location()
+                == Antares::Modeler::Config::Location::MASTER_AND_SUBPROBLEMS);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/study/system-model/test_library.cpp
+++ b/src/tests/src/study/system-model/test_library.cpp
@@ -212,7 +212,9 @@ BOOST_AUTO_TEST_CASE(variable_decomposition)
     ModelBuilder model_builder;
     model_builder.withId("model");
     std::vector<Variable> variables;
+    variables.push_back({"x", {}, {}, ValueType::FLOAT, {}, {}});
     variables.push_back({"y", {}, {}, ValueType::FLOAT, {}, {}});
+    variables.push_back({"z", {}, {}, ValueType::FLOAT, {}, {}});
     model_builder.withVariables(std::move(variables));
     auto model = model_builder.build();
     std::vector<Model> models;
@@ -225,19 +227,38 @@ BOOST_AUTO_TEST_CASE(variable_decomposition)
 
     // optim-config's YAML
     const auto folder = std::filesystem::temp_directory_path();
+    const auto input = folder / "input";
 
-    const auto yamlPath = folder / "optim-config.yml";
-    std::ofstream outfile(yamlPath);
+    std::filesystem::create_directory(input);
+    const auto yamlPath = input / "optim-config.yml";
+    std::ofstream outfile(yamlPath, std::ofstream::trunc | std::ofstream::out);
     outfile << R"(models:
   - id: library.model
     model-decomposition:
       variables:
+        - id: x
+          location: master
         - id: y
-          location: master-and-subproblems)";
+          location: master-and-subproblems
+        - id: z
+          location: subproblems)";
+    outfile.flush();
 
     Antares::Solver::LoadFiles::loadOptimConfig(folder, libraries);
-    BOOST_CHECK(libraries[0].Models()["model"].Variables()[0].location()
-                == Antares::Modeler::Config::Location::MASTER_AND_SUBPROBLEMS);
+    const auto& modelVariables = libraries[0].Models()["model"].Variables();
+
+    using namespace Antares::Modeler::Config;
+    // x
+    BOOST_CHECK_EQUAL(modelVariables[0].Id(), "x");
+    BOOST_CHECK(modelVariables[0].location() == Location::MASTER);
+
+    // y
+    BOOST_CHECK_EQUAL(modelVariables[1].Id(), "y");
+    BOOST_CHECK(modelVariables[1].location() == Location::MASTER_AND_SUBPROBLEMS);
+
+    // z
+    BOOST_CHECK_EQUAL(modelVariables[2].Id(), "z");
+    BOOST_CHECK(modelVariables[2].location() == Location::SUBPROBLEMS);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Add unit test for variables
- Allow absence of attribute `variables` and `objective-contributions` when parsing optim-config.yml 

```yaml
models:
  - id: library.model
    model-decomposition:
      variables:
        - id: y
          location: master-and-subproblems
```