### PR TITLE
Add a few missing install directives

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(solver_api
 # Single problem library
 # This API allows the developper to build problems on-demand
 add_library(single_problem_api)
+add_library(Antares::single_problem_api ALIAS single_problem_api)
 
 target_sources(single_problem_api
 	PRIVATE

--- a/src/libs/antares/enums/CMakeLists.txt
+++ b/src/libs/antares/enums/CMakeLists.txt
@@ -14,6 +14,10 @@ target_include_directories(enums
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
+install(DIRECTORY include/antares
+        DESTINATION "include"
+)
+
 target_link_libraries(enums
         PUBLIC
         Antares::exception

--- a/src/libs/antares/study-loader/CMakeLists.txt
+++ b/src/libs/antares/study-loader/CMakeLists.txt
@@ -6,6 +6,10 @@ target_sources(study-loader INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/antares/study-loader/IStudyLoader.h>
 )
 
+install(DIRECTORY include/antares
+        DESTINATION "include"
+)
+
 target_include_directories(study-loader
         INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/modeler-optimisation-container/CMakeLists.txt
+++ b/src/modeler-optimisation-container/CMakeLists.txt
@@ -24,6 +24,10 @@ target_link_libraries(${PROJ}
         Antares::linear-problem-api
 )
 
+install(DIRECTORY include/antares
+        DESTINATION "include"
+)
+
 target_include_directories(${PROJ}
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/modeler/modeler/CMakeLists.txt
+++ b/src/modeler/modeler/CMakeLists.txt
@@ -21,3 +21,7 @@ target_include_directories(modeler-lib
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
+
+install(DIRECTORY include/antares
+        DESTINATION "include"
+)

--- a/src/optimisation/linear-problem-api/CMakeLists.txt
+++ b/src/optimisation/linear-problem-api/CMakeLists.txt
@@ -20,6 +20,9 @@ add_library(Antares::${PROJ} ALIAS ${PROJ})
 
 set_target_properties(${PROJ} PROPERTIES LINKER_LANGUAGE CXX)
 
+install(DIRECTORY include/antares
+        DESTINATION "include"
+)
 
 target_include_directories(${PROJ}
         PUBLIC

--- a/src/optimisation/linear-problem-data-impl/CMakeLists.txt
+++ b/src/optimisation/linear-problem-data-impl/CMakeLists.txt
@@ -28,6 +28,10 @@ target_link_libraries(${PROJ}
         Antares::exception
 )
 
+install(DIRECTORY include/antares
+        DESTINATION "include"
+)
+
 target_include_directories(${PROJ}
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -11,8 +11,8 @@ set(TARGET_LIBS #No alias
         # it is available for everything
 
         solver_api # What we want to export
+	single_problem_api
 
-        # solver_api
         study
         scenario-builder-utils
         study-loader
@@ -39,7 +39,6 @@ set(TARGET_LIBS #No alias
 
         # study-loader : nothing
 
-        # file-tree-study-loader
         application
 
         # run-mode


### PR DESCRIPTION
Some headers are required to expose the "single problem getter" API externally.

```cpp
#include <antares/api/singleProblemGetter.h>
```

~~There may be more to come.~~