### PR TITLE
Expose studyPath instead of study

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(single_problem_api
         Antares::optimization-options
 	model_antares
 	Antares::hydro
+	Antares::file-tree-study-loader
         PUBLIC
         Antares::study
         Antares::lps)
@@ -74,8 +75,7 @@ target_link_libraries(single_problem_api
 # TODO move
 add_executable(api_test main.cpp)
 target_link_libraries(api_test
-	single_problem_api
-	Antares::file-tree-study-loader)
+	single_problem_api)
 
 install(DIRECTORY include/antares
         DESTINATION "include")

--- a/src/api/include/antares/api/singleProblemGetter.h
+++ b/src/api/include/antares/api/singleProblemGetter.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <memory>
 
 #include "antares/solver/lps/LpsFromAntares.h"
@@ -36,7 +37,7 @@ namespace Antares::Solver
 class SingleProblemGetter
 {
 public:
-    explicit SingleProblemGetter(std::unique_ptr<Antares::Data::Study>&& study);
+    explicit SingleProblemGetter(const std::filesystem::path& studyPath);
     ~SingleProblemGetter();
     ConstantDataFromAntares getConstantData();
     WeeklyDataFromAntares getWeeklyData(WeeklyProblemId id);

--- a/src/api/main.cpp
+++ b/src/api/main.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 
 #include "antares/api/singleProblemGetter.h"
-#include "antares/file-tree-study-loader/FileTreeStudyLoader.h"
 
 constexpr int kMaxDisplay = 10'000;
 
@@ -46,10 +45,7 @@ int main(int argc, char** argv)
     const unsigned int year = toInt(argv[2]);
     const unsigned int week = toInt(argv[3]);
 
-    Antares::FileTreeStudyLoader loader(argv[1]);
-    auto study = loader.load();
-
-    Antares::Solver::SingleProblemGetter getter(std::move(study));
+    Antares::Solver::SingleProblemGetter getter(argv[1]);
     auto constant = getter.getConstantData();
     auto weekly = getter.getWeeklyData({year, week});
 

--- a/src/api/private/singleProblemGetterImpl.h
+++ b/src/api/private/singleProblemGetterImpl.h
@@ -24,6 +24,7 @@ using AllData = std::map<unsigned int /* year */, YearlyData>;
 class SingleProblemGetter
 {
 public:
+    explicit SingleProblemGetter(const std::filesystem::path& studyPath);
     explicit SingleProblemGetter(std::unique_ptr<Antares::Data::Study>&& study);
     ConstantDataFromAntares getConstantData();
     WeeklyDataFromAntares getWeeklyData(WeeklyProblemId id);

--- a/src/api/singleProblemGetter.cpp
+++ b/src/api/singleProblemGetter.cpp
@@ -25,8 +25,8 @@
 
 namespace Antares::Solver
 {
-SingleProblemGetter::SingleProblemGetter(std::unique_ptr<Antares::Data::Study>&& study):
-    impl_(std::make_unique<Implementation::SingleProblemGetter>(std::move(study)))
+SingleProblemGetter::SingleProblemGetter(const std::filesystem::path& studyPath):
+    impl_(std::make_unique<Implementation::SingleProblemGetter>(studyPath))
 {
 }
 

--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "antares/benchmarking/DurationCollector.h"
+#include "antares/file-tree-study-loader/FileTreeStudyLoader.h"
 #include "antares/solver/hydro/management/HydroInputsChecker.h"
 #include "antares/solver/optimisation/LinearProblemMatrix.h"
 #include "antares/solver/optimisation/opt_fonctions.h"
@@ -43,10 +44,23 @@ constexpr int DernierPdtDeLIntervalle = 168; // 1 week = 7*24 hours
 const std::string kName = "my-name";         // Arbitrary
 Antares::Solver::NullResultWriter gResultWriter;
 Benchmarking::DurationCollector gDurationCollector;
+
+std::unique_ptr<Antares::Data::Study> loadStudy(const std::filesystem::path& studyPath)
+{
+    Antares::FileTreeStudyLoader loader(studyPath);
+    auto study = loader.load();
+    return study;
+}
 } // namespace
 
 namespace Antares::Solver::Implementation
 {
+
+SingleProblemGetter::SingleProblemGetter(const std::filesystem::path& studyPath):
+    SingleProblemGetter(loadStudy(studyPath))
+{
+}
+
 SingleProblemGetter::SingleProblemGetter(std::unique_ptr<Antares::Data::Study>&& study):
     study_(std::move(study))
 {

--- a/src/tests/src/api_lib/CMakeLists.txt
+++ b/src/tests/src/api_lib/CMakeLists.txt
@@ -9,4 +9,9 @@ add_boost_test(test-single-problem-api
   test_single_problem_api.cpp
   LIBS
   single_problem_api
-  Antares::tests::in-memory-study)
+  Antares::tests::in-memory-study
+# While this is ugly, but we need Implementation::SingleProblemGetter
+# since unlike SingleProblemGetter, it exposes the
+# "Study" constructor, allowing to create the study in memory
+  INCLUDE
+  "${CMAKE_SOURCE_DIR}/api/private")

--- a/src/tests/src/api_lib/test_single_problem_api.cpp
+++ b/src/tests/src/api_lib/test_single_problem_api.cpp
@@ -27,10 +27,10 @@
 #include <boost/test/unit_test.hpp>
 
 #include "antares/antares/constants.h"
-#include "antares/api/singleProblemGetter.h"
 #include "antares/study/study.h"
 
 #include "in-memory-study.h"
+#include "singleProblemGetterImpl.h"
 
 constexpr double EPSILON = 1.e-6;
 
@@ -97,7 +97,7 @@ std::unique_ptr<Antares::Data::Study> buildStudy(bool thermal, bool hydro)
 BOOST_AUTO_TEST_CASE(single_problem_thermal_first_week_nominal_case)
 {
     auto study = buildStudy(true, false);
-    Antares::Solver::SingleProblemGetter getter(std::move(study));
+    Antares::Solver::Implementation::SingleProblemGetter getter(std::move(study));
     const Antares::Solver::ConstantDataFromAntares constantData = getter.getConstantData();
     // 504 = 3*168, 3 sets of variables
     // unsupplied energy
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(single_problem_thermal_first_week_nominal_case)
 BOOST_AUTO_TEST_CASE(single_problem_hydro_two_weeks_nominal_case)
 {
     auto study = buildStudy(false, true);
-    Antares::Solver::SingleProblemGetter getter(std::move(study));
+    Antares::Solver::Implementation::SingleProblemGetter getter(std::move(study));
     const Antares::Solver::ConstantDataFromAntares constantData = getter.getConstantData();
     // Total 1008
     // 168 unsupplied energy


### PR DESCRIPTION
`Implementation::SingleProblemGetter` has 2 constructors
- `std::unique_ptr<Study>&&` used in the tests for "in-memory" tests
- `const std::filesystem::path&` used by `SingleProblemGetter` 

`SingleProblemGetter` has a single constructor `const std::filesystem::path` used by main.cpp (test utility) and Xpansion.