### PR TITLE
Add unit testing on benders decomposition (structure.txt)

### DIFF
--- a/src/modeler/modeler/Modeler.cpp
+++ b/src/modeler/modeler/Modeler.cpp
@@ -187,10 +187,15 @@ void Modeler::run() const
         writer_.init(simulationTableSuffix);
         auto output = writer_.outputPath();
 
+        // 1-1.mps
         Write(subproblem, output / "1-1.mps");
+        // master.mps
         Write(master_problem, output / "master.mps");
+
+        // structure.txt
+        BendersDecompositionWriter writer(bendersDecomposition);
         std::ofstream of(output / "structure.txt");
-        bendersDecomposition.write(of);
+        writer.write(of);
     }
 
     logs.info() << "Launching resolution...";

--- a/src/solver/optim-model-filler/ComponentFiller.cpp
+++ b/src/solver/optim-model-filler/ComponentFiller.cpp
@@ -111,9 +111,14 @@ void BendersDecomposition::collectConnectionVariables(std::vector<std::string>&&
     }
 }
 
-void BendersDecomposition::write(std::ostream& os) const
+BendersDecompositionWriter::BendersDecompositionWriter(const BendersDecomposition& bd):
+    bd_(bd)
 {
-    for (const auto& [problemId, v]: connectionVars_)
+}
+
+void BendersDecompositionWriter::write(std::ostream& os) const
+{
+    for (const auto& [problemId, v]: bd_.connections())
     {
         for (const auto& [variableName, variableIndex]: v)
         {

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ComponentFiller.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ComponentFiller.h
@@ -46,11 +46,25 @@ public:
     BendersDecomposition() = default;
     void setCurrentProblemId(std::string id);
     void collectConnectionVariables(std::vector<std::string>&& varnames, unsigned varsCountInPb);
-    void write(std::ostream& os) const;
+
+    const std::map<std::string, std::vector<ConnectionVariable>>& connections() const
+    {
+        return connectionVars_;
+    }
 
 private:
     std::map<std::string, std::vector<ConnectionVariable>> connectionVars_;
     std::string currentProblemId_ = "master";
+};
+
+class BendersDecompositionWriter
+{
+public:
+    BendersDecompositionWriter(const BendersDecomposition& bd);
+    void write(std::ostream& os) const;
+
+private:
+    const BendersDecomposition& bd_;
 };
 
 /**

--- a/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.cpp
+++ b/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.cpp
@@ -58,3 +58,19 @@ std::vector<Variable> TwoSubPbVarsCreator::Create(
     variables.emplace_back(std::move(var_2));
     return variables;
 }
+
+std::vector<Variable> SingleMixedVariable::Create(
+  Antares::Expressions::Registry<Node>& nodeRegistry)
+{
+    Variable var_1("var-1",
+                   createLiteral("low-bound", 0., nodeRegistry),
+                   createLiteral("up-bound", 1., nodeRegistry),
+                   ValueType::FLOAT,
+                   TimeDependent::NO,
+                   ScenarioDependent::NO,
+                   Config::Location::MASTER_AND_SUBPROBLEMS);
+
+    std::vector<Variable> variables;
+    variables.emplace_back(std::move(var_1));
+    return variables;
+}

--- a/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.h
+++ b/src/tests/src/solver/optim-model-filler/component-filler-utils/variables-creators.h
@@ -17,3 +17,9 @@ struct TwoSubPbVarsCreator
     static std::vector<ModelerStudy::SystemModel::Variable> Create(
       Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& registry);
 };
+
+struct SingleMixedVariable
+{
+    static std::vector<ModelerStudy::SystemModel::Variable> Create(
+      Antares::Expressions::Registry<Antares::Expressions::Nodes::Node>& registry);
+};

--- a/src/tests/src/solver/optim-model-filler/test-component-filler-to-master-pb.cpp
+++ b/src/tests/src/solver/optim-model-filler/test-component-filler-to-master-pb.cpp
@@ -20,6 +20,7 @@ using namespace Antares::Expressions::Nodes;
 using namespace Antares::Optimisation::LinearProblemMpsolverImpl;
 using namespace Antares::Optimisation::LinearProblemApi;
 using namespace Antares::Optimisation::LinearProblemDataImpl;
+using namespace Antares::Modeler::Config;
 
 template<class VariablesCreator, class ObjectivesCreator>
 class FactoryFixture
@@ -53,6 +54,8 @@ public:
 
     FillContext time_scenario_ctx = {0, 0, 0, 0, 0};
 
+    BendersDecomposition bendersDecomposition;
+
 private:
     // Function members
     void createModel()
@@ -81,21 +84,23 @@ private:
 
 namespace Fixtures
 {
-using _1 = FactoryFixture<TwoVarsCreator_OneSubPb_OneMaster, NoObjectiveCreator>;
-using _2 = FactoryFixture<TwoVarsCreator_OneSubPb_OneMaster, NoObjectiveCreator>;
-using _3 = FactoryFixture<TwoSubPbVarsCreator, TwoObjsCreator_OneSubPb_OneMaster>;
-using _4 = FactoryFixture<TwoSubPbVarsCreator, TwoObjsCreator_OneSubPb_OneMaster>;
+using VarOneSubOneMasterNoObjective = FactoryFixture<TwoVarsCreator_OneSubPb_OneMaster,
+                                                     NoObjectiveCreator>;
+using VarTwoSubObjeOneSubOneMaster = FactoryFixture<TwoSubPbVarsCreator,
+                                                    TwoObjsCreator_OneSubPb_OneMaster>;
+using SingleMixedVarNoObjective = FactoryFixture<SingleMixedVariable, NoObjectiveCreator>;
 } // namespace Fixtures
 
 BOOST_AUTO_TEST_SUITE(add_variables_to_master_linear_problem)
 
 BOOST_FIXTURE_TEST_CASE(adding_variables_to_master_pb_actually_adds_only_master_variables,
-                        Fixtures::_1)
+                        Fixtures::VarOneSubOneMasterNoObjective)
 {
     ComponentFiller componentFiller(*component,
                                     optimEntityContainer,
                                     scenario_group_repo,
-                                    Antares::Modeler::Config::Location::MASTER);
+                                    Location::MASTER,
+                                    &bendersDecomposition);
 
     // Act
     componentFiller.addVariables(time_scenario_ctx);
@@ -104,15 +109,18 @@ BOOST_FIXTURE_TEST_CASE(adding_variables_to_master_pb_actually_adds_only_master_
     BOOST_CHECK_EQUAL(linear_pb.variableCount(), 1);
     auto* var = linear_pb.lookupVariable("my-component.var-2");
     BOOST_REQUIRE(var);
+
+    BOOST_CHECK(bendersDecomposition.connections().empty());
 }
 
 BOOST_FIXTURE_TEST_CASE(adding_variables_to_pb_actually_adds_only_subproblem_variables,
-                        Fixtures::_2)
+                        Fixtures::VarOneSubOneMasterNoObjective)
 {
     ComponentFiller componentFiller(*component,
                                     optimEntityContainer,
                                     scenario_group_repo,
-                                    Antares::Modeler::Config::Location::SUBPROBLEMS);
+                                    Location::SUBPROBLEMS,
+                                    &bendersDecomposition);
 
     // Act
     componentFiller.addVariables(time_scenario_ctx);
@@ -121,6 +129,7 @@ BOOST_FIXTURE_TEST_CASE(adding_variables_to_pb_actually_adds_only_subproblem_var
     BOOST_CHECK_EQUAL(linear_pb.variableCount(), 1);
     auto* var = linear_pb.lookupVariable("my-component.var-1");
     BOOST_REQUIRE(var);
+    BOOST_CHECK(bendersDecomposition.connections().empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -128,12 +137,13 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(add_constraints_to_master_linear_problem)
 
 BOOST_FIXTURE_TEST_CASE(adding_objectives_to_pb_actually_adds_only_subproblem_objectives,
-                        Fixtures::_3)
+                        Fixtures::VarTwoSubObjeOneSubOneMaster)
 {
     ComponentFiller componentFiller(*component,
                                     optimEntityContainer,
                                     scenario_group_repo,
-                                    Antares::Modeler::Config::Location::SUBPROBLEMS);
+                                    Location::SUBPROBLEMS,
+                                    &bendersDecomposition);
 
     // Act
     componentFiller.addVariables(time_scenario_ctx);
@@ -149,18 +159,45 @@ BOOST_FIXTURE_TEST_CASE(adding_objectives_to_pb_actually_adds_only_subproblem_ob
     BOOST_CHECK_EQUAL(linear_pb.getObjectiveCoefficient(var1), 1);
     // No objective associated to var2 found in problem
     BOOST_CHECK_EQUAL(linear_pb.getObjectiveCoefficient(var2), 0);
+    BOOST_CHECK(bendersDecomposition.connections().empty());
 }
 
 BOOST_FIXTURE_TEST_CASE(adding_objectives_to_master_pb_actually_adds_only_master_objectives,
-                        Fixtures::_4)
+                        Fixtures::VarTwoSubObjeOneSubOneMaster)
 {
     ComponentFiller componentFiller(*component,
                                     optimEntityContainer,
                                     scenario_group_repo,
-                                    Antares::Modeler::Config::Location::MASTER);
+                                    Location::MASTER,
+                                    &bendersDecomposition);
 
     componentFiller.addVariables(time_scenario_ctx);
     BOOST_CHECK_EQUAL(linear_pb.variableCount(), 0);
+    BOOST_CHECK(bendersDecomposition.connections().empty());
+}
+
+// TODO expand with 1 mixed variable located in 1 master and N subproblems
+// For now we only have MASTER, mostly because the fixture has a single optimEntityContainer
+// There should be optimEntityContainer_master and optimEntityContainer_subproblems
+BOOST_FIXTURE_TEST_CASE(mixed_variable_listed_in_benders_decomposition,
+                        Fixtures::SingleMixedVarNoObjective)
+{
+    ComponentFiller masterFiller(*component,
+                                 optimEntityContainer,
+                                 scenario_group_repo,
+                                 Location::MASTER,
+                                 &bendersDecomposition);
+
+    masterFiller.addVariables(time_scenario_ctx);
+    BOOST_CHECK_EQUAL(linear_pb.variableCount(), 1);
+
+    BOOST_REQUIRE_EQUAL(bendersDecomposition.connections().size(), 1);
+    // connections = {{"master", {"my-component.var-1", 0}}
+    const auto& [name, connections] = *bendersDecomposition.connections().begin();
+    BOOST_CHECK_EQUAL(name, "master");
+    const auto& connection = connections[0];
+    BOOST_CHECK_EQUAL(connection.name, "my-component.var-1");
+    BOOST_CHECK_EQUAL(connection.indexInProblem, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Extract writing responsabilities from `BendersDecomposition` into `BendersDecompositionWriter`
- Rename fixtures, avoid duplicates (`_1 == _2` and `_3==_4`)
- Add fixture for a single mixed variable (MASTER_AND_SUBPROBLEMS), check the contents of `BendersDecomposition`