### PR TITLE
Remove unused `OptimComponent::index`

### DIFF
--- a/src/modeler-optimisation-container/OptimEntityContainer.cpp
+++ b/src/modeler-optimisation-container/OptimEntityContainer.cpp
@@ -65,8 +65,7 @@ void OptimEntityContainer::addFromSystemComponents(const std::vector<Component>&
             }
         }
         optimComponents_.push_back(
-          {.index = component.Index(),
-           .modelVariableGlobalIndices = modelVariableGlobalIndices,
+          {.modelVariableGlobalIndices = modelVariableGlobalIndices,
            .evaluationContext = Optimisation::EvaluationContext(
              &component,
              data_,

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -36,7 +36,6 @@ namespace Antares::Optimisation
 {
 struct OptimComponent
 {
-    unsigned int index = 0;
     std::vector<unsigned> modelVariableGlobalIndices;
     std::vector<unsigned> modelConstraintsGlobalIndices;
     std::vector<TimeIndex> modelConstraintsTimeIndex;

--- a/src/tests/src/solver/optim-model-filler/visitorFixture.hpp
+++ b/src/tests/src/solver/optim-model-filler/visitorFixture.hpp
@@ -69,7 +69,6 @@ struct VisitorFixture: Registry<Node>
     {
         optimContainer.addFromSystemComponents(components);
         auto& optimComponent = optimContainer.getOptimComponent(0);
-        optimComponent.index = 0;
         optimComponent.modelVariableGlobalIndices = {0, 1, 2};
         {
             optimContainer.addStartColumn();


### PR DESCRIPTION
`OptimComponents` don't need to store the index of the corresponding `Component`, since they're usually accessed by `component.Index()`, for example

```cpp
const auto& optimComponent = optimComponents_.at(component.Index());
```