### PR TITLE
Single problem getter API - fix day numbers

### DIFF
--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -184,6 +184,8 @@ ConstantDataFromAntares SingleProblemGetter::getConstantData()
     // before building variable list and the common matrix
     fillLinksProperties(pb_, *study_);
 
+    OPT_NumeroDeJourDuPasDeTemps(&pb_);
+
     OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaire(&pb_);
 
     auto builder_data = NewGetConstraintBuilderFromProblemHebdo(&pb_);


### PR DESCRIPTION
There was a minor bug for daily binding constraints.

## Before
```
 E  Storing_balance::daily::day<0>
 E  Storing_balance::daily::day<0>
 E  Storing_balance::daily::day<0>
 E  Storing_balance::daily::day<0>
 E  Storing_balance::daily::day<0>
 E  Storing_balance::daily::day<0>
 E  Storing_balance::daily::day<0>
```
## After
```
 E  Storing_balance::daily::day<0>
 E  Storing_balance::daily::day<1>
 E  Storing_balance::daily::day<2>
 E  Storing_balance::daily::day<3>
 E  Storing_balance::daily::day<4>
 E  Storing_balance::daily::day<5>
 E  Storing_balance::daily::day<6>
```