### PR TITLE
Revert "Use highs by default in tests"

### DIFF
--- a/src/tests/cucumber/CMakeLists.txt
+++ b/src/tests/cucumber/CMakeLists.txt
@@ -5,7 +5,5 @@ antares-solver = $<TARGET_FILE:antares-solver>\
 \n\
 antares-modeler = $<TARGET_FILE:antares-modeler>\
 \n\
-linear-solver = highs\
-\n\
 resources-path = ${CMAKE_SOURCE_DIR}/tests/resources"
         CONDITION $<STREQUAL:$<CONFIG>,${CMAKE_BUILD_TYPE}>)

--- a/src/tests/cucumber/features/solver-features/medium_tests.feature
+++ b/src/tests/cucumber/features/solver-features/medium_tests.feature
@@ -5,7 +5,7 @@ Feature: medium tests
     Given the solver study path is "Antares_Simulator_Tests_NR/medium-tests/035 Mixed Expansion - Smart grid model 2"
     When I run antares simulator
     Then the simulation succeeds
-    And the simulation takes less than 45 seconds
+    And the simulation takes less than 30 seconds
     And the expected value of the annual system cost is 3.725e+10
     And the minimum annual system cost is 3.642e+10
     And the maximum annual system cost is 4.011e+10

--- a/src/tests/cucumber/features/solver-features/short_tests.feature
+++ b/src/tests/cucumber/features/solver-features/short_tests.feature
@@ -293,7 +293,7 @@ Feature: short tests
     Given the solver study path is "Antares_Simulator_Tests_NR/short-tests/021 Four areas - DC law"
     When I run antares simulator
     Then the simulation succeeds
-    And the simulation takes less than 30 seconds
+    And the simulation takes less than 25 seconds
     And the annual system cost is
       | EXP       | STD       | MIN       | MAX       |
       | 7.972e+10 | 2.258e+10 | 5.613e+10 | 1.082e+11 |

--- a/src/tests/cucumber/features/solver-features/tests_for_v9.3.feature
+++ b/src/tests/cucumber/features/solver-features/tests_for_v9.3.feature
@@ -25,15 +25,15 @@ Feature: tests for v9.3
     Then the simulation takes less than 2 seconds
     And the simulation succeeds
     And in area "area", year 1 and hour 0, near price cap is 0 hours
-    And in area "area", year 1 and hour 48, near price cap is 0 hours
+    And in area "area", year 1 and hour 48, near price cap is 1 hours
     And in area "area 2", year 1 and hour 0, near price cap is 0 hours
-    And in area "area 2", year 1 and hour 48, near price cap is 0 hours
+    And in area "area 2", year 1 and hour 48, near price cap is 1 hours
     And in area "area 2", year 1 and hour 120, near price cap is 0 hours
-    And in area "area 2", year 1 and hour 144, near price cap is 0 hours
+    And in area "area 2", year 1 and hour 144, near price cap is 1 hours
     And in area "area 3", year 1 and hour 0, near price cap is 0 hours
-    And in area "area 3", year 1 and hour 120, near price cap is 0 hours
+    And in area "area 3", year 1 and hour 120, near price cap is 1 hours
     And in area "area 4", year 1 and hour 0, near price cap is 0 hours
-    And in area "area 4", year 1 and hour 11, near price cap is 0 hours
-    And in area "area 4", year 1 and hour 12, near price cap is 0 hours
+    And in area "area 4", year 1 and hour 11, near price cap is 1 hours
+    And in area "area 4", year 1 and hour 12, near price cap is 1 hours
     And in area "area 4", year 1 and hour 13, near price cap is 0 hours
-    And in area "area 4", year 1 and hour 17, near price cap is 0 hours
+    And in area "area 4", year 1 and hour 17, near price cap is 1 hours

--- a/src/tests/end-to-end/modeler/test-modeler.cpp
+++ b/src/tests/end-to-end/modeler/test-modeler.cpp
@@ -100,7 +100,7 @@ class InMemoryLoader final: public Antares::Solver::ILoader
 public:
     Antares::Solver::ModelerParameters loadParameters() override
     {
-        return {.solver = "highs",
+        return {.solver = "sirius",
                 .solverLogs = false,
                 .solverParameters = "DUMMY",
                 .noOutput = true,

--- a/src/tests/resources/modeler/1_1/parameters.yml
+++ b/src/tests/resources/modeler/1_1/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/1_2/parameters.yml
+++ b/src/tests/resources/modeler/1_2/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/1_3/parameters.yml
+++ b/src/tests/resources/modeler/1_3/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/1_5/parameters.yml
+++ b/src/tests/resources/modeler/1_5/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/1_6/parameters.yml
+++ b/src/tests/resources/modeler/1_6/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/2_1/parameters.yml
+++ b/src/tests/resources/modeler/2_1/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/2_2/parameters.yml
+++ b/src/tests/resources/modeler/2_2/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/2_3/parameters.yml
+++ b/src/tests/resources/modeler/2_3/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/2_4/parameters.yml
+++ b/src/tests/resources/modeler/2_4/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/3_1/parameters.yml
+++ b/src/tests/resources/modeler/3_1/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/3_2/parameters.yml
+++ b/src/tests/resources/modeler/3_2/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/3_3/parameters.yml
+++ b/src/tests/resources/modeler/3_3/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/4_1/parameters.yml
+++ b/src/tests/resources/modeler/4_1/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/4_2/parameters.yml
+++ b/src/tests/resources/modeler/4_2/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/4_3/parameters.yml
+++ b/src/tests/resources/modeler/4_3/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/4_4/parameters.yml
+++ b/src/tests/resources/modeler/4_4/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/5_1/parameters.yml
+++ b/src/tests/resources/modeler/5_1/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/6_1/parameters.yml
+++ b/src/tests/resources/modeler/6_1/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/6_1_scenariobuilder/parameters.yml
+++ b/src/tests/resources/modeler/6_1_scenariobuilder/parameters.yml
@@ -1,4 +1,4 @@
-solver: highs
+solver: sirius
 solver-logs: true
 solver-parameters: THREADS 1
 no-output: false

--- a/src/tests/resources/modeler/epic2/us2.5/study_2.5.1/parameters.yml
+++ b/src/tests/resources/modeler/epic2/us2.5/study_2.5.1/parameters.yml
@@ -1,6 +1,6 @@
-solver: highs
+solver: sirius
 solver-logs: false
-solver-parameters:
+solver-parameters: 
 no-output: false
 first-time-step: 0
 last-time-step: 0

--- a/src/tests/src/modeler/loadFiles/testParameters.cpp
+++ b/src/tests/src/modeler/loadFiles/testParameters.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(read_parameters)
     auto studyPath = CREATE_TMP_DIR_BASED_ON_TEST_NAME();
     std::ofstream paramStream(studyPath / "parameters.yml");
     paramStream << R"(
-        solver: highs
+        solver: sirius
         solver-logs: false
         solver-parameters: PRESOLVE 1
         no-output: true
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(read_parameters)
     paramStream.close();
 
     auto params = Antares::Solver::LoadFiles::loadParameters(studyPath);
-    BOOST_CHECK_EQUAL(params.solver, "highs");
+    BOOST_CHECK_EQUAL(params.solver, "sirius");
     BOOST_CHECK_EQUAL(params.solverLogs, false);
     BOOST_CHECK_EQUAL(params.solverParameters, "PRESOLVE 1");
     BOOST_CHECK_EQUAL(params.noOutput, true);
@@ -53,14 +53,14 @@ BOOST_AUTO_TEST_CASE(read_parameters_out_of_order)
     std::ofstream paramStream(studyPath / "parameters.yml");
     paramStream << R"(
         solver-logs: false
-        solver: highs
+        solver: sirius
         solver-parameters: PRESOLVE 1
         no-output: true
     )";
     paramStream.close();
 
     auto params = Antares::Solver::LoadFiles::loadParameters(studyPath);
-    BOOST_CHECK_EQUAL(params.solver, "highs");
+    BOOST_CHECK_EQUAL(params.solver, "sirius");
     BOOST_CHECK_EQUAL(params.solverLogs, false);
     BOOST_CHECK_EQUAL(params.solverParameters, "PRESOLVE 1");
     BOOST_CHECK_EQUAL(params.noOutput, true);


### PR DESCRIPTION
Reference results are generated with Sirius. To not create difficulties with potential difference between solvers we revert usage of highs in tests