### PR TITLE
APIv2 - Fix initial hydro levels

### DIFF
--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -143,7 +143,8 @@ void SingleProblemGetter::initializeRandomNumbers()
 
     MersenneTwister randomHydroGenerator;
     randomHydroGenerator.reset(study_->parameters.seed[Data::seedHydroManagement]);
-    randomForParallelYears_->compute(*study_, 1, isYearPerformed, randomHydroGenerator);
+    const unsigned int finalYear = 1 + study_->runtime.rangeLimits.year[Data::rangeEnd];
+    randomForParallelYears_->compute(*study_, finalYear, isYearPerformed, randomHydroGenerator);
 }
 
 void SingleProblemGetter::writeNTCTimeSeries(const std::filesystem::path& outputDir)


### PR DESCRIPTION
Providing the proper `nbYears` argument to `randomNumbers::compute` prevents a bug when the year 0 is disabled in the user playlist
```cpp
for (unsigned y = 0; y < nbYears; ++y)
{
	bool isPerformed = isYearPerformed[y];
}
// ...
if (isPerformed) // skipped if isYearPerformed[0] is false
{
	pYears[indexYear].pReservoirLevels[areaIndex] = randomLevel; // pReservoirLevels is left untouched, so 0 values
}
```