### PR TITLE
Use checkMessage from test_utils_unit

### DIFF
--- a/src/tests/src/expressions/CMakeLists.txt
+++ b/src/tests/src/expressions/CMakeLists.txt
@@ -16,4 +16,5 @@ add_boost_test(test-expressions
         expressions-iterators
         linear-problem-data-impl
         mock-modeler-objects
-        Antares::antares-study-system-model)
+        Antares::antares-study-system-model
+	test_utils_unit)

--- a/src/tests/src/expressions/test_CompareVisitor.cpp
+++ b/src/tests/src/expressions/test_CompareVisitor.cpp
@@ -231,7 +231,6 @@ BOOST_FIXTURE_TEST_CASE(compare_dual, ComparisonFixture)
     CloneVisitor clone_visitor(registry_);
     const auto clone = clone_visitor.dispatch(dual1);
     const auto* n = dynamic_cast<FunctionNode*>(clone);
-    std::cout << "**** clone.type = " << n->typeToString() << std::endl;
     BOOST_CHECK(compareVisitor.dispatch(dual1, clone));
     BOOST_CHECK(!compareVisitor.dispatch(dual1, dual2));
 }

--- a/src/tests/src/expressions/test_LinearVisitor.cpp
+++ b/src/tests/src/expressions/test_LinearVisitor.cpp
@@ -33,6 +33,7 @@
 #include <antares/modeler-optimisation-container/TimeIndex.h>
 
 #include "UtilMocks.h"
+#include "unit_test_utils.h"
 
 using namespace Antares::Expressions;
 using namespace Antares::Expressions::Nodes;
@@ -374,24 +375,16 @@ BOOST_FIXTURE_TEST_CASE(dual_reducedCost, MyDummyFixture)
     BOOST_CHECK_EXCEPTION(
       LinearityVisitor(optimEntityContainer, ctx, components.front()).dispatch(dual),
       NodeTypeShouldBeInExtraOutput,
-      [](const NodeTypeShouldBeInExtraOutput& e)
-      {
-          return std::string(e.what())
-                 == "This type of node: 'dual' should only be used in "
-                    "extra outputs expressions";
-      });
+      checkMessage("This type of node: 'dual' should only be used in "
+                   "extra outputs expressions"));
 
     Node* reducedCost = create<FunctionNode>(FunctionNodeType::reduced_cost,
                                              create<VariableNode>("var1", 0));
     BOOST_CHECK_EXCEPTION(
       LinearityVisitor(optimEntityContainer, ctx, components.front()).dispatch(reducedCost),
       NodeTypeShouldBeInExtraOutput,
-      [](const NodeTypeShouldBeInExtraOutput& e)
-      {
-          return std::string(e.what())
-                 == "This type of node: 'reduced_cost' should only be used in "
-                    "extra outputs expressions";
-      });
+      checkMessage("This type of node: 'reduced_cost' should only be used in "
+                   "extra outputs expressions"));
 }
 
 BOOST_FIXTURE_TEST_CASE(maxNode, MyDummyFixture)


### PR DESCRIPTION
Instead of creating lambda functions, use the existing `checkMessage` mechanism to check the string returned by `exception.what()`.