### PR TITLE
Remove useless `std::unique_ptr` around temporary objects

### DIFF
--- a/src/solver/hydro/daily/h2o_j_resoudre_le_probleme_lineaire.cpp
+++ b/src/solver/hydro/daily/h2o_j_resoudre_le_probleme_lineaire.cpp
@@ -19,8 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <memory>
-
 #include "antares/solver/hydro/daily/h2o_j_donnees_mensuelles.h"
 #include "antares/solver/hydro/daily/h2o_j_fonctions.h"
 
@@ -38,7 +36,7 @@ void H2O_J_ResoudreLeProblemeLineaire(DONNEES_MENSUELLES* DonneesMensuelles, int
                                                                     [NumeroDeProbleme];
 
     PROBLEME_SPX* ProbSpx = ProblemeHydraulique.ProblemeSpx[NumeroDeProbleme].get();
-    std::unique_ptr<PROBLEME_SIMPLEXE> Probleme = std::make_unique<PROBLEME_SIMPLEXE>();
+    PROBLEME_SIMPLEXE Probleme;
 
     bool PremierPassage = true;
 
@@ -46,14 +44,14 @@ RESOLUTION:
 
     if (!ProbSpx)
     {
-        Probleme->Contexte = SIMPLEXE_SEUL;
-        Probleme->BaseDeDepartFournie = NON_SPX;
+        Probleme.Contexte = SIMPLEXE_SEUL;
+        Probleme.BaseDeDepartFournie = NON_SPX;
     }
     else
     {
-        Probleme->Contexte = BRANCH_AND_BOUND_OU_CUT_NOEUD;
+        Probleme.Contexte = BRANCH_AND_BOUND_OU_CUT_NOEUD;
 
-        Probleme->BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
+        Probleme.BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
 
         SPX_ModifierLeVecteurSecondMembre(ProbSpx,
                                           ProblemeLineairePartieVariable.SecondMembre.data(),
@@ -61,68 +59,68 @@ RESOLUTION:
                                           ProblemeLineairePartieFixe.NombreDeContraintes);
     }
 
-    Probleme->NombreMaxDIterations = -1;
-    Probleme->DureeMaxDuCalcul = -1.;
+    Probleme.NombreMaxDIterations = -1;
+    Probleme.DureeMaxDuCalcul = -1.;
 
-    Probleme->CoutLineaire = ProblemeLineairePartieFixe.CoutLineaire.data();
-    Probleme->X = ProblemeLineairePartieVariable.X.data();
-    Probleme->Xmin = ProblemeLineairePartieVariable.Xmin.data();
-    Probleme->Xmax = ProblemeLineairePartieVariable.Xmax.data();
-    Probleme->NombreDeVariables = ProblemeLineairePartieFixe.NombreDeVariables;
-    Probleme->TypeDeVariable = ProblemeLineairePartieFixe.TypeDeVariable.data();
+    Probleme.CoutLineaire = ProblemeLineairePartieFixe.CoutLineaire.data();
+    Probleme.X = ProblemeLineairePartieVariable.X.data();
+    Probleme.Xmin = ProblemeLineairePartieVariable.Xmin.data();
+    Probleme.Xmax = ProblemeLineairePartieVariable.Xmax.data();
+    Probleme.NombreDeVariables = ProblemeLineairePartieFixe.NombreDeVariables;
+    Probleme.TypeDeVariable = ProblemeLineairePartieFixe.TypeDeVariable.data();
 
-    Probleme->NombreDeContraintes = ProblemeLineairePartieFixe.NombreDeContraintes;
-    Probleme->IndicesDebutDeLigne = ProblemeLineairePartieFixe.IndicesDebutDeLigne.data();
-    Probleme->NombreDeTermesDesLignes = ProblemeLineairePartieFixe.NombreDeTermesDesLignes.data();
-    Probleme->IndicesColonnes = ProblemeLineairePartieFixe.IndicesColonnes.data();
-    Probleme->CoefficientsDeLaMatriceDesContraintes = ProblemeLineairePartieFixe
-                                                        .CoefficientsDeLaMatriceDesContraintes
-                                                        .data();
-    Probleme->Sens = ProblemeLineairePartieFixe.Sens.data();
-    Probleme->SecondMembre = ProblemeLineairePartieVariable.SecondMembre.data();
+    Probleme.NombreDeContraintes = ProblemeLineairePartieFixe.NombreDeContraintes;
+    Probleme.IndicesDebutDeLigne = ProblemeLineairePartieFixe.IndicesDebutDeLigne.data();
+    Probleme.NombreDeTermesDesLignes = ProblemeLineairePartieFixe.NombreDeTermesDesLignes.data();
+    Probleme.IndicesColonnes = ProblemeLineairePartieFixe.IndicesColonnes.data();
+    Probleme.CoefficientsDeLaMatriceDesContraintes = ProblemeLineairePartieFixe
+                                                       .CoefficientsDeLaMatriceDesContraintes
+                                                       .data();
+    Probleme.Sens = ProblemeLineairePartieFixe.Sens.data();
+    Probleme.SecondMembre = ProblemeLineairePartieVariable.SecondMembre.data();
 
-    Probleme->ChoixDeLAlgorithme = SPX_DUAL;
+    Probleme.ChoixDeLAlgorithme = SPX_DUAL;
 
-    Probleme->TypeDePricing = PRICING_STEEPEST_EDGE;
-    Probleme->FaireDuScaling = OUI_SPX;
-    Probleme->StrategieAntiDegenerescence = AGRESSIF;
+    Probleme.TypeDePricing = PRICING_STEEPEST_EDGE;
+    Probleme.FaireDuScaling = OUI_SPX;
+    Probleme.StrategieAntiDegenerescence = AGRESSIF;
 
-    Probleme->PositionDeLaVariable = ProblemeLineairePartieVariable.PositionDeLaVariable.data();
-    Probleme->NbVarDeBaseComplementaires = 0;
-    Probleme->ComplementDeLaBase = ProblemeLineairePartieVariable.ComplementDeLaBase.data();
+    Probleme.PositionDeLaVariable = ProblemeLineairePartieVariable.PositionDeLaVariable.data();
+    Probleme.NbVarDeBaseComplementaires = 0;
+    Probleme.ComplementDeLaBase = ProblemeLineairePartieVariable.ComplementDeLaBase.data();
 
-    Probleme->LibererMemoireALaFin = NON_SPX;
+    Probleme.LibererMemoireALaFin = NON_SPX;
 
-    Probleme->UtiliserCoutMax = NON_SPX;
-    Probleme->CoutMax = 0.0;
+    Probleme.UtiliserCoutMax = NON_SPX;
+    Probleme.CoutMax = 0.0;
 
-    Probleme->CoutsMarginauxDesContraintes = ProblemeLineairePartieVariable
-                                               .CoutsMarginauxDesContraintes.data();
-    Probleme->CoutsReduits = ProblemeLineairePartieVariable.CoutsReduits.data();
+    Probleme.CoutsMarginauxDesContraintes = ProblemeLineairePartieVariable
+                                              .CoutsMarginauxDesContraintes.data();
+    Probleme.CoutsReduits = ProblemeLineairePartieVariable.CoutsReduits.data();
 
 #ifndef NDEBUG
     if (PremierPassage)
     {
-        Probleme->AffichageDesTraces = NON_SPX;
+        Probleme.AffichageDesTraces = NON_SPX;
     }
     else
     {
-        Probleme->AffichageDesTraces = OUI_SPX;
+        Probleme.AffichageDesTraces = OUI_SPX;
     }
 #else
-    Probleme->AffichageDesTraces = NON_SPX;
+    Probleme.AffichageDesTraces = NON_SPX;
 #endif
 
-    Probleme->NombreDeContraintesCoupes = 0;
+    Probleme.NombreDeContraintesCoupes = 0;
 
-    ProbSpx = SPX_Simplexe(Probleme.get(), ProbSpx);
+    ProbSpx = SPX_Simplexe(&Probleme, ProbSpx);
 
     if (ProbSpx)
     {
         ProblemeHydraulique.ProblemeSpx[NumeroDeProbleme].reset(ProbSpx);
     }
 
-    ProblemeLineairePartieVariable.ExistenceDUneSolution = Probleme->ExistenceDUneSolution;
+    ProblemeLineairePartieVariable.ExistenceDUneSolution = Probleme.ExistenceDUneSolution;
 
     if (ProblemeLineairePartieVariable.ExistenceDUneSolution != OUI_SPX && PremierPassage
         && ProbSpx)

--- a/src/solver/hydro/daily2/h2o2_j_resoudre_le_probleme_lineaire.cpp
+++ b/src/solver/hydro/daily2/h2o2_j_resoudre_le_probleme_lineaire.cpp
@@ -34,7 +34,7 @@ void H2O2_J_ResoudreLeProblemeLineaire(DONNEES_MENSUELLES_ETENDUES& DonneesMensu
                                                .ProblemeLineaireEtenduPartieFixe[NumeroDeProbleme];
 
     PROBLEME_SPX* ProbSpx = ProblemeHydrauliqueEtendu.ProblemeSpx[NumeroDeProbleme].get();
-    auto Probleme = std::make_unique<PROBLEME_SIMPLEXE>();
+    PROBLEME_SIMPLEXE Probleme;
 
     bool premierPassage = true;
 
@@ -42,14 +42,14 @@ RESOLUTION:
 
     if (!ProbSpx)
     {
-        Probleme->Contexte = SIMPLEXE_SEUL;
-        Probleme->BaseDeDepartFournie = NON_SPX;
+        Probleme.Contexte = SIMPLEXE_SEUL;
+        Probleme.BaseDeDepartFournie = NON_SPX;
     }
     else
     {
-        Probleme->Contexte = BRANCH_AND_BOUND_OU_CUT_NOEUD;
+        Probleme.Contexte = BRANCH_AND_BOUND_OU_CUT_NOEUD;
 
-        Probleme->BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
+        Probleme.BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
 
         SPX_ModifierLeVecteurSecondMembre(ProbSpx,
                                           ProblemeLineaireEtenduPartieVariable.SecondMembre.data(),
@@ -57,70 +57,70 @@ RESOLUTION:
                                           ProblemeLineaireEtenduPartieFixe.NombreDeContraintes);
     }
 
-    Probleme->NombreMaxDIterations = -1;
-    Probleme->DureeMaxDuCalcul = -1.;
+    Probleme.NombreMaxDIterations = -1;
+    Probleme.DureeMaxDuCalcul = -1.;
 
-    Probleme->CoutLineaire = ProblemeLineaireEtenduPartieFixe.CoutLineaire.data();
-    Probleme->X = ProblemeLineaireEtenduPartieVariable.X.data();
-    Probleme->Xmin = ProblemeLineaireEtenduPartieVariable.Xmin.data();
-    Probleme->Xmax = ProblemeLineaireEtenduPartieVariable.Xmax.data();
-    Probleme->NombreDeVariables = ProblemeLineaireEtenduPartieFixe.NombreDeVariables;
-    Probleme->TypeDeVariable = ProblemeLineaireEtenduPartieFixe.TypeDeVariable.data();
+    Probleme.CoutLineaire = ProblemeLineaireEtenduPartieFixe.CoutLineaire.data();
+    Probleme.X = ProblemeLineaireEtenduPartieVariable.X.data();
+    Probleme.Xmin = ProblemeLineaireEtenduPartieVariable.Xmin.data();
+    Probleme.Xmax = ProblemeLineaireEtenduPartieVariable.Xmax.data();
+    Probleme.NombreDeVariables = ProblemeLineaireEtenduPartieFixe.NombreDeVariables;
+    Probleme.TypeDeVariable = ProblemeLineaireEtenduPartieFixe.TypeDeVariable.data();
 
-    Probleme->NombreDeContraintes = ProblemeLineaireEtenduPartieFixe.NombreDeContraintes;
-    Probleme->IndicesDebutDeLigne = ProblemeLineaireEtenduPartieFixe.IndicesDebutDeLigne.data();
-    Probleme->NombreDeTermesDesLignes = ProblemeLineaireEtenduPartieFixe.NombreDeTermesDesLignes
-                                          .data();
-    Probleme->IndicesColonnes = ProblemeLineaireEtenduPartieFixe.IndicesColonnes.data();
-    Probleme->CoefficientsDeLaMatriceDesContraintes = ProblemeLineaireEtenduPartieFixe
-                                                        .CoefficientsDeLaMatriceDesContraintes
-                                                        .data();
-    Probleme->Sens = ProblemeLineaireEtenduPartieFixe.Sens.data();
-    Probleme->SecondMembre = ProblemeLineaireEtenduPartieVariable.SecondMembre.data();
+    Probleme.NombreDeContraintes = ProblemeLineaireEtenduPartieFixe.NombreDeContraintes;
+    Probleme.IndicesDebutDeLigne = ProblemeLineaireEtenduPartieFixe.IndicesDebutDeLigne.data();
+    Probleme.NombreDeTermesDesLignes = ProblemeLineaireEtenduPartieFixe.NombreDeTermesDesLignes
+                                         .data();
+    Probleme.IndicesColonnes = ProblemeLineaireEtenduPartieFixe.IndicesColonnes.data();
+    Probleme.CoefficientsDeLaMatriceDesContraintes = ProblemeLineaireEtenduPartieFixe
+                                                       .CoefficientsDeLaMatriceDesContraintes
+                                                       .data();
+    Probleme.Sens = ProblemeLineaireEtenduPartieFixe.Sens.data();
+    Probleme.SecondMembre = ProblemeLineaireEtenduPartieVariable.SecondMembre.data();
 
-    Probleme->ChoixDeLAlgorithme = SPX_DUAL;
+    Probleme.ChoixDeLAlgorithme = SPX_DUAL;
 
-    Probleme->TypeDePricing = PRICING_STEEPEST_EDGE;
-    Probleme->FaireDuScaling = OUI_SPX;
-    Probleme->StrategieAntiDegenerescence = AGRESSIF;
+    Probleme.TypeDePricing = PRICING_STEEPEST_EDGE;
+    Probleme.FaireDuScaling = OUI_SPX;
+    Probleme.StrategieAntiDegenerescence = AGRESSIF;
 
-    Probleme->PositionDeLaVariable = ProblemeLineaireEtenduPartieVariable.PositionDeLaVariable
-                                       .data();
-    Probleme->NbVarDeBaseComplementaires = 0;
-    Probleme->ComplementDeLaBase = ProblemeLineaireEtenduPartieVariable.ComplementDeLaBase.data();
+    Probleme.PositionDeLaVariable = ProblemeLineaireEtenduPartieVariable.PositionDeLaVariable
+                                      .data();
+    Probleme.NbVarDeBaseComplementaires = 0;
+    Probleme.ComplementDeLaBase = ProblemeLineaireEtenduPartieVariable.ComplementDeLaBase.data();
 
-    Probleme->LibererMemoireALaFin = NON_SPX;
+    Probleme.LibererMemoireALaFin = NON_SPX;
 
-    Probleme->UtiliserCoutMax = NON_SPX;
-    Probleme->CoutMax = 0.0;
+    Probleme.UtiliserCoutMax = NON_SPX;
+    Probleme.CoutMax = 0.0;
 
-    Probleme->CoutsMarginauxDesContraintes = ProblemeLineaireEtenduPartieVariable
-                                               .CoutsMarginauxDesContraintes.data();
-    Probleme->CoutsReduits = ProblemeLineaireEtenduPartieVariable.CoutsReduits.data();
+    Probleme.CoutsMarginauxDesContraintes = ProblemeLineaireEtenduPartieVariable
+                                              .CoutsMarginauxDesContraintes.data();
+    Probleme.CoutsReduits = ProblemeLineaireEtenduPartieVariable.CoutsReduits.data();
 
 #ifndef NDEBUG
     if (premierPassage)
     {
-        Probleme->AffichageDesTraces = NON_SPX;
+        Probleme.AffichageDesTraces = NON_SPX;
     }
     else
     {
-        Probleme->AffichageDesTraces = OUI_SPX;
+        Probleme.AffichageDesTraces = OUI_SPX;
     }
 #else
-    Probleme->AffichageDesTraces = NON_SPX;
+    Probleme.AffichageDesTraces = NON_SPX;
 #endif
 
-    Probleme->NombreDeContraintesCoupes = 0;
+    Probleme.NombreDeContraintesCoupes = 0;
 
-    ProbSpx = SPX_Simplexe(Probleme.get(), ProbSpx);
+    ProbSpx = SPX_Simplexe(&Probleme, ProbSpx);
 
     if (ProbSpx)
     {
         ProblemeHydrauliqueEtendu.ProblemeSpx[NumeroDeProbleme].reset(ProbSpx);
     }
 
-    ProblemeLineaireEtenduPartieVariable.ExistenceDUneSolution = Probleme->ExistenceDUneSolution;
+    ProblemeLineaireEtenduPartieVariable.ExistenceDUneSolution = Probleme.ExistenceDUneSolution;
 
     if (ProblemeLineaireEtenduPartieVariable.ExistenceDUneSolution != OUI_SPX && premierPassage
         && ProbSpx)
@@ -143,9 +143,9 @@ RESOLUTION:
     if (ProblemeLineaireEtenduPartieVariable.ExistenceDUneSolution == OUI_SPX)
     {
         DonneesMensuelles.CoutSolution = 0.0;
-        for (int Var = 0; Var < Probleme->NombreDeVariables; Var++)
+        for (int Var = 0; Var < Probleme.NombreDeVariables; Var++)
         {
-            DonneesMensuelles.CoutSolution += Probleme->CoutLineaire[Var] * Probleme->X[Var];
+            DonneesMensuelles.CoutSolution += Probleme.CoutLineaire[Var] * Probleme.X[Var];
         }
 
         DonneesMensuelles.ResultatsValides = OUI;

--- a/src/solver/hydro/monthly/h2o_m_resoudre_le_probleme_lineaire.cpp
+++ b/src/solver/hydro/monthly/h2o_m_resoudre_le_probleme_lineaire.cpp
@@ -19,7 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-#include <memory>
 
 #include "antares/solver/hydro/monthly/h2o_m_donnees_annuelles.h"
 #include "antares/solver/hydro/monthly/h2o_m_fonctions.h"
@@ -35,7 +34,7 @@ void H2O_M_ResoudreLeProblemeLineaire(DONNEES_ANNUELLES& DonneesAnnuelles, int N
                                                                   .ProblemeLineairePartieFixe;
 
     PROBLEME_SPX* ProbSpx = ProblemeHydraulique.ProblemeSpx[NumeroDeReservoir].get();
-    std::unique_ptr<PROBLEME_SIMPLEXE> Probleme = std::make_unique<PROBLEME_SIMPLEXE>();
+    PROBLEME_SIMPLEXE Probleme;
 
     bool PremierPassage = true;
 
@@ -43,14 +42,14 @@ RESOLUTION:
 
     if (!ProbSpx)
     {
-        Probleme->Contexte = SIMPLEXE_SEUL;
-        Probleme->BaseDeDepartFournie = NON_SPX;
+        Probleme.Contexte = SIMPLEXE_SEUL;
+        Probleme.BaseDeDepartFournie = NON_SPX;
     }
     else
     {
-        Probleme->Contexte = BRANCH_AND_BOUND_OU_CUT_NOEUD;
+        Probleme.Contexte = BRANCH_AND_BOUND_OU_CUT_NOEUD;
 
-        Probleme->BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
+        Probleme.BaseDeDepartFournie = UTILISER_LA_BASE_DU_PROBLEME_SPX;
 
         SPX_ModifierLeVecteurSecondMembre(ProbSpx,
                                           ProblemeLineairePartieVariable.SecondMembre.data(),
@@ -58,68 +57,68 @@ RESOLUTION:
                                           ProblemeLineairePartieFixe.NombreDeContraintes);
     }
 
-    Probleme->NombreMaxDIterations = -1;
-    Probleme->DureeMaxDuCalcul = -1.;
+    Probleme.NombreMaxDIterations = -1;
+    Probleme.DureeMaxDuCalcul = -1.;
 
-    Probleme->CoutLineaire = ProblemeLineairePartieFixe.CoutLineaireBruite.data();
-    Probleme->X = ProblemeLineairePartieVariable.X.data();
-    Probleme->Xmin = ProblemeLineairePartieVariable.Xmin.data();
-    Probleme->Xmax = ProblemeLineairePartieVariable.Xmax.data();
-    Probleme->NombreDeVariables = ProblemeLineairePartieFixe.NombreDeVariables;
-    Probleme->TypeDeVariable = ProblemeLineairePartieFixe.TypeDeVariable.data();
+    Probleme.CoutLineaire = ProblemeLineairePartieFixe.CoutLineaireBruite.data();
+    Probleme.X = ProblemeLineairePartieVariable.X.data();
+    Probleme.Xmin = ProblemeLineairePartieVariable.Xmin.data();
+    Probleme.Xmax = ProblemeLineairePartieVariable.Xmax.data();
+    Probleme.NombreDeVariables = ProblemeLineairePartieFixe.NombreDeVariables;
+    Probleme.TypeDeVariable = ProblemeLineairePartieFixe.TypeDeVariable.data();
 
-    Probleme->NombreDeContraintes = ProblemeLineairePartieFixe.NombreDeContraintes;
-    Probleme->IndicesDebutDeLigne = ProblemeLineairePartieFixe.IndicesDebutDeLigne.data();
-    Probleme->NombreDeTermesDesLignes = ProblemeLineairePartieFixe.NombreDeTermesDesLignes.data();
-    Probleme->IndicesColonnes = ProblemeLineairePartieFixe.IndicesColonnes.data();
-    Probleme->CoefficientsDeLaMatriceDesContraintes = ProblemeLineairePartieFixe
-                                                        .CoefficientsDeLaMatriceDesContraintes
-                                                        .data();
-    Probleme->Sens = ProblemeLineairePartieFixe.Sens.data();
-    Probleme->SecondMembre = ProblemeLineairePartieVariable.SecondMembre.data();
+    Probleme.NombreDeContraintes = ProblemeLineairePartieFixe.NombreDeContraintes;
+    Probleme.IndicesDebutDeLigne = ProblemeLineairePartieFixe.IndicesDebutDeLigne.data();
+    Probleme.NombreDeTermesDesLignes = ProblemeLineairePartieFixe.NombreDeTermesDesLignes.data();
+    Probleme.IndicesColonnes = ProblemeLineairePartieFixe.IndicesColonnes.data();
+    Probleme.CoefficientsDeLaMatriceDesContraintes = ProblemeLineairePartieFixe
+                                                       .CoefficientsDeLaMatriceDesContraintes
+                                                       .data();
+    Probleme.Sens = ProblemeLineairePartieFixe.Sens.data();
+    Probleme.SecondMembre = ProblemeLineairePartieVariable.SecondMembre.data();
 
-    Probleme->ChoixDeLAlgorithme = SPX_DUAL;
+    Probleme.ChoixDeLAlgorithme = SPX_DUAL;
 
-    Probleme->TypeDePricing = PRICING_STEEPEST_EDGE;
-    Probleme->FaireDuScaling = OUI_SPX;
-    Probleme->StrategieAntiDegenerescence = AGRESSIF;
+    Probleme.TypeDePricing = PRICING_STEEPEST_EDGE;
+    Probleme.FaireDuScaling = OUI_SPX;
+    Probleme.StrategieAntiDegenerescence = AGRESSIF;
 
-    Probleme->PositionDeLaVariable = ProblemeLineairePartieVariable.PositionDeLaVariable.data();
-    Probleme->NbVarDeBaseComplementaires = 0;
-    Probleme->ComplementDeLaBase = ProblemeLineairePartieVariable.ComplementDeLaBase.data();
+    Probleme.PositionDeLaVariable = ProblemeLineairePartieVariable.PositionDeLaVariable.data();
+    Probleme.NbVarDeBaseComplementaires = 0;
+    Probleme.ComplementDeLaBase = ProblemeLineairePartieVariable.ComplementDeLaBase.data();
 
-    Probleme->LibererMemoireALaFin = NON_SPX;
+    Probleme.LibererMemoireALaFin = NON_SPX;
 
-    Probleme->UtiliserCoutMax = NON_SPX;
-    Probleme->CoutMax = 0.0;
+    Probleme.UtiliserCoutMax = NON_SPX;
+    Probleme.CoutMax = 0.0;
 
-    Probleme->CoutsMarginauxDesContraintes = ProblemeLineairePartieVariable
-                                               .CoutsMarginauxDesContraintes.data();
-    Probleme->CoutsReduits = ProblemeLineairePartieVariable.CoutsReduits.data();
+    Probleme.CoutsMarginauxDesContraintes = ProblemeLineairePartieVariable
+                                              .CoutsMarginauxDesContraintes.data();
+    Probleme.CoutsReduits = ProblemeLineairePartieVariable.CoutsReduits.data();
 
 #ifndef NDEBUG
     if (PremierPassage)
     {
-        Probleme->AffichageDesTraces = NON_SPX;
+        Probleme.AffichageDesTraces = NON_SPX;
     }
     else
     {
-        Probleme->AffichageDesTraces = OUI_SPX;
+        Probleme.AffichageDesTraces = OUI_SPX;
     }
 #else
-    Probleme->AffichageDesTraces = NON_SPX;
+    Probleme.AffichageDesTraces = NON_SPX;
 #endif
 
-    Probleme->NombreDeContraintesCoupes = 0;
+    Probleme.NombreDeContraintesCoupes = 0;
 
-    ProbSpx = SPX_Simplexe(Probleme.get(), ProbSpx);
+    ProbSpx = SPX_Simplexe(&Probleme, ProbSpx);
 
     if (ProbSpx)
     {
         ProblemeHydraulique.ProblemeSpx[NumeroDeReservoir].reset(ProbSpx);
     }
 
-    ProblemeLineairePartieVariable.ExistenceDUneSolution = Probleme->ExistenceDUneSolution;
+    ProblemeLineairePartieVariable.ExistenceDUneSolution = Probleme.ExistenceDUneSolution;
 
     if (ProblemeLineairePartieVariable.ExistenceDUneSolution != OUI_SPX && PremierPassage
         && ProbSpx)
@@ -142,18 +141,18 @@ RESOLUTION:
     if (ProblemeLineairePartieVariable.ExistenceDUneSolution == OUI_SPX)
     {
         ProblemeHydraulique.CoutDeLaSolution = 0.0;
-        for (int var = 0; var < Probleme->NombreDeVariables; var++)
+        for (int var = 0; var < Probleme.NombreDeVariables; var++)
         {
             ProblemeHydraulique.CoutDeLaSolution += ProblemeLineairePartieFixe.CoutLineaire[var]
-                                                    * Probleme->X[var];
+                                                    * Probleme.X[var];
         }
 
         ProblemeHydraulique.CoutDeLaSolutionBruite = 0.0;
-        for (int var = 0; var < Probleme->NombreDeVariables; var++)
+        for (int var = 0; var < Probleme.NombreDeVariables; var++)
         {
             ProblemeHydraulique.CoutDeLaSolutionBruite += ProblemeLineairePartieFixe
                                                             .CoutLineaireBruite[var]
-                                                          * Probleme->X[var];
+                                                          * Probleme.X[var];
         }
 
         DonneesAnnuelles.ResultatsValides = OUI;

--- a/src/solver/hydro/monthly/h2o_m_resoudre_le_probleme_lineaire.cpp
+++ b/src/solver/hydro/monthly/h2o_m_resoudre_le_probleme_lineaire.cpp
@@ -19,7 +19,6 @@
 ** along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
 */
 
-
 #include "antares/solver/hydro/monthly/h2o_m_donnees_annuelles.h"
 #include "antares/solver/hydro/monthly/h2o_m_fonctions.h"
 


### PR DESCRIPTION
1. Remove dependency on `std::unique_ptr`
2. Avoid dynamic allocations where not needed
3. Simplify the code overall