### PR TITLE
fix: build std::type_index is not constexpr

### DIFF
--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -43,7 +43,7 @@ std::type_index forbiddenNodeKey()
 }
 
 template<Expressions::Nodes::FunctionNodeType T>
-constexpr std::type_index forbiddenNodeKey()
+std::type_index forbiddenNodeKey()
 {
     using Tag = std::integral_constant<Expressions::Nodes::FunctionNodeType, T>;
     return std::type_index(typeid(Tag));


### PR DESCRIPTION
Building with clang 20 I get the following error

> In file included from /tmp/deps/Antares_Simulator/src/io/inputs/model-converter/NodeChecker.cpp:21:
In file included from /tmp/deps/Antares_Simulator/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h:29:
/tmp/deps/Antares_Simulator/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h:46:27: fatal error: constexpr function's return type 'std::type_index' is not a literal type
   46 | constexpr std::type_index forbiddenNodeKey()
      |                           ^
/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/typeindex:55:10: note: 'type_index' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
   55 |   struct type_index
      |          ^
1 error generated.

Indeed the constructor is not constexpr : https://en.cppreference.com/w/cpp/types/type_index/type_index.html

I don't know why it build with gcc though