### PR TITLE
Single problem API - Fix `IntercoGereeAvecDesCouts` not initialized [ANT-2334]

### DIFF
--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -168,8 +168,22 @@ void SingleProblemGetter::writeStudyDescriptionFiles(const std::filesystem::path
     OPT_ExportStructures(&pb_, *writer);
 }
 
+void fillLinks(PROBLEME_HEBDO& pb, const Antares::Data::Study& study)
+{
+    auto& studyruntime = study.runtime;
+    for (uint k = 0; k < studyruntime.interconnectionsCount(); ++k)
+    {
+        auto* lnk = studyruntime.areaLink[k];
+        pb.CoutDeTransport[k].IntercoGereeAvecDesCouts = lnk->useHurdlesCost;
+    }
+}
+
 ConstantDataFromAntares SingleProblemGetter::getConstantData()
 {
+    // IntercoGereeAvecDesCouts needs to be initialized
+    // before building variable list and the common matrix
+    fillLinks(pb_, *study_);
+
     OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(&pb_);
 
     auto builder_data = NewGetConstraintBuilderFromProblemHebdo(&pb_);

--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -168,12 +168,12 @@ void SingleProblemGetter::writeStudyDescriptionFiles(const std::filesystem::path
     OPT_ExportStructures(&pb_, *writer);
 }
 
-void fillLinks(PROBLEME_HEBDO& pb, const Antares::Data::Study& study)
+void fillLinksProperties(PROBLEME_HEBDO& pb, const Antares::Data::Study& study)
 {
-    auto& studyruntime = study.runtime;
+    const auto& studyruntime = study.runtime;
     for (uint k = 0; k < studyruntime.interconnectionsCount(); ++k)
     {
-        auto* lnk = studyruntime.areaLink[k];
+        const auto* lnk = studyruntime.areaLink[k];
         pb.CoutDeTransport[k].IntercoGereeAvecDesCouts = lnk->useHurdlesCost;
     }
 }
@@ -182,7 +182,7 @@ ConstantDataFromAntares SingleProblemGetter::getConstantData()
 {
     // IntercoGereeAvecDesCouts needs to be initialized
     // before building variable list and the common matrix
-    fillLinks(pb_, *study_);
+    fillLinksProperties(pb_, *study_);
 
     OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(&pb_);
 


### PR DESCRIPTION
Function `OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire` needs to have `problemeHebdo->CoutDeTransport[interco].IntercoGereeAvecDesCouts` initialized properly, otherwise some variables are not created

## Initialization to `false` in `PROBLEME_HEBDO`
https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/aa2a654edc27b689438b50bf5881bfaf2aea0e68/src/solver/simulation/sim_alloc_probleme_hebdo.cpp#L237-L251

## Where the value is usually imported from `PROBLEME_HEBDO`
https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/aa2a654edc27b689438b50bf5881bfaf2aea0e68/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp#L57-L69