### PR TITLE
Namers (variables and constraints) : improve readability

### DIFF
--- a/src/solver/optimisation/adequacy_patch_csr/constraints/CsrBindingConstraintHour.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/constraints/CsrBindingConstraintHour.cpp
@@ -54,7 +54,7 @@ void CsrBindingConstraintHour::add(int CntCouplante)
 
         ConstraintNamer namer(builder.data.NomDesContraintes);
         namer.UpdateTimeStep(data.hour);
-        namer.CsrBindingConstraintHour(
+        namer.BindingConstraintHour(
           builder.data.nombreDeContraintes,
           data.MatriceDesContraintesCouplantes[CntCouplante].NomDeLaContrainteCouplante);
         builder.SetOperator(

--- a/src/solver/optimisation/adequacy_patch_csr/constraints/CsrFlowDissociation.cpp
+++ b/src/solver/optimisation/adequacy_patch_csr/constraints/CsrFlowDissociation.cpp
@@ -45,7 +45,8 @@ void CsrFlowDissociation::add()
                                    .NomsDesPays[data.PaysOrigineDeLInterconnexion[interco]];
             const auto& destination = builder.data
                                         .NomsDesPays[data.PaysExtremiteDeLInterconnexion[interco]];
-            namer.CsrFlowDissociation(builder.data.nombreDeContraintes, origin, destination);
+            namer.updateExtremities(origin, destination);
+            namer.CsrFlowDissociation(builder.data.nombreDeContraintes);
             builder.equalTo();
             builder.build();
         }

--- a/src/solver/optimisation/constraints/FlowDissociation.cpp
+++ b/src/solver/optimisation/constraints/FlowDissociation.cpp
@@ -32,8 +32,9 @@ void FlowDissociation::add(int pdt, int interco)
         const auto destination = builder.data
                                    .NomsDesPays[data.PaysExtremiteDeLInterconnexion[interco]];
         ConstraintNamer namer(builder.data.NomDesContraintes);
+        namer.updateExtremities(origin, destination);
         namer.UpdateTimeStep(builder.data.weekInTheYear * 168 + pdt);
-        namer.FlowDissociation(builder.data.nombreDeContraintes, origin, destination);
+        namer.FlowDissociation(builder.data.nombreDeContraintes);
 
         builder.updateHourWithinWeek(pdt);
         builder.NTCDirect(interco, 1.0)

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -128,6 +128,7 @@ public:
                                     unsigned constrIndex,
                                     const std::string& sts_name,
                                     const std::string& constrIndex_name);
+
 private:
     void BindingConstraint(unsigned constrIndex,
                            const std::string& name,

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -26,26 +26,10 @@
 class Namer
 {
 public:
-    explicit Namer(std::vector<std::string>& target_names):
-        names_(target_names)
-    {
-    }
-
-    void UpdateTimeStep(unsigned timeStep)
-    {
-        timeStep_ = timeStep;
-    }
-
-    void UpdateArea(const std::string& area)
-    {
-        area_ = area;
-    }
-
-    void updateExtremities(const std::string& origin, const std::string& destination)
-    {
-        origin_ = origin;
-        destination_ = destination;
-    }
+    explicit Namer(std::vector<std::string>& target_names);
+    void UpdateTimeStep(unsigned timeStep);
+    void UpdateArea(const std::string& area);
+    void updateExtremities(const std::string& origin, const std::string& destination);
 
 protected:
     void SetLinkElementName(unsigned varIndex, const std::string& variableType);
@@ -60,14 +44,14 @@ protected:
     std::string TimeIdentifier(const std::string& timeStepType);
     std::string linkLocation();
     std::string areaLocation();
-
-    std::vector<std::string>& names_;
+    std::vector<std::string>& names();
 
 private:
     std::string origin_;
     std::string destination_;
     std::string area_;
     unsigned timeStep_ = 0;
+    std::vector<std::string>& names_;
 };
 
 class VariableNamer: public Namer
@@ -138,11 +122,9 @@ public:
     void CsrFlowDissociation(unsigned constrIndex);
     void CsrAreaBalance(unsigned constrIndex);
     void CsrBindingConstraintHour(unsigned constrIndex, const std::string& name);
-
     void ShortTermStorageCostVariation(const std::string& constrIndex_name,
                                        unsigned constrIndex,
                                        const std::string& sts_name);
-
     void ShortTermStorageCumulation(const std::string& constraint_type,
                                     unsigned constrIndex,
                                     const std::string& sts_name,

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -23,32 +23,15 @@
 #include <string>
 #include <vector>
 
-class TargetVectorUpdater
-{
-public:
-    explicit TargetVectorUpdater(std::vector<std::string>& target):
-        target_(target)
-    {
-    }
-
-    void UpdateTargetAtIndex(const std::string& full_name, unsigned int index)
-    {
-        target_[index] = full_name;
-    }
-
-private:
-    std::vector<std::string>& target_;
-};
-
 class Namer
 {
 public:
-    explicit Namer(std::vector<std::string>& target):
-        targetUpdater_(target)
+    explicit Namer(std::vector<std::string>& target_names):
+        names_(target_names)
     {
     }
 
-    void UpdateTimeStep(unsigned int timeStep)
+    void UpdateTimeStep(unsigned timeStep)
     {
         timeStep_ = timeStep;
     }
@@ -58,68 +41,63 @@ public:
         area_ = area;
     }
 
-    void SetLinkElementName(unsigned int variable, const std::string& variableType);
-    void SetAreaElementNameHour(unsigned int variable, const std::string& variableType);
-    void SetAreaElementNameWeek(unsigned int variable, const std::string& variableType);
-    void SetAreaElementName(unsigned int variable,
-                            const std::string& variableType,
+protected:
+    void SetLinkElementName(unsigned varIndex, const std::string& varIndexType);
+    void SetAreaElementNameHour(unsigned varIndex, const std::string& varIndexType);
+    void SetAreaElementNameWeek(unsigned varIndex, const std::string& varIndexType);
+    void SetAreaElementName(unsigned varIndex,
+                            const std::string& varIndexType,
                             const std::string& timeStepType);
-    void SetThermalClusterElementName(unsigned int variable,
-                                      const std::string& variableType,
+    void SetThermalClusterElementName(unsigned varIndex,
+                                      const std::string& varIndexType,
                                       const std::string& clusterName);
 
-    unsigned int timeStep_ = 0;
+    unsigned timeStep_ = 0;
     std::string origin_;
     std::string destination_;
     std::string area_;
-    TargetVectorUpdater targetUpdater_;
+    std::vector<std::string>& names_;
 };
 
 class VariableNamer: public Namer
 {
 public:
     using Namer::Namer;
-    void DispatchableProduction(unsigned int variable, const std::string& clusterName);
-    void NODU(unsigned int variable, const std::string& clusterName);
-    void NumberStoppingDispatchableUnits(unsigned int variable, const std::string& clusterName);
-    void NumberStartingDispatchableUnits(unsigned int variable, const std::string& clusterName);
-    void NumberBreakingDownDispatchableUnits(unsigned int variable, const std::string& clusterName);
-    void NTCDirect(unsigned int variable,
-                   const std::string& origin,
-                   const std::string& destination);
-    void IntercoDirectCost(unsigned int variable,
+    void DispatchableProduction(unsigned varIndex, const std::string& clusterName);
+    void NODU(unsigned varIndex, const std::string& clusterName);
+    void NumberStoppingDispatchableUnits(unsigned varIndex, const std::string& clusterName);
+    void NumberStartingDispatchableUnits(unsigned varIndex, const std::string& clusterName);
+    void NumberBreakingDownDispatchableUnits(unsigned varIndex, const std::string& clusterName);
+    void NTCDirect(unsigned varIndex, const std::string& origin, const std::string& destination);
+    void IntercoDirectCost(unsigned varIndex,
                            const std::string& origin,
                            const std::string& destination);
-    void IntercoIndirectCost(unsigned int variable,
+    void IntercoIndirectCost(unsigned varIndex,
                              const std::string& origin,
                              const std::string& destination);
-    void ShortTermStorageInjection(unsigned int variable, const std::string& shortTermStorageName);
-    void ShortTermStorageWithdrawal(unsigned int variable, const std::string& shortTermStorageName);
-    void ShortTermStorageLevel(unsigned int variable, const std::string& shortTermStorageName);
-    void ShortTermStorageOverflow(unsigned int variable, const std::string& shortTermStorageName);
-    void ShortTermStorageCostVariationInjection(unsigned int variable,
-                                                const std::string& shortTermStorageName);
-    void ShortTermStorageCostVariationWithdrawal(unsigned int variable,
-                                                 const std::string& shortTermStorageName);
-    void HydProd(unsigned int variable);
-    void HydProdDown(unsigned int variable);
-    void HydProdUp(unsigned int variable);
-    void Pumping(unsigned int variable);
-    void HydroLevel(unsigned int variable);
-    void Overflow(unsigned int variable);
-    void FinalStorage(unsigned int variable);
-    void LayerStorage(unsigned int variable, int layerIndex);
-    void PositiveUnsuppliedEnergy(unsigned int variable);
-    void NegativeUnsuppliedEnergy(unsigned int variable);
-    void AreaBalance(unsigned int variable);
+    void ShortTermStorageInjection(unsigned varIndex, const std::string& sts_name);
+    void ShortTermStorageWithdrawal(unsigned varIndex, const std::string& sts_name);
+    void ShortTermStorageLevel(unsigned varIndex, const std::string& sts_name);
+    void ShortTermStorageOverflow(unsigned varIndex, const std::string& sts_name);
+    void ShortTermStorageCostVariationInjection(unsigned varIndex, const std::string& sts_name);
+    void ShortTermStorageCostVariationWithdrawal(unsigned varIndex, const std::string& sts_name);
+    void HydProd(unsigned varIndex);
+    void HydProdDown(unsigned varIndex);
+    void HydProdUp(unsigned varIndex);
+    void Pumping(unsigned varIndex);
+    void HydroLevel(unsigned varIndex);
+    void Overflow(unsigned varIndex);
+    void FinalStorage(unsigned varIndex);
+    void LayerStorage(unsigned varIndex, int layerIndex);
+    void PositiveUnsuppliedEnergy(unsigned varIndex);
+    void NegativeUnsuppliedEnergy(unsigned varIndex);
+    void AreaBalance(unsigned varIndex);
 
 private:
-    void SetAreaVariableName(unsigned int variable,
-                             const std::string& variableType,
-                             int layerIndex);
-    void SetShortTermStorageVariableName(unsigned int variable,
-                                         const std::string& variableType,
-                                         const std::string& shortTermStorageName);
+    void SetAreaVariableName(unsigned varIndex, const std::string& varIndexType, int layerIndex);
+    void SetShortTermStorageVariableName(unsigned varIndex,
+                                         const std::string& varIndexType,
+                                         const std::string& sts_name);
 };
 
 class ConstraintNamer: public Namer
@@ -127,50 +105,50 @@ class ConstraintNamer: public Namer
 public:
     using Namer::Namer;
 
-    void FlowDissociation(unsigned int constraint,
+    void FlowDissociation(unsigned constrIndex,
                           const std::string& origin,
                           const std::string& destination);
 
-    void AreaBalance(unsigned int constraint);
-    void FictiveLoads(unsigned int constraint);
-    void HydroPower(unsigned int constraint);
-    void HydroPowerSmoothingUsingVariationSum(unsigned int constraint);
-    void HydroPowerSmoothingUsingVariationMaxDown(unsigned int constraint);
-    void HydroPowerSmoothingUsingVariationMaxUp(unsigned int constraint);
-    void MinHydroPower(unsigned int constraint);
-    void MaxHydroPower(unsigned int constraint);
-    void MaxPumping(unsigned int constraint);
-    void AreaHydroLevel(unsigned int constraint);
-    void FinalStockEquivalent(unsigned int constraint);
-    void FinalStockExpression(unsigned int constraint);
-    void NbUnitsOutageLessThanNbUnitsStop(unsigned int constraint, const std::string& clusterName);
-    void NbDispUnitsMinBoundSinceMinUpTime(unsigned int constraint, const std::string& clusterName);
-    void MinDownTime(unsigned int constraint, const std::string& clusterName);
-    void PMaxDispatchableGeneration(unsigned int constraint, const std::string& clusterName);
-    void PMinDispatchableGeneration(unsigned int constraint, const std::string& clusterName);
-    void ConsistenceNODU(unsigned int constraint, const std::string& clusterName);
-    void ShortTermStorageLevel(unsigned int constraint, const std::string& name);
-    void BindingConstraintHour(unsigned int constraint, const std::string& name);
-    void BindingConstraintDay(unsigned int constraint, const std::string& name);
-    void BindingConstraintWeek(unsigned int constraint, const std::string& name);
-    void CsrFlowDissociation(unsigned int constraint,
+    void AreaBalance(unsigned constrIndex);
+    void FictiveLoads(unsigned constrIndex);
+    void HydroPower(unsigned constrIndex);
+    void HydroPowerSmoothingUsingVariationSum(unsigned constrIndex);
+    void HydroPowerSmoothingUsingVariationMaxDown(unsigned constrIndex);
+    void HydroPowerSmoothingUsingVariationMaxUp(unsigned constrIndex);
+    void MinHydroPower(unsigned constrIndex);
+    void MaxHydroPower(unsigned constrIndex);
+    void MaxPumping(unsigned constrIndex);
+    void AreaHydroLevel(unsigned constrIndex);
+    void FinalStockEquivalent(unsigned constrIndex);
+    void FinalStockExpression(unsigned constrIndex);
+    void NbUnitsOutageLessThanNbUnitsStop(unsigned constrIndex, const std::string& clusterName);
+    void NbDispUnitsMinBoundSinceMinUpTime(unsigned constrIndex, const std::string& clusterName);
+    void MinDownTime(unsigned constrIndex, const std::string& clusterName);
+    void PMaxDispatchableGeneration(unsigned constrIndex, const std::string& clusterName);
+    void PMinDispatchableGeneration(unsigned constrIndex, const std::string& clusterName);
+    void ConsistenceNODU(unsigned constrIndex, const std::string& clusterName);
+    void ShortTermStorageLevel(unsigned constrIndex, const std::string& name);
+    void BindingConstraintHour(unsigned constrIndex, const std::string& name);
+    void BindingConstraintDay(unsigned constrIndex, const std::string& name);
+    void BindingConstraintWeek(unsigned constrIndex, const std::string& name);
+    void CsrFlowDissociation(unsigned constrIndex,
                              const std::string& origin,
                              const std::string& destination);
 
-    void CsrAreaBalance(unsigned int constraint);
-    void CsrBindingConstraintHour(unsigned int constraint, const std::string& name);
+    void CsrAreaBalance(unsigned constrIndex);
+    void CsrBindingConstraintHour(unsigned constrIndex, const std::string& name);
 
-    void ShortTermStorageCostVariation(const std::string& constraint_name,
-                                       unsigned int constraint,
+    void ShortTermStorageCostVariation(const std::string& constrIndex_name,
+                                       unsigned constrIndex,
                                        const std::string& sts_name);
 
-    void ShortTermStorageCumulation(const std::string& constraint_type,
-                                    unsigned int constraint,
+    void ShortTermStorageCumulation(const std::string& constrIndex_type,
+                                    unsigned constrIndex,
                                     const std::string& sts_name,
-                                    const std::string& constraint_name);
+                                    const std::string& constrIndex_name);
 
 private:
-    void nameWithTimeGranularity(unsigned int constraint,
+    void nameWithTimeGranularity(unsigned constrIndex,
                                  const std::string& name,
                                  const std::string& type);
 };

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -42,14 +42,14 @@ public:
     }
 
 protected:
-    void SetLinkElementName(unsigned varIndex, const std::string& varIndexType);
-    void SetAreaElementNameHour(unsigned varIndex, const std::string& varIndexType);
-    void SetAreaElementNameWeek(unsigned varIndex, const std::string& varIndexType);
+    void SetLinkElementName(unsigned varIndex, const std::string& variableType);
+    void SetAreaElementNameHour(unsigned varIndex, const std::string& variableType);
+    void SetAreaElementNameWeek(unsigned varIndex, const std::string& variableType);
     void SetAreaElementName(unsigned varIndex,
-                            const std::string& varIndexType,
+                            const std::string& variableType,
                             const std::string& timeStepType);
     void SetThermalClusterElementName(unsigned varIndex,
-                                      const std::string& varIndexType,
+                                      const std::string& variableType,
                                       const std::string& clusterName);
 
     unsigned timeStep_ = 0;
@@ -94,9 +94,9 @@ public:
     void AreaBalance(unsigned varIndex);
 
 private:
-    void SetAreaVariableName(unsigned varIndex, const std::string& varIndexType, int layerIndex);
+    void SetAreaVariableName(unsigned varIndex, const std::string& variableType, int layerIndex);
     void SetShortTermStorageVariableName(unsigned varIndex,
-                                         const std::string& varIndexType,
+                                         const std::string& variableType,
                                          const std::string& sts_name);
 };
 
@@ -142,7 +142,7 @@ public:
                                        unsigned constrIndex,
                                        const std::string& sts_name);
 
-    void ShortTermStorageCumulation(const std::string& constrIndex_type,
+    void ShortTermStorageCumulation(const std::string& constraint_type,
                                     unsigned constrIndex,
                                     const std::string& sts_name,
                                     const std::string& constrIndex_name);

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -41,6 +41,12 @@ public:
         area_ = area;
     }
 
+    void updateExtremities(const std::string& origin, const std::string& destination)
+    {
+        origin_ = origin;
+        destination_ = destination;
+    }
+
 protected:
     void SetLinkElementName(unsigned varIndex, const std::string& variableType);
     void SetAreaElementNameHour(unsigned varIndex, const std::string& variableType);
@@ -52,13 +58,15 @@ protected:
                                       const std::string& variableType,
                                       const std::string& clusterName);
     std::string TimeIdentifier(const std::string& timeStepType);
+    std::string linkLocation();
+    std::string areaLocation();
 
-    std::string origin_;
-    std::string destination_;
-    std::string area_;
     std::vector<std::string>& names_;
 
 private:
+    std::string origin_;
+    std::string destination_;
+    std::string area_;
     unsigned timeStep_ = 0;
 };
 
@@ -71,13 +79,9 @@ public:
     void NumberStoppingDispatchableUnits(unsigned varIndex, const std::string& clusterName);
     void NumberStartingDispatchableUnits(unsigned varIndex, const std::string& clusterName);
     void NumberBreakingDownDispatchableUnits(unsigned varIndex, const std::string& clusterName);
-    void NTCDirect(unsigned varIndex, const std::string& origin, const std::string& destination);
-    void IntercoDirectCost(unsigned varIndex,
-                           const std::string& origin,
-                           const std::string& destination);
-    void IntercoIndirectCost(unsigned varIndex,
-                             const std::string& origin,
-                             const std::string& destination);
+    void NTCDirect(unsigned varIndex);
+    void IntercoDirectCost(unsigned varIndex);
+    void IntercoIndirectCost(unsigned varIndex);
     void ShortTermStorageInjection(unsigned varIndex, const std::string& sts_name);
     void ShortTermStorageWithdrawal(unsigned varIndex, const std::string& sts_name);
     void ShortTermStorageLevel(unsigned varIndex, const std::string& sts_name);
@@ -108,10 +112,7 @@ class ConstraintNamer: public Namer
 public:
     using Namer::Namer;
 
-    void FlowDissociation(unsigned constrIndex,
-                          const std::string& origin,
-                          const std::string& destination);
-
+    void FlowDissociation(unsigned constrIndex);
     void AreaBalance(unsigned constrIndex);
     void FictiveLoads(unsigned constrIndex);
     void HydroPower(unsigned constrIndex);
@@ -134,10 +135,7 @@ public:
     void BindingConstraintHour(unsigned constrIndex, const std::string& name);
     void BindingConstraintDay(unsigned constrIndex, const std::string& name);
     void BindingConstraintWeek(unsigned constrIndex, const std::string& name);
-    void CsrFlowDissociation(unsigned constrIndex,
-                             const std::string& origin,
-                             const std::string& destination);
-
+    void CsrFlowDissociation(unsigned constrIndex);
     void CsrAreaBalance(unsigned constrIndex);
     void CsrBindingConstraintHour(unsigned constrIndex, const std::string& name);
 

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -37,11 +37,11 @@ protected:
     void SetAreaElementNameWeek(unsigned varIndex, const std::string& variableType);
     void SetAreaElementName(unsigned varIndex,
                             const std::string& variableType,
-                            const std::string& timeStepType);
+                            const std::string& timeGranularity);
     void SetThermalClusterElementName(unsigned varIndex,
                                       const std::string& variableType,
                                       const std::string& clusterName);
-    std::string TimeIdentifier(const std::string& timeStepType);
+    std::string TimeIdentifier(const std::string& timeGranularity);
     std::string linkLocation();
     std::string areaLocation();
     std::vector<std::string>& names();
@@ -121,7 +121,6 @@ public:
     void BindingConstraintWeek(unsigned constrIndex, const std::string& name);
     void CsrFlowDissociation(unsigned constrIndex);
     void CsrAreaBalance(unsigned constrIndex);
-    void CsrBindingConstraintHour(unsigned constrIndex, const std::string& name);
     void ShortTermStorageCostVariation(const std::string& constrIndex_name,
                                        unsigned constrIndex,
                                        const std::string& sts_name);
@@ -129,9 +128,8 @@ public:
                                     unsigned constrIndex,
                                     const std::string& sts_name,
                                     const std::string& constrIndex_name);
-
 private:
-    void nameWithTimeGranularity(unsigned constrIndex,
-                                 const std::string& name,
-                                 const std::string& type);
+    void BindingConstraint(unsigned constrIndex,
+                           const std::string& name,
+                           const std::pair<std::string, std::string>& timeGranularity);
 };

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -51,12 +51,15 @@ protected:
     void SetThermalClusterElementName(unsigned varIndex,
                                       const std::string& variableType,
                                       const std::string& clusterName);
+    std::string TimeIdentifier(const std::string& timeStepType);
 
-    unsigned timeStep_ = 0;
     std::string origin_;
     std::string destination_;
     std::string area_;
     std::vector<std::string>& names_;
+
+private:
+    unsigned timeStep_ = 0;
 };
 
 class VariableNamer: public Namer

--- a/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
+++ b/src/solver/optimisation/opt_construction_variables_optimisees_lineaire.cpp
@@ -51,7 +51,8 @@ void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(PROBLEME_HEBD
                                   [problemeHebdo->PaysOrigineDeLInterconnexion[interco]];
             const auto destination = problemeHebdo->NomsDesPays
                                        [problemeHebdo->PaysExtremiteDeLInterconnexion[interco]];
-            variableNamer.NTCDirect(NombreDeVariables, origin, destination);
+            variableNamer.updateExtremities(origin, destination);
+            variableNamer.NTCDirect(NombreDeVariables);
             NombreDeVariables++;
 
             if (problemeHebdo->CoutDeTransport[interco].IntercoGereeAvecDesCouts)
@@ -59,12 +60,12 @@ void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(PROBLEME_HEBD
                 variableManager.IntercoDirectCost(interco, pdt) = NombreDeVariables;
                 ProblemeAResoudre->TypeDeVariable[NombreDeVariables]
                   = VARIABLE_BORNEE_DES_DEUX_COTES;
-                variableNamer.IntercoDirectCost(NombreDeVariables, origin, destination);
+                variableNamer.IntercoDirectCost(NombreDeVariables);
                 NombreDeVariables++;
                 variableManager.IntercoIndirectCost(interco, pdt) = NombreDeVariables;
                 ProblemeAResoudre->TypeDeVariable[NombreDeVariables]
                   = VARIABLE_BORNEE_DES_DEUX_COTES;
-                variableNamer.IntercoIndirectCost(NombreDeVariables, origin, destination);
+                variableNamer.IntercoIndirectCost(NombreDeVariables);
                 NombreDeVariables++;
             }
         }

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -32,9 +32,6 @@ const std::string DAY("day");
 const std::string WEEK("week");
 const std::string LINK("link");
 const std::string AREA("area");
-const std::map<std::string, std::string> TimeGranularity = {{HOUR, "hourly"},
-                                                            {DAY, "daily"},
-                                                            {WEEK, "weekly"}};
 
 std::string ShortTermStorageCumulationIdentifier(const std::string& name)
 {
@@ -76,9 +73,9 @@ void Namer::updateExtremities(const std::string& origin, const std::string& dest
     destination_ = destination;
 }
 
-std::string Namer::TimeIdentifier(const std::string& timeStepType)
+std::string Namer::TimeIdentifier(const std::string& timeGranularity)
 {
-    return timeStepType + "<" + std::to_string(timeStep_) + ">";
+    return timeGranularity + "<" + std::to_string(timeStep_) + ">";
 }
 
 std::string Namer::linkLocation()
@@ -116,10 +113,10 @@ void Namer::SetAreaElementNameWeek(unsigned elementIndex, const std::string& ele
 
 void Namer::SetAreaElementName(unsigned elementIndex,
                                const std::string& elementType,
-                               const std::string& timeStepType)
+                               const std::string& timeGranularity)
 {
     std::string location = LocationIdentifier(area_, AREA);
-    std::string time = TimeIdentifier(timeStepType);
+    std::string time = TimeIdentifier(timeGranularity);
     std::string name = BuildName(elementType, location, time);
     names_[elementIndex] = name;
 }
@@ -359,14 +356,28 @@ void ConstraintNamer::FinalStockExpression(unsigned constrIndex)
     SetAreaElementNameHour(constrIndex, "FinalStockExpression");
 }
 
-void ConstraintNamer::nameWithTimeGranularity(unsigned constrIndex,
-                                              const std::string& name,
-                                              const std::string& type)
+void ConstraintNamer::BindingConstraint(unsigned constrIndex,
+                                        const std::string& name,
+                                        const std::pair<std::string, std::string>& timeGranularity)
 {
-    std::string granularity = TimeGranularity.at(type);
-    std::string time = TimeIdentifier(type);
-    std::string changed_name = BuildName(name, granularity, time);
-    names()[constrIndex] = changed_name;
+    std::string time = TimeIdentifier(timeGranularity.first);
+    std::string new_name = BuildName(name, timeGranularity.second, time);
+    names()[constrIndex] = new_name;
+}
+
+void ConstraintNamer::BindingConstraintHour(unsigned constrIndex, const std::string& name)
+{
+    BindingConstraint(constrIndex, name, {HOUR, "hourly"});
+}
+
+void ConstraintNamer::BindingConstraintDay(unsigned constrIndex, const std::string& name)
+{
+    BindingConstraint(constrIndex, name, {DAY, "daily"});
+}
+
+void ConstraintNamer::BindingConstraintWeek(unsigned constrIndex, const std::string& name)
+{
+    BindingConstraint(constrIndex, name, {WEEK, "weekly"});
 }
 
 void ConstraintNamer::NbUnitsOutageLessThanNbUnitsStop(unsigned constrIndex,
@@ -409,26 +420,6 @@ void ConstraintNamer::ShortTermStorageLevel(unsigned constrIndex, const std::str
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName("Level", location, time);
     names()[constrIndex] = name;
-}
-
-void ConstraintNamer::BindingConstraintHour(unsigned constrIndex, const std::string& name)
-{
-    nameWithTimeGranularity(constrIndex, name, HOUR);
-}
-
-void ConstraintNamer::CsrBindingConstraintHour(unsigned constrIndex, const std::string& name)
-{
-    nameWithTimeGranularity(constrIndex, name, HOUR);
-}
-
-void ConstraintNamer::BindingConstraintDay(unsigned constrIndex, const std::string& name)
-{
-    nameWithTimeGranularity(constrIndex, name, DAY);
-}
-
-void ConstraintNamer::BindingConstraintWeek(unsigned constrIndex, const std::string& name)
-{
-    nameWithTimeGranularity(constrIndex, name, WEEK);
 }
 
 void ConstraintNamer::ShortTermStorageCostVariation(const std::string& constraint_name,

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -57,9 +57,19 @@ std::string Namer::TimeIdentifier(const std::string& timeStepType)
     return timeStepType + "<" + std::to_string(timeStep_) + ">";
 }
 
+std::string Namer::linkLocation()
+{
+    return LocationIdentifier(origin_ + AREA_SEP + destination_, LINK);
+}
+
+std::string Namer::areaLocation()
+{
+    return LocationIdentifier(area_, AREA);
+}
+
 void Namer::SetLinkElementName(unsigned elementIndex, const std::string& elementType)
 {
-    std::string location = LocationIdentifier(origin_ + AREA_SEP + destination_, LINK);
+    std::string location = linkLocation();
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(elementType, location, time);
     names_[elementIndex] = name;
@@ -89,8 +99,7 @@ void VariableNamer::SetAreaVariableName(unsigned varIndex,
                                         const std::string& variableType,
                                         int layerIndex)
 {
-    std::string location = LocationIdentifier(area_, AREA) + SEP + "Layer<"
-                           + std::to_string(layerIndex) + ">";
+    std::string location = areaLocation() + SEP + "Layer<" + std::to_string(layerIndex) + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(variableType, location, time);
     names_[varIndex] = name;
@@ -100,8 +109,7 @@ void Namer::SetThermalClusterElementName(unsigned varIndex,
                                          const std::string& elementType,
                                          const std::string& clusterName)
 {
-    std::string location = LocationIdentifier(area_, AREA) + SEP + "ThermalCluster" + "<"
-                           + clusterName + ">";
+    std::string location = areaLocation() + SEP + "ThermalCluster" + "<" + clusterName + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(elementType, location, time);
     names_[varIndex] = name;
@@ -135,30 +143,18 @@ void VariableNamer::NumberBreakingDownDispatchableUnits(unsigned varIndex,
     SetThermalClusterElementName(varIndex, "NumberBreakingDownDispatchableUnits", clusterName);
 }
 
-void VariableNamer::NTCDirect(unsigned varIndex,
-                              const std::string& origin,
-                              const std::string& destination)
+void VariableNamer::NTCDirect(unsigned varIndex)
 {
-    origin_ = origin;
-    destination_ = destination;
     SetLinkElementName(varIndex, "NTCDirect");
 }
 
-void VariableNamer::IntercoDirectCost(unsigned varIndex,
-                                      const std::string& origin,
-                                      const std::string& destination)
+void VariableNamer::IntercoDirectCost(unsigned varIndex)
 {
-    origin_ = origin;
-    destination_ = destination;
     SetLinkElementName(varIndex, "IntercoDirectCost");
 }
 
-void VariableNamer::IntercoIndirectCost(unsigned varIndex,
-                                        const std::string& origin,
-                                        const std::string& destination)
+void VariableNamer::IntercoIndirectCost(unsigned varIndex)
 {
-    origin_ = origin;
-    destination_ = destination;
     SetLinkElementName(varIndex, "IntercoIndirectCost");
 }
 
@@ -166,8 +162,7 @@ void VariableNamer::SetShortTermStorageVariableName(unsigned varIndex,
                                                     const std::string& variableType,
                                                     const std::string& sts_name)
 {
-    std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
-                           + sts_name + ">";
+    std::string location = areaLocation() + SEP + "ShortTermStorage" + "<" + sts_name + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(variableType, location, time);
     names_[varIndex] = name;
@@ -260,21 +255,13 @@ void VariableNamer::AreaBalance(unsigned varIndex)
     SetAreaElementNameHour(varIndex, "AreaBalance");
 }
 
-void ConstraintNamer::FlowDissociation(unsigned constrIndex,
-                                       const std::string& origin,
-                                       const std::string& destination)
+void ConstraintNamer::FlowDissociation(unsigned constrIndex)
 {
-    origin_ = origin;
-    destination_ = destination;
     SetLinkElementName(constrIndex, "FlowDissociation");
 }
 
-void ConstraintNamer::CsrFlowDissociation(unsigned constrIndex,
-                                          const std::string& origin,
-                                          const std::string& destination)
+void ConstraintNamer::CsrFlowDissociation(unsigned constrIndex)
 {
-    origin_ = origin;
-    destination_ = destination;
     SetLinkElementName(constrIndex, "CsrFlowDissociation");
 }
 
@@ -389,8 +376,7 @@ void ConstraintNamer::ConsistenceNODU(unsigned constrIndex, const std::string& c
 
 void ConstraintNamer::ShortTermStorageLevel(unsigned constrIndex, const std::string& sts_name)
 {
-    std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
-                           + sts_name + ">";
+    std::string location = areaLocation() + SEP + "ShortTermStorage" + "<" + sts_name + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName("Level", location, time);
     names_[constrIndex] = name;
@@ -420,8 +406,7 @@ void ConstraintNamer::ShortTermStorageCostVariation(const std::string& constrain
                                                     unsigned constrIndex,
                                                     const std::string& sts_name)
 {
-    std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
-                           + sts_name + ">";
+    std::string location = areaLocation() + SEP + "ShortTermStorage" + "<" + sts_name + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(constraint_name, location, time);
     names_[constrIndex] = name;
@@ -432,8 +417,8 @@ void ConstraintNamer::ShortTermStorageCumulation(const std::string& constraint_t
                                                  const std::string& sts_name,
                                                  const std::string& constraint_name)
 {
-    std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
-                           + sts_name + ">" + SEP + "Constraint" + "<" + constraint_name + ">";
+    std::string location = areaLocation() + SEP + "ShortTermStorage" + "<" + sts_name + ">" + SEP
+                           + "Constraint" + "<" + constraint_name + ">";
     std::string time = TimeIdentifier(WEEK);
     std::string name = BuildName(constraint_type, location, time);
     names_[constrIndex] = name;

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -60,387 +60,378 @@ std::string BuildName(const std::string& name,
     return result;
 }
 
-void Namer::SetLinkElementName(unsigned int element, const std::string& elementType)
+void Namer::SetLinkElementName(unsigned elementIndex, const std::string& elementType)
 {
-    const auto location = origin_ + AREA_SEP + destination_;
-    targetUpdater_.UpdateTargetAtIndex(BuildName(elementType,
-                                                 LocationIdentifier(location, LINK),
-                                                 TimeIdentifier(timeStep_, HOUR)),
-                                       element);
+    std::string location = LocationIdentifier(origin_ + AREA_SEP + destination_, LINK);
+    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string name = BuildName(elementType, location, time);
+    names_[elementIndex] = name;
 }
 
-void Namer::SetAreaElementNameHour(unsigned int element, const std::string& elementType)
+void Namer::SetAreaElementNameHour(unsigned elementIndex, const std::string& elementType)
 {
-    SetAreaElementName(element, elementType, HOUR);
+    SetAreaElementName(elementIndex, elementType, HOUR);
 }
 
-void Namer::SetAreaElementNameWeek(unsigned int element, const std::string& elementType)
+void Namer::SetAreaElementNameWeek(unsigned elementIndex, const std::string& elementType)
 {
-    SetAreaElementName(element, elementType, WEEK);
+    SetAreaElementName(elementIndex, elementType, WEEK);
 }
 
-void Namer::SetAreaElementName(unsigned int element,
+void Namer::SetAreaElementName(unsigned elementIndex,
                                const std::string& elementType,
                                const std::string& timeStepType)
 {
-    targetUpdater_.UpdateTargetAtIndex(BuildName(elementType,
-                                                 LocationIdentifier(area_, AREA),
-                                                 TimeIdentifier(timeStep_, timeStepType)),
-                                       element);
+    std::string location = LocationIdentifier(area_, AREA);
+    std::string time = TimeIdentifier(timeStep_, timeStepType);
+    std::string name = BuildName(elementType, location, time);
+    names_[elementIndex] = name;
 }
 
-void VariableNamer::SetAreaVariableName(unsigned int variable,
+void VariableNamer::SetAreaVariableName(unsigned varIndex,
                                         const std::string& variableType,
                                         int layerIndex)
 {
-    targetUpdater_.UpdateTargetAtIndex(BuildName(variableType,
-                                                 LocationIdentifier(area_, AREA) + SEP + "Layer<"
-                                                   + std::to_string(layerIndex) + ">",
-                                                 TimeIdentifier(timeStep_, HOUR)),
-                                       variable);
+    std::string location = LocationIdentifier(area_, AREA) + SEP + "Layer<"
+                           + std::to_string(layerIndex) + ">";
+    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string name = BuildName(variableType, location, time);
+    names_[varIndex] = name;
 }
 
-void Namer::SetThermalClusterElementName(unsigned int variable,
+void Namer::SetThermalClusterElementName(unsigned varIndex,
                                          const std::string& elementType,
                                          const std::string& clusterName)
 {
-    const auto location = LocationIdentifier(area_, AREA) + SEP + "ThermalCluster" + "<"
-                          + clusterName + ">";
-
-    targetUpdater_.UpdateTargetAtIndex(BuildName(elementType,
-                                                 location,
-                                                 TimeIdentifier(timeStep_, HOUR)),
-                                       variable);
+    std::string location = LocationIdentifier(area_, AREA) + SEP + "ThermalCluster" + "<"
+                           + clusterName + ">";
+    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string name = BuildName(elementType, location, time);
+    names_[varIndex] = name;
 }
 
-void VariableNamer::DispatchableProduction(unsigned int variable, const std::string& clusterName)
+void VariableNamer::DispatchableProduction(unsigned varIndex, const std::string& clusterName)
 {
-    SetThermalClusterElementName(variable, "DispatchableProduction", clusterName);
+    SetThermalClusterElementName(varIndex, "DispatchableProduction", clusterName);
 }
 
-void VariableNamer::NODU(unsigned int variable, const std::string& clusterName)
+void VariableNamer::NODU(unsigned varIndex, const std::string& clusterName)
 {
-    SetThermalClusterElementName(variable, "NODU", clusterName);
+    SetThermalClusterElementName(varIndex, "NODU", clusterName);
 }
 
-void VariableNamer::NumberStoppingDispatchableUnits(unsigned int variable,
+void VariableNamer::NumberStoppingDispatchableUnits(unsigned varIndex,
                                                     const std::string& clusterName)
 {
-    SetThermalClusterElementName(variable, "NumberStoppingDispatchableUnits", clusterName);
+    SetThermalClusterElementName(varIndex, "NumberStoppingDispatchableUnits", clusterName);
 }
 
-void VariableNamer::NumberStartingDispatchableUnits(unsigned int variable,
+void VariableNamer::NumberStartingDispatchableUnits(unsigned varIndex,
                                                     const std::string& clusterName)
 {
-    SetThermalClusterElementName(variable, "NumberStartingDispatchableUnits", clusterName);
+    SetThermalClusterElementName(varIndex, "NumberStartingDispatchableUnits", clusterName);
 }
 
-void VariableNamer::NumberBreakingDownDispatchableUnits(unsigned int variable,
+void VariableNamer::NumberBreakingDownDispatchableUnits(unsigned varIndex,
                                                         const std::string& clusterName)
 {
-    SetThermalClusterElementName(variable, "NumberBreakingDownDispatchableUnits", clusterName);
+    SetThermalClusterElementName(varIndex, "NumberBreakingDownDispatchableUnits", clusterName);
 }
 
-void VariableNamer::NTCDirect(unsigned int variable,
+void VariableNamer::NTCDirect(unsigned varIndex,
                               const std::string& origin,
                               const std::string& destination)
 {
     origin_ = origin;
     destination_ = destination;
-    SetLinkElementName(variable, "NTCDirect");
+    SetLinkElementName(varIndex, "NTCDirect");
 }
 
-void VariableNamer::IntercoDirectCost(unsigned int variable,
+void VariableNamer::IntercoDirectCost(unsigned varIndex,
                                       const std::string& origin,
                                       const std::string& destination)
 {
     origin_ = origin;
     destination_ = destination;
-    SetLinkElementName(variable, "IntercoDirectCost");
+    SetLinkElementName(varIndex, "IntercoDirectCost");
 }
 
-void VariableNamer::IntercoIndirectCost(unsigned int variable,
+void VariableNamer::IntercoIndirectCost(unsigned varIndex,
                                         const std::string& origin,
                                         const std::string& destination)
 {
     origin_ = origin;
     destination_ = destination;
-    SetLinkElementName(variable, "IntercoIndirectCost");
+    SetLinkElementName(varIndex, "IntercoIndirectCost");
 }
 
-void VariableNamer::SetShortTermStorageVariableName(unsigned int variable,
+void VariableNamer::SetShortTermStorageVariableName(unsigned varIndex,
                                                     const std::string& variableType,
-                                                    const std::string& shortTermStorageName)
+                                                    const std::string& sts_name)
 {
-    const auto location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
-                          + shortTermStorageName + ">";
-    targetUpdater_.UpdateTargetAtIndex(BuildName(variableType,
-                                                 location,
-                                                 TimeIdentifier(timeStep_, HOUR)),
-                                       variable);
+    std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
+                           + sts_name + ">";
+    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string name = BuildName(variableType, location, time);
+    names_[varIndex] = name;
 }
 
-void VariableNamer::ShortTermStorageInjection(unsigned int variable,
-                                              const std::string& shortTermStorageName)
+void VariableNamer::ShortTermStorageInjection(unsigned varIndex, const std::string& sts_name)
 {
-    SetShortTermStorageVariableName(variable, "Injection", shortTermStorageName);
+    SetShortTermStorageVariableName(varIndex, "Injection", sts_name);
 }
 
-void VariableNamer::ShortTermStorageWithdrawal(unsigned int variable,
-                                               const std::string& shortTermStorageName)
+void VariableNamer::ShortTermStorageWithdrawal(unsigned varIndex, const std::string& sts_name)
 {
-    SetShortTermStorageVariableName(variable, "Withdrawal", shortTermStorageName);
+    SetShortTermStorageVariableName(varIndex, "Withdrawal", sts_name);
 }
 
-void VariableNamer::ShortTermStorageLevel(unsigned int variable,
-                                          const std::string& shortTermStorageName)
+void VariableNamer::ShortTermStorageLevel(unsigned varIndex, const std::string& sts_name)
 {
-    SetShortTermStorageVariableName(variable, "Level", shortTermStorageName);
+    SetShortTermStorageVariableName(varIndex, "Level", sts_name);
 }
 
-void VariableNamer::ShortTermStorageOverflow(unsigned int variable,
-                                             const std::string& shortTermStorageName)
+void VariableNamer::ShortTermStorageOverflow(unsigned varIndex, const std::string& sts_name)
 {
-    SetShortTermStorageVariableName(variable, "Overflow", shortTermStorageName);
+    SetShortTermStorageVariableName(varIndex, "Overflow", sts_name);
 }
 
-void VariableNamer::ShortTermStorageCostVariationInjection(unsigned int variable,
-                                                           const std::string& shortTermStorageName)
+void VariableNamer::ShortTermStorageCostVariationInjection(unsigned varIndex,
+                                                           const std::string& sts_name)
 {
-    SetShortTermStorageVariableName(variable, "CostVariationInjection", shortTermStorageName);
+    SetShortTermStorageVariableName(varIndex, "CostVariationInjection", sts_name);
 }
 
-void VariableNamer::ShortTermStorageCostVariationWithdrawal(unsigned int variable,
-                                                            const std::string& shortTermStorageName)
+void VariableNamer::ShortTermStorageCostVariationWithdrawal(unsigned varIndex,
+                                                            const std::string& sts_name)
 {
-    SetShortTermStorageVariableName(variable, "CostVariationWithdrawal", shortTermStorageName);
+    SetShortTermStorageVariableName(varIndex, "CostVariationWithdrawal", sts_name);
 }
 
-void VariableNamer::HydProd(unsigned int variable)
+void VariableNamer::HydProd(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "HydProd");
+    SetAreaElementNameHour(varIndex, "HydProd");
 }
 
-void VariableNamer::HydProdDown(unsigned int variable)
+void VariableNamer::HydProdDown(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "HydProdDown");
+    SetAreaElementNameHour(varIndex, "HydProdDown");
 }
 
-void VariableNamer::HydProdUp(unsigned int variable)
+void VariableNamer::HydProdUp(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "HydProdUp");
+    SetAreaElementNameHour(varIndex, "HydProdUp");
 }
 
-void VariableNamer::Pumping(unsigned int variable)
+void VariableNamer::Pumping(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "Pumping");
+    SetAreaElementNameHour(varIndex, "Pumping");
 }
 
-void VariableNamer::HydroLevel(unsigned int variable)
+void VariableNamer::HydroLevel(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "HydroLevel");
+    SetAreaElementNameHour(varIndex, "HydroLevel");
 }
 
-void VariableNamer::Overflow(unsigned int variable)
+void VariableNamer::Overflow(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "Overflow");
+    SetAreaElementNameHour(varIndex, "Overflow");
 }
 
-void VariableNamer::LayerStorage(unsigned int variable, int layerIndex)
+void VariableNamer::LayerStorage(unsigned varIndex, int layerIndex)
 {
-    SetAreaVariableName(variable, "LayerStorage", layerIndex);
+    SetAreaVariableName(varIndex, "LayerStorage", layerIndex);
 }
 
-void VariableNamer::FinalStorage(unsigned int variable)
+void VariableNamer::FinalStorage(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "FinalStorage");
+    SetAreaElementNameHour(varIndex, "FinalStorage");
 }
 
-void VariableNamer::PositiveUnsuppliedEnergy(unsigned int variable)
+void VariableNamer::PositiveUnsuppliedEnergy(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "PositiveUnsuppliedEnergy");
+    SetAreaElementNameHour(varIndex, "PositiveUnsuppliedEnergy");
 }
 
-void VariableNamer::NegativeUnsuppliedEnergy(unsigned int variable)
+void VariableNamer::NegativeUnsuppliedEnergy(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "NegativeUnsuppliedEnergy");
+    SetAreaElementNameHour(varIndex, "NegativeUnsuppliedEnergy");
 }
 
-void VariableNamer::AreaBalance(unsigned int variable)
+void VariableNamer::AreaBalance(unsigned varIndex)
 {
-    SetAreaElementNameHour(variable, "AreaBalance");
+    SetAreaElementNameHour(varIndex, "AreaBalance");
 }
 
-void ConstraintNamer::FlowDissociation(unsigned int constraint,
+void ConstraintNamer::FlowDissociation(unsigned constrIndex,
                                        const std::string& origin,
                                        const std::string& destination)
 {
     origin_ = origin;
     destination_ = destination;
-    SetLinkElementName(constraint, "FlowDissociation");
+    SetLinkElementName(constrIndex, "FlowDissociation");
 }
 
-void ConstraintNamer::CsrFlowDissociation(unsigned int constraint,
+void ConstraintNamer::CsrFlowDissociation(unsigned constrIndex,
                                           const std::string& origin,
                                           const std::string& destination)
 {
     origin_ = origin;
     destination_ = destination;
-    SetLinkElementName(constraint, "CsrFlowDissociation");
+    SetLinkElementName(constrIndex, "CsrFlowDissociation");
 }
 
-void ConstraintNamer::CsrAreaBalance(unsigned int constraint)
+void ConstraintNamer::CsrAreaBalance(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "CsrAreaBalance");
+    SetAreaElementNameHour(constrIndex, "CsrAreaBalance");
 }
 
-void ConstraintNamer::AreaBalance(unsigned int constraint)
+void ConstraintNamer::AreaBalance(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "AreaBalance");
+    SetAreaElementNameHour(constrIndex, "AreaBalance");
 }
 
-void ConstraintNamer::FictiveLoads(unsigned int constraint)
+void ConstraintNamer::FictiveLoads(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "FictiveLoads");
+    SetAreaElementNameHour(constrIndex, "FictiveLoads");
 }
 
-void ConstraintNamer::HydroPower(unsigned int constraint)
+void ConstraintNamer::HydroPower(unsigned constrIndex)
 {
-    SetAreaElementNameWeek(constraint, "HydroPower");
+    SetAreaElementNameWeek(constrIndex, "HydroPower");
 }
 
-void ConstraintNamer::HydroPowerSmoothingUsingVariationSum(unsigned int constraint)
+void ConstraintNamer::HydroPowerSmoothingUsingVariationSum(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "HydroPowerSmoothingUsingVariationSum");
+    SetAreaElementNameHour(constrIndex, "HydroPowerSmoothingUsingVariationSum");
 }
 
-void ConstraintNamer::HydroPowerSmoothingUsingVariationMaxDown(unsigned int constraint)
+void ConstraintNamer::HydroPowerSmoothingUsingVariationMaxDown(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "HydroPowerSmoothingUsingVariationMaxDown");
+    SetAreaElementNameHour(constrIndex, "HydroPowerSmoothingUsingVariationMaxDown");
 }
 
-void ConstraintNamer::HydroPowerSmoothingUsingVariationMaxUp(unsigned int constraint)
+void ConstraintNamer::HydroPowerSmoothingUsingVariationMaxUp(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "HydroPowerSmoothingUsingVariationMaxUp");
+    SetAreaElementNameHour(constrIndex, "HydroPowerSmoothingUsingVariationMaxUp");
 }
 
-void ConstraintNamer::MinHydroPower(unsigned int constraint)
+void ConstraintNamer::MinHydroPower(unsigned constrIndex)
 {
-    SetAreaElementNameWeek(constraint, "MinHydroPower");
+    SetAreaElementNameWeek(constrIndex, "MinHydroPower");
 }
 
-void ConstraintNamer::MaxHydroPower(unsigned int constraint)
+void ConstraintNamer::MaxHydroPower(unsigned constrIndex)
 {
-    SetAreaElementNameWeek(constraint, "MaxHydroPower");
+    SetAreaElementNameWeek(constrIndex, "MaxHydroPower");
 }
 
-void ConstraintNamer::MaxPumping(unsigned int constraint)
+void ConstraintNamer::MaxPumping(unsigned constrIndex)
 {
-    SetAreaElementNameWeek(constraint, "MaxPumping");
+    SetAreaElementNameWeek(constrIndex, "MaxPumping");
 }
 
-void ConstraintNamer::AreaHydroLevel(unsigned int constraint)
+void ConstraintNamer::AreaHydroLevel(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "AreaHydroLevel");
+    SetAreaElementNameHour(constrIndex, "AreaHydroLevel");
 }
 
-void ConstraintNamer::FinalStockEquivalent(unsigned int constraint)
+void ConstraintNamer::FinalStockEquivalent(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "FinalStockEquivalent");
+    SetAreaElementNameHour(constrIndex, "FinalStockEquivalent");
 }
 
-void ConstraintNamer::FinalStockExpression(unsigned int constraint)
+void ConstraintNamer::FinalStockExpression(unsigned constrIndex)
 {
-    SetAreaElementNameHour(constraint, "FinalStockExpression");
+    SetAreaElementNameHour(constrIndex, "FinalStockExpression");
 }
 
-void ConstraintNamer::nameWithTimeGranularity(unsigned int constraint,
+void ConstraintNamer::nameWithTimeGranularity(unsigned constrIndex,
                                               const std::string& name,
                                               const std::string& type)
 {
-    targetUpdater_.UpdateTargetAtIndex(BuildName(name,
-                                                 BindingConstraintTimeGranularity.at(type),
-                                                 TimeIdentifier(timeStep_, type)),
-                                       constraint);
+    std::string granularity = BindingConstraintTimeGranularity.at(type);
+    std::string time = TimeIdentifier(timeStep_, type);
+    std::string changed_name = BuildName(name, granularity, time);
+    names_[constrIndex] = changed_name;
 }
 
-void ConstraintNamer::NbUnitsOutageLessThanNbUnitsStop(unsigned int constraint,
+void ConstraintNamer::NbUnitsOutageLessThanNbUnitsStop(unsigned constrIndex,
                                                        const std::string& clusterName)
 {
-    SetThermalClusterElementName(constraint, "NbUnitsOutageLessThanNbUnitsStop", clusterName);
+    SetThermalClusterElementName(constrIndex, "NbUnitsOutageLessThanNbUnitsStop", clusterName);
 }
 
-void ConstraintNamer::NbDispUnitsMinBoundSinceMinUpTime(unsigned int constraint,
+void ConstraintNamer::NbDispUnitsMinBoundSinceMinUpTime(unsigned constrIndex,
                                                         const std::string& clusterName)
 {
-    SetThermalClusterElementName(constraint, "NbDispUnitsMinBoundSinceMinUpTime", clusterName);
+    SetThermalClusterElementName(constrIndex, "NbDispUnitsMinBoundSinceMinUpTime", clusterName);
 }
 
-void ConstraintNamer::MinDownTime(unsigned int constraint, const std::string& clusterName)
+void ConstraintNamer::MinDownTime(unsigned constrIndex, const std::string& clusterName)
 {
-    SetThermalClusterElementName(constraint, "MinDownTime", clusterName);
+    SetThermalClusterElementName(constrIndex, "MinDownTime", clusterName);
 }
 
-void ConstraintNamer::PMaxDispatchableGeneration(unsigned int constraint,
+void ConstraintNamer::PMaxDispatchableGeneration(unsigned constrIndex,
                                                  const std::string& clusterName)
 {
-    SetThermalClusterElementName(constraint, "PMaxDispatchableGeneration", clusterName);
+    SetThermalClusterElementName(constrIndex, "PMaxDispatchableGeneration", clusterName);
 }
 
-void ConstraintNamer::PMinDispatchableGeneration(unsigned int constraint,
+void ConstraintNamer::PMinDispatchableGeneration(unsigned constrIndex,
                                                  const std::string& clusterName)
 {
-    SetThermalClusterElementName(constraint, "PMinDispatchableGeneration", clusterName);
+    SetThermalClusterElementName(constrIndex, "PMinDispatchableGeneration", clusterName);
 }
 
-void ConstraintNamer::ConsistenceNODU(unsigned int constraint, const std::string& clusterName)
+void ConstraintNamer::ConsistenceNODU(unsigned constrIndex, const std::string& clusterName)
 {
-    SetThermalClusterElementName(constraint, "ConsistenceNODU", clusterName);
+    SetThermalClusterElementName(constrIndex, "ConsistenceNODU", clusterName);
 }
 
-void ConstraintNamer::ShortTermStorageLevel(unsigned int constraint, const std::string& name)
+void ConstraintNamer::ShortTermStorageLevel(unsigned constrIndex, const std::string& sts_name)
 {
-    targetUpdater_.UpdateTargetAtIndex(BuildName("Level",
-                                                 LocationIdentifier(area_, AREA) + SEP
-                                                   + "ShortTermStorage" + "<" + name + ">",
-                                                 TimeIdentifier(timeStep_, HOUR)),
-                                       constraint);
+    std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
+                           + sts_name + ">";
+    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string name = BuildName("Level", location, time);
+    names_[constrIndex] = name;
 }
 
-void ConstraintNamer::BindingConstraintHour(unsigned int constraint, const std::string& name)
+void ConstraintNamer::BindingConstraintHour(unsigned constrIndex, const std::string& name)
 {
-    nameWithTimeGranularity(constraint, name, HOUR);
+    nameWithTimeGranularity(constrIndex, name, HOUR);
 }
 
-void ConstraintNamer::CsrBindingConstraintHour(unsigned int constraint, const std::string& name)
+void ConstraintNamer::CsrBindingConstraintHour(unsigned constrIndex, const std::string& name)
 {
-    nameWithTimeGranularity(constraint, name, HOUR);
+    nameWithTimeGranularity(constrIndex, name, HOUR);
 }
 
-void ConstraintNamer::BindingConstraintDay(unsigned int constraint, const std::string& name)
+void ConstraintNamer::BindingConstraintDay(unsigned constrIndex, const std::string& name)
 {
-    nameWithTimeGranularity(constraint, name, DAY);
+    nameWithTimeGranularity(constrIndex, name, DAY);
 }
 
-void ConstraintNamer::BindingConstraintWeek(unsigned int constraint, const std::string& name)
+void ConstraintNamer::BindingConstraintWeek(unsigned constrIndex, const std::string& name)
 {
-    nameWithTimeGranularity(constraint, name, WEEK);
+    nameWithTimeGranularity(constrIndex, name, WEEK);
 }
 
 void ConstraintNamer::ShortTermStorageCostVariation(const std::string& constraint_name,
-                                                    unsigned int constraint,
+                                                    unsigned constrIndex,
                                                     const std::string& sts_name)
 {
     std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
                            + sts_name + ">";
     std::string time = TimeIdentifier(timeStep_, HOUR);
     std::string name = BuildName(constraint_name, location, time);
-
-    targetUpdater_.UpdateTargetAtIndex(name, constraint);
+    names_[constrIndex] = name;
 }
 
 void ConstraintNamer::ShortTermStorageCumulation(const std::string& constraint_type,
-                                                 unsigned int constraint,
+                                                 unsigned constrIndex,
                                                  const std::string& sts_name,
                                                  const std::string& constraint_name)
 {
@@ -448,6 +439,5 @@ void ConstraintNamer::ShortTermStorageCumulation(const std::string& constraint_t
                            + sts_name + ">" + SEP + "Constraint" + "<" + constraint_name + ">";
     std::string time = TimeIdentifier(timeStep_, WEEK);
     std::string name = BuildName(constraint_type, location, time);
-
-    targetUpdater_.UpdateTargetAtIndex(name, constraint);
+    names_[constrIndex] = name;
 }

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -52,6 +52,32 @@ std::string BuildName(const std::string& name,
     return result;
 }
 
+Namer::Namer(std::vector<std::string>& target_names):
+    names_(target_names)
+{
+}
+
+void Namer::UpdateTimeStep(unsigned timeStep)
+{
+    timeStep_ = timeStep;
+}
+
+void Namer::UpdateArea(const std::string& area)
+{
+    area_ = area;
+}
+
+void Namer::updateExtremities(const std::string& origin, const std::string& destination)
+{
+    origin_ = origin;
+    destination_ = destination;
+}
+
+void Namer::updateName(const unsigned index, const std::string& name)
+{
+    names_[index] = name;
+}
+
 std::string Namer::TimeIdentifier(const std::string& timeStepType)
 {
     return timeStepType + "<" + std::to_string(timeStep_) + ">";
@@ -102,7 +128,7 @@ void VariableNamer::SetAreaVariableName(unsigned varIndex,
     std::string location = areaLocation() + SEP + "Layer<" + std::to_string(layerIndex) + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(variableType, location, time);
-    names_[varIndex] = name;
+    names()[varIndex] = name;
 }
 
 void Namer::SetThermalClusterElementName(unsigned varIndex,
@@ -165,7 +191,7 @@ void VariableNamer::SetShortTermStorageVariableName(unsigned varIndex,
     std::string location = areaLocation() + SEP + "ShortTermStorage" + "<" + sts_name + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(variableType, location, time);
-    names_[varIndex] = name;
+    names()[varIndex] = name;
 }
 
 void VariableNamer::ShortTermStorageInjection(unsigned varIndex, const std::string& sts_name)
@@ -337,7 +363,7 @@ void ConstraintNamer::nameWithTimeGranularity(unsigned constrIndex,
     std::string granularity = "hourly";
     std::string time = TimeIdentifier(type);
     std::string changed_name = BuildName(name, granularity, time);
-    names_[constrIndex] = changed_name;
+    names()[constrIndex] = changed_name;
 }
 
 void ConstraintNamer::NbUnitsOutageLessThanNbUnitsStop(unsigned constrIndex,
@@ -379,7 +405,7 @@ void ConstraintNamer::ShortTermStorageLevel(unsigned constrIndex, const std::str
     std::string location = areaLocation() + SEP + "ShortTermStorage" + "<" + sts_name + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName("Level", location, time);
-    names_[constrIndex] = name;
+    names()[constrIndex] = name;
 }
 
 void ConstraintNamer::BindingConstraintHour(unsigned constrIndex, const std::string& name)
@@ -409,7 +435,7 @@ void ConstraintNamer::ShortTermStorageCostVariation(const std::string& constrain
     std::string location = areaLocation() + SEP + "ShortTermStorage" + "<" + sts_name + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(constraint_name, location, time);
-    names_[constrIndex] = name;
+    names()[constrIndex] = name;
 }
 
 void ConstraintNamer::ShortTermStorageCumulation(const std::string& constraint_type,
@@ -421,5 +447,5 @@ void ConstraintNamer::ShortTermStorageCumulation(const std::string& constraint_t
                            + "Constraint" + "<" + constraint_name + ">";
     std::string time = TimeIdentifier(WEEK);
     std::string name = BuildName(constraint_type, location, time);
-    names_[constrIndex] = name;
+    names()[constrIndex] = name;
 }

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -73,11 +73,6 @@ void Namer::updateExtremities(const std::string& origin, const std::string& dest
     destination_ = destination;
 }
 
-void Namer::updateName(const unsigned index, const std::string& name)
-{
-    names_[index] = name;
-}
-
 std::string Namer::TimeIdentifier(const std::string& timeStepType)
 {
     return timeStepType + "<" + std::to_string(timeStep_) + ">";
@@ -91,6 +86,11 @@ std::string Namer::linkLocation()
 std::string Namer::areaLocation()
 {
     return LocationIdentifier(area_, AREA);
+}
+
+std::vector<std::string>& Namer::names()
+{
+    return names_;
 }
 
 void Namer::SetLinkElementName(unsigned elementIndex, const std::string& elementType)

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -30,9 +30,6 @@ const std::string AREA_SEP = "$$";
 const std::string HOUR("hour");
 const std::string DAY("day");
 const std::string WEEK("week");
-const std::map<std::string, std::string> BindingConstraintTimeGranularity = {{HOUR, "hourly"},
-                                                                             {DAY, "daily"},
-                                                                             {WEEK, "weekly"}};
 const std::string LINK("link");
 const std::string AREA("area");
 
@@ -350,7 +347,7 @@ void ConstraintNamer::nameWithTimeGranularity(unsigned constrIndex,
                                               const std::string& name,
                                               const std::string& type)
 {
-    std::string granularity = BindingConstraintTimeGranularity.at(type);
+    std::string granularity = "hourly";
     std::string time = TimeIdentifier(type);
     std::string changed_name = BuildName(name, granularity, time);
     names_[constrIndex] = changed_name;

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -36,11 +36,6 @@ const std::map<std::string, std::string> BindingConstraintTimeGranularity = {{HO
 const std::string LINK("link");
 const std::string AREA("area");
 
-std::string TimeIdentifier(unsigned timeStep, const std::string& timeStepType)
-{
-    return timeStepType + "<" + std::to_string(timeStep) + ">";
-}
-
 std::string ShortTermStorageCumulationIdentifier(const std::string& name)
 {
     return "Constraint<" + name + ">";
@@ -60,10 +55,15 @@ std::string BuildName(const std::string& name,
     return result;
 }
 
+std::string Namer::TimeIdentifier(const std::string& timeStepType)
+{
+    return timeStepType + "<" + std::to_string(timeStep_) + ">";
+}
+
 void Namer::SetLinkElementName(unsigned elementIndex, const std::string& elementType)
 {
     std::string location = LocationIdentifier(origin_ + AREA_SEP + destination_, LINK);
-    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(elementType, location, time);
     names_[elementIndex] = name;
 }
@@ -83,7 +83,7 @@ void Namer::SetAreaElementName(unsigned elementIndex,
                                const std::string& timeStepType)
 {
     std::string location = LocationIdentifier(area_, AREA);
-    std::string time = TimeIdentifier(timeStep_, timeStepType);
+    std::string time = TimeIdentifier(timeStepType);
     std::string name = BuildName(elementType, location, time);
     names_[elementIndex] = name;
 }
@@ -94,7 +94,7 @@ void VariableNamer::SetAreaVariableName(unsigned varIndex,
 {
     std::string location = LocationIdentifier(area_, AREA) + SEP + "Layer<"
                            + std::to_string(layerIndex) + ">";
-    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(variableType, location, time);
     names_[varIndex] = name;
 }
@@ -105,7 +105,7 @@ void Namer::SetThermalClusterElementName(unsigned varIndex,
 {
     std::string location = LocationIdentifier(area_, AREA) + SEP + "ThermalCluster" + "<"
                            + clusterName + ">";
-    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(elementType, location, time);
     names_[varIndex] = name;
 }
@@ -171,7 +171,7 @@ void VariableNamer::SetShortTermStorageVariableName(unsigned varIndex,
 {
     std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
                            + sts_name + ">";
-    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(variableType, location, time);
     names_[varIndex] = name;
 }
@@ -351,7 +351,7 @@ void ConstraintNamer::nameWithTimeGranularity(unsigned constrIndex,
                                               const std::string& type)
 {
     std::string granularity = BindingConstraintTimeGranularity.at(type);
-    std::string time = TimeIdentifier(timeStep_, type);
+    std::string time = TimeIdentifier(type);
     std::string changed_name = BuildName(name, granularity, time);
     names_[constrIndex] = changed_name;
 }
@@ -394,7 +394,7 @@ void ConstraintNamer::ShortTermStorageLevel(unsigned constrIndex, const std::str
 {
     std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
                            + sts_name + ">";
-    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName("Level", location, time);
     names_[constrIndex] = name;
 }
@@ -425,7 +425,7 @@ void ConstraintNamer::ShortTermStorageCostVariation(const std::string& constrain
 {
     std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
                            + sts_name + ">";
-    std::string time = TimeIdentifier(timeStep_, HOUR);
+    std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(constraint_name, location, time);
     names_[constrIndex] = name;
 }
@@ -437,7 +437,7 @@ void ConstraintNamer::ShortTermStorageCumulation(const std::string& constraint_t
 {
     std::string location = LocationIdentifier(area_, AREA) + SEP + "ShortTermStorage" + "<"
                            + sts_name + ">" + SEP + "Constraint" + "<" + constraint_name + ">";
-    std::string time = TimeIdentifier(timeStep_, WEEK);
+    std::string time = TimeIdentifier(WEEK);
     std::string name = BuildName(constraint_type, location, time);
     names_[constrIndex] = name;
 }

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -32,6 +32,9 @@ const std::string DAY("day");
 const std::string WEEK("week");
 const std::string LINK("link");
 const std::string AREA("area");
+const std::map<std::string, std::string> TimeGranularity = {{HOUR, "hourly"},
+                                                            {DAY, "daily"},
+                                                            {WEEK, "weekly"}};
 
 std::string ShortTermStorageCumulationIdentifier(const std::string& name)
 {
@@ -360,7 +363,7 @@ void ConstraintNamer::nameWithTimeGranularity(unsigned constrIndex,
                                               const std::string& name,
                                               const std::string& type)
 {
-    std::string granularity = "hourly";
+    std::string granularity = TimeGranularity.at(type);
     std::string time = TimeIdentifier(type);
     std::string changed_name = BuildName(name, granularity, time);
     names()[constrIndex] = changed_name;

--- a/src/tests/src/solver/optimisation/constraints/constraints_builder.cpp
+++ b/src/tests/src/solver/optimisation/constraints/constraints_builder.cpp
@@ -86,13 +86,13 @@ struct STScumulativeConstaintFixture
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-    PROPERTIES sts_propertes_1 = {.additionalConstraints = {addc1_withdrawal},
+    PROPERTIES sts_properties_1 = {.additionalConstraints = {addc1_withdrawal},
                                   .clusterGlobalIndex = 0,
                                   .name = "cluster_1"};
-    PROPERTIES sts_propertes_2 = {.additionalConstraints = {addc2_injection},
+    PROPERTIES sts_properties_2 = {.additionalConstraints = {addc2_injection},
                                   .clusterGlobalIndex = 1,
                                   .name = "cluster_2"};
-    PROPERTIES sts_propertes_3 = {.injectionEfficiency = 45,
+    PROPERTIES sts_properties_3 = {.injectionEfficiency = 45,
                                   .withdrawalEfficiency = 2025,
                                   .additionalConstraints = {addc3_netting},
                                   .clusterGlobalIndex = 2,
@@ -100,9 +100,9 @@ struct STScumulativeConstaintFixture
 #pragma GCC diagnostic pop
 
     std::vector<CORRESPONDANCES_DES_CONTRAINTES> CorrespondanceCntNativesCntOptim;
-    std::vector<::AREA_INPUT> shortTermStorage = {{sts_propertes_1},
-                                                  {sts_propertes_2},
-                                                  {sts_propertes_3}};
+    std::vector<::AREA_INPUT> shortTermStorage = {{sts_properties_1},
+                                                  {sts_properties_2},
+                                                  {sts_properties_3}};
 
     CORRESPONDANCES_DES_CONTRAINTES_HEBDOMADAIRES CorrespondanceCntNativesCntOptimHebdomadaires{
       {},
@@ -320,9 +320,9 @@ BOOST_FIXTURE_TEST_CASE(AddNettingConstraint, ConstraintBuilderFixture)
     BOOST_CHECK_EQUAL(builder.data.IndicesDebutDeLigne[1], 4); // Check next line index
 
     // Verify that the correct variables and values were updated in the matrix
-    BOOST_CHECK_EQUAL(builder.data.Pi[0], sts_propertes_3.injectionEfficiency);
+    BOOST_CHECK_EQUAL(builder.data.Pi[0], sts_properties_3.injectionEfficiency);
     // Verify the first term's coefficient (adjust based on actual expected values)
-    BOOST_CHECK_EQUAL(builder.data.Pi[1], -sts_propertes_3.withdrawalEfficiency);
+    BOOST_CHECK_EQUAL(builder.data.Pi[1], -sts_properties_3.withdrawalEfficiency);
     // Verify the first term's coefficient (adjust based on actual expected values)
     BOOST_CHECK_EQUAL(builder.data.Colonne[0], 4); // Verify the first term's column index
     BOOST_CHECK_EQUAL(builder.data.Colonne[1], 5); // Verify the first term's column index

--- a/src/tests/src/solver/optimisation/constraints/constraints_builder.cpp
+++ b/src/tests/src/solver/optimisation/constraints/constraints_builder.cpp
@@ -87,16 +87,16 @@ struct STScumulativeConstaintFixture
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
     PROPERTIES sts_properties_1 = {.additionalConstraints = {addc1_withdrawal},
-                                  .clusterGlobalIndex = 0,
-                                  .name = "cluster_1"};
+                                   .clusterGlobalIndex = 0,
+                                   .name = "cluster_1"};
     PROPERTIES sts_properties_2 = {.additionalConstraints = {addc2_injection},
-                                  .clusterGlobalIndex = 1,
-                                  .name = "cluster_2"};
+                                   .clusterGlobalIndex = 1,
+                                   .name = "cluster_2"};
     PROPERTIES sts_properties_3 = {.injectionEfficiency = 45,
-                                  .withdrawalEfficiency = 2025,
-                                  .additionalConstraints = {addc3_netting},
-                                  .clusterGlobalIndex = 2,
-                                  .name = "cluster_3"};
+                                   .withdrawalEfficiency = 2025,
+                                   .additionalConstraints = {addc3_netting},
+                                   .clusterGlobalIndex = 2,
+                                   .name = "cluster_3"};
 #pragma GCC diagnostic pop
 
     std::vector<CORRESPONDANCES_DES_CONTRAINTES> CorrespondanceCntNativesCntOptim;


### PR DESCRIPTION
Improves code readability in names.

What was done : 
- [x] class TargetVectorUpdater was removed (seemed overkill)
- [x] class **Namer** : 
   - [x] data members were made **private** instead of **public**
   - [x] many methods were made protected
- [x] some methods bodies were clarified
- [x] simplifications
- [x] renaming