### PR TITLE
Short term storage :  unit tests improve

### DIFF
--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/container.h
@@ -57,5 +57,9 @@ public:
 
     /// Number cumulative - constraint
     std::size_t cumulativeConstraintCount() const;
+
+private:
+    bool loadAdditionalConstraintsFromIni(const std::filesystem::path& filePath);
+    bool loadAdditionalConstraintsRHS(const std::filesystem::path& filePath);
 };
 } // namespace Antares::Data::ShortTermStorage

--- a/src/libs/antares/study/include/antares/study/parts/short-term-storage/series.h
+++ b/src/libs/antares/study/include/antares/study/parts/short-term-storage/series.h
@@ -64,9 +64,6 @@ private:
     bool validateLowerRuleCurve(const std::string&) const;
 };
 
-bool loadFile(const std::filesystem::path& folder, std::vector<double>& vect);
-bool loadFile(const std::filesystem::path& file, TimeSeries& series, bool average);
-bool writeVectorToFile(const std::string& path, const std::vector<double>& vect);
-void fillIfEmpty(std::vector<double>& v, double value);
+bool loadFile(const std::filesystem::path& file, TimeSeries& series);
 void fillIfEmpty(TimeSeries& series, double value);
 } // namespace Antares::Data::ShortTermStorage

--- a/src/libs/antares/study/parts/short-term-storage/container.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/container.cpp
@@ -152,7 +152,7 @@ static bool loadAdditionalConstraintsProperties(AdditionalConstraints* additiona
     return true;
 }
 
-bool STStorageInput::loadAdditionalConstraints(const fs::path& parentPath)
+bool STStorageInput::loadAdditionalConstraintsFromIni(const fs::path& parentPath)
 {
     for (auto& sts: storagesByIndex)
     {
@@ -177,19 +177,11 @@ bool STStorageInput::loadAdditionalConstraints(const fs::path& parentPath)
                 return false;
             }
 
-            // We don't want load RHS and link the STS time if the constraint is disabled
             if (!additionalConstraints->enabled)
             {
                 logs.info() << "Additional constraints disabled for ST "
                             << additionalConstraints->cluster_id;
                 continue;
-            }
-
-            const auto rhsPath = data_path / ("rhs_" + additionalConstraints->id + ".txt");
-            if (!readRHS(rhsPath, additionalConstraints->rhs()))
-            {
-                logs.error() << "Error while reading rhs file: " << rhsPath;
-                return false;
             }
 
             if (auto [ok, error_msg] = ShortTermStorage::validate(*additionalConstraints); !ok)
@@ -205,6 +197,29 @@ bool STStorageInput::loadAdditionalConstraints(const fs::path& parentPath)
         }
     }
     return true;
+}
+
+bool STStorageInput::loadAdditionalConstraintsRHS(const fs::path& parentPath)
+{
+    for (auto& sts: storagesByIndex)
+    {
+        auto data_path = parentPath / sts.id;
+        for (auto& additionalConstraints: sts.additionalConstraints)
+        {
+            const auto rhsPath = data_path / ("rhs_" + additionalConstraints->id + ".txt");
+            if (!readRHS(rhsPath, additionalConstraints->rhs()))
+            {
+                logs.error() << "Error while reading rhs file: " << rhsPath;
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool STStorageInput::loadAdditionalConstraints(const fs::path& parentPath)
+{
+    return loadAdditionalConstraintsFromIni(parentPath) && loadAdditionalConstraintsRHS(parentPath);
 }
 
 bool STStorageInput::loadSeriesFromFolder(const fs::path& folder, StudyVersion studyVersion) const

--- a/src/libs/antares/study/parts/short-term-storage/container.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/container.cpp
@@ -100,7 +100,7 @@ static std::vector<SingleAdditionalConstraint> makeConstraints(std::string& hour
 
 static bool readRHS(const fs::path& rhsPath, TimeSeries& rhsSeries)
 {
-    const bool ret = loadFile(rhsPath, rhsSeries, /*.average =*/false);
+    const bool ret = loadFile(rhsPath, rhsSeries);
     if (ret)
     {
         fillIfEmpty(rhsSeries, 0.0);
@@ -142,13 +142,19 @@ static bool loadAdditionalConstraintsProperties(AdditionalConstraints* additiona
                 return false;
             }
         }
+        else
+        {
+            logs.error() << "Constraint " << additionalConstraints->name << " : "
+                         << "has a wrong key : " << key;
+            return false;
+        }
     }
     return true;
 }
 
 bool STStorageInput::loadAdditionalConstraints(const fs::path& parentPath)
 {
-    for (const auto& sts: storagesByIndex)
+    for (auto& sts: storagesByIndex)
     {
         auto data_path = parentPath / sts.id;
         IniFile ini;
@@ -156,7 +162,7 @@ bool STStorageInput::loadAdditionalConstraints(const fs::path& parentPath)
         if (!ini.open(pathIni, false))
         {
             logs.info() << "There is no: " << pathIni;
-            return true;
+            continue;
         }
 
         for (auto* section = ini.firstSection; section; section = section->next)
@@ -176,11 +182,11 @@ bool STStorageInput::loadAdditionalConstraints(const fs::path& parentPath)
             {
                 logs.info() << "Additional constraints disabled for ST "
                             << additionalConstraints->cluster_id;
-                return true;
+                continue;
             }
 
-            if (const auto rhsPath = data_path / ("rhs_" + additionalConstraints->id + ".txt");
-                !readRHS(rhsPath, additionalConstraints->rhs()))
+            const auto rhsPath = data_path / ("rhs_" + additionalConstraints->id + ".txt");
+            if (!readRHS(rhsPath, additionalConstraints->rhs()))
             {
                 logs.error() << "Error while reading rhs file: " << rhsPath;
                 return false;
@@ -193,29 +199,11 @@ bool STStorageInput::loadAdditionalConstraints(const fs::path& parentPath)
                 return false;
             }
 
-            auto it = std::ranges::find_if(storagesByIndex,
-                                           [&additionalConstraints](const STStorageCluster& cluster)
-                                           {
-                                               return cluster.id
-                                                      == additionalConstraints->cluster_id;
-                                           });
-            if (it == storagesByIndex.end())
-            {
-                logs.warning() << " from file " << pathIni;
-                logs.warning() << "Constraint " << section->name
-                               << " does not reference an existing cluster";
-                return false;
-            }
-            else
-            {
-                logs.info() << "Loaded ST additional constraint "
-                            << additionalConstraints->cluster_id << "/"
-                            << additionalConstraints->name;
-                it->additionalConstraints.push_back(additionalConstraints);
-            }
+            logs.info() << "Loaded ST additional constraint " << additionalConstraints->cluster_id
+                        << "/" << additionalConstraints->name;
+            sts.additionalConstraints.push_back(additionalConstraints);
         }
     }
-
     return true;
 }
 

--- a/src/libs/antares/study/parts/short-term-storage/series.cpp
+++ b/src/libs/antares/study/parts/short-term-storage/series.cpp
@@ -40,39 +40,6 @@ Series::Series():
 {
 }
 
-bool Series::loadFromFolder(const fs::path& folder, StudyVersion studyVersion)
-{
-    bool ret = true;
-
-    ret = loadFile(folder / "PMAX-injection.txt", maxInjectionModulation) && ret;
-    ret = loadFile(folder / "PMAX-withdrawal.txt", maxWithdrawalModulation) && ret;
-
-    if (auto path = folder / "inflows.txt"; std::filesystem::exists(path))
-    {
-        ret = inflows.loadFromFile(path, false, Matrix<>::optImmediate) && ret;
-    }
-    else
-    {
-        logs.info() << "Optional file not found: " << path
-                    << ", default values will be used if needed";
-    }
-
-    ret = loadFile(folder / "lower-rule-curve.txt", lowerRuleCurve) && ret;
-    ret = loadFile(folder / "upper-rule-curve.txt", upperRuleCurve) && ret;
-    if (studyVersion >= StudyVersion(9, 2))
-    {
-        ret = loadFile(folder / "cost-injection.txt", costInjection) && ret;
-        ret = loadFile(folder / "cost-withdrawal.txt", costWithdrawal) && ret;
-        ret = loadFile(folder / "cost-level.txt", costLevel) && ret;
-
-        ret = loadFile(folder / "cost-variation-injection.txt", costVariationInjection) && ret;
-
-        ret = loadFile(folder / "cost-variation-withdrawal.txt", costVariationWithdrawal) && ret;
-    }
-
-    return ret;
-}
-
 bool loadFile(const fs::path& path, std::vector<double>& vect)
 {
     logs.debug() << "  :: loading file " << path;
@@ -126,15 +93,48 @@ bool loadFile(const fs::path& path, std::vector<double>& vect)
     return true;
 }
 
-bool loadFile(const std::filesystem::path& file, TimeSeries& series, const bool average)
+bool loadFile(const std::filesystem::path& file, TimeSeries& series)
 {
     logs.debug() << "  :: loading file " << file;
     if (std::filesystem::is_regular_file(file))
     {
-        return series.loadFromFile(file, average);
+        return series.loadFromFile(file, false);
     }
     logs.info() << "Optional file not found: " << file << ", default values will be used if needed";
     return true;
+}
+
+bool Series::loadFromFolder(const fs::path& folder, StudyVersion studyVersion)
+{
+    bool ret = true;
+
+    ret = loadFile(folder / "PMAX-injection.txt", maxInjectionModulation) && ret;
+    ret = loadFile(folder / "PMAX-withdrawal.txt", maxWithdrawalModulation) && ret;
+
+    if (auto path = folder / "inflows.txt"; std::filesystem::exists(path))
+    {
+        ret = inflows.loadFromFile(path, false, Matrix<>::optImmediate) && ret;
+    }
+    else
+    {
+        logs.info() << "Optional file not found: " << path
+                    << ", default values will be used if needed";
+    }
+
+    ret = loadFile(folder / "lower-rule-curve.txt", lowerRuleCurve) && ret;
+    ret = loadFile(folder / "upper-rule-curve.txt", upperRuleCurve) && ret;
+    if (studyVersion >= StudyVersion(9, 2))
+    {
+        ret = loadFile(folder / "cost-injection.txt", costInjection) && ret;
+        ret = loadFile(folder / "cost-withdrawal.txt", costWithdrawal) && ret;
+        ret = loadFile(folder / "cost-level.txt", costLevel) && ret;
+
+        ret = loadFile(folder / "cost-variation-injection.txt", costVariationInjection) && ret;
+
+        ret = loadFile(folder / "cost-variation-withdrawal.txt", costVariationWithdrawal) && ret;
+    }
+
+    return ret;
 }
 
 void fillIfEmpty(std::vector<double>& v, double value)
@@ -171,6 +171,27 @@ void Series::fillDefaultSeriesIfEmpty()
     fillIfEmpty(costVariationWithdrawal, 0.0);
 }
 
+bool writeVectorToFile(const std::string& path, const std::vector<double>& vect)
+{
+    try
+    {
+        std::ofstream fout(path);
+        fout << std::setprecision(14);
+
+        for (const auto& x: vect)
+        {
+            fout << x << '\n';
+        }
+    }
+    catch (...)
+    {
+        logs.error() << "Error while trying to save series file: " << path;
+        return false;
+    }
+
+    return true;
+}
+
 bool Series::saveToFolder(const std::string& folder) const
 {
     logs.debug() << "Saving series into folder: " << folder;
@@ -199,27 +220,6 @@ bool Series::saveToFolder(const std::string& folder) const
     checkWrite("cost-variation-withdrawal.txt", costVariationWithdrawal);
 
     return ret;
-}
-
-bool writeVectorToFile(const std::string& path, const std::vector<double>& vect)
-{
-    try
-    {
-        std::ofstream fout(path);
-        fout << std::setprecision(14);
-
-        for (const auto& x: vect)
-        {
-            fout << x << '\n';
-        }
-    }
-    catch (...)
-    {
-        logs.error() << "Error while trying to save series file: " << path;
-        return false;
-    }
-
-    return true;
 }
 
 bool Series::validate(const std::string& id, StudyVersion studyVersion) const

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -91,63 +91,6 @@ void createIndividualFileSeries(const fs::path& path, unsigned int size)
     outfile.close();
 }
 
-void createIniFile(bool enabled)
-{
-    fs::path folder = fs::temp_directory_path() / "blabla";
-
-    std::ofstream outfile;
-    outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
-
-    outfile << "[area]" << std::endl;
-    outfile << "name = area" << std::endl;
-    outfile << "group = PSP_open" << std::endl;
-    outfile << "injectionnominalcapacity = 870.000000" << std::endl;
-    outfile << "withdrawalnominalcapacity = 900.000000" << std::endl;
-    outfile << "reservoircapacity = 31200.000000" << std::endl;
-    outfile << "efficiency = 0.75" << std::endl;
-    outfile << "efficiencywithdrawal = 0.9" << std::endl;
-    outfile << "initiallevel = 0.50000" << std::endl;
-    outfile << "enabled = " << (enabled ? "true" : "false") << std::endl;
-    outfile.close();
-}
-
-void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
-{
-    fs::path folder = fs::temp_directory_path() / "blabla";
-
-    std::ofstream outfile;
-    outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
-
-    outfile << "[area]" << std::endl;
-    outfile << "name = area" << std::endl;
-    outfile << "group = PSP_open" << std::endl;
-    outfile << "penalize-variation-injection = " << std::boolalpha
-            << penaltyCostOnVariation.injection << std::endl;
-    outfile << "penalize-variation-withdrawal = " << std::boolalpha
-            << penaltyCostOnVariation.withdrawal << std::endl;
-    outfile.close();
-}
-
-void createIniFileWrongValue()
-{
-    fs::path folder = fs::temp_directory_path() / "blabla";
-
-    std::ofstream outfile;
-    outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
-
-    outfile << "[area]" << std::endl;
-    outfile << "name = area" << std::endl;
-    outfile << "group = abcde" << std::endl;
-    outfile << "injectionnominalcapacity = -870.000000" << std::endl;
-    outfile << "withdrawalnominalcapacity = -900.000000" << std::endl;
-    outfile << "reservoircapacity = -31200.000000" << std::endl;
-    outfile << "efficiency = 4" << std::endl;
-    outfile << "efficiencywithdrawal = -2" << std::endl;
-    outfile << "initiallevel = -0.50000" << std::endl;
-
-    outfile.close();
-}
-
 void createEmptyIniFile()
 {
     fs::path folder = fs::temp_directory_path() / "blabla";
@@ -156,11 +99,6 @@ void createEmptyIniFile()
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
 
     outfile.close();
-}
-
-void removeIniFile()
-{
-    fs::remove(fs::temp_directory_path() / "blabla" / "list.ini");
 }
 } // namespace
 
@@ -181,7 +119,9 @@ struct Fixture
 
     void createFileSeries(double value, unsigned int size);
     void createFileSeries(unsigned int size);
-   
+    void createIniFileWrongValue();
+    void createIniFile(bool enabled);
+    void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation);
 
     ~Fixture()
     {
@@ -232,6 +172,56 @@ void Fixture::createFileSeries(unsigned int size)
 
     createIndividualFileSeries(folder / "cost-variation-injection.txt", size);
     createIndividualFileSeries(folder / "cost-variation-withdrawal.txt", size);
+}
+
+void Fixture::createIniFile(bool enabled)
+{
+    std::ofstream iniFile;
+    iniFile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+
+    iniFile << "[area]" << std::endl;
+    iniFile << "name = area" << std::endl;
+    iniFile << "group = PSP_open" << std::endl;
+    iniFile << "injectionnominalcapacity = 870.000000" << std::endl;
+    iniFile << "withdrawalnominalcapacity = 900.000000" << std::endl;
+    iniFile << "reservoircapacity = 31200.000000" << std::endl;
+    iniFile << "efficiency = 0.75" << std::endl;
+    iniFile << "efficiencywithdrawal = 0.9" << std::endl;
+    iniFile << "initiallevel = 0.50000" << std::endl;
+    iniFile << "enabled = " << (enabled ? "true" : "false") << std::endl;
+    iniFile.close();
+}
+
+void Fixture::createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
+{
+    std::ofstream iniFile;
+    iniFile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+
+    iniFile << "[area]" << std::endl;
+    iniFile << "name = area" << std::endl;
+    iniFile << "group = PSP_open" << std::endl;
+    iniFile << "penalize-variation-injection = " << std::boolalpha
+            << penaltyCostOnVariation.injection << std::endl;
+    iniFile << "penalize-variation-withdrawal = " << std::boolalpha
+            << penaltyCostOnVariation.withdrawal << std::endl;
+    iniFile.close();
+}
+
+void Fixture::createIniFileWrongValue()
+{
+    std::ofstream iniFile;
+    iniFile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+
+    iniFile << "[area]" << std::endl;
+    iniFile << "name = area" << std::endl;
+    iniFile << "group = abcde" << std::endl;
+    iniFile << "injectionnominalcapacity = -870.000000" << std::endl;
+    iniFile << "withdrawalnominalcapacity = -900.000000" << std::endl;
+    iniFile << "reservoircapacity = -31200.000000" << std::endl;
+    iniFile << "efficiency = 4" << std::endl;
+    iniFile << "efficiencywithdrawal = -2" << std::endl;
+    iniFile << "initiallevel = -0.50000" << std::endl;
+    iniFile.close();
 }
 
 // ==================
@@ -478,10 +468,9 @@ BOOST_FIXTURE_TEST_CASE(check_file_save, Fixture)
 
     BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
 
-    removeIniFile();
+    fs::remove(folder / "list.ini");
 
     BOOST_CHECK(container.saveToFolder(folder.string()));
-
     BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
 }
 

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -526,6 +526,9 @@ BOOST_FIXTURE_TEST_CASE(check_series_save, Fixture)
 
 BOOST_AUTO_TEST_SUITE_END()
 
+// Test data for parameterization
+namespace bdata = boost::unit_test::data;
+
 BOOST_AUTO_TEST_SUITE(ValidatingAdditionalConstraints)
 
 BOOST_AUTO_TEST_CASE(Validate_ClusterIdEmpty)
@@ -615,6 +618,27 @@ BOOST_AUTO_TEST_CASE(Validate_ValidConstraints)
 
     constraints.constraints = {constraint1, constraint2};
 
+    auto [ok, error_msg] = validate(constraints);
+    BOOST_CHECK_EQUAL(ok, true);
+    BOOST_CHECK(error_msg.empty());
+}
+
+BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinations,
+                     bdata::make({"injection", "withdrawal", "netting"})
+                       ^ bdata::make({"less", "equal", "greater"}),
+                     variable,
+                     op)
+{
+    ShortTermStorage::AdditionalConstraints
+      constraints("name", "name", "clusterA", variable, op, true, {});
+
+    // Create constraints with valid hours
+    constraints.constraints.push_back(ShortTermStorage::SingleAdditionalConstraint{{1, 2, 3}});
+    constraints.constraints.push_back(ShortTermStorage::SingleAdditionalConstraint{{50, 100, 150}});
+    constraints.constraints.push_back(
+      ShortTermStorage::SingleAdditionalConstraint{{120, 121, 122}});
+
+    // Validate the constraints
     auto [ok, error_msg] = validate(constraints);
     BOOST_CHECK_EQUAL(ok, true);
     BOOST_CHECK(error_msg.empty());
@@ -881,30 +905,6 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile)
     BOOST_CHECK_EQUAL(result, false);
 
     std::filesystem::remove_all(testPath);
-}
-
-// Test data for parameterization
-namespace bdata = boost::unit_test::data;
-
-BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinations,
-                     bdata::make({"injection", "withdrawal", "netting"})
-                       ^ bdata::make({"less", "equal", "greater"}),
-                     variable,
-                     op)
-{
-    ShortTermStorage::AdditionalConstraints
-      constraints("name", "name", "clusterA", variable, op, true, {});
-
-    // Create constraints with valid hours
-    constraints.constraints.push_back(ShortTermStorage::SingleAdditionalConstraint{{1, 2, 3}});
-    constraints.constraints.push_back(ShortTermStorage::SingleAdditionalConstraint{{50, 100, 150}});
-    constraints.constraints.push_back(
-      ShortTermStorage::SingleAdditionalConstraint{{120, 121, 122}});
-
-    // Validate the constraints
-    auto [ok, error_msg] = validate(constraints);
-    BOOST_CHECK_EQUAL(ok, true);
-    BOOST_CHECK(error_msg.empty());
 }
 
 BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -603,7 +603,7 @@ AdditionalConstraintsFixture::AdditionalConstraintsFixture()
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstraintsFixture)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
@@ -619,13 +619,13 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstrain
     BOOST_CHECK_EQUAL(result, true);
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 1);
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints[0]->name,
-                      "constraint1");
+                      "my_constr");
 }
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, AdditionalConstraintsFixture)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[0,1]\n"; // Invalid hours
@@ -650,7 +650,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditionalConstraintsFixture)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=invalid\n"; // Invalid variable
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
@@ -668,7 +668,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditionalC
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraintsFixture)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
@@ -754,7 +754,7 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixtur
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalConstraintsFixture)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
@@ -776,13 +776,13 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalCons
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditionalConstraintsFixture)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     rhsFile << "1.0\n2.0\ninvalid\n4.0\n"; // Malformed line
     rhsFile.close();
 
@@ -798,13 +798,13 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditionalCo
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditionalConstraintsFixture)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (int i = 0; i < 10; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -828,14 +828,14 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
                        op)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=" << variable << "\n";
     iniFile << "operator=" << op << "\n";
     iniFile << "enabled=true\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -872,7 +872,7 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
 BOOST_FIXTURE_TEST_CASE(Load_disabled, AdditionalConstraintsFixture)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[constraint1]\n";
+    iniFile << "[my_constr]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "enabled=false\n";

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -590,14 +590,19 @@ BOOST_AUTO_TEST_SUITE(LoadingAdditionalConstraints)
 
 struct AdditionalConstraintsFixture: public WorkDirCreationFixture
 {
-
+    AdditionalConstraintsFixture();
+    fs::path sts_dir;
 };
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, WorkDirCreationFixture)
+AdditionalConstraintsFixture::AdditionalConstraintsFixture()
 {
-    fs::create_directories(work_dir / "cluster1");
+    sts_dir = work_dir / "my-sts";
+    fs::create_directories(sts_dir);
+}
 
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstraintsFixture)
+{
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
@@ -606,7 +611,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, WorkDirCreationFixt
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     bool result = storageInput.loadAdditionalConstraints(work_dir);
@@ -617,11 +622,9 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, WorkDirCreationFixt
                       "constraint1");
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, WorkDirCreationFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, AdditionalConstraintsFixture)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
@@ -630,7 +633,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, WorkDirCreationF
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     bool result = storageInput.loadAdditionalConstraints(work_dir);
@@ -644,11 +647,9 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
     BOOST_CHECK_EQUAL(result, true);
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, WorkDirCreationFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditionalConstraintsFixture)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=invalid\n"; // Invalid variable
     iniFile << "operator=less\n";
@@ -657,25 +658,23 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, WorkDirCrea
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(result, false);
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, WorkDirCreationFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraintsFixture)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -684,7 +683,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, WorkDirCreationFixtu
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     bool result = storageInput.loadAdditionalConstraints(work_dir);
@@ -696,11 +695,9 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, WorkDirCreationFixtu
     BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
 }
 
-BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, WorkDirCreationFixture)
+BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixture)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << R"([constraint1]
                   variable=injection
                   operator=less
@@ -711,7 +708,7 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, WorkDirCreationFixture)
                   hours=[5,33])";
     iniFile.close();
 
-    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -720,7 +717,7 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, WorkDirCreationFixture)
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     bool result = storageInput.loadAdditionalConstraints(work_dir);
@@ -754,11 +751,9 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, WorkDirCreationFixture)
     BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), 0);
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, WorkDirCreationFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalConstraintsFixture)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
@@ -767,7 +762,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, WorkDirCreatio
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     bool result = storageInput.loadAdditionalConstraints(work_dir);
@@ -778,42 +773,38 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, WorkDirCreatio
     BOOST_CHECK_EQUAL(constraintRhs.getCoefficient(0, 0), 0.0);
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, WorkDirCreationFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditionalConstraintsFixture)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
     rhsFile << "1.0\n2.0\ninvalid\n4.0\n"; // Malformed line
     rhsFile.close();
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(result, false);
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, WorkDirCreationFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditionalConstraintsFixture)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
     for (int i = 0; i < 10; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -822,23 +813,21 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, WorkDirCrea
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(result, false);
 }
 
-BOOST_DATA_TEST_CASE_F(WorkDirCreationFixture,
+BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
                        Validate_AllVariableOperatorCombinationsFromFile,
                        bdata::make({"injection", "withdrawal", "netting"})
                          * bdata::make({"less", "equal", "greater"}),
                        variable,
                        op)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=" << variable << "\n";
     iniFile << "operator=" << op << "\n";
@@ -846,7 +835,7 @@ BOOST_DATA_TEST_CASE_F(WorkDirCreationFixture,
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -856,7 +845,7 @@ BOOST_DATA_TEST_CASE_F(WorkDirCreationFixture,
     // Setup storage input and cluster
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
@@ -880,11 +869,9 @@ BOOST_DATA_TEST_CASE_F(WorkDirCreationFixture,
     }
 }
 
-BOOST_FIXTURE_TEST_CASE(Load_disabled, WorkDirCreationFixture)
+BOOST_FIXTURE_TEST_CASE(Load_disabled, AdditionalConstraintsFixture)
 {
-    fs::create_directories(work_dir / "cluster1");
-
-    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
@@ -895,7 +882,7 @@ BOOST_FIXTURE_TEST_CASE(Load_disabled, WorkDirCreationFixture)
     // Setup storage input and cluster
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "cluster1";
+    cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
     // Load constraints from the `.ini` file

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -603,12 +603,17 @@ struct AdditionalConstraintsFixture: public WorkDirCreationFixture
     void makeIniFile(const std::vector<IniConstraint>& ini_constraints);
 
     fs::path sts_dir;
+    STStorageInput storageInput;
+    STStorageCluster sts;
 };
 
 AdditionalConstraintsFixture::AdditionalConstraintsFixture()
 {
     sts_dir = work_dir / "my-sts";
     fs::create_directories(sts_dir);
+
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 }
 
 void AdditionalConstraintsFixture::makeIniFile(const std::vector<IniConstraint>& ini_constraints)
@@ -629,11 +634,6 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstrain
 {
     makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
 
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
-
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 1);
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints[0]->name, "my_constr");
@@ -642,11 +642,6 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstrain
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, AdditionalConstraintsFixture)
 {
     makeIniFile({{"my_constr", "injection", "less", "[0,1]"}}); // Invalid hours
-
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
@@ -661,11 +656,6 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditionalC
 {
     makeIniFile({{"my_constr", "invalid", "less", "[1,2,3]"}}); // Invalid variable
 
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
-
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
@@ -679,11 +669,6 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraint
         rhsFile << i << "\n";
     }
     rhsFile.close();
-
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
 
@@ -704,11 +689,6 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixtur
         rhsFile << i << "\n";
     }
     rhsFile.close();
-
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 2);
@@ -743,11 +723,6 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalCons
 {
     makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
 
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
-
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
 
     const auto& constraintRhs = storageInput.storagesByIndex[0].additionalConstraints[0]->rhs();
@@ -763,11 +738,6 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditionalCo
     rhsFile << "1.0\n2.0\ninvalid\n4.0\n"; // Malformed line
     rhsFile.close();
 
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
-
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
@@ -781,11 +751,6 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditionalC
         rhsFile << i << "\n";
     }
     rhsFile.close();
-
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
@@ -805,12 +770,6 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
         rhsFile << i << "\n";
     }
     rhsFile.close();
-
-    // Setup storage input and sts
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 1);
@@ -834,12 +793,6 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
 BOOST_FIXTURE_TEST_CASE(Load_disabled, AdditionalConstraintsFixture)
 {
     makeIniFile({{"my_constr", "injection", "less", "[1,2,3]", "false"}});
-
-    // Setup storage input and sts
-    STStorageInput storageInput;
-    STStorageCluster sts;
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 0);

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -28,19 +28,13 @@
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <yuni/io/file.h>
-
 #include "antares/antares/constants.h"
 #include "antares/study/parts/short-term-storage/additionalConstraints.h"
 #include "antares/study/parts/short-term-storage/container.h"
 
-using namespace std;
 using namespace Antares::Data;
 
 namespace fs = std::filesystem;
-
-namespace
-{
 
 struct PenaltyCostOnVariation
 {
@@ -91,26 +85,11 @@ void createIndividualFileSeries(const fs::path& path, unsigned int size)
     outfile.close();
 }
 
-void createEmptyIniFile()
-{
-    fs::path folder = fs::temp_directory_path() / "blabla";
-
-    std::ofstream outfile;
-    outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
-
-    outfile.close();
-}
-} // namespace
-
 // =================
 // The fixture
 // =================
 struct Fixture
 {
-    Fixture(const Fixture& f) = delete;
-    Fixture(const Fixture&& f) = delete;
-    Fixture& operator=(const Fixture& f) = delete;
-    Fixture& operator=(const Fixture&& f) = delete;
     Fixture()
     {
         folder = fs::temp_directory_path() / "blabla";
@@ -122,6 +101,7 @@ struct Fixture
     void createIniFileWrongValue();
     void createIniFile(bool enabled);
     void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation);
+    void createEmptyIniFile();
 
     ~Fixture()
     {
@@ -202,9 +182,15 @@ void Fixture::createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation
     iniFile_ << "name = area" << std::endl;
     iniFile_ << "group = PSP_open" << std::endl;
     iniFile_ << "penalize-variation-injection = " << std::boolalpha
-            << penaltyCostOnVariation.injection << std::endl;
+             << penaltyCostOnVariation.injection << std::endl;
     iniFile_ << "penalize-variation-withdrawal = " << std::boolalpha
-            << penaltyCostOnVariation.withdrawal << std::endl;
+             << penaltyCostOnVariation.withdrawal << std::endl;
+    iniFile_.close();
+}
+
+void Fixture::createEmptyIniFile()
+{
+    iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
     iniFile_.close();
 }
 

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -526,7 +526,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_save, Fixture)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(AdditionalConstraintsTests)
+BOOST_AUTO_TEST_SUITE(VaidatingAdditionalConstraints)
 
 BOOST_AUTO_TEST_CASE(Validate_ClusterIdEmpty)
 {
@@ -619,6 +619,10 @@ BOOST_AUTO_TEST_CASE(Validate_ValidConstraints)
     BOOST_CHECK_EQUAL(ok, true);
     BOOST_CHECK(error_msg.empty());
 }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(LoadingAdditionalConstraints)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidFile)
 {

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -33,6 +33,7 @@
 #include "antares/study/parts/short-term-storage/container.h"
 
 using namespace Antares::Data;
+using namespace Antares::Data::ShortTermStorage;
 
 namespace fs = std::filesystem;
 
@@ -92,16 +93,16 @@ struct FileCreationFixture
 {
     FileCreationFixture()
     {
-        folder = fs::temp_directory_path() / "blabla";
-        fs::create_directories(folder);
+        work_dir = fs::temp_directory_path() / "testWorkDir";
+        fs::create_directories(work_dir);
     }
 
     ~FileCreationFixture()
     {
-        fs::remove_all(folder);
+        fs::remove_all(work_dir);
     }
 
-    fs::path folder;
+    fs::path work_dir;
 };
 
 struct Fixture: public FileCreationFixture
@@ -127,38 +128,38 @@ private:
 
 void Fixture::createFileSeries(double value, unsigned int size)
 {
-    createIndividualFileSeries(folder / "PMAX-injection.txt", value, size);
-    createIndividualFileSeries(folder / "PMAX-withdrawal.txt", value, size);
-    createIndividualFileSeries(folder / "inflows.txt", value, size);
-    createIndividualFileSeries(folder / "lower-rule-curve.txt", value, size);
-    createIndividualFileSeries(folder / "upper-rule-curve.txt", value, size);
+    createIndividualFileSeries(work_dir / "PMAX-injection.txt", value, size);
+    createIndividualFileSeries(work_dir / "PMAX-withdrawal.txt", value, size);
+    createIndividualFileSeries(work_dir / "inflows.txt", value, size);
+    createIndividualFileSeries(work_dir / "lower-rule-curve.txt", value, size);
+    createIndividualFileSeries(work_dir / "upper-rule-curve.txt", value, size);
 
-    createIndividualFileSeries(folder / "cost-injection.txt", value, size);
-    createIndividualFileSeries(folder / "cost-withdrawal.txt", value, size);
-    createIndividualFileSeries(folder / "cost-level.txt", value, size);
-    createIndividualFileSeries(folder / "cost-variation-injection.txt", value, size);
-    createIndividualFileSeries(folder / "cost-variation-withdrawal.txt", value, size);
+    createIndividualFileSeries(work_dir / "cost-injection.txt", value, size);
+    createIndividualFileSeries(work_dir / "cost-withdrawal.txt", value, size);
+    createIndividualFileSeries(work_dir / "cost-level.txt", value, size);
+    createIndividualFileSeries(work_dir / "cost-variation-injection.txt", value, size);
+    createIndividualFileSeries(work_dir / "cost-variation-withdrawal.txt", value, size);
 }
 
 void Fixture::createFileSeries(unsigned int size)
 {
-    createIndividualFileSeries(folder / "PMAX-injection.txt", size);
-    createIndividualFileSeries(folder / "PMAX-withdrawal.txt", size);
-    createIndividualFileSeries(folder / "inflows.txt", size);
-    createIndividualFileSeries(folder / "lower-rule-curve.txt", size);
-    createIndividualFileSeries(folder / "upper-rule-curve.txt", size);
+    createIndividualFileSeries(work_dir / "PMAX-injection.txt", size);
+    createIndividualFileSeries(work_dir / "PMAX-withdrawal.txt", size);
+    createIndividualFileSeries(work_dir / "inflows.txt", size);
+    createIndividualFileSeries(work_dir / "lower-rule-curve.txt", size);
+    createIndividualFileSeries(work_dir / "upper-rule-curve.txt", size);
 
-    createIndividualFileSeries(folder / "cost-injection.txt", size);
-    createIndividualFileSeries(folder / "cost-withdrawal.txt", size);
-    createIndividualFileSeries(folder / "cost-level.txt", size);
+    createIndividualFileSeries(work_dir / "cost-injection.txt", size);
+    createIndividualFileSeries(work_dir / "cost-withdrawal.txt", size);
+    createIndividualFileSeries(work_dir / "cost-level.txt", size);
 
-    createIndividualFileSeries(folder / "cost-variation-injection.txt", size);
-    createIndividualFileSeries(folder / "cost-variation-withdrawal.txt", size);
+    createIndividualFileSeries(work_dir / "cost-variation-injection.txt", size);
+    createIndividualFileSeries(work_dir / "cost-variation-withdrawal.txt", size);
 }
 
 void Fixture::createIniFile(bool enabled)
 {
-    iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+    iniFile_.open(work_dir / "list.ini", std::ofstream::out | std::ofstream::trunc);
     iniFile_ << "[area]" << std::endl;
     iniFile_ << "name = area" << std::endl;
     iniFile_ << "group = PSP_open" << std::endl;
@@ -174,7 +175,7 @@ void Fixture::createIniFile(bool enabled)
 
 void Fixture::createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
 {
-    iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+    iniFile_.open(work_dir / "list.ini", std::ofstream::out | std::ofstream::trunc);
     iniFile_ << "[area]" << std::endl;
     iniFile_ << "name = area" << std::endl;
     iniFile_ << "group = PSP_open" << std::endl;
@@ -187,13 +188,13 @@ void Fixture::createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation
 
 void Fixture::createEmptyIniFile()
 {
-    iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+    iniFile_.open(work_dir / "list.ini", std::ofstream::out | std::ofstream::trunc);
     iniFile_.close();
 }
 
 void Fixture::createIniFileWrongValue()
 {
-    iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+    iniFile_.open(work_dir / "list.ini", std::ofstream::out | std::ofstream::trunc);
     iniFile_ << "[area]" << std::endl;
     iniFile_ << "name = area" << std::endl;
     iniFile_ << "group = abcde" << std::endl;
@@ -228,7 +229,7 @@ void checkSizeFirst(const TimeSeries& series, double value)
 BOOST_FIXTURE_TEST_CASE(check_empty, Fixture)
 {
     createFileSeries(0); // Empty files
-    series.loadFromFolder(folder, StudyVersion(9, 2));
+    series.loadFromFolder(work_dir, StudyVersion(9, 2));
     series.fillDefaultSeriesIfEmpty();
 
     // version<9.2
@@ -259,7 +260,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading, Fixture)
 {
     createFileSeries(1.0, 8760);
 
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
     BOOST_CHECK(series.inflows.getCoefficient(0, 0) == 1);
     BOOST_CHECK(series.maxInjectionModulation[8759] == 1);
@@ -272,7 +273,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_880, Fixture)
 {
     createFileSeries(1.0, 8760);
 
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion(8, 8)));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion(8, 8)));
     BOOST_CHECK(series.validate("", StudyVersion(8, 8)));
     BOOST_CHECK(series.inflows.getCoefficient(0, 0) == 1);
     BOOST_CHECK(series.maxInjectionModulation[8759] == 1);
@@ -287,7 +288,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values_880, Fixtur
 {
     createFileSeries(8760);
 
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion(8, 8)));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion(8, 8)));
     BOOST_CHECK(series.validate("", StudyVersion(8, 8)));
 }
 
@@ -295,7 +296,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values, Fixture)
 {
     createFileSeries(8760);
 
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
 }
 
@@ -303,7 +304,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_negative_value, Fixture)
 {
     createFileSeries(-247.0, 8760);
 
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(!series.validate("", StudyVersion::latest()));
 }
 
@@ -311,7 +312,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_too_big, Fixture)
 {
     createFileSeries(1.0, 9000);
 
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
 }
 
@@ -319,7 +320,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_too_big_880, Fixture)
 {
     createFileSeries(1.0, 9000);
 
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion(8, 8)));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion(8, 8)));
     BOOST_CHECK(series.validate("", StudyVersion(8, 8)));
 }
 
@@ -327,13 +328,13 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_too_small, Fixture)
 {
     createFileSeries(1.0, 100);
 
-    BOOST_CHECK(!series.loadFromFolder(folder, StudyVersion::latest()));
+    BOOST_CHECK(!series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(!series.validate("", StudyVersion::latest()));
 }
 
 BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_empty, Fixture)
 {
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(!series.validate("", StudyVersion::latest()));
 }
 
@@ -345,7 +346,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_vector_fill, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(check_cluster_series_vector_fill, Fixture)
 {
-    BOOST_CHECK(cluster.loadSeries(folder, StudyVersion::latest()));
+    BOOST_CHECK(cluster.loadSeries(work_dir, StudyVersion::latest()));
     BOOST_CHECK(cluster.series->validate("", StudyVersion::latest()));
 }
 
@@ -353,7 +354,7 @@ BOOST_FIXTURE_TEST_CASE(check_cluster_series_load_vector, Fixture)
 {
     createFileSeries(0.5, 8760);
 
-    BOOST_CHECK(cluster.loadSeries(folder, StudyVersion::latest()));
+    BOOST_CHECK(cluster.loadSeries(work_dir, StudyVersion::latest()));
     BOOST_CHECK(cluster.series->validate("", StudyVersion::latest()));
     BOOST_CHECK(cluster.series->maxWithdrawalModulation[0] == 0.5);
     BOOST_CHECK(cluster.series->inflows.getCoefficient(0, 2756) == 0.5);
@@ -366,7 +367,7 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load, Fixture)
 {
     createIniFile(true);
 
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
 
     auto& properties = container.storagesByIndex[0].properties;
 
@@ -383,7 +384,7 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load_with_cost_variat
     penaltyCostOnVariation = {.injection = true, .withdrawal = false};
     createIniFile(penaltyCostOnVariation);
 
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
 
     auto& properties = container.storagesByIndex[0].properties;
 
@@ -396,7 +397,7 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load_with_cost_variat
     penaltyCostOnVariation = {.injection = false, .withdrawal = true};
     createIniFile(penaltyCostOnVariation);
 
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
 
     auto& properties = container.storagesByIndex[0].properties;
 
@@ -410,7 +411,7 @@ BOOST_FIXTURE_TEST_CASE(
     penaltyCostOnVariation = {.injection = true, .withdrawal = true};
     createIniFile(penaltyCostOnVariation);
 
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
 
     auto& properties = container.storagesByIndex[0].properties;
 
@@ -422,7 +423,7 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_disabled_load, Fixture)
 {
     createIniFile(false);
 
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
 
     auto& properties = container.storagesByIndex[0].properties;
 
@@ -435,7 +436,7 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_wrong_value, Fixture)
 {
     createIniFileWrongValue();
 
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
     BOOST_CHECK(!container.storagesByIndex[0].properties.validate());
 }
 
@@ -443,7 +444,7 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_empty_file, Fixture)
 {
     createEmptyIniFile();
 
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
 }
 
 #ifdef BUILD_UI
@@ -451,22 +452,22 @@ BOOST_FIXTURE_TEST_CASE(check_file_save, Fixture)
 {
     createIniFile(true);
 
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
 
-    fs::remove(folder / "list.ini");
+    fs::remove(work_dir / "list.ini");
 
-    BOOST_CHECK(container.saveToFolder(folder.string()));
-    BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
+    BOOST_CHECK(container.saveToFolder(work_dir.string()));
+    BOOST_CHECK(container.createSTStorageClustersFromIniFile(work_dir));
 }
 
 BOOST_FIXTURE_TEST_CASE(check_series_save, Fixture)
 {
     resizeFillVectors(series, 0.123456789, 8760);
 
-    BOOST_CHECK(series.saveToFolder(folder.string()));
+    BOOST_CHECK(series.saveToFolder(work_dir.string()));
     resizeFillVectors(series, 0, 0);
 
-    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
 }
 #endif
@@ -480,8 +481,7 @@ BOOST_AUTO_TEST_SUITE(ValidatingAdditionalConstraints)
 
 BOOST_AUTO_TEST_CASE(Validate_ClusterIdEmpty)
 {
-    ShortTermStorage::AdditionalConstraints
-      constraints("name", "name", "", "injection", "less", true, {});
+    AdditionalConstraints constraints("name", "name", "", "injection", "less", true, {});
 
     auto [ok, error_msg] = validate(constraints);
     BOOST_CHECK_EQUAL(ok, false);
@@ -490,8 +490,7 @@ BOOST_AUTO_TEST_CASE(Validate_ClusterIdEmpty)
 
 BOOST_AUTO_TEST_CASE(Validate_InvalidVariable)
 {
-    ShortTermStorage::AdditionalConstraints
-      constraints("name", "name", "ClusterA", "invalid", "less", true, {});
+    AdditionalConstraints constraints("name", "name", "ClusterA", "invalid", "less", true, {});
     auto [ok, error_msg] = validate(constraints);
     BOOST_CHECK_EQUAL(ok, false);
     BOOST_CHECK_EQUAL(error_msg,
@@ -500,8 +499,7 @@ BOOST_AUTO_TEST_CASE(Validate_InvalidVariable)
 
 BOOST_AUTO_TEST_CASE(Validate_InvalidOperatorType)
 {
-    ShortTermStorage::AdditionalConstraints
-      constraints("name", "name", "ClusterA", "injection", "invalid", true, {});
+    AdditionalConstraints constraints("name", "name", "ClusterA", "injection", "invalid", true, {});
 
     auto [ok, error_msg] = validate(constraints);
     BOOST_CHECK_EQUAL(ok, false);
@@ -510,11 +508,11 @@ BOOST_AUTO_TEST_CASE(Validate_InvalidOperatorType)
 
 BOOST_AUTO_TEST_CASE(Validate_InvalidHours_Empty)
 {
-    ShortTermStorage::SingleAdditionalConstraint constraint;
+    SingleAdditionalConstraint constraint;
     // Case : Empty hours
     constraint.hours = {}; // Invalid: empty
 
-    ShortTermStorage::AdditionalConstraints
+    AdditionalConstraints
       constraints("name", "name", "ClusterA", "injection", "less", true, {constraint});
 
     auto [ok, error_msg] = validate(constraints);
@@ -524,11 +522,10 @@ BOOST_AUTO_TEST_CASE(Validate_InvalidHours_Empty)
 
 BOOST_AUTO_TEST_CASE(Validate_InvalidHours_Out_of_range)
 {
-    ShortTermStorage::AdditionalConstraints
-      constraints("name", "name", "ClusterA", "injection", "less", true, {});
+    AdditionalConstraints constraints("name", "name", "ClusterA", "injection", "less", true, {});
 
     // Case: Out of range
-    ShortTermStorage::SingleAdditionalConstraint constraint;
+    SingleAdditionalConstraint constraint;
     constraint.hours = {120, 169}; // Invalid: out of range
     constraints.constraints.push_back(constraint);
 
@@ -539,11 +536,10 @@ BOOST_AUTO_TEST_CASE(Validate_InvalidHours_Out_of_range)
 
 BOOST_AUTO_TEST_CASE(Validate_InvalidHours_Below_minimum)
 {
-    ShortTermStorage::AdditionalConstraints
-      constraints("name", "name", "ClusterA", "injection", "less", true, {});
+    AdditionalConstraints constraints("name", "name", "ClusterA", "injection", "less", true, {});
 
     // Case : Below minimum
-    ShortTermStorage::SingleAdditionalConstraint constraint;
+    SingleAdditionalConstraint constraint;
     constraint.hours = {0, 1}; // Invalid: below minimum
     constraints.constraints.push_back(constraint);
 
@@ -554,13 +550,12 @@ BOOST_AUTO_TEST_CASE(Validate_InvalidHours_Below_minimum)
 
 BOOST_AUTO_TEST_CASE(Validate_ValidConstraints)
 {
-    ShortTermStorage::AdditionalConstraints
-      constraints("name", "name", "ClusterA", "injection", "less", true, {});
+    AdditionalConstraints constraints("name", "name", "ClusterA", "injection", "less", true, {});
 
-    ShortTermStorage::SingleAdditionalConstraint constraint1;
+    SingleAdditionalConstraint constraint1;
     constraint1.hours = {1, 2, 3}; // Valid hours
 
-    ShortTermStorage::SingleAdditionalConstraint constraint2;
+    SingleAdditionalConstraint constraint2;
     constraint2.hours = {100, 150, 168}; // Valid hours
 
     constraints.constraints = {constraint1, constraint2};
@@ -576,14 +571,12 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinations,
                      variable,
                      op)
 {
-    ShortTermStorage::AdditionalConstraints
-      constraints("name", "name", "clusterA", variable, op, true, {});
+    AdditionalConstraints constraints("name", "name", "clusterA", variable, op, true, {});
 
     // Create constraints with valid hours
-    constraints.constraints.push_back(ShortTermStorage::SingleAdditionalConstraint{{1, 2, 3}});
-    constraints.constraints.push_back(ShortTermStorage::SingleAdditionalConstraint{{50, 100, 150}});
-    constraints.constraints.push_back(
-      ShortTermStorage::SingleAdditionalConstraint{{120, 121, 122}});
+    constraints.constraints.push_back(SingleAdditionalConstraint{{1, 2, 3}});
+    constraints.constraints.push_back(SingleAdditionalConstraint{{50, 100, 150}});
+    constraints.constraints.push_back(SingleAdditionalConstraint{{120, 121, 122}});
 
     // Validate the constraints
     auto [ok, error_msg] = validate(constraints);
@@ -607,8 +600,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidFile)
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -634,8 +627,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidHours)
     iniFile << "hours=[0,1]\n"; // Invalid hours
     iniFile.close();
 
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "ClusterA";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -647,7 +640,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidHours)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
 {
-    ShortTermStorage::STStorageInput storageInput;
+    STStorageInput storageInput;
     bool result = storageInput.loadAdditionalConstraints("nonexistent_path");
     BOOST_CHECK_EQUAL(result, true);
 }
@@ -664,8 +657,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidConstraint)
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -694,8 +687,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidRhs)
     }
     rhsFile.close();
 
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -733,8 +726,8 @@ BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
     }
     rhsFile.close();
 
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -783,8 +776,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingRhsFile)
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -814,8 +807,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile)
     rhsFile << "1.0\n2.0\ninvalid\n4.0\n"; // Malformed line
     rhsFile.close();
 
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -843,8 +836,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile)
     }
     rhsFile.close();
 
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -882,8 +875,8 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
     rhsFile.close();
 
     // Setup storage input and cluster
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "clustera";
     storageInput.storagesByIndex.push_back(cluster);
 
@@ -931,8 +924,8 @@ BOOST_AUTO_TEST_CASE(Load_disabled)
     iniFile.close();
 
     // Setup storage input and cluster
-    ShortTermStorage::STStorageInput storageInput;
-    ShortTermStorage::STStorageCluster cluster;
+    STStorageInput storageInput;
+    STStorageCluster cluster;
     cluster.id = "clustera";
     storageInput.storagesByIndex.push_back(cluster);
 

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -43,7 +43,7 @@ struct PenaltyCostOnVariation
     bool withdrawal = false;
 };
 
-void resizeFillVectors(ShortTermStorage::Series& series, double value, unsigned int size)
+void resizeFillVectors(ShortTermStorage::Series& series, double value, unsigned size)
 {
     series.maxInjectionModulation.resize(size, value);
     series.maxWithdrawalModulation.resize(size, value);
@@ -60,11 +60,11 @@ void resizeFillVectors(ShortTermStorage::Series& series, double value, unsigned 
     series.costVariationWithdrawal.resize(size, value);
 }
 
-void createIndividualFileSeries(const fs::path& path, double value, unsigned int size)
+void createIndividualFileSeries(const fs::path& path, double value, unsigned size)
 {
     std::ofstream outfile(path);
 
-    for (unsigned int i = 0; i < size; i++)
+    for (unsigned i = 0; i < size; i++)
     {
         outfile << value << std::endl;
     }
@@ -72,12 +72,12 @@ void createIndividualFileSeries(const fs::path& path, double value, unsigned int
     outfile.close();
 }
 
-void createIndividualFileSeries(const fs::path& path, unsigned int size)
+void createIndividualFileSeries(const fs::path& path, unsigned size)
 {
     std::ofstream outfile;
     outfile.open(path, std::ofstream::out | std::ofstream::trunc);
 
-    for (unsigned int i = 0; i < size; i++)
+    for (unsigned i = 0; i < size; i++)
     {
         double value = i * 0.0001;
         outfile << value << std::endl;
@@ -108,8 +108,8 @@ struct WorkDirCreationFixture
 struct Fixture: public WorkDirCreationFixture
 {
     Fixture() = default;
-    void createFileSeries(double value, unsigned int size);
-    void createFileSeries(unsigned int size);
+    void createFileSeries(double value, unsigned size);
+    void createFileSeries(unsigned size);
     void createIniFileWrongValue();
     void createIniFile(bool enabled);
     void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation);
@@ -126,7 +126,7 @@ private:
     std::ofstream iniFile_;
 };
 
-void Fixture::createFileSeries(double value, unsigned int size)
+void Fixture::createFileSeries(double value, unsigned size)
 {
     createIndividualFileSeries(work_dir / "PMAX-injection.txt", value, size);
     createIndividualFileSeries(work_dir / "PMAX-withdrawal.txt", value, size);
@@ -141,7 +141,7 @@ void Fixture::createFileSeries(double value, unsigned int size)
     createIndividualFileSeries(work_dir / "cost-variation-withdrawal.txt", value, size);
 }
 
-void Fixture::createFileSeries(unsigned int size)
+void Fixture::createFileSeries(unsigned size)
 {
     createIndividualFileSeries(work_dir / "PMAX-injection.txt", size);
     createIndividualFileSeries(work_dir / "PMAX-withdrawal.txt", size);
@@ -674,7 +674,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraint
     makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
 
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
-    for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
+    for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
     }
@@ -699,7 +699,7 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixtur
                  {"constraint2", "withdrawal", "greater", "[5,33]"}});
 
     std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
-    for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
+    for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
     }
@@ -800,7 +800,7 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
     makeIniFile({{"my_constr", variable, op, "[1,2,3]"}});
 
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
-    for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
+    for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
     }

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -588,6 +588,11 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(LoadingAdditionalConstraints)
 
+struct AdditionalConstraintsFixture: public WorkDirCreationFixture
+{
+
+};
+
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, WorkDirCreationFixture)
 {
     fs::create_directories(work_dir / "cluster1");
@@ -824,17 +829,15 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, WorkDirCrea
     BOOST_CHECK_EQUAL(result, false);
 }
 
-BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
-                     bdata::make({"injection", "withdrawal", "netting"})
-                       * bdata::make({"less", "equal", "greater"}),
-                     variable,
-                     op)
+BOOST_DATA_TEST_CASE_F(WorkDirCreationFixture,
+                       Validate_AllVariableOperatorCombinationsFromFile,
+                       bdata::make({"injection", "withdrawal", "netting"})
+                         * bdata::make({"less", "equal", "greater"}),
+                       variable,
+                       op)
 {
-    // Define the path for the test data
-    fs::path work_dir = fs::temp_directory_path() / "test_data";
     fs::create_directories(work_dir / "cluster1");
 
-    // Write the `.ini` file for this test case
     std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=" << variable << "\n";
@@ -843,7 +846,6 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    // Write the `rhs_constraint1.txt` file
     std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
@@ -857,32 +859,25 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    // Load constraints from the `.ini` file
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
+    BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 1);
 
-    // Assertions
-    BOOST_CHECK_EQUAL(result, true);
-    // Validate loaded constraints
-    auto& built_cluster = storageInput.storagesByIndex[0];
-    BOOST_REQUIRE_EQUAL(built_cluster.additionalConstraints.size(), 1);
+    auto& sts = storageInput.storagesByIndex[0];
+    BOOST_REQUIRE_EQUAL(sts.additionalConstraints.size(), 1);
 
-    const auto& loadedConstraint = *built_cluster.additionalConstraints[0];
+    const auto loadedConstraint = sts.additionalConstraints[0];
+    BOOST_CHECK_EQUAL(loadedConstraint->variable, variable);
+    BOOST_CHECK_EQUAL(loadedConstraint->operatorType, op);
 
-    // Check variable, operator type, and rhs values
-    BOOST_CHECK_EQUAL(loadedConstraint.variable, variable);
-    BOOST_CHECK_EQUAL(loadedConstraint.operatorType, op);
-    const auto& rhs = loadedConstraint.rhs();
+    const auto& rhs = loadedConstraint->rhs();
     BOOST_REQUIRE_EQUAL(rhs.timeSeries.height, HOURS_PER_YEAR);
 
-    unsigned int i = 0;
-    do
+    unsigned i = 0;
+    while (i < HOURS_PER_YEAR)
     {
-        BOOST_CHECK_CLOSE(rhs.getCoefficient(0, i), i * 1.0, 0.001);
-        // Check rhs values within a tolerance
-
+        BOOST_CHECK_CLOSE(rhs.getCoefficient(0, i), i, 0.001 /* tolerance */);
         i += HOURS_PER_YEAR / 5;
-    } while (i < HOURS_PER_YEAR);
+    }
 }
 
 BOOST_FIXTURE_TEST_CASE(Load_disabled, WorkDirCreationFixture)

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -526,7 +526,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_save, Fixture)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_AUTO_TEST_SUITE(VaidatingAdditionalConstraints)
+BOOST_AUTO_TEST_SUITE(ValidatingAdditionalConstraints)
 
 BOOST_AUTO_TEST_CASE(Validate_ClusterIdEmpty)
 {

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -400,8 +400,6 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load, Fixture)
     BOOST_CHECK(properties.validate());
     BOOST_CHECK(!properties.penalizeVariationInjection);
     BOOST_CHECK(!properties.penalizeVariationWithdrawal);
-
-    removeIniFile();
 }
 
 BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load_with_cost_variation_injection,
@@ -415,8 +413,6 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load_with_cost_variat
     auto& properties = container.storagesByIndex[0].properties;
 
     BOOST_CHECK(properties.penalizeVariationInjection);
-
-    removeIniFile();
 }
 
 BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load_with_cost_variation_withdrawal,
@@ -430,8 +426,6 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load_with_cost_variat
     auto& properties = container.storagesByIndex[0].properties;
 
     BOOST_CHECK(properties.penalizeVariationWithdrawal);
-
-    removeIniFile();
 }
 
 BOOST_FIXTURE_TEST_CASE(
@@ -447,8 +441,6 @@ BOOST_FIXTURE_TEST_CASE(
 
     BOOST_CHECK(properties.penalizeVariationInjection);
     BOOST_CHECK(properties.penalizeVariationWithdrawal);
-
-    removeIniFile();
 }
 
 BOOST_FIXTURE_TEST_CASE(check_container_properties_disabled_load, Fixture)
@@ -462,8 +454,6 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_disabled_load, Fixture)
     BOOST_CHECK(!properties.enabled);
     BOOST_CHECK_EQUAL(container.count(), 0);
     BOOST_CHECK(properties.validate());
-
-    removeIniFile();
 }
 
 BOOST_FIXTURE_TEST_CASE(check_container_properties_wrong_value, Fixture)
@@ -472,8 +462,6 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_wrong_value, Fixture)
 
     BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
     BOOST_CHECK(!container.storagesByIndex[0].properties.validate());
-
-    removeIniFile();
 }
 
 BOOST_FIXTURE_TEST_CASE(check_container_properties_empty_file, Fixture)
@@ -481,8 +469,6 @@ BOOST_FIXTURE_TEST_CASE(check_container_properties_empty_file, Fixture)
     createEmptyIniFile();
 
     BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
-
-    removeIniFile();
 }
 
 #ifdef BUILD_UI
@@ -497,8 +483,6 @@ BOOST_FIXTURE_TEST_CASE(check_file_save, Fixture)
     BOOST_CHECK(container.saveToFolder(folder.string()));
 
     BOOST_CHECK(container.createSTStorageClustersFromIniFile(folder));
-
-    removeIniFile();
 }
 
 BOOST_FIXTURE_TEST_CASE(check_series_save, Fixture)

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -89,15 +89,15 @@ void createIndividualFileSeries(const fs::path& path, unsigned int size)
 // =================
 // The fixture
 // =================
-struct FileCreationFixture
+struct WorkDirCreationFixture
 {
-    FileCreationFixture()
+    WorkDirCreationFixture()
     {
         work_dir = fs::temp_directory_path() / "testWorkDir";
         fs::create_directories(work_dir);
     }
 
-    ~FileCreationFixture()
+    ~WorkDirCreationFixture()
     {
         fs::remove_all(work_dir);
     }
@@ -105,7 +105,7 @@ struct FileCreationFixture
     fs::path work_dir;
 };
 
-struct Fixture: public FileCreationFixture
+struct Fixture: public WorkDirCreationFixture
 {
     Fixture() = default;
     void createFileSeries(double value, unsigned int size);
@@ -588,12 +588,11 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(LoadingAdditionalConstraints)
 
-BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidFile)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, WorkDirCreationFixture)
 {
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "cluster1");
+    fs::create_directories(work_dir / "cluster1");
 
-    std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
@@ -605,22 +604,19 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidFile)
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
 
     BOOST_CHECK_EQUAL(result, true);
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 1);
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints[0]->name,
                       "constraint1");
-
-    fs::remove_all(testPath);
 }
 
-BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidHours)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, WorkDirCreationFixture)
 {
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "ClusterA");
+    fs::create_directories(work_dir / "cluster1");
 
-    std::ofstream iniFile(testPath / "ClusterA" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
@@ -629,13 +625,11 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidHours)
 
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "ClusterA";
+    cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(result, false);
-
-    fs::remove_all(testPath);
 }
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
@@ -645,12 +639,11 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
     BOOST_CHECK_EQUAL(result, true);
 }
 
-BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidConstraint)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, WorkDirCreationFixture)
 {
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "cluster1");
+    fs::create_directories(work_dir / "cluster1");
 
-    std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=invalid\n"; // Invalid variable
     iniFile << "operator=less\n";
@@ -662,25 +655,22 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidConstraint)
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(result, false);
-
-    fs::remove_all(testPath);
 }
 
-BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidRhs)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, WorkDirCreationFixture)
 {
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "cluster1");
+    fs::create_directories(work_dir / "cluster1");
 
-    std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(testPath / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -692,23 +682,20 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidRhs)
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
 
     BOOST_CHECK_EQUAL(result, true);
     const auto& constraint1Rhs = storageInput.storagesByIndex[0].additionalConstraints[0]->rhs();
     BOOST_CHECK_EQUAL(constraint1Rhs.timeSeries.height, HOURS_PER_YEAR);
     BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, 0), 0.0);
     BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
-
-    fs::remove_all(testPath);
 }
 
-BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
+BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, WorkDirCreationFixture)
 {
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "cluster1");
+    fs::create_directories(work_dir / "cluster1");
 
-    std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << R"([constraint1]
                   variable=injection
                   operator=less
@@ -719,7 +706,7 @@ BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
                   hours=[5,33])";
     iniFile.close();
 
-    std::ofstream rhsFile(testPath / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -731,7 +718,7 @@ BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
 
     BOOST_CHECK_EQUAL(result, true);
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 2);
@@ -760,16 +747,13 @@ BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
     BOOST_CHECK_EQUAL(constraint2Rhs.timeSeries.height, HOURS_PER_YEAR);
     BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, 0), 0.0);
     BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), 0);
-
-    fs::remove_all(testPath);
 }
 
-BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingRhsFile)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, WorkDirCreationFixture)
 {
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "cluster1");
+    fs::create_directories(work_dir / "cluster1");
 
-    std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
@@ -781,29 +765,26 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingRhsFile)
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
 
     BOOST_CHECK_EQUAL(result, true);
     const auto& constraintRhs = storageInput.storagesByIndex[0].additionalConstraints[0]->rhs();
     BOOST_CHECK_EQUAL(constraintRhs.timeSeries.height, HOURS_PER_YEAR);
     BOOST_CHECK_EQUAL(constraintRhs.getCoefficient(0, 0), 0.0);
-
-    fs::remove_all(testPath);
 }
 
-BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, WorkDirCreationFixture)
 {
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "cluster1");
+    fs::create_directories(work_dir / "cluster1");
 
-    std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(testPath / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
     rhsFile << "1.0\n2.0\ninvalid\n4.0\n"; // Malformed line
     rhsFile.close();
 
@@ -812,24 +793,22 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile)
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(result, false);
-    fs::remove_all(testPath);
 }
 
-BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, WorkDirCreationFixture)
 {
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "cluster1");
+    fs::create_directories(work_dir / "cluster1");
 
-    std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(testPath / "cluster1" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
     for (int i = 0; i < 10; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -841,10 +820,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile)
     cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(result, false);
-
-    fs::remove_all(testPath);
 }
 
 BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
@@ -854,11 +831,11 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
                      op)
 {
     // Define the path for the test data
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "clustera");
+    fs::path work_dir = fs::temp_directory_path() / "test_data";
+    fs::create_directories(work_dir / "cluster1");
 
     // Write the `.ini` file for this test case
-    std::ofstream iniFile(testPath / "clustera" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=" << variable << "\n";
     iniFile << "operator=" << op << "\n";
@@ -867,7 +844,7 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
     iniFile.close();
 
     // Write the `rhs_constraint1.txt` file
-    std::ofstream rhsFile(testPath / "clustera" / "rhs_constraint1.txt");
+    std::ofstream rhsFile(work_dir / "cluster1" / "rhs_constraint1.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -877,11 +854,11 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
     // Setup storage input and cluster
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "clustera";
+    cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
     // Load constraints from the `.ini` file
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 1);
 
     // Assertions
@@ -908,14 +885,11 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
     } while (i < HOURS_PER_YEAR);
 }
 
-BOOST_AUTO_TEST_CASE(Load_disabled)
+BOOST_FIXTURE_TEST_CASE(Load_disabled, WorkDirCreationFixture)
 {
-    // Define the path for the test data
-    fs::path testPath = fs::temp_directory_path() / "test_data";
-    fs::create_directories(testPath / "clustera");
+    fs::create_directories(work_dir / "cluster1");
 
-    // Write the `.ini` file for this test case
-    std::ofstream iniFile(testPath / "clustera" / "additional-constraints.ini");
+    std::ofstream iniFile(work_dir / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
     iniFile << "variable=injection\n";
     iniFile << "operator=less\n";
@@ -926,11 +900,11 @@ BOOST_AUTO_TEST_CASE(Load_disabled)
     // Setup storage input and cluster
     STStorageInput storageInput;
     STStorageCluster cluster;
-    cluster.id = "clustera";
+    cluster.id = "cluster1";
     storageInput.storagesByIndex.push_back(cluster);
 
     // Load constraints from the `.ini` file
-    bool result = storageInput.loadAdditionalConstraints(testPath);
+    bool result = storageInput.loadAdditionalConstraints(work_dir);
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 0);
 
     // Assertions

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -588,9 +588,20 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(LoadingAdditionalConstraints)
 
+struct IniConstraint
+{
+    std::string name;
+    std::string variable;
+    std::string op;
+    std::string hours;
+    std::string enabled = "true";
+};
+
 struct AdditionalConstraintsFixture: public WorkDirCreationFixture
 {
     AdditionalConstraintsFixture();
+    void makeIniFile(const std::vector<IniConstraint>& ini_constraints);
+
     fs::path sts_dir;
 };
 
@@ -600,19 +611,28 @@ AdditionalConstraintsFixture::AdditionalConstraintsFixture()
     fs::create_directories(sts_dir);
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstraintsFixture)
+void AdditionalConstraintsFixture::makeIniFile(const std::vector<IniConstraint>& ini_constraints)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=injection\n";
-    iniFile << "operator=less\n";
-    iniFile << "hours=[1,2,3]\n";
+    for (const auto& c : ini_constraints)
+    {
+        iniFile << "[" + c.name + "]\n";
+        iniFile << "variable=" + c.variable + "\n";
+        iniFile << "operator=" + c.op + "\n";
+        iniFile << "hours=" + c.hours + "\n";
+        iniFile << "enabled=" + c.enabled + "\n";
+    }
     iniFile.close();
+}
+
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstraintsFixture)
+{
+    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
 
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 1);
@@ -621,17 +641,12 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstrain
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, AdditionalConstraintsFixture)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=injection\n";
-    iniFile << "operator=less\n";
-    iniFile << "hours=[0,1]\n"; // Invalid hours
-    iniFile.close();
+    makeIniFile({{"my_constr", "injection", "less", "[0,1]"}}); // Invalid hours
 
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
@@ -644,29 +659,19 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditionalConstraintsFixture)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=invalid\n"; // Invalid variable
-    iniFile << "operator=less\n";
-    iniFile << "hours=[1,2,3]\n";
-    iniFile.close();
+    makeIniFile({{"my_constr", "invalid", "less", "[1,2,3]"}}); // Invalid variable
 
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraintsFixture)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=injection\n";
-    iniFile << "operator=less\n";
-    iniFile << "hours=[1,2,3]\n";
-    iniFile.close();
+    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
 
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
@@ -690,16 +695,8 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraint
 
 BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixture)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << R"([constraint1]
-                  variable=injection
-                  operator=less
-                  hours=[1,2,3]
-                  [constraint2]
-                  variable=withdrawal
-                  operator=greater
-                  hours=[5,33])";
-    iniFile.close();
+    makeIniFile({{"constraint1", "injection", "less", "[1,2,3]"},
+                 {"constraint2", "withdrawal", "greater", "[5,33]"}});
 
     std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
@@ -744,12 +741,7 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixtur
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalConstraintsFixture)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=injection\n";
-    iniFile << "operator=less\n";
-    iniFile << "hours=[1,2,3]\n";
-    iniFile.close();
+    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
 
     STStorageInput storageInput;
     STStorageCluster sts;
@@ -765,12 +757,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalCons
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditionalConstraintsFixture)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=injection\n";
-    iniFile << "operator=less\n";
-    iniFile << "hours=[1,2,3]\n";
-    iniFile.close();
+    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
 
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     rhsFile << "1.0\n2.0\ninvalid\n4.0\n"; // Malformed line
@@ -786,12 +773,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditionalCo
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditionalConstraintsFixture)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=injection\n";
-    iniFile << "operator=less\n";
-    iniFile << "hours=[1,2,3]\n";
-    iniFile.close();
+    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
 
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (int i = 0; i < 10; ++i)
@@ -815,13 +797,7 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
                        variable,
                        op)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=" << variable << "\n";
-    iniFile << "operator=" << op << "\n";
-    iniFile << "enabled=true\n";
-    iniFile << "hours=[1,2,3]\n";
-    iniFile.close();
+    makeIniFile({{"my_constr", variable, op, "[1,2,3]"}});
 
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
@@ -857,13 +833,7 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
 
 BOOST_FIXTURE_TEST_CASE(Load_disabled, AdditionalConstraintsFixture)
 {
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    iniFile << "[my_constr]\n";
-    iniFile << "variable=injection\n";
-    iniFile << "operator=less\n";
-    iniFile << "enabled=false\n";
-    iniFile << "hours=[1,2,3]\n";
-    iniFile.close();
+    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]", "false"}});
 
     // Setup storage input and sts
     STStorageInput storageInput;

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -88,32 +88,31 @@ void createIndividualFileSeries(const fs::path& path, unsigned int size)
 // =================
 // The fixture
 // =================
-struct Fixture
+struct FileCreationFixture
 {
-    Fixture()
+    FileCreationFixture()
     {
         folder = fs::temp_directory_path() / "blabla";
         fs::create_directories(folder);
     }
 
+    ~FileCreationFixture()
+    {
+        fs::remove_all(folder);
+    }
+
+    fs::path folder;
+};
+
+struct Fixture: public FileCreationFixture
+{
+    Fixture() = default;
     void createFileSeries(double value, unsigned int size);
     void createFileSeries(unsigned int size);
     void createIniFileWrongValue();
     void createIniFile(bool enabled);
     void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation);
     void createEmptyIniFile();
-
-    ~Fixture()
-    {
-        fs::remove_all(folder);
-    }
-
-    bool loadFromFolder(StudyVersion version)
-    {
-        return series.loadFromFolder(folder, version);
-    }
-
-    fs::path folder;
 
     ShortTermStorage::Series series;
     ShortTermStorage::Properties properties;
@@ -160,7 +159,6 @@ void Fixture::createFileSeries(unsigned int size)
 void Fixture::createIniFile(bool enabled)
 {
     iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
-
     iniFile_ << "[area]" << std::endl;
     iniFile_ << "name = area" << std::endl;
     iniFile_ << "group = PSP_open" << std::endl;
@@ -177,7 +175,6 @@ void Fixture::createIniFile(bool enabled)
 void Fixture::createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
 {
     iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
-
     iniFile_ << "[area]" << std::endl;
     iniFile_ << "name = area" << std::endl;
     iniFile_ << "group = PSP_open" << std::endl;
@@ -197,7 +194,6 @@ void Fixture::createEmptyIniFile()
 void Fixture::createIniFileWrongValue()
 {
     iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
-
     iniFile_ << "[area]" << std::endl;
     iniFile_ << "name = area" << std::endl;
     iniFile_ << "group = abcde" << std::endl;
@@ -232,7 +228,7 @@ void checkSizeFirst(const TimeSeries& series, double value)
 BOOST_FIXTURE_TEST_CASE(check_empty, Fixture)
 {
     createFileSeries(0); // Empty files
-    loadFromFolder(StudyVersion(9, 2));
+    series.loadFromFolder(folder, StudyVersion(9, 2));
     series.fillDefaultSeriesIfEmpty();
 
     // version<9.2
@@ -263,21 +259,24 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading, Fixture)
 {
     createFileSeries(1.0, 8760);
 
-    BOOST_CHECK(loadFromFolder(StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
-    BOOST_CHECK(series.inflows.getCoefficient(0, 0) == 1 && series.maxInjectionModulation[8759] == 1
-                && series.upperRuleCurve[1343] == 1 && series.costVariationInjection[0] == 1
-                && series.costVariationWithdrawal[0] == 1);
+    BOOST_CHECK(series.inflows.getCoefficient(0, 0) == 1);
+    BOOST_CHECK(series.maxInjectionModulation[8759] == 1);
+    BOOST_CHECK(series.upperRuleCurve[1343] == 1);
+    BOOST_CHECK(series.costVariationInjection[0] == 1);
+    BOOST_CHECK(series.costVariationWithdrawal[0] == 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_880, Fixture)
 {
     createFileSeries(1.0, 8760);
 
-    BOOST_CHECK(loadFromFolder(StudyVersion(8, 8)));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion(8, 8)));
     BOOST_CHECK(series.validate("", StudyVersion(8, 8)));
-    BOOST_CHECK(series.inflows.getCoefficient(0, 0) == 1 && series.maxInjectionModulation[8759] == 1
-                && series.upperRuleCurve[1343]);
+    BOOST_CHECK(series.inflows.getCoefficient(0, 0) == 1);
+    BOOST_CHECK(series.maxInjectionModulation[8759] == 1);
+    BOOST_CHECK(series.upperRuleCurve[1343]);
 
     // New elements should NOT be loaded if the study version is < 9.2
     BOOST_CHECK(series.costVariationInjection.empty());
@@ -288,7 +287,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values_880, Fixtur
 {
     createFileSeries(8760);
 
-    BOOST_CHECK(loadFromFolder(StudyVersion(8, 8)));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion(8, 8)));
     BOOST_CHECK(series.validate("", StudyVersion(8, 8)));
 }
 
@@ -296,7 +295,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values, Fixture)
 {
     createFileSeries(8760);
 
-    BOOST_CHECK(loadFromFolder(StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
 }
 
@@ -304,7 +303,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_negative_value, Fixture)
 {
     createFileSeries(-247.0, 8760);
 
-    BOOST_CHECK(loadFromFolder(StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
     BOOST_CHECK(!series.validate("", StudyVersion::latest()));
 }
 
@@ -312,7 +311,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_too_big, Fixture)
 {
     createFileSeries(1.0, 9000);
 
-    BOOST_CHECK(loadFromFolder(StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
 }
 
@@ -320,7 +319,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_too_big_880, Fixture)
 {
     createFileSeries(1.0, 9000);
 
-    BOOST_CHECK(loadFromFolder(StudyVersion(8, 8)));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion(8, 8)));
     BOOST_CHECK(series.validate("", StudyVersion(8, 8)));
 }
 
@@ -328,13 +327,13 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_too_small, Fixture)
 {
     createFileSeries(1.0, 100);
 
-    BOOST_CHECK(!loadFromFolder(StudyVersion::latest()));
+    BOOST_CHECK(!series.loadFromFolder(folder, StudyVersion::latest()));
     BOOST_CHECK(!series.validate("", StudyVersion::latest()));
 }
 
 BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_empty, Fixture)
 {
-    BOOST_CHECK(loadFromFolder(StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
     BOOST_CHECK(!series.validate("", StudyVersion::latest()));
 }
 
@@ -467,7 +466,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_save, Fixture)
     BOOST_CHECK(series.saveToFolder(folder.string()));
     resizeFillVectors(series, 0, 0);
 
-    BOOST_CHECK(loadFromFolder(StudyVersion::latest()));
+    BOOST_CHECK(series.loadFromFolder(folder, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
 }
 #endif

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -614,12 +614,9 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstrain
     cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
-
-    BOOST_CHECK_EQUAL(result, true);
+    BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 1);
-    BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints[0]->name,
-                      "my_constr");
+    BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints[0]->name, "my_constr");
 }
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, AdditionalConstraintsFixture)
@@ -636,15 +633,13 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, AdditionalConstr
     cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
-    BOOST_CHECK_EQUAL(result, false);
+    BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
 {
     STStorageInput storageInput;
-    bool result = storageInput.loadAdditionalConstraints("nonexistent_path");
-    BOOST_CHECK_EQUAL(result, true);
+    BOOST_CHECK(storageInput.loadAdditionalConstraints("nonexistent_path"));
 }
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditionalConstraintsFixture)
@@ -661,8 +656,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditionalC
     cluster.id = "my-sts";
     storageInput.storagesByIndex.push_back(cluster);
 
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
-    BOOST_CHECK_EQUAL(result, false);
+    BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraintsFixture)
@@ -674,7 +668,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraint
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
+    std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         rhsFile << i * 1.0 << "\n";
@@ -682,17 +676,16 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraint
     rhsFile.close();
 
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
+    BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
 
-    BOOST_CHECK_EQUAL(result, true);
-    const auto& constraint1Rhs = storageInput.storagesByIndex[0].additionalConstraints[0]->rhs();
-    BOOST_CHECK_EQUAL(constraint1Rhs.timeSeries.height, HOURS_PER_YEAR);
-    BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, 0), 0.0);
-    BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
+    const auto& rhs = storageInput.storagesByIndex[0].additionalConstraints[0]->rhs();
+    BOOST_CHECK_EQUAL(rhs.timeSeries.height, HOURS_PER_YEAR);
+    BOOST_CHECK_EQUAL(rhs.getCoefficient(0, 0), 0.0);
+    BOOST_CHECK_EQUAL(rhs.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixture)
@@ -716,36 +709,34 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixtur
     rhsFile.close();
 
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
-
-    BOOST_CHECK_EQUAL(result, true);
+    BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 2);
 
     //------- constraint1 ----------
-    const auto& constraint1 = *storageInput.storagesByIndex[0].additionalConstraints[0];
-    BOOST_CHECK_EQUAL(constraint1.name, "constraint1");
-    BOOST_CHECK_EQUAL(constraint1.operatorType, "less");
-    BOOST_CHECK_EQUAL(constraint1.variable, "injection");
-    BOOST_CHECK_EQUAL(constraint1.cluster_id, cluster.id);
+    const auto& constraint1 = storageInput.storagesByIndex[0].additionalConstraints[0];
+    BOOST_CHECK_EQUAL(constraint1->name, "constraint1");
+    BOOST_CHECK_EQUAL(constraint1->operatorType, "less");
+    BOOST_CHECK_EQUAL(constraint1->variable, "injection");
+    BOOST_CHECK_EQUAL(constraint1->cluster_id, sts.id);
 
-    const auto& constraint1Rhs = constraint1.rhs();
+    const auto& constraint1Rhs = constraint1->rhs();
     BOOST_CHECK_EQUAL(constraint1Rhs.timeSeries.height, HOURS_PER_YEAR);
     BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, 0), 0.0);
     BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
 
     //------- constraint2 ----------
 
-    const auto& constraint2 = *storageInput.storagesByIndex[0].additionalConstraints[1];
-    BOOST_CHECK_EQUAL(constraint2.name, "constraint2");
-    BOOST_CHECK_EQUAL(constraint2.operatorType, "greater");
-    BOOST_CHECK_EQUAL(constraint2.variable, "withdrawal");
-    BOOST_CHECK_EQUAL(constraint2.cluster_id, cluster.id);
+    const auto& constraint2 = storageInput.storagesByIndex[0].additionalConstraints[1];
+    BOOST_CHECK_EQUAL(constraint2->name, "constraint2");
+    BOOST_CHECK_EQUAL(constraint2->operatorType, "greater");
+    BOOST_CHECK_EQUAL(constraint2->variable, "withdrawal");
+    BOOST_CHECK_EQUAL(constraint2->cluster_id, sts.id);
 
-    const auto& constraint2Rhs = constraint2.rhs();
+    const auto& constraint2Rhs = constraint2->rhs();
     BOOST_CHECK_EQUAL(constraint2Rhs.timeSeries.height, HOURS_PER_YEAR);
     BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, 0), 0.0);
     BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), 0);
@@ -761,13 +752,12 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalCons
     iniFile.close();
 
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
+    BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
 
-    BOOST_CHECK_EQUAL(result, true);
     const auto& constraintRhs = storageInput.storagesByIndex[0].additionalConstraints[0]->rhs();
     BOOST_CHECK_EQUAL(constraintRhs.timeSeries.height, HOURS_PER_YEAR);
     BOOST_CHECK_EQUAL(constraintRhs.getCoefficient(0, 0), 0.0);
@@ -787,12 +777,11 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditionalCo
     rhsFile.close();
 
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
-    BOOST_CHECK_EQUAL(result, false);
+    BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
 BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditionalConstraintsFixture)
@@ -812,12 +801,11 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditionalC
     rhsFile.close();
 
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
-    BOOST_CHECK_EQUAL(result, false);
+    BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
 BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
@@ -842,19 +830,17 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
     }
     rhsFile.close();
 
-    // Setup storage input and cluster
+    // Setup storage input and sts
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 1);
+    BOOST_REQUIRE_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 1);
 
-    auto& sts = storageInput.storagesByIndex[0];
-    BOOST_REQUIRE_EQUAL(sts.additionalConstraints.size(), 1);
-
-    const auto loadedConstraint = sts.additionalConstraints[0];
+    const auto loadedConstraint = storageInput.storagesByIndex[0].additionalConstraints[0];
     BOOST_CHECK_EQUAL(loadedConstraint->variable, variable);
     BOOST_CHECK_EQUAL(loadedConstraint->operatorType, op);
 
@@ -879,21 +865,15 @@ BOOST_FIXTURE_TEST_CASE(Load_disabled, AdditionalConstraintsFixture)
     iniFile << "hours=[1,2,3]\n";
     iniFile.close();
 
-    // Setup storage input and cluster
+    // Setup storage input and sts
     STStorageInput storageInput;
-    STStorageCluster cluster;
-    cluster.id = "my-sts";
-    storageInput.storagesByIndex.push_back(cluster);
+    STStorageCluster sts;
+    sts.id = "my-sts";
+    storageInput.storagesByIndex.push_back(sts);
 
-    // Load constraints from the `.ini` file
-    bool result = storageInput.loadAdditionalConstraints(work_dir);
+    BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 0);
-
-    // Assertions
-    BOOST_CHECK_EQUAL(result, true);
-    // Validate loaded constraints
-    auto& built_cluster = storageInput.storagesByIndex[0];
-    BOOST_REQUIRE_EQUAL(built_cluster.additionalConstraints.size(), 0);
+    BOOST_REQUIRE_EQUAL(sts.additionalConstraints.size(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -820,7 +820,7 @@ BOOST_FIXTURE_TEST_CASE(Load_disabled, AdditConstrFixture<1>)
 BOOST_FIXTURE_TEST_CASE(multiple_sts__one_sts_has_no_additional_constraint__all_constr_fully_loaded,
                         AdditConstrFixture<2> /* 2 STS are built here */)
 {
-    // Fixture builds 2 short term storage here. 
+    // Fixture builds 2 short term storage here.
     // We make 2 constraints for the first one.
     makeAdditConstrIniFile(pathsToSTS[1],
                            {{"constr_2a", "injection", "less", "[1]"},

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -619,7 +619,7 @@ AdditionalConstraintsFixture::AdditionalConstraintsFixture()
 void AdditionalConstraintsFixture::makeIniFile(const std::vector<IniConstraint>& ini_constraints)
 {
     std::ofstream iniFile(sts_dir / "additional-constraints.ini");
-    for (const auto& c : ini_constraints)
+    for (const auto& c: ini_constraints)
     {
         iniFile << "[" + c.name + "]\n";
         iniFile << "variable=" + c.variable + "\n";

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -252,13 +252,13 @@ BOOST_FIXTURE_TEST_CASE(check_vector_sizes, Fixture)
     resizeFillVectors(series, 0.0, 12);
     BOOST_CHECK(!series.validate("", StudyVersion::latest()));
 
-    resizeFillVectors(series, 0.0, 8760);
+    resizeFillVectors(series, 0.0, HOURS_PER_YEAR);
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
 }
 
 BOOST_FIXTURE_TEST_CASE(check_series_folder_loading, Fixture)
 {
-    createFileSeries(1.0, 8760);
+    createFileSeries(1.0, HOURS_PER_YEAR);
 
     BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
@@ -271,7 +271,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_880, Fixture)
 {
-    createFileSeries(1.0, 8760);
+    createFileSeries(1.0, HOURS_PER_YEAR);
 
     BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion(8, 8)));
     BOOST_CHECK(series.validate("", StudyVersion(8, 8)));
@@ -286,7 +286,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_880, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values_880, Fixture)
 {
-    createFileSeries(8760);
+    createFileSeries(HOURS_PER_YEAR);
 
     BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion(8, 8)));
     BOOST_CHECK(series.validate("", StudyVersion(8, 8)));
@@ -294,7 +294,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values_880, Fixtur
 
 BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values, Fixture)
 {
-    createFileSeries(8760);
+    createFileSeries(HOURS_PER_YEAR);
 
     BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(series.validate("", StudyVersion::latest()));
@@ -302,7 +302,7 @@ BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_different_values, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(check_series_folder_loading_negative_value, Fixture)
 {
-    createFileSeries(-247.0, 8760);
+    createFileSeries(-247.0, HOURS_PER_YEAR);
 
     BOOST_CHECK(series.loadFromFolder(work_dir, StudyVersion::latest()));
     BOOST_CHECK(!series.validate("", StudyVersion::latest()));
@@ -352,7 +352,7 @@ BOOST_FIXTURE_TEST_CASE(check_cluster_series_vector_fill, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(check_cluster_series_load_vector, Fixture)
 {
-    createFileSeries(0.5, 8760);
+    createFileSeries(0.5, HOURS_PER_YEAR);
 
     BOOST_CHECK(cluster.loadSeries(work_dir, StudyVersion::latest()));
     BOOST_CHECK(cluster.series->validate("", StudyVersion::latest()));
@@ -462,7 +462,7 @@ BOOST_FIXTURE_TEST_CASE(check_file_save, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(check_series_save, Fixture)
 {
-    resizeFillVectors(series, 0.123456789, 8760);
+    resizeFillVectors(series, 0.123456789, HOURS_PER_YEAR);
 
     BOOST_CHECK(series.saveToFolder(work_dir.string()));
     resizeFillVectors(series, 0, 0);
@@ -597,28 +597,9 @@ struct IniConstraint
     std::string enabled = "true";
 };
 
-struct AdditionalConstraintsFixture: public WorkDirCreationFixture
+void makeAdditConstrIniFile(fs::path& dir, const std::vector<IniConstraint>& ini_constraints)
 {
-    AdditionalConstraintsFixture();
-    void makeIniFile(const std::vector<IniConstraint>& ini_constraints);
-
-    fs::path sts_dir;
-    STStorageInput storageInput;
-    STStorageCluster sts;
-};
-
-AdditionalConstraintsFixture::AdditionalConstraintsFixture()
-{
-    sts_dir = work_dir / "my-sts";
-    fs::create_directories(sts_dir);
-
-    sts.id = "my-sts";
-    storageInput.storagesByIndex.push_back(sts);
-}
-
-void AdditionalConstraintsFixture::makeIniFile(const std::vector<IniConstraint>& ini_constraints)
-{
-    std::ofstream iniFile(sts_dir / "additional-constraints.ini");
+    std::ofstream iniFile(dir / "additional-constraints.ini");
     for (const auto& c: ini_constraints)
     {
         iniFile << "[" + c.name + "]\n";
@@ -630,18 +611,77 @@ void AdditionalConstraintsFixture::makeIniFile(const std::vector<IniConstraint>&
     iniFile.close();
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditionalConstraintsFixture)
+void makeRHSforConstraint(fs::path& dir, unsigned nb_lines, const std::string& constraint_name)
 {
-    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
+    std::string filename = "rhs_" + constraint_name + ".txt";
+    std::ofstream rhsFile(dir / filename);
+
+    for (unsigned i = 0; i < nb_lines; ++i)
+    {
+        rhsFile << i << "\n";
+    }
+    rhsFile.close();
+}
+
+// =========================================
+// Fixture : AdditConstrFixture
+// =========================================
+
+template<unsigned nb_sts>
+struct AdditConstrFixture: public WorkDirCreationFixture
+{
+    AdditConstrFixture();
+
+    STStorageInput storageInput;
+    std::vector<fs::path> pathsToSTS;
+    std::vector<std::string> sts_names;
+};
+
+template<unsigned nb_sts>
+AdditConstrFixture<nb_sts>::AdditConstrFixture()
+{
+    for (unsigned i = 1; i <= nb_sts; i++)
+    {
+        std::string sts_name = "my-sts-" + std::to_string(i);
+        sts_names.push_back(sts_name);
+
+        fs::path sts_dir = work_dir / sts_name;
+        pathsToSTS.push_back(work_dir / sts_name); // Storing path tp STS data
+
+        fs::create_directories(sts_dir);
+
+        STStorageCluster sts;
+        sts.id = sts_name;
+        storageInput.storagesByIndex.push_back(sts);
+    }
+}
+
+// =========================================
+// Test on loading additional constraints
+// =========================================
+BOOST_FIXTURE_TEST_CASE(constraint_has_a_unknown_key___loading_returns_false, AdditConstrFixture<1>)
+{
+    std::ofstream iniFile(pathsToSTS[0] / "additional-constraints.ini");
+    iniFile << "[some constraint]\n";
+    iniFile << "blabla=some value\n";
+    iniFile.close();
+
+    BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
+}
+
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidFile, AdditConstrFixture<1>)
+{
+    makeAdditConstrIniFile(pathsToSTS[0], {{"my_constr", "injection", "less", "[1,2,3]"}});
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 1);
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints[0]->name, "my_constr");
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, AdditionalConstraintsFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidHours, AdditConstrFixture<1>)
 {
-    makeIniFile({{"my_constr", "injection", "less", "[0,1]"}}); // Invalid hours
+    makeAdditConstrIniFile(pathsToSTS[0],
+                           {{"my_constr", "injection", "less", "[0,1]"}}); // Invalid hours
 
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
@@ -652,23 +692,18 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
     BOOST_CHECK(storageInput.loadAdditionalConstraints("nonexistent_path"));
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditionalConstraintsFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_InvalidConstraint, AdditConstrFixture<1>)
 {
-    makeIniFile({{"my_constr", "invalid", "less", "[1,2,3]"}}); // Invalid variable
+    makeAdditConstrIniFile(pathsToSTS[0],
+                           {{"my_constr", "invalid", "less", "[1,2,3]"}}); // Invalid variable
 
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraintsFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditConstrFixture<1>)
 {
-    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
-
-    std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
-    for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
-    {
-        rhsFile << i << "\n";
-    }
-    rhsFile.close();
+    makeAdditConstrIniFile(pathsToSTS[0], {{"my_constr", "injection", "less", "[1,2,3]"}});
+    makeRHSforConstraint(pathsToSTS[0], HOURS_PER_YEAR, "my_constr");
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
 
@@ -678,17 +713,13 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraint
     BOOST_CHECK_EQUAL(rhs.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
 }
 
-BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixture)
+BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditConstrFixture<1>)
 {
-    makeIniFile({{"constraint1", "injection", "less", "[1,2,3]"},
-                 {"constraint2", "withdrawal", "greater", "[5,33]"}});
+    makeAdditConstrIniFile(pathsToSTS[0],
+                           {{"constraint1", "injection", "less", "[1,2,3]"},
+                            {"constraint2", "withdrawal", "greater", "[5,33]"}});
 
-    std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
-    for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
-    {
-        rhsFile << i << "\n";
-    }
-    rhsFile.close();
+    makeRHSforConstraint(pathsToSTS[0], HOURS_PER_YEAR, "constraint1");
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 2);
@@ -698,30 +729,29 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixtur
     BOOST_CHECK_EQUAL(constraint1->name, "constraint1");
     BOOST_CHECK_EQUAL(constraint1->operatorType, "less");
     BOOST_CHECK_EQUAL(constraint1->variable, "injection");
-    BOOST_CHECK_EQUAL(constraint1->cluster_id, sts.id);
+    BOOST_CHECK_EQUAL(constraint1->cluster_id, sts_names[0]);
 
-    const auto& constraint1Rhs = constraint1->rhs();
-    BOOST_CHECK_EQUAL(constraint1Rhs.timeSeries.height, HOURS_PER_YEAR);
-    BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, 0), 0.0);
-    BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
+    const auto& rhs1 = constraint1->rhs();
+    BOOST_CHECK_EQUAL(rhs1.timeSeries.height, HOURS_PER_YEAR);
+    BOOST_CHECK_EQUAL(rhs1.getCoefficient(0, 0), 0.0);
+    BOOST_CHECK_EQUAL(rhs1.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
 
     //------- constraint2 ----------
-
     const auto& constraint2 = storageInput.storagesByIndex[0].additionalConstraints[1];
     BOOST_CHECK_EQUAL(constraint2->name, "constraint2");
     BOOST_CHECK_EQUAL(constraint2->operatorType, "greater");
     BOOST_CHECK_EQUAL(constraint2->variable, "withdrawal");
-    BOOST_CHECK_EQUAL(constraint2->cluster_id, sts.id);
+    BOOST_CHECK_EQUAL(constraint2->cluster_id, sts_names[0]);
 
-    const auto& constraint2Rhs = constraint2->rhs();
-    BOOST_CHECK_EQUAL(constraint2Rhs.timeSeries.height, HOURS_PER_YEAR);
-    BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, 0), 0.0);
-    BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), 0);
+    const auto& rhs2 = constraint2->rhs();
+    BOOST_CHECK_EQUAL(rhs2.timeSeries.height, HOURS_PER_YEAR);
+    BOOST_CHECK_EQUAL(rhs2.getCoefficient(0, 0), 0.0);
+    BOOST_CHECK_EQUAL(rhs2.getCoefficient(0, HOURS_PER_YEAR - 1), 0);
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalConstraintsFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditConstrFixture<1>)
 {
-    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
+    makeAdditConstrIniFile(pathsToSTS[0], {{"my_constr", "injection", "less", "[1,2,3]"}});
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
 
@@ -730,46 +760,35 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MissingRhsFile, AdditionalCons
     BOOST_CHECK_EQUAL(constraintRhs.getCoefficient(0, 0), 0.0);
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditionalConstraintsFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile, AdditConstrFixture<1>)
 {
-    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
+    makeAdditConstrIniFile(pathsToSTS[0], {{"my_constr", "injection", "less", "[1,2,3]"}});
 
-    std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
+    std::ofstream rhsFile(pathsToSTS[0] / "rhs_my_constr.txt");
     rhsFile << "1.0\n2.0\ninvalid\n4.0\n"; // Malformed line
     rhsFile.close();
 
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
-BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditionalConstraintsFixture)
+BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditConstrFixture<1>)
 {
-    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]"}});
+    makeAdditConstrIniFile(pathsToSTS[0], {{"my_constr", "injection", "less", "[1,2,3]"}});
 
-    std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
-    for (int i = 0; i < 10; ++i)
-    {
-        rhsFile << i << "\n";
-    }
-    rhsFile.close();
+    makeRHSforConstraint(pathsToSTS[0], 10, "my_constr");
 
     BOOST_CHECK(!storageInput.loadAdditionalConstraints(work_dir));
 }
 
-BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
+BOOST_DATA_TEST_CASE_F(AdditConstrFixture<1>,
                        Validate_AllVariableOperatorCombinationsFromFile,
                        bdata::make({"injection", "withdrawal", "netting"})
                          * bdata::make({"less", "equal", "greater"}),
                        variable,
                        op)
 {
-    makeIniFile({{"my_constr", variable, op, "[1,2,3]"}});
-
-    std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
-    for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
-    {
-        rhsFile << i << "\n";
-    }
-    rhsFile.close();
+    makeAdditConstrIniFile(pathsToSTS[0], {{"my_constr", variable, op, "[1,2,3]"}});
+    makeRHSforConstraint(pathsToSTS[0], HOURS_PER_YEAR, "my_constr");
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 1);
@@ -790,13 +809,58 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
     }
 }
 
-BOOST_FIXTURE_TEST_CASE(Load_disabled, AdditionalConstraintsFixture)
+BOOST_FIXTURE_TEST_CASE(Load_disabled, AdditConstrFixture<1>)
 {
-    makeIniFile({{"my_constr", "injection", "less", "[1,2,3]", "false"}});
+    makeAdditConstrIniFile(pathsToSTS[0], {{"my_constr", "injection", "less", "[1,2,3]", "false"}});
 
     BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
     BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 0);
-    BOOST_REQUIRE_EQUAL(sts.additionalConstraints.size(), 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(multiple_sts__one_sts_has_no_additional_constraint__all_constr_fully_loaded,
+                        AdditConstrFixture<2> /* 2 STS are built here */)
+{
+    // Fixture builds 2 short term storage here. 
+    // We make 2 constraints for the first one.
+    makeAdditConstrIniFile(pathsToSTS[1],
+                           {{"constr_2a", "injection", "less", "[1]"},
+                            {"constr_2b", "netting", "greater", "[1,3]"}});
+    makeRHSforConstraint(pathsToSTS[1], HOURS_PER_YEAR, "constr_2a");
+    makeRHSforConstraint(pathsToSTS[1], HOURS_PER_YEAR, "constr_2b");
+
+    BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
+
+    BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 2);
+    BOOST_REQUIRE_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 0);
+    BOOST_REQUIRE_EQUAL(storageInput.storagesByIndex[1].additionalConstraints.size(), 2);
+
+    const auto& constr_2a = storageInput.storagesByIndex[1].additionalConstraints[0];
+    const auto& constr_2b = storageInput.storagesByIndex[1].additionalConstraints[1];
+
+    BOOST_REQUIRE_EQUAL(constr_2a->id, "constr_2a");
+    BOOST_REQUIRE_EQUAL(constr_2b->id, "constr_2b");
+}
+
+BOOST_FIXTURE_TEST_CASE(one_sts_with_many_constraints_one_is_disabled__all_constr_fully_loaded,
+                        AdditConstrFixture<1> /* 1 sts here */)
+{
+    makeAdditConstrIniFile(pathsToSTS[0],
+                           {{"constr_1", "withdrawal", "less", "[1]", "false"}, // Disabled
+                            {"constr_2", "injection", "less", "[1,6]"},
+                            {"constr_3", "netting", "greater", "[1,3]"}});
+    makeRHSforConstraint(pathsToSTS[0], HOURS_PER_YEAR, "constr_2");
+    makeRHSforConstraint(pathsToSTS[0], HOURS_PER_YEAR, "constr_3");
+
+    BOOST_CHECK(storageInput.loadAdditionalConstraints(work_dir));
+
+    BOOST_CHECK_EQUAL(storageInput.cumulativeConstraintCount(), 2);
+    BOOST_REQUIRE_EQUAL(storageInput.storagesByIndex[0].additionalConstraints.size(), 2);
+
+    const auto& constr_2 = storageInput.storagesByIndex[0].additionalConstraints[0];
+    const auto& constr_3 = storageInput.storagesByIndex[0].additionalConstraints[1];
+
+    BOOST_REQUIRE_EQUAL(constr_2->id, "constr_2");
+    BOOST_REQUIRE_EQUAL(constr_3->id, "constr_3");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -141,6 +141,9 @@ struct Fixture
     ShortTermStorage::STStorageInput container;
 
     PenaltyCostOnVariation penaltyCostOnVariation;
+
+private:
+    std::ofstream iniFile_;
 };
 
 void Fixture::createFileSeries(double value, unsigned int size)
@@ -176,52 +179,49 @@ void Fixture::createFileSeries(unsigned int size)
 
 void Fixture::createIniFile(bool enabled)
 {
-    std::ofstream iniFile;
-    iniFile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+    iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
 
-    iniFile << "[area]" << std::endl;
-    iniFile << "name = area" << std::endl;
-    iniFile << "group = PSP_open" << std::endl;
-    iniFile << "injectionnominalcapacity = 870.000000" << std::endl;
-    iniFile << "withdrawalnominalcapacity = 900.000000" << std::endl;
-    iniFile << "reservoircapacity = 31200.000000" << std::endl;
-    iniFile << "efficiency = 0.75" << std::endl;
-    iniFile << "efficiencywithdrawal = 0.9" << std::endl;
-    iniFile << "initiallevel = 0.50000" << std::endl;
-    iniFile << "enabled = " << (enabled ? "true" : "false") << std::endl;
-    iniFile.close();
+    iniFile_ << "[area]" << std::endl;
+    iniFile_ << "name = area" << std::endl;
+    iniFile_ << "group = PSP_open" << std::endl;
+    iniFile_ << "injectionnominalcapacity = 870.000000" << std::endl;
+    iniFile_ << "withdrawalnominalcapacity = 900.000000" << std::endl;
+    iniFile_ << "reservoircapacity = 31200.000000" << std::endl;
+    iniFile_ << "efficiency = 0.75" << std::endl;
+    iniFile_ << "efficiencywithdrawal = 0.9" << std::endl;
+    iniFile_ << "initiallevel = 0.50000" << std::endl;
+    iniFile_ << "enabled = " << (enabled ? "true" : "false") << std::endl;
+    iniFile_.close();
 }
 
 void Fixture::createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
 {
-    std::ofstream iniFile;
-    iniFile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+    iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
 
-    iniFile << "[area]" << std::endl;
-    iniFile << "name = area" << std::endl;
-    iniFile << "group = PSP_open" << std::endl;
-    iniFile << "penalize-variation-injection = " << std::boolalpha
+    iniFile_ << "[area]" << std::endl;
+    iniFile_ << "name = area" << std::endl;
+    iniFile_ << "group = PSP_open" << std::endl;
+    iniFile_ << "penalize-variation-injection = " << std::boolalpha
             << penaltyCostOnVariation.injection << std::endl;
-    iniFile << "penalize-variation-withdrawal = " << std::boolalpha
+    iniFile_ << "penalize-variation-withdrawal = " << std::boolalpha
             << penaltyCostOnVariation.withdrawal << std::endl;
-    iniFile.close();
+    iniFile_.close();
 }
 
 void Fixture::createIniFileWrongValue()
 {
-    std::ofstream iniFile;
-    iniFile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
+    iniFile_.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
 
-    iniFile << "[area]" << std::endl;
-    iniFile << "name = area" << std::endl;
-    iniFile << "group = abcde" << std::endl;
-    iniFile << "injectionnominalcapacity = -870.000000" << std::endl;
-    iniFile << "withdrawalnominalcapacity = -900.000000" << std::endl;
-    iniFile << "reservoircapacity = -31200.000000" << std::endl;
-    iniFile << "efficiency = 4" << std::endl;
-    iniFile << "efficiencywithdrawal = -2" << std::endl;
-    iniFile << "initiallevel = -0.50000" << std::endl;
-    iniFile.close();
+    iniFile_ << "[area]" << std::endl;
+    iniFile_ << "name = area" << std::endl;
+    iniFile_ << "group = abcde" << std::endl;
+    iniFile_ << "injectionnominalcapacity = -870.000000" << std::endl;
+    iniFile_ << "withdrawalnominalcapacity = -900.000000" << std::endl;
+    iniFile_ << "reservoircapacity = -31200.000000" << std::endl;
+    iniFile_ << "efficiency = 4" << std::endl;
+    iniFile_ << "efficiencywithdrawal = -2" << std::endl;
+    iniFile_ << "initiallevel = -0.50000" << std::endl;
+    iniFile_.close();
 }
 
 // ==================

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -48,11 +48,6 @@ struct PenaltyCostOnVariation
     bool withdrawal = false;
 };
 
-fs::path getFolder()
-{
-    return fs::temp_directory_path();
-}
-
 void resizeFillVectors(ShortTermStorage::Series& series, double value, unsigned int size)
 {
     series.maxInjectionModulation.resize(size, value);
@@ -98,7 +93,7 @@ void createIndividualFileSeries(const fs::path& path, unsigned int size)
 
 void createFileSeries(double value, unsigned int size)
 {
-    fs::path folder = getFolder();
+    fs::path folder = fs::temp_directory_path();
 
     createIndividualFileSeries(folder / "PMAX-injection.txt", value, size);
     createIndividualFileSeries(folder / "PMAX-withdrawal.txt", value, size);
@@ -115,7 +110,7 @@ void createFileSeries(double value, unsigned int size)
 
 void createFileSeries(unsigned int size)
 {
-    fs::path folder = getFolder();
+    fs::path folder = fs::temp_directory_path();
 
     createIndividualFileSeries(folder / "PMAX-injection.txt", size);
     createIndividualFileSeries(folder / "PMAX-withdrawal.txt", size);
@@ -133,7 +128,7 @@ void createFileSeries(unsigned int size)
 
 void createIniFile(bool enabled)
 {
-    fs::path folder = getFolder();
+    fs::path folder = fs::temp_directory_path();
 
     std::ofstream outfile;
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
@@ -153,7 +148,7 @@ void createIniFile(bool enabled)
 
 void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
 {
-    fs::path folder = getFolder();
+    fs::path folder = fs::temp_directory_path();
 
     std::ofstream outfile;
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
@@ -170,7 +165,7 @@ void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
 
 void createIniFileWrongValue()
 {
-    fs::path folder = getFolder();
+    fs::path folder = fs::temp_directory_path();
 
     std::ofstream outfile;
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
@@ -190,7 +185,7 @@ void createIniFileWrongValue()
 
 void createEmptyIniFile()
 {
-    fs::path folder = getFolder();
+    fs::path folder = fs::temp_directory_path();
 
     std::ofstream outfile;
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
@@ -200,7 +195,7 @@ void createEmptyIniFile()
 
 void removeIniFile()
 {
-    fs::remove(getFolder() / "list.ini");
+    fs::remove(fs::temp_directory_path() / "list.ini");
 }
 } // namespace
 
@@ -236,7 +231,7 @@ struct Fixture
         return series.loadFromFolder(folder, version);
     }
 
-    fs::path folder = getFolder();
+    fs::path folder = fs::temp_directory_path();
     ShortTermStorage::Series series;
     ShortTermStorage::Properties properties;
     ShortTermStorage::STStorageCluster cluster;
@@ -650,7 +645,7 @@ BOOST_AUTO_TEST_SUITE(LoadingAdditionalConstraints)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidFile)
 {
-    std::filesystem::path testPath = getFolder() / "test_data";
+    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
     std::filesystem::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
@@ -677,7 +672,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidFile)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidHours)
 {
-    std::filesystem::path testPath = getFolder() / "test_data";
+    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
     std::filesystem::create_directories(testPath / "ClusterA");
 
     std::ofstream iniFile(testPath / "ClusterA" / "additional-constraints.ini");
@@ -707,7 +702,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidConstraint)
 {
-    std::filesystem::path testPath = getFolder() / "test_data";
+    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
     std::filesystem::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
@@ -730,7 +725,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidConstraint)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidRhs)
 {
-    std::filesystem::path testPath = getFolder() / "test_data";
+    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
     std::filesystem::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
@@ -765,7 +760,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidRhs)
 
 BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
 {
-    std::filesystem::path testPath = getFolder() / "test_data";
+    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
     std::filesystem::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
@@ -826,7 +821,7 @@ BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingRhsFile)
 {
-    std::filesystem::path testPath = getFolder() / "test_data";
+    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
     std::filesystem::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
@@ -853,7 +848,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingRhsFile)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile)
 {
-    std::filesystem::path testPath = getFolder() / "test_data";
+    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
     std::filesystem::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
@@ -879,7 +874,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile)
 {
-    std::filesystem::path testPath = getFolder() / "test_data";
+    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
     std::filesystem::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -91,41 +91,6 @@ void createIndividualFileSeries(const fs::path& path, unsigned int size)
     outfile.close();
 }
 
-void createFileSeries(double value, unsigned int size)
-{
-    fs::path folder = fs::temp_directory_path() / "blabla";
-
-    createIndividualFileSeries(folder / "PMAX-injection.txt", value, size);
-    createIndividualFileSeries(folder / "PMAX-withdrawal.txt", value, size);
-    createIndividualFileSeries(folder / "inflows.txt", value, size);
-    createIndividualFileSeries(folder / "lower-rule-curve.txt", value, size);
-    createIndividualFileSeries(folder / "upper-rule-curve.txt", value, size);
-
-    createIndividualFileSeries(folder / "cost-injection.txt", value, size);
-    createIndividualFileSeries(folder / "cost-withdrawal.txt", value, size);
-    createIndividualFileSeries(folder / "cost-level.txt", value, size);
-    createIndividualFileSeries(folder / "cost-variation-injection.txt", value, size);
-    createIndividualFileSeries(folder / "cost-variation-withdrawal.txt", value, size);
-}
-
-void createFileSeries(unsigned int size)
-{
-    fs::path folder = fs::temp_directory_path() / "blabla";
-
-    createIndividualFileSeries(folder / "PMAX-injection.txt", size);
-    createIndividualFileSeries(folder / "PMAX-withdrawal.txt", size);
-    createIndividualFileSeries(folder / "inflows.txt", size);
-    createIndividualFileSeries(folder / "lower-rule-curve.txt", size);
-    createIndividualFileSeries(folder / "upper-rule-curve.txt", size);
-
-    createIndividualFileSeries(folder / "cost-injection.txt", size);
-    createIndividualFileSeries(folder / "cost-withdrawal.txt", size);
-    createIndividualFileSeries(folder / "cost-level.txt", size);
-
-    createIndividualFileSeries(folder / "cost-variation-injection.txt", size);
-    createIndividualFileSeries(folder / "cost-variation-withdrawal.txt", size);
-}
-
 void createIniFile(bool enabled)
 {
     fs::path folder = fs::temp_directory_path() / "blabla";
@@ -214,6 +179,10 @@ struct Fixture
         fs::create_directories(folder);
     }
 
+    void createFileSeries(double value, unsigned int size);
+    void createFileSeries(unsigned int size);
+   
+
     ~Fixture()
     {
         fs::remove_all(folder);
@@ -233,6 +202,37 @@ struct Fixture
 
     PenaltyCostOnVariation penaltyCostOnVariation;
 };
+
+void Fixture::createFileSeries(double value, unsigned int size)
+{
+    createIndividualFileSeries(folder / "PMAX-injection.txt", value, size);
+    createIndividualFileSeries(folder / "PMAX-withdrawal.txt", value, size);
+    createIndividualFileSeries(folder / "inflows.txt", value, size);
+    createIndividualFileSeries(folder / "lower-rule-curve.txt", value, size);
+    createIndividualFileSeries(folder / "upper-rule-curve.txt", value, size);
+
+    createIndividualFileSeries(folder / "cost-injection.txt", value, size);
+    createIndividualFileSeries(folder / "cost-withdrawal.txt", value, size);
+    createIndividualFileSeries(folder / "cost-level.txt", value, size);
+    createIndividualFileSeries(folder / "cost-variation-injection.txt", value, size);
+    createIndividualFileSeries(folder / "cost-variation-withdrawal.txt", value, size);
+}
+
+void Fixture::createFileSeries(unsigned int size)
+{
+    createIndividualFileSeries(folder / "PMAX-injection.txt", size);
+    createIndividualFileSeries(folder / "PMAX-withdrawal.txt", size);
+    createIndividualFileSeries(folder / "inflows.txt", size);
+    createIndividualFileSeries(folder / "lower-rule-curve.txt", size);
+    createIndividualFileSeries(folder / "upper-rule-curve.txt", size);
+
+    createIndividualFileSeries(folder / "cost-injection.txt", size);
+    createIndividualFileSeries(folder / "cost-withdrawal.txt", size);
+    createIndividualFileSeries(folder / "cost-level.txt", size);
+
+    createIndividualFileSeries(folder / "cost-variation-injection.txt", size);
+    createIndividualFileSeries(folder / "cost-variation-withdrawal.txt", size);
+}
 
 // ==================
 // Tests section

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -676,7 +676,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_ValidRhs, AdditionalConstraint
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
     {
-        rhsFile << i * 1.0 << "\n";
+        rhsFile << i << "\n";
     }
     rhsFile.close();
 
@@ -701,7 +701,7 @@ BOOST_FIXTURE_TEST_CASE(Load2ConstraintsFromIniFile, AdditionalConstraintsFixtur
     std::ofstream rhsFile(sts_dir / "rhs_constraint1.txt");
     for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
     {
-        rhsFile << i * 1.0 << "\n";
+        rhsFile << i << "\n";
     }
     rhsFile.close();
 
@@ -778,7 +778,7 @@ BOOST_FIXTURE_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile, AdditionalC
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (int i = 0; i < 10; ++i)
     {
-        rhsFile << i * 1.0 << "\n";
+        rhsFile << i << "\n";
     }
     rhsFile.close();
 
@@ -802,7 +802,7 @@ BOOST_DATA_TEST_CASE_F(AdditionalConstraintsFixture,
     std::ofstream rhsFile(sts_dir / "rhs_my_constr.txt");
     for (unsigned i = 0; i < HOURS_PER_YEAR; ++i)
     {
-        rhsFile << i * 1.0 << "\n";
+        rhsFile << i << "\n";
     }
     rhsFile.close();
 

--- a/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
+++ b/src/tests/src/libs/antares/study/short-term-storage-input/short-term-storage-input-output.cpp
@@ -93,7 +93,7 @@ void createIndividualFileSeries(const fs::path& path, unsigned int size)
 
 void createFileSeries(double value, unsigned int size)
 {
-    fs::path folder = fs::temp_directory_path();
+    fs::path folder = fs::temp_directory_path() / "blabla";
 
     createIndividualFileSeries(folder / "PMAX-injection.txt", value, size);
     createIndividualFileSeries(folder / "PMAX-withdrawal.txt", value, size);
@@ -110,7 +110,7 @@ void createFileSeries(double value, unsigned int size)
 
 void createFileSeries(unsigned int size)
 {
-    fs::path folder = fs::temp_directory_path();
+    fs::path folder = fs::temp_directory_path() / "blabla";
 
     createIndividualFileSeries(folder / "PMAX-injection.txt", size);
     createIndividualFileSeries(folder / "PMAX-withdrawal.txt", size);
@@ -128,7 +128,7 @@ void createFileSeries(unsigned int size)
 
 void createIniFile(bool enabled)
 {
-    fs::path folder = fs::temp_directory_path();
+    fs::path folder = fs::temp_directory_path() / "blabla";
 
     std::ofstream outfile;
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
@@ -148,7 +148,7 @@ void createIniFile(bool enabled)
 
 void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
 {
-    fs::path folder = fs::temp_directory_path();
+    fs::path folder = fs::temp_directory_path() / "blabla";
 
     std::ofstream outfile;
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
@@ -165,7 +165,7 @@ void createIniFile(const PenaltyCostOnVariation& penaltyCostOnVariation)
 
 void createIniFileWrongValue()
 {
-    fs::path folder = fs::temp_directory_path();
+    fs::path folder = fs::temp_directory_path() / "blabla";
 
     std::ofstream outfile;
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
@@ -185,7 +185,7 @@ void createIniFileWrongValue()
 
 void createEmptyIniFile()
 {
-    fs::path folder = fs::temp_directory_path();
+    fs::path folder = fs::temp_directory_path() / "blabla";
 
     std::ofstream outfile;
     outfile.open(folder / "list.ini", std::ofstream::out | std::ofstream::trunc);
@@ -195,7 +195,7 @@ void createEmptyIniFile()
 
 void removeIniFile()
 {
-    fs::remove(fs::temp_directory_path() / "list.ini");
+    fs::remove(fs::temp_directory_path() / "blabla" / "list.ini");
 }
 } // namespace
 
@@ -208,22 +208,15 @@ struct Fixture
     Fixture(const Fixture&& f) = delete;
     Fixture& operator=(const Fixture& f) = delete;
     Fixture& operator=(const Fixture&& f) = delete;
-    Fixture() = default;
+    Fixture()
+    {
+        folder = fs::temp_directory_path() / "blabla";
+        fs::create_directories(folder);
+    }
 
     ~Fixture()
     {
-        fs::remove(folder / "PMAX-injection.txt");
-        fs::remove(folder / "PMAX-withdrawal.txt");
-        fs::remove(folder / "inflows.txt");
-        fs::remove(folder / "lower-rule-curve.txt");
-        fs::remove(folder / "upper-rule-curve.txt");
-
-        fs::remove(folder / "cost-injection.txt");
-        fs::remove(folder / "cost-withdrawal.txt");
-        fs::remove(folder / "cost-level.txt");
-
-        fs::remove(folder / "cost-variation-injection.txt");
-        fs::remove(folder / "cost-variation-withdrawal.txt");
+        fs::remove_all(folder);
     }
 
     bool loadFromFolder(StudyVersion version)
@@ -231,7 +224,8 @@ struct Fixture
         return series.loadFromFolder(folder, version);
     }
 
-    fs::path folder = fs::temp_directory_path();
+    fs::path folder;
+
     ShortTermStorage::Series series;
     ShortTermStorage::Properties properties;
     ShortTermStorage::STStorageCluster cluster;
@@ -386,11 +380,11 @@ BOOST_FIXTURE_TEST_CASE(check_cluster_series_load_vector, Fixture)
 
     BOOST_CHECK(cluster.loadSeries(folder, StudyVersion::latest()));
     BOOST_CHECK(cluster.series->validate("", StudyVersion::latest()));
-    BOOST_CHECK(cluster.series->maxWithdrawalModulation[0] == 0.5
-                && cluster.series->inflows.getCoefficient(0, 2756) == 0.5
-                && cluster.series->lowerRuleCurve[6392] == 0.5
-                && cluster.series->costVariationInjection[15] == 0.5
-                && cluster.series->costVariationWithdrawal[756] == 0.5);
+    BOOST_CHECK(cluster.series->maxWithdrawalModulation[0] == 0.5);
+    BOOST_CHECK(cluster.series->inflows.getCoefficient(0, 2756) == 0.5);
+    BOOST_CHECK(cluster.series->lowerRuleCurve[6392] == 0.5);
+    BOOST_CHECK(cluster.series->costVariationInjection[15] == 0.5);
+    BOOST_CHECK(cluster.series->costVariationWithdrawal[756] == 0.5);
 }
 
 BOOST_FIXTURE_TEST_CASE(check_container_properties_enabled_load, Fixture)
@@ -645,8 +639,8 @@ BOOST_AUTO_TEST_SUITE(LoadingAdditionalConstraints)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidFile)
 {
-    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "cluster1");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
@@ -667,13 +661,13 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidFile)
     BOOST_CHECK_EQUAL(storageInput.storagesByIndex[0].additionalConstraints[0]->name,
                       "constraint1");
 
-    std::filesystem::remove_all(testPath);
+    fs::remove_all(testPath);
 }
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidHours)
 {
-    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "ClusterA");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "ClusterA");
 
     std::ofstream iniFile(testPath / "ClusterA" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
@@ -690,7 +684,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidHours)
     bool result = storageInput.loadAdditionalConstraints(testPath);
     BOOST_CHECK_EQUAL(result, false);
 
-    std::filesystem::remove_all(testPath);
+    fs::remove_all(testPath);
 }
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
@@ -702,8 +696,8 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingFile)
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidConstraint)
 {
-    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "cluster1");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
@@ -720,13 +714,13 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_InvalidConstraint)
     bool result = storageInput.loadAdditionalConstraints(testPath);
     BOOST_CHECK_EQUAL(result, false);
 
-    std::filesystem::remove_all(testPath);
+    fs::remove_all(testPath);
 }
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidRhs)
 {
-    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "cluster1");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
@@ -755,13 +749,13 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_ValidRhs)
     BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, 0), 0.0);
     BOOST_CHECK_EQUAL(constraint1Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), HOURS_PER_YEAR - 1);
 
-    std::filesystem::remove_all(testPath);
+    fs::remove_all(testPath);
 }
 
 BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
 {
-    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "cluster1");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
     iniFile << R"([constraint1]
@@ -816,13 +810,13 @@ BOOST_AUTO_TEST_CASE(Load2ConstraintsFromIniFile)
     BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, 0), 0.0);
     BOOST_CHECK_EQUAL(constraint2Rhs.getCoefficient(0, HOURS_PER_YEAR - 1), 0);
 
-    std::filesystem::remove_all(testPath);
+    fs::remove_all(testPath);
 }
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingRhsFile)
 {
-    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "cluster1");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
@@ -843,13 +837,13 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MissingRhsFile)
     BOOST_CHECK_EQUAL(constraintRhs.timeSeries.height, HOURS_PER_YEAR);
     BOOST_CHECK_EQUAL(constraintRhs.getCoefficient(0, 0), 0.0);
 
-    std::filesystem::remove_all(testPath);
+    fs::remove_all(testPath);
 }
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile)
 {
-    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "cluster1");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
@@ -869,13 +863,13 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_MalformedRhsFile)
 
     bool result = storageInput.loadAdditionalConstraints(testPath);
     BOOST_CHECK_EQUAL(result, false);
-    std::filesystem::remove_all(testPath);
+    fs::remove_all(testPath);
 }
 
 BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile)
 {
-    std::filesystem::path testPath = fs::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "cluster1");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "cluster1");
 
     std::ofstream iniFile(testPath / "cluster1" / "additional-constraints.ini");
     iniFile << "[constraint1]\n";
@@ -899,7 +893,7 @@ BOOST_AUTO_TEST_CASE(loadAdditionalConstraints_IncompleteRhsFile)
     bool result = storageInput.loadAdditionalConstraints(testPath);
     BOOST_CHECK_EQUAL(result, false);
 
-    std::filesystem::remove_all(testPath);
+    fs::remove_all(testPath);
 }
 
 BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
@@ -909,8 +903,8 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
                      op)
 {
     // Define the path for the test data
-    std::filesystem::path testPath = std::filesystem::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "clustera");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "clustera");
 
     // Write the `.ini` file for this test case
     std::ofstream iniFile(testPath / "clustera" / "additional-constraints.ini");
@@ -966,8 +960,8 @@ BOOST_DATA_TEST_CASE(Validate_AllVariableOperatorCombinationsFromFile,
 BOOST_AUTO_TEST_CASE(Load_disabled)
 {
     // Define the path for the test data
-    std::filesystem::path testPath = std::filesystem::temp_directory_path() / "test_data";
-    std::filesystem::create_directories(testPath / "clustera");
+    fs::path testPath = fs::temp_directory_path() / "test_data";
+    fs::create_directories(testPath / "clustera");
 
     // Write the `.ini` file for this test case
     std::ofstream iniFile(testPath / "clustera" / "additional-constraints.ini");


### PR DESCRIPTION
What is done here : 
- [x] unit tests still do exactly the same things they used to do
-  [x] renaming
-  [x] removing code duplication (especially by introducing fixtures)
-  [x] make test more simple

As a result, the test file is much shorter.