### PR TITLE
Add week number to additional constraint name

### DIFF
--- a/src/solver/optimisation/constraints/ShortTermStorageCumulation.cpp
+++ b/src/solver/optimisation/constraints/ShortTermStorageCumulation.cpp
@@ -74,6 +74,7 @@ char ConvertSense(const std::string& sense)
 void ShortTermStorageCumulation::add(int pays)
 {
     ConstraintNamer namer(builder.data.NomDesContraintes);
+    namer.UpdateTimeStep(builder.data.weekInTheYear);
     namer.UpdateArea(builder.data.NomsDesPays[pays]);
 
     for (const auto& storage: data.ShortTermStorage[pays])

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -426,10 +426,11 @@ void ConstraintNamer::ShortTermStorageCumulation(const std::string& constraint_t
                                                  const std::string& short_term_name,
                                                  const std::string& constraint_name)
 {
-    targetUpdater_.UpdateTargetAtIndex(
-      BuildName(constraint_type,
-                LocationIdentifier(area_, AREA) + SEPARATOR + "ShortTermStorage" + "<"
-                  + short_term_name + ">",
-                ShortTermStorageCumulationIdentifier(constraint_name)),
-      constraint);
+    targetUpdater_.UpdateTargetAtIndex(BuildName(constraint_type,
+                                                 LocationIdentifier(area_, AREA) + SEPARATOR
+                                                   + "ShortTermStorage" + "<" + short_term_name
+                                                   + ">" + SEPARATOR + "Constraint" + "<"
+                                                   + constraint_name + ">",
+                                                 TimeIdentifier(timeStep_, WEEK)),
+                                       constraint);
 }

--- a/src/tests/src/solver/optimisation/constraints/CMakeLists.txt
+++ b/src/tests/src/solver/optimisation/constraints/CMakeLists.txt
@@ -5,3 +5,10 @@ add_boost_test(constraints_builder
         constraints_builder.cpp
         LIBS
 	solver-lib)
+
+add_boost_test(constraints_namer
+        SRC
+        constraints_namer.cpp
+        LIBS
+	model_antares)
+

--- a/src/tests/src/solver/optimisation/constraints/constraints_builder.cpp
+++ b/src/tests/src/solver/optimisation/constraints/constraints_builder.cpp
@@ -227,10 +227,10 @@ BOOST_FIXTURE_TEST_CASE(AddWithdrawalConstraint, BB)
     // Verify that the constraint names are correctly generated and stored
     BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[0],
                       "WithdrawalSum::area<CountryA>::ShortTermStorage<cluster_1>::Constraint<"
-                      "addc1_withdrawal_0>"); // Assuming this is the generated name
+                      "addc1_withdrawal_0>::week<1>"); // Assuming this is the generated name
     BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[1],
                       "WithdrawalSum::area<CountryA>::ShortTermStorage<cluster_1>::Constraint<"
-                      "addc1_withdrawal_1>"); // Check the second constraint
+                      "addc1_withdrawal_1>::week<1>"); // Check the second constraint
     //
     // // Verify that the correct number of terms have been added to the matrix
     BOOST_CHECK_EQUAL(builder.data.nombreDeTermesDansLaMatriceDeContrainte, 4);
@@ -278,10 +278,10 @@ BOOST_FIXTURE_TEST_CASE(AddInjectionConstraint, BB)
     // Verify that the constraint names are correctly generated and stored
     BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[0],
                       "InjectionSum::area<CountryB>::ShortTermStorage<cluster_2>::Constraint<addc2_"
-                      "injection_0>"); // Assuming this is the generated name
+                      "injection_0>::week<1>"); // Assuming this is the generated name
     BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[1],
                       "InjectionSum::area<CountryB>::ShortTermStorage<cluster_2>::Constraint<addc2_"
-                      "injection_1>"); // Check the second constraint
+                      "injection_1>::week<1>"); // Check the second constraint
     //
     // // Verify that the correct number of terms have been added to the matrix
     BOOST_CHECK_EQUAL(builder.data.nombreDeTermesDansLaMatriceDeContrainte, 4);
@@ -329,10 +329,10 @@ BOOST_FIXTURE_TEST_CASE(AddNettingConstraint, BB)
     // Verify that the constraint names are correctly generated and stored
     BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[0],
                       "NettingSum::area<CountryC>::ShortTermStorage<cluster_3>::Constraint<addc3_"
-                      "netting_0>"); // Assuming this is the generated name
+                      "netting_0>::week<1>"); // Assuming this is the generated name
     BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[1],
                       "NettingSum::area<CountryC>::ShortTermStorage<cluster_3>::Constraint<addc3_"
-                      "netting_1>"); // Check the second constraint
+                      "netting_1>::week<1>"); // Check the second constraint
     //
     // // Verify that the correct number of terms have been added to the matrix
     BOOST_CHECK_EQUAL(builder.data.nombreDeTermesDansLaMatriceDeContrainte, 8);
@@ -378,18 +378,18 @@ BOOST_FIXTURE_TEST_CASE(MultipleAreasTest, BB)
     BOOST_CHECK_EQUAL(builder.data.nombreDeContraintes, 4);
 
     // Verify the names of the constraints for both countries
-    BOOST_CHECK_EQUAL(
-      builder.data.NomDesContraintes[0],
-      "WithdrawalSum::area<CountryA>::ShortTermStorage<cluster_1>::Constraint<addc1_withdrawal_0>");
-    BOOST_CHECK_EQUAL(
-      builder.data.NomDesContraintes[1],
-      "WithdrawalSum::area<CountryA>::ShortTermStorage<cluster_1>::Constraint<addc1_withdrawal_1>");
-    BOOST_CHECK_EQUAL(
-      builder.data.NomDesContraintes[2],
-      "InjectionSum::area<CountryB>::ShortTermStorage<cluster_2>::Constraint<addc2_injection_0>");
-    BOOST_CHECK_EQUAL(
-      builder.data.NomDesContraintes[3],
-      "InjectionSum::area<CountryB>::ShortTermStorage<cluster_2>::Constraint<addc2_injection_1>");
+    BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[0],
+                      "WithdrawalSum::area<CountryA>::ShortTermStorage<cluster_1>::Constraint<"
+                      "addc1_withdrawal_0>::week<1>");
+    BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[1],
+                      "WithdrawalSum::area<CountryA>::ShortTermStorage<cluster_1>::Constraint<"
+                      "addc1_withdrawal_1>::week<1>");
+    BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[2],
+                      "InjectionSum::area<CountryB>::ShortTermStorage<cluster_2>::Constraint<addc2_"
+                      "injection_0>::week<1>");
+    BOOST_CHECK_EQUAL(builder.data.NomDesContraintes[3],
+                      "InjectionSum::area<CountryB>::ShortTermStorage<cluster_2>::Constraint<addc2_"
+                      "injection_1>::week<1>");
 
     // Check if the sense of constraints was updated correctly for all areas
     BOOST_CHECK_EQUAL(builder.data.Sens[0], '<');

--- a/src/tests/src/solver/optimisation/constraints/constraints_namer.cpp
+++ b/src/tests/src/solver/optimisation/constraints/constraints_namer.cpp
@@ -1,0 +1,29 @@
+#include <string>
+#include <vector>
+
+#include <antares/solver/optimisation/opt_rename_problem.h>
+
+#define BOOST_TEST_MODULE "constraints_namer"
+
+#include <boost/test/unit_test.hpp>
+
+constexpr std::size_t kNbConstraints = 2;
+
+BOOST_AUTO_TEST_CASE(cumulation_constraint)
+{
+    int constraintGlobalIndex = 0;
+    std::vector<std::string> constraintNames(kNbConstraints);
+
+    ConstraintNamer namer(constraintNames);
+    namer.UpdateArea("fr");
+
+    namer.UpdateTimeStep(33);
+    namer.ShortTermStorageCumulation("a", constraintGlobalIndex++, "b", "c");
+    BOOST_CHECK_EQUAL(constraintNames[0],
+                      "a::area<fr>::ShortTermStorage<b>::Constraint<c>::week<33>");
+
+    namer.UpdateTimeStep(34);
+    namer.ShortTermStorageCumulation("a", constraintGlobalIndex++, "b", "c");
+    BOOST_CHECK_EQUAL(constraintNames[1],
+                      "a::area<fr>::ShortTermStorage<b>::Constraint<c>::week<34>");
+}

--- a/src/tests/src/solver/optimisation/constraints/constraints_namer.cpp
+++ b/src/tests/src/solver/optimisation/constraints/constraints_namer.cpp
@@ -9,6 +9,8 @@
 
 constexpr std::size_t kNbConstraints = 2;
 
+// TODO add more tests
+
 BOOST_AUTO_TEST_CASE(cumulation_constraint)
 {
     int constraintGlobalIndex = 0;


### PR DESCRIPTION
## Short description
The absence of a week number would trigger an error in Xpansion

## Before/after
Study valid-v920/ST-additional-constraints
Output file problem-1-1--optim-nb-1.mps

```diff
- E  WithdrawalSum::area<area>::ShortTermStorage<cluster-11>::Constraint<withdrawal-1_0>
+ E  WithdrawalSum::area<area>::ShortTermStorage<cluster-11>::Constraint<withdrawal-1_0>::week<1>
```