### PR TITLE
Remove unused LpsFromAntares data members

### DIFF
--- a/src/solver/lps/include/antares/solver/lps/LpsFromAntares.h
+++ b/src/solver/lps/include/antares/solver/lps/LpsFromAntares.h
@@ -61,15 +61,12 @@ struct ConstantDataFromAntares
     // IndicesColonnes.size()=
     // CoefficientsDeLaMatriceDesContraintes.size()
 
-    std::vector<unsigned> VariablesType; // Variables entières ou biniaires
     std::vector<unsigned> Mdeb; // Indique dans les indices dans le vecteur IndicesColonnes qui
     // correspondent au début de chaque ligne. Ex : Mdeb[3] = 8 et
     // Mdeb[4] = 13 -> Les termes IndicesColonnes[8] à
     // IndicesColonnes[12] correspondent à des Id de colonnes de la
     // ligne 3 de la matrice (en supposant que les lignes sont indexées
     // à partir de 0)
-    std::vector<unsigned> NotNullTermCount; // Nombre de termes non nuls sur chaque ligne.
-    // Inutile car NbTerm[i] = Mdeb[i+1] - Mdeb[i]
     std::vector<unsigned> ColumnIndexes; // Id des colonnes des termes de
     // CoefficientsDeLaMatriceDesContraintes : Ex
     // IndicesColonnes[3] = 8 ->

--- a/src/solver/optimisation/HebdoProblemToLpsTranslator.cpp
+++ b/src/solver/optimisation/HebdoProblemToLpsTranslator.cpp
@@ -112,8 +112,6 @@ ConstantDataFromAntares HebdoProblemToLpsTranslator::commonProblemData(
     ret.CoeffCount = problem->IndicesDebutDeLigne[problem->NombreDeContraintes - 1]
                      + problem->NombreDeTermesDesLignes[problem->NombreDeContraintes - 1];
 
-    copy(problem->TypeDeVariable, ret.VariablesType);
-
     copy(problem->CoefficientsDeLaMatriceDesContraintes, ret.ConstraintsMatrixCoeff);
     ret.ConstraintsMatrixCoeff.resize(ret.CoeffCount);
     copy(problem->IndicesColonnes, ret.ColumnIndexes);
@@ -128,7 +126,6 @@ ConstantDataFromAntares HebdoProblemToLpsTranslator::commonProblemData(
     // It is then updated to the exact number resp. ret.VariablesCount and ret.ConstraintesCount.
     // To avoid wasting memory and errors, we resize ret.VariablesMeaning and ret.ConstraintsMeaning
     resizeIfLargerThan(ret.VariablesMeaning, ret.VariablesCount);
-    resizeIfLargerThan(ret.VariablesType, ret.VariablesCount);
     resizeIfLargerThan(ret.ConstraintsMeaning, ret.ConstraintesCount);
     return ret;
 }

--- a/src/tests/src/solver/optimisation/translator/test_translator.cpp
+++ b/src/tests/src/solver/optimisation/translator/test_translator.cpp
@@ -126,7 +126,6 @@ BOOST_AUTO_TEST_CASE(common_data_properly_copied)
     PROBLEME_ANTARES_A_RESOUDRE problemHebdo;
     problemHebdo.NombreDeVariables = 3;
     problemHebdo.NombreDeContraintes = 2;
-    problemHebdo.TypeDeVariable = {0, 1, 2};
     problemHebdo.IndicesDebutDeLigne = {0, 3};
     problemHebdo.NombreDeTermesDesLignes = {3, 3};
     problemHebdo.NomDesVariables = {"a", "b", "c"};
@@ -138,7 +137,6 @@ BOOST_AUTO_TEST_CASE(common_data_properly_copied)
 
     BOOST_CHECK_EQUAL(ret.VariablesCount, problemHebdo.NombreDeVariables);
     BOOST_CHECK_EQUAL(ret.ConstraintesCount, problemHebdo.NombreDeContraintes);
-    BOOST_CHECK(std::ranges::equal(ret.VariablesType, problemHebdo.TypeDeVariable));
     BOOST_CHECK(ret.ConstraintsMatrixCoeff == problemHebdo.CoefficientsDeLaMatriceDesContraintes);
     BOOST_CHECK(std::ranges::equal(ret.ColumnIndexes, problemHebdo.IndicesColonnes));
     auto expectedMdeb = problemHebdo.IndicesDebutDeLigne;


### PR DESCRIPTION
- `ConstantDataFromAntares::VariablesType`
- `ConstantDataFromAntares::NotNullTermCount`

are not used in Xpansion. So we remove them.