### PR TITLE
Small improvements for slack analysis

### DIFF
--- a/src/solver/infeasible-problem-analysis/constraint-slack-analysis.cpp
+++ b/src/solver/infeasible-problem-analysis/constraint-slack-analysis.cpp
@@ -149,7 +149,7 @@ void ConstraintSlackAnalysis::printReport() const
     InfeasibleProblemReport report(slackVariables_);
     report.storeSuspiciousConstraints();
     report.storeInfeasibilityCauses();
-    std::ranges::for_each(report.getLogs(), [](auto& line) { logs.notice() << line; });
+    std::ranges::for_each(report.getLogs(), [](const std::string& line) { logs.notice() << line; });
 }
 
 } // namespace Antares::Optimization

--- a/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/report.h
+++ b/src/solver/infeasible-problem-analysis/include/antares/solver/infeasible-problem-analysis/report.h
@@ -42,10 +42,9 @@ public:
     explicit InfeasibleProblemReport(const std::vector<const operations_research::MPVariable*>&);
     void storeSuspiciousConstraints();
     void storeInfeasibilityCauses();
-    std::vector<std::string> getLogs();
+    const std::vector<std::string>& getLogs() const;
 
 private:
-    void buildConstraintsFromSlackVars(const std::vector<const operations_research::MPVariable*>&);
     void filterConstraintsToOneByType();
 
     std::vector<std::shared_ptr<WatchedConstraint>> constraints_;

--- a/src/solver/infeasible-problem-analysis/report.cpp
+++ b/src/solver/infeasible-problem-analysis/report.cpp
@@ -28,6 +28,7 @@ namespace Antares::Optimization
 InfeasibleProblemReport::InfeasibleProblemReport(
   const std::vector<const operations_research::MPVariable*>& slackVariables)
 {
+    // Build constraints from slack variables (one constraint per slack variable)
     const ConstraintsFactory constraintsFactory;
     for (const auto* slackVar: slackVariables)
     {

--- a/src/solver/infeasible-problem-analysis/report.cpp
+++ b/src/solver/infeasible-problem-analysis/report.cpp
@@ -22,17 +22,10 @@
 
 #include <algorithm>
 #include <regex>
-#include <typeindex>
 
 namespace Antares::Optimization
 {
 InfeasibleProblemReport::InfeasibleProblemReport(
-  const std::vector<const operations_research::MPVariable*>& slackVariables)
-{
-    buildConstraintsFromSlackVars(slackVariables);
-}
-
-void InfeasibleProblemReport::buildConstraintsFromSlackVars(
   const std::vector<const operations_research::MPVariable*>& slackVariables)
 {
     const ConstraintsFactory constraintsFactory;
@@ -49,18 +42,14 @@ void InfeasibleProblemReport::buildConstraintsFromSlackVars(
 bool lessTypeName(const std::shared_ptr<WatchedConstraint> a,
                   const std::shared_ptr<WatchedConstraint> b)
 {
-    const WatchedConstraint* a_raw = a.get();
-    const WatchedConstraint* b_raw = b.get();
     // TODO Compiler-dependent behavior
-    return std::type_index(typeid(*a_raw)) < std::type_index(typeid(*b_raw));
+    return typeid(*a).before(typeid(*b));
 }
 
 bool sameType(const std::shared_ptr<WatchedConstraint> a,
               const std::shared_ptr<WatchedConstraint> b)
 {
-    const WatchedConstraint* a_raw = a.get();
-    const WatchedConstraint* b_raw = b.get();
-    return std::type_index(typeid(*a_raw)) == std::type_index(typeid(*b_raw));
+    return typeid(*a) == typeid(*b);
 }
 
 bool greaterValue(const std::shared_ptr<WatchedConstraint> a, std::shared_ptr<WatchedConstraint> b)
@@ -99,7 +88,7 @@ void InfeasibleProblemReport::storeInfeasibilityCauses()
     }
 }
 
-std::vector<std::string> InfeasibleProblemReport::getLogs()
+const std::vector<std::string>& InfeasibleProblemReport::getLogs() const
 {
     return report_;
 }


### PR DESCRIPTION
- Remove dependency on `std::type_index`
- Remove function used once
- Remove call `get()` for `std::shared_ptr`s