### PR TITLE
test: handle invalid-studies

### DIFF
--- a/src/tests/cucumber/features/solver-features/hybrid_studies.feature
+++ b/src/tests/cucumber/features/solver-features/hybrid_studies.feature
@@ -82,7 +82,7 @@ Feature: hybrid (simulator+modeler) studies
 
   @fast @short
   Scenario: Invalid study - scenario-independent variable
-    Given the solver study path is "Antares_Simulator_Tests_NR/hybrid/Scenario-independent variable"
+    Given the solver study path is "Antares_Simulator_Tests_NR/invalid-studies/hybrid/Scenario-independent variable"
     When I run antares simulator
     Then the simulation fails
     And the message "Scenario-independent variables are not supported in hybrid studies" is reported in the logs


### PR DESCRIPTION
In test NR, Scenario-independent variable study is an invalid hybrid study. It's wanted because a test check that it fails properly. However this study impair reference result generation. Thus the study has been moved to another directory specific for invalid studies that is excluded from generation