### PR TITLE
Single problem API - Problem name depends on the `WeeklyProblemId`

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -64,6 +64,7 @@ target_include_directories(single_problem_api
 
 target_link_libraries(single_problem_api
         PRIVATE
+	fmt::fmt
         antares-solver-simulation
         Antares::optimization-options
 	model_antares

--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -37,6 +37,8 @@
 #include "antares/solver/simulation/simulation.h"
 #include "antares/writer/i_writer.h"
 
+#include "fmt/format.h"
+
 namespace
 {
 constexpr int optimizationNumber = 1;  // the 1st optim is available for now
@@ -44,7 +46,6 @@ constexpr int numeroDeLIntervalle = 0; // simplex-range = week
 constexpr int numSpace = 0;            // full sequential
 constexpr int PremierPdtDeLIntervalle = 0;
 constexpr int DernierPdtDeLIntervalle = 168; // 1 week = 7*24 hours
-const std::string kName = "my-name";         // Arbitrary
 Antares::Solver::NullResultWriter gResultWriter;
 Benchmarking::DurationCollector gDurationCollector;
 
@@ -53,6 +54,11 @@ std::unique_ptr<Antares::Data::Study> loadStudy(const std::filesystem::path& stu
     Antares::FileTreeStudyLoader loader(studyPath);
     auto study = loader.load();
     return study;
+}
+
+std::string problemName(const WeeklyProblemId& id)
+{
+    return fmt::format("problem-{}-{}.txt", id.year, id.week);
 }
 } // namespace
 
@@ -248,7 +254,7 @@ WeeklyDataFromAntares SingleProblemGetter::getWeeklyData(WeeklyProblemId id)
                                                     optimizationNumber);
 
     OPT_InitialiserLesCoutsLineaire(&pb_, PremierPdtDeLIntervalle, DernierPdtDeLIntervalle);
-    return translator_.translate(pb_.ProblemeAResoudre.get(), kName);
+    return translator_.translate(pb_.ProblemeAResoudre.get(), problemName(id));
 }
 
 const YearlyData& SingleProblemGetter::getYearlyData(unsigned year)

--- a/src/tests/src/api_lib/test_single_problem_api.cpp
+++ b/src/tests/src/api_lib/test_single_problem_api.cpp
@@ -130,6 +130,8 @@ BOOST_AUTO_TEST_CASE(single_problem_thermal_first_week_nominal_case)
     BOOST_CHECK_EQUAL(constantData.ConstraintsMatrixCoeff[1], -1);
 
     const Antares::Solver::WeeklyDataFromAntares firstWeekData = getter.getWeeklyData({0, 1});
+    BOOST_CHECK_EQUAL(firstWeekData.name, "problem-0-1.txt");
+
     // COST
     BOOST_CHECK_CLOSE(firstWeekData.LinearCost[dispatchableVariable],
                       19.999456400134147,
@@ -208,6 +210,8 @@ BOOST_AUTO_TEST_CASE(single_problem_hydro_two_weeks_nominal_case)
     BOOST_CHECK_CLOSE(secondWeekData.RHS[areaHydroLevel],
                       3048.5130614352684,
                       EPSILON); // random initial level
+
+    BOOST_CHECK_EQUAL(secondWeekData.name, "problem-0-2.txt");
 }
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Before this change, all subproblems were named "my-name", creating collisions. Now we have e.g
```
omnesflo@gm0winl772:~/xpansion/data_test/examples/additionnal-constraints/output/20251205-1607eco/lp$ ls problem-*
problem-0-10.svf  problem-0-27.svf  problem-0-43.svf  problem-1-12.svf  problem-1-29.svf  problem-1-45.svf  problem-2-14.svf  problem-2-30.svf  problem-2-47.svf
problem-0-11.svf  problem-0-28.svf  problem-0-44.svf  problem-1-13.svf  problem-1-2.svf   problem-1-46.svf  problem-2-15.svf  problem-2-31.svf  problem-2-48.svf
problem-0-12.svf  problem-0-29.svf  problem-0-45.svf  problem-1-14.svf  problem-1-30.svf  problem-1-47.svf  problem-2-16.svf  problem-2-32.svf  problem-2-49.svf
problem-0-13.svf  problem-0-2.svf   problem-0-46.svf  problem-1-15.svf  problem-1-31.svf  problem-1-48.svf  problem-2-17.svf  problem-2-33.svf  problem-2-4.svf
problem-0-14.svf  problem-0-30.svf  problem-0-47.svf  problem-1-16.svf  problem-1-32.svf  problem-1-49.svf  problem-2-18.svf  problem-2-34.svf  problem-2-50.svf
problem-0-15.svf  problem-0-31.svf  problem-0-48.svf  problem-1-17.svf  problem-1-33.svf  problem-1-4.svf   problem-2-19.svf  problem-2-35.svf  problem-2-51.svf
problem-0-16.svf  problem-0-32.svf  problem-0-49.svf  problem-1-18.svf  problem-1-34.svf  problem-1-50.svf  problem-2-1.svf   problem-2-36.svf  problem-2-52.svf
problem-0-17.svf  problem-0-33.svf  problem-0-4.svf   problem-1-19.svf  problem-1-35.svf  problem-1-51.svf  problem-2-20.svf  problem-2-37.svf  problem-2-5.svf
problem-0-18.svf  problem-0-34.svf  problem-0-50.svf  problem-1-1.svf   problem-1-36.svf  problem-1-52.svf  problem-2-21.svf  problem-2-38.svf  problem-2-6.svf
problem-0-19.svf  problem-0-35.svf  problem-0-51.svf  problem-1-20.svf  problem-1-37.svf  problem-1-5.svf   problem-2-22.svf  problem-2-39.svf  problem-2-7.svf
problem-0-1.svf   problem-0-36.svf  problem-0-52.svf  problem-1-21.svf  problem-1-38.svf  problem-1-6.svf   problem-2-23.svf  problem-2-3.svf   problem-2-8.svf
problem-0-20.svf  problem-0-37.svf  problem-0-5.svf   problem-1-22.svf  problem-1-39.svf  problem-1-7.svf   problem-2-24.svf  problem-2-40.svf  problem-2-9.svf
problem-0-21.svf  problem-0-38.svf  problem-0-6.svf   problem-1-23.svf  problem-1-3.svf   problem-1-8.svf   problem-2-25.svf  problem-2-41.svf
problem-0-22.svf  problem-0-39.svf  problem-0-7.svf   problem-1-24.svf  problem-1-40.svf  problem-1-9.svf   problem-2-26.svf  problem-2-42.svf
problem-0-23.svf  problem-0-3.svf   problem-0-8.svf   problem-1-25.svf  problem-1-41.svf  problem-2-10.svf  problem-2-27.svf  problem-2-43.svf
problem-0-24.svf  problem-0-40.svf  problem-0-9.svf   problem-1-26.svf  problem-1-42.svf  problem-2-11.svf  problem-2-28.svf  problem-2-44.svf
problem-0-25.svf  problem-0-41.svf  problem-1-10.svf  problem-1-27.svf  problem-1-43.svf  problem-2-12.svf  problem-2-29.svf  problem-2-45.svf
problem-0-26.svf  problem-0-42.svf  problem-1-11.svf  problem-1-28.svf  problem-1-44.svf  problem-2-13.svf  problem-2-2.svf   problem-2-46.svf
```