### PR TITLE
Modeler : simplify forbidden nodes

### DIFF
--- a/src/io/inputs/model-converter/CMakeLists.txt
+++ b/src/io/inputs/model-converter/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
         modelConverter.cpp
         convertorVisitor.cpp
         NodeChecker.cpp
+        ForbiddenNodes.cpp
         include/antares/io/inputs/model-converter/modelConverter.h
         include/antares/io/inputs/model-converter/convertorVisitor.h
         include/antares/io/inputs/model-converter/ForbiddenNodes.h

--- a/src/io/inputs/model-converter/CMakeLists.txt
+++ b/src/io/inputs/model-converter/CMakeLists.txt
@@ -3,12 +3,12 @@
 set(SOURCES
         modelConverter.cpp
         convertorVisitor.cpp
-        NodeChecker.cpp
+        ForbiddenNodesVisitor.cpp
         ForbiddenNodes.cpp
         include/antares/io/inputs/model-converter/modelConverter.h
         include/antares/io/inputs/model-converter/convertorVisitor.h
         include/antares/io/inputs/model-converter/ForbiddenNodes.h
-        include/antares/io/inputs/model-converter/NodeChecker.h
+        include/antares/io/inputs/model-converter/ForbiddenNodesVisitor.h
 )
 
 # Create the library

--- a/src/io/inputs/model-converter/ForbiddenNodes.cpp
+++ b/src/io/inputs/model-converter/ForbiddenNodes.cpp
@@ -1,0 +1,16 @@
+#include <antares/io/inputs/model-converter/ForbiddenNodes.h>
+
+namespace Antares::IO::Inputs::ModelConverter
+{
+bool ForbiddenNodes::isGloballyForbidden(const std::type_index& typeId) const
+{
+    return global_.contains(typeId);
+}
+
+bool ForbiddenNodes::isForbiddenByParent(const std::type_index& parentTypeId,
+                                         const std::type_index& nodeTypeId) const
+{
+    const auto& it = rules_.find(parentTypeId);
+    return (it != rules_.end()) && it->second.contains(nodeTypeId);
+}
+} // namespace Antares::IO::Inputs::ModelConverter

--- a/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
+++ b/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
@@ -78,21 +78,21 @@ void ForbiddenNodesVisitor::visit(const DivisionNode* divisionNode)
 void ForbiddenNodesVisitor::visit(const EqualNode* equalNode)
 {
     std::type_index nodeTypeId = typeIndexOf<EqualNode>();
-    checkIsForbidden(nodeTypeId, equalNode);
+    checkIsForbidden(equalNode, nodeTypeId);
     visitChildren(equalNode, nodeTypeId);
 }
 
 void ForbiddenNodesVisitor::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
 {
     std::type_index nodeTypeId = typeIndexOf<LessThanOrEqualNode>();
-    checkIsForbidden(nodeTypeId, lessThanOrEqualNode);
+    checkIsForbidden(lessThanOrEqualNode, nodeTypeId);
     visitChildren(lessThanOrEqualNode, nodeTypeId);
 }
 
 void ForbiddenNodesVisitor::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
 {
     std::type_index nodeTypeId = typeIndexOf<GreaterThanOrEqualNode>();
-    checkIsForbidden(nodeTypeId, greaterThanOrEqualNode);
+    checkIsForbidden(greaterThanOrEqualNode, nodeTypeId);
     visitChildren(greaterThanOrEqualNode, nodeTypeId);
 }
 
@@ -108,7 +108,7 @@ void ForbiddenNodesVisitor::visit(const LiteralNode*)
 
 void ForbiddenNodesVisitor::visit(const VariableNode* variableNode)
 {
-    checkIsForbidden(typeIndexOf<VariableNode>(), variableNode);
+    checkIsForbidden(variableNode, typeIndexOf<VariableNode>());
 }
 
 void ForbiddenNodesVisitor::visit(const ParameterNode*)
@@ -118,39 +118,39 @@ void ForbiddenNodesVisitor::visit(const ParameterNode*)
 
 void ForbiddenNodesVisitor::visit(const PortFieldNode* portFieldNode)
 {
-    checkIsForbidden(typeIndexOf<PortFieldNode>(), portFieldNode);
+    checkIsForbidden(portFieldNode, typeIndexOf<PortFieldNode>());
 }
 
 void ForbiddenNodesVisitor::visit(const PortFieldSumNode* portFieldSumNode)
 {
-    checkIsForbidden(typeIndexOf<PortFieldSumNode>(), portFieldSumNode);
+    checkIsForbidden(portFieldSumNode, typeIndexOf<PortFieldSumNode>());
 }
 
 void ForbiddenNodesVisitor::visit(const TimeShiftNode* timeShiftNode)
 {
     std::type_index nodeTypeId = typeIndexOf<TimeShiftNode>();
-    checkIsForbidden(nodeTypeId, timeShiftNode);
+    checkIsForbidden(timeShiftNode, nodeTypeId);
     visitChildren(timeShiftNode, nodeTypeId);
 }
 
 void ForbiddenNodesVisitor::visit(const TimeIndexNode* timeIndexNode)
 {
     std::type_index nodeTypeId = typeIndexOf<TimeIndexNode>();
-    checkIsForbidden(nodeTypeId, timeIndexNode);
+    checkIsForbidden(timeIndexNode, nodeTypeId);
     visitChildren(timeIndexNode, nodeTypeId);
 }
 
 void ForbiddenNodesVisitor::visit(const TimeSumNode* timeSumNode)
 {
     std::type_index nodeTypeId = typeIndexOf<TimeSumNode>();
-    checkIsForbidden(nodeTypeId, timeSumNode);
+    checkIsForbidden(timeSumNode, nodeTypeId);
     visitChildren(timeSumNode, nodeTypeId);
 }
 
 void ForbiddenNodesVisitor::visit(const AllTimeSumNode* allTimeSumNode)
 {
     std::type_index nodeTypeId = typeIndexOf<AllTimeSumNode>();
-    checkIsForbidden(nodeTypeId, allTimeSumNode);
+    checkIsForbidden(allTimeSumNode, nodeTypeId);
     visitChildren(allTimeSumNode, nodeTypeId);
 }
 
@@ -182,12 +182,12 @@ void ForbiddenNodesVisitor::visit(const FunctionNode* functionNode)
         break;
     }
 
-    checkIsForbidden(nodeTypeId, functionNode);
+    checkIsForbidden(functionNode, nodeTypeId);
     visitChildren(functionNode, nodeTypeId);
 }
 
-void ForbiddenNodesVisitor::checkIsForbidden(const std::type_index& nodeTypeId,
-                                             const Node* node) const
+void ForbiddenNodesVisitor::checkIsForbidden(const Node* node,
+                                             const std::type_index& nodeTypeId) const
 {
     checkIGloballyForbidden(nodeTypeId, node);
     checkIsForbiddenByParent(nodeTypeId, node);

--- a/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
+++ b/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
@@ -154,7 +154,7 @@ void ForbiddenNodesVisitor::visit(const AllTimeSumNode* allTimeSumNode)
     visitChildren(allTimeSumNode, nodeTypeId);
 }
 
-std::type_index getTypeIndex(const FunctionNode* functionNode)
+std::type_index functionNodeTypeIndex(const FunctionNode* functionNode)
 {
     switch (functionNode->type())
     {
@@ -177,7 +177,7 @@ std::type_index getTypeIndex(const FunctionNode* functionNode)
 
 void ForbiddenNodesVisitor::visit(const FunctionNode* functionNode)
 {
-    std::type_index nodeTypeId(getTypeIndex(functionNode));
+    std::type_index nodeTypeId(functionNodeTypeIndex(functionNode));
     checkIsForbidden(functionNode, nodeTypeId);
     visitChildren(functionNode, nodeTypeId);
 }

--- a/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
+++ b/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
@@ -154,34 +154,30 @@ void ForbiddenNodesVisitor::visit(const AllTimeSumNode* allTimeSumNode)
     visitChildren(allTimeSumNode, nodeTypeId);
 }
 
-void ForbiddenNodesVisitor::visit(const FunctionNode* functionNode)
+std::type_index getTypeIndex(const FunctionNode* functionNode)
 {
-    std::type_index nodeTypeId(typeid(int)); // Must be default constructed here
-
     switch (functionNode->type())
     {
     case FunctionNodeType::reduced_cost:
-        nodeTypeId = typeIndexOf<FunctionNodeType::reduced_cost>();
-        break;
+        return typeIndexOf<FunctionNodeType::reduced_cost>();
     case FunctionNodeType::dual:
-        nodeTypeId = typeIndexOf<FunctionNodeType::dual>();
-        break;
+        return typeIndexOf<FunctionNodeType::dual>();
     case FunctionNodeType::min:
-        nodeTypeId = typeIndexOf<FunctionNodeType::min>();
-        break;
+        return typeIndexOf<FunctionNodeType::min>();
     case FunctionNodeType::max:
-        nodeTypeId = typeIndexOf<FunctionNodeType::max>();
-        break;
+        return typeIndexOf<FunctionNodeType::max>();
     case FunctionNodeType::pow:
-        nodeTypeId = typeIndexOf<FunctionNodeType::pow>();
-        break;
+        return typeIndexOf<FunctionNodeType::pow>();
     case FunctionNodeType::floor:
-        nodeTypeId = typeIndexOf<FunctionNodeType::floor>();
-        break;
+        return typeIndexOf<FunctionNodeType::floor>();
     default:
-        break;
+        return typeid(int); // Supposed to be dead code (never reached)
     }
+}
 
+void ForbiddenNodesVisitor::visit(const FunctionNode* functionNode)
+{
+    std::type_index nodeTypeId(getTypeIndex(functionNode));
     checkIsForbidden(functionNode, nodeTypeId);
     visitChildren(functionNode, nodeTypeId);
 }

--- a/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
+++ b/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
@@ -18,7 +18,7 @@
  * You should have received a copy of the Mozilla Public Licence 2.0
  * along with Antares_Simulator. If not, see <https://opensource.org/license/mpl-2-0/>.
  */
-#include "include/antares/io/inputs/model-converter/NodeChecker.h"
+#include "include/antares/io/inputs/model-converter/ForbiddenNodesVisitor.h"
 
 #include <antares/expressions/nodes/ExpressionsNodes.h>
 using namespace Antares::Expressions::Nodes;
@@ -43,117 +43,118 @@ ForbiddenNodeFound::ForbiddenNodeFound(const std::string expr,
 {
 }
 
-NodeChecker::NodeChecker(const ForbiddenNodes& forbiddenNodes, const std::string& expression):
+ForbiddenNodesVisitor::ForbiddenNodesVisitor(const ForbiddenNodes& forbiddenNodes,
+                                             const std::string& expression):
     forbiddenNodes_(forbiddenNodes),
     expression_(expression)
 {
 }
 
-std::string NodeChecker::name() const
+std::string ForbiddenNodesVisitor::name() const
 {
-    return "NodeChecker";
+    return "ForbiddenNodesVisitor";
 }
 
-void NodeChecker::visit(const SumNode* sumNode)
+void ForbiddenNodesVisitor::visit(const SumNode* sumNode)
 {
     visitChildren(sumNode, typeIndexOf<SumNode>());
 }
 
-void NodeChecker::visit(const SubtractionNode* subtractionNode)
+void ForbiddenNodesVisitor::visit(const SubtractionNode* subtractionNode)
 {
     visitChildren(subtractionNode, typeIndexOf<SubtractionNode>());
 }
 
-void NodeChecker::visit(const MultiplicationNode* multiplicationNode)
+void ForbiddenNodesVisitor::visit(const MultiplicationNode* multiplicationNode)
 {
     visitChildren(multiplicationNode, typeIndexOf<MultiplicationNode>());
 }
 
-void NodeChecker::visit(const DivisionNode* divisionNode)
+void ForbiddenNodesVisitor::visit(const DivisionNode* divisionNode)
 {
     visitChildren(divisionNode, typeIndexOf<DivisionNode>());
 }
 
-void NodeChecker::visit(const EqualNode* equalNode)
+void ForbiddenNodesVisitor::visit(const EqualNode* equalNode)
 {
     std::type_index nodeTypeId = typeIndexOf<EqualNode>();
     checkIsForbidden(nodeTypeId, equalNode);
     visitChildren(equalNode, nodeTypeId);
 }
 
-void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
+void ForbiddenNodesVisitor::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
 {
     std::type_index nodeTypeId = typeIndexOf<LessThanOrEqualNode>();
     checkIsForbidden(nodeTypeId, lessThanOrEqualNode);
     visitChildren(lessThanOrEqualNode, nodeTypeId);
 }
 
-void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
+void ForbiddenNodesVisitor::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
 {
     std::type_index nodeTypeId = typeIndexOf<GreaterThanOrEqualNode>();
     checkIsForbidden(nodeTypeId, greaterThanOrEqualNode);
     visitChildren(greaterThanOrEqualNode, nodeTypeId);
 }
 
-void NodeChecker::visit(const NegationNode* negationNode)
+void ForbiddenNodesVisitor::visit(const NegationNode* negationNode)
 {
     dispatch(negationNode->child());
 }
 
-void NodeChecker::visit(const LiteralNode*)
+void ForbiddenNodesVisitor::visit(const LiteralNode*)
 {
     // keep empty
 }
 
-void NodeChecker::visit(const VariableNode* variableNode)
+void ForbiddenNodesVisitor::visit(const VariableNode* variableNode)
 {
     checkIsForbidden(typeIndexOf<VariableNode>(), variableNode);
 }
 
-void NodeChecker::visit(const ParameterNode*)
+void ForbiddenNodesVisitor::visit(const ParameterNode*)
 {
     // keep empty
 }
 
-void NodeChecker::visit(const PortFieldNode* portFieldNode)
+void ForbiddenNodesVisitor::visit(const PortFieldNode* portFieldNode)
 {
     checkIsForbidden(typeIndexOf<PortFieldNode>(), portFieldNode);
 }
 
-void NodeChecker::visit(const PortFieldSumNode* portFieldSumNode)
+void ForbiddenNodesVisitor::visit(const PortFieldSumNode* portFieldSumNode)
 {
     checkIsForbidden(typeIndexOf<PortFieldSumNode>(), portFieldSumNode);
 }
 
-void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
+void ForbiddenNodesVisitor::visit(const TimeShiftNode* timeShiftNode)
 {
     std::type_index nodeTypeId = typeIndexOf<TimeShiftNode>();
     checkIsForbidden(nodeTypeId, timeShiftNode);
     visitChildren(timeShiftNode, nodeTypeId);
 }
 
-void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
+void ForbiddenNodesVisitor::visit(const TimeIndexNode* timeIndexNode)
 {
     std::type_index nodeTypeId = typeIndexOf<TimeIndexNode>();
     checkIsForbidden(nodeTypeId, timeIndexNode);
     visitChildren(timeIndexNode, nodeTypeId);
 }
 
-void NodeChecker::visit(const TimeSumNode* timeSumNode)
+void ForbiddenNodesVisitor::visit(const TimeSumNode* timeSumNode)
 {
     std::type_index nodeTypeId = typeIndexOf<TimeSumNode>();
     checkIsForbidden(nodeTypeId, timeSumNode);
     visitChildren(timeSumNode, nodeTypeId);
 }
 
-void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
+void ForbiddenNodesVisitor::visit(const AllTimeSumNode* allTimeSumNode)
 {
     std::type_index nodeTypeId = typeIndexOf<AllTimeSumNode>();
     checkIsForbidden(nodeTypeId, allTimeSumNode);
     visitChildren(allTimeSumNode, nodeTypeId);
 }
 
-void NodeChecker::visit(const FunctionNode* functionNode)
+void ForbiddenNodesVisitor::visit(const FunctionNode* functionNode)
 {
     std::type_index nodeTypeId(typeid(int)); // Must be default constructed here
 
@@ -185,14 +186,15 @@ void NodeChecker::visit(const FunctionNode* functionNode)
     visitChildren(functionNode, nodeTypeId);
 }
 
-void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId, const Node* node) const
+void ForbiddenNodesVisitor::checkIsForbidden(const std::type_index& nodeTypeId,
+                                             const Node* node) const
 {
     checkIGloballyForbidden(nodeTypeId, node);
     checkIsForbiddenByParent(nodeTypeId, node);
 }
 
-void NodeChecker::checkIGloballyForbidden(const std::type_index& nodeTypeId,
-                                          const Antares::Expressions::Nodes::Node* node) const
+void ForbiddenNodesVisitor::checkIGloballyForbidden(const std::type_index& nodeTypeId,
+                                                    const Node* node) const
 {
     if (forbiddenNodes_.isGloballyForbidden(nodeTypeId))
     {
@@ -200,8 +202,8 @@ void NodeChecker::checkIGloballyForbidden(const std::type_index& nodeTypeId,
     }
 }
 
-void NodeChecker::checkIsForbiddenByParent(const std::type_index& nodeTypeId,
-                                           const Antares::Expressions::Nodes::Node* node) const
+void ForbiddenNodesVisitor::checkIsForbiddenByParent(const std::type_index& nodeTypeId,
+                                                     const Node* node) const
 {
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
@@ -212,8 +214,8 @@ void NodeChecker::checkIsForbiddenByParent(const std::type_index& nodeTypeId,
     }
 }
 
-void NodeChecker::visitChildren(const Expressions::Nodes::ParentNode* node,
-                                const std::type_index& nodeTypeId)
+void ForbiddenNodesVisitor::visitChildren(const Expressions::Nodes::ParentNode* node,
+                                          const std::type_index& nodeTypeId)
 {
     parentsStack_.emplace_back(node->name(), nodeTypeId);
     for (const auto* childNode: node->getOperands())

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -77,21 +77,21 @@ void NodeChecker::visit(const DivisionNode* divisionNode)
 void NodeChecker::visit(const EqualNode* equalNode)
 {
     std::string nodeName = "expression with =";
-    checkConsistencyWithParents<EqualNode>(nodeName);
+    checkIsForbidden<EqualNode>(nodeName);
     visitChildren<EqualNode>(nodeName, equalNode->getOperands());
 }
 
 void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
 {
     std::string nodeName = "expression with <=";
-    checkConsistencyWithParents<LessThanOrEqualNode>(nodeName);
+    checkIsForbidden<LessThanOrEqualNode>(nodeName);
     visitChildren<LessThanOrEqualNode>(nodeName, lessThanOrEqualNode->getOperands());
 }
 
 void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
 {
     std::string nodeName = "expression with >=";
-    checkConsistencyWithParents<GreaterThanOrEqualNode>(nodeName);
+    checkIsForbidden<GreaterThanOrEqualNode>(nodeName);
     visitChildren<GreaterThanOrEqualNode>(nodeName, greaterThanOrEqualNode->getOperands());
 }
 
@@ -107,7 +107,7 @@ void NodeChecker::visit(const LiteralNode*)
 
 void NodeChecker::visit(const VariableNode* variableNode)
 {
-    checkConsistencyWithParents<VariableNode>("variable(" + variableNode->value() + ")");
+    checkIsForbidden<VariableNode>("variable(" + variableNode->value() + ")");
 }
 
 void NodeChecker::visit(const ParameterNode*)
@@ -117,40 +117,40 @@ void NodeChecker::visit(const ParameterNode*)
 
 void NodeChecker::visit(const PortFieldNode* portFieldNode)
 {
-    checkConsistencyWithParents<PortFieldNode>("port field (" + portFieldNode->getPortName() + "."
-                                               + portFieldNode->getFieldName() + ")");
+    checkIsForbidden<PortFieldNode>("port field (" + portFieldNode->getPortName() + "."
+                                    + portFieldNode->getFieldName() + ")");
 }
 
 void NodeChecker::visit(const PortFieldSumNode*)
 {
-    checkConsistencyWithParents<PortFieldSumNode>("sum_connections");
+    checkIsForbidden<PortFieldSumNode>("sum_connections");
 }
 
 void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
 {
     std::string nodeName = "timeShift";
-    checkConsistencyWithParents<TimeShiftNode>(nodeName);
+    checkIsForbidden<TimeShiftNode>(nodeName);
     visitChildren<TimeShiftNode>(nodeName, timeShiftNode->getOperands());
 }
 
 void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
 {
     std::string nodeName = "timeIndex";
-    checkConsistencyWithParents<TimeIndexNode>(nodeName);
+    checkIsForbidden<TimeIndexNode>(nodeName);
     visitChildren<TimeIndexNode>(nodeName, timeIndexNode->getOperands());
 }
 
 void NodeChecker::visit(const TimeSumNode* timeSumNode)
 {
     std::string nodeName = "sum";
-    checkConsistencyWithParents<TimeIndexNode>(nodeName);
+    checkIsForbidden<TimeIndexNode>(nodeName);
     visitChildren<TimeSumNode>(nodeName, timeSumNode->getOperands());
 }
 
 void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 {
     std::string nodeName = "sum";
-    checkConsistencyWithParents<AllTimeSumNode>(nodeName);
+    checkIsForbidden<AllTimeSumNode>(nodeName);
     visitChildren<AllTimeSumNode>(nodeName, allTimeSumNode->getOperands());
 }
 
@@ -163,21 +163,27 @@ void NodeChecker::visit(const FunctionNode* functionNode)
     switch (type)
     {
     case FunctionNodeType::reduced_cost:
+        checkIsForbidden<FunctionNodeType::reduced_cost>(type_str);
         visitChildren<FunctionNodeType::reduced_cost>(type_str, operands);
         break;
     case FunctionNodeType::dual:
+        checkIsForbidden<FunctionNodeType::dual>(type_str);
         visitChildren<FunctionNodeType::dual>(type_str, operands);
         break;
     case FunctionNodeType::min:
+        checkIsForbidden<FunctionNodeType::min>(type_str);
         visitChildren<FunctionNodeType::min>(type_str, operands);
         break;
     case FunctionNodeType::max:
+        checkIsForbidden<FunctionNodeType::max>(type_str);
         visitChildren<FunctionNodeType::max>(type_str, operands);
         break;
     case FunctionNodeType::pow:
+        checkIsForbidden<FunctionNodeType::pow>(type_str);
         visitChildren<FunctionNodeType::pow>(type_str, operands);
         break;
     case FunctionNodeType::floor:
+        checkIsForbidden<FunctionNodeType::floor>(type_str);
         visitChildren<FunctionNodeType::floor>(type_str, operands);
         break;
     default:

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -56,37 +56,43 @@ std::string NodeChecker::name() const
 
 void NodeChecker::visit(const SumNode* sumNode)
 {
-    visitChildren<SumNode>("sum", sumNode->getOperands(), false);
+    visitChildren<SumNode>("sum", sumNode->getOperands());
 }
 
 void NodeChecker::visit(const SubtractionNode* subtractionNode)
 {
-    visitChildren<SubtractionNode>("subtraction", subtractionNode->getOperands(), false);
+    visitChildren<SubtractionNode>("subtraction", subtractionNode->getOperands());
 }
 
 void NodeChecker::visit(const MultiplicationNode* multiplicationNode)
 {
-    visitChildren<MultiplicationNode>("multiplication", multiplicationNode->getOperands(), false);
+    visitChildren<MultiplicationNode>("multiplication", multiplicationNode->getOperands());
 }
 
 void NodeChecker::visit(const DivisionNode* divisionNode)
 {
-    visitChildren<DivisionNode>("division", divisionNode->getOperands(), false);
+    visitChildren<DivisionNode>("division", divisionNode->getOperands());
 }
 
 void NodeChecker::visit(const EqualNode* equalNode)
 {
-    visitComparisonNode<EqualNode>("=", equalNode->getOperands());
+    std::string nodeName = "expression with =";
+    checkConsistencyWithParents<EqualNode>(nodeName);
+    visitChildren<EqualNode>(nodeName, equalNode->getOperands());
 }
 
 void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
 {
-    visitComparisonNode<LessThanOrEqualNode>("<=", lessThanOrEqualNode->getOperands());
+    std::string nodeName = "expression with <=";
+    checkConsistencyWithParents<LessThanOrEqualNode>(nodeName);
+    visitChildren<LessThanOrEqualNode>(nodeName, lessThanOrEqualNode->getOperands());
 }
 
 void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
 {
-    visitComparisonNode<GreaterThanOrEqualNode>(">=", greaterThanOrEqualNode->getOperands());
+    std::string nodeName = "expression with >=";
+    checkConsistencyWithParents<GreaterThanOrEqualNode>(nodeName);
+    visitChildren<GreaterThanOrEqualNode>(nodeName, greaterThanOrEqualNode->getOperands());
 }
 
 void NodeChecker::visit(const NegationNode* negationNode)
@@ -122,22 +128,30 @@ void NodeChecker::visit(const PortFieldSumNode*)
 
 void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
 {
-    visitChildren<TimeShiftNode>("timeShift", timeShiftNode->getOperands(), true);
+    std::string nodeName = "timeShift";
+    checkConsistencyWithParents<TimeShiftNode>(nodeName);
+    visitChildren<TimeShiftNode>(nodeName, timeShiftNode->getOperands());
 }
 
 void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
 {
-    visitChildren<TimeIndexNode>("timeIndex", timeIndexNode->getOperands(), true);
+    std::string nodeName = "timeIndex";
+    checkConsistencyWithParents<TimeIndexNode>(nodeName);
+    visitChildren<TimeIndexNode>(nodeName, timeIndexNode->getOperands());
 }
 
 void NodeChecker::visit(const TimeSumNode* timeSumNode)
 {
-    visitChildren<TimeSumNode>("sum", timeSumNode->getOperands(), true);
+    std::string nodeName = "sum";
+    checkConsistencyWithParents<TimeIndexNode>(nodeName);
+    visitChildren<TimeSumNode>(nodeName, timeSumNode->getOperands());
 }
 
 void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 {
-    visitChildren<AllTimeSumNode>("sum", allTimeSumNode->getOperands(), true);
+    std::string nodeName = "sum";
+    checkConsistencyWithParents<AllTimeSumNode>(nodeName);
+    visitChildren<AllTimeSumNode>(nodeName, allTimeSumNode->getOperands());
 }
 
 void NodeChecker::visit(const FunctionNode* functionNode)

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -56,24 +56,22 @@ std::string NodeChecker::name() const
 
 void NodeChecker::visit(const SumNode* sumNode)
 {
-    visitChildren("sum", sumNode->getOperands(), typeIndexOf<SumNode>());
+    visitChildren("sum", sumNode, typeIndexOf<SumNode>());
 }
 
 void NodeChecker::visit(const SubtractionNode* subtractionNode)
 {
-    visitChildren("subtraction", subtractionNode->getOperands(), typeIndexOf<SubtractionNode>());
+    visitChildren("subtraction", subtractionNode, typeIndexOf<SubtractionNode>());
 }
 
 void NodeChecker::visit(const MultiplicationNode* multiplicationNode)
 {
-    visitChildren("multiplication",
-                  multiplicationNode->getOperands(),
-                  typeIndexOf<MultiplicationNode>());
+    visitChildren("multiplication", multiplicationNode, typeIndexOf<MultiplicationNode>());
 }
 
 void NodeChecker::visit(const DivisionNode* divisionNode)
 {
-    visitChildren("division", divisionNode->getOperands(), typeIndexOf<DivisionNode>());
+    visitChildren("division", divisionNode, typeIndexOf<DivisionNode>());
 }
 
 void NodeChecker::visit(const EqualNode* equalNode)
@@ -81,7 +79,7 @@ void NodeChecker::visit(const EqualNode* equalNode)
     std::string nodeName = "expression with =";
     std::type_index nodeTypeId = typeIndexOf<EqualNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, equalNode->getOperands(), nodeTypeId);
+    visitChildren(nodeName, equalNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
@@ -89,7 +87,7 @@ void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
     std::string nodeName = "expression with <=";
     std::type_index nodeTypeId = typeIndexOf<LessThanOrEqualNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, lessThanOrEqualNode->getOperands(), nodeTypeId);
+    visitChildren(nodeName, lessThanOrEqualNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
@@ -97,7 +95,7 @@ void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
     std::string nodeName = "expression with >=";
     std::type_index nodeTypeId = typeIndexOf<GreaterThanOrEqualNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, greaterThanOrEqualNode->getOperands(), nodeTypeId);
+    visitChildren(nodeName, greaterThanOrEqualNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const NegationNode* negationNode)
@@ -138,7 +136,7 @@ void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
     std::string nodeName = "timeShift";
     std::type_index nodeTypeId = typeIndexOf<TimeShiftNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, timeShiftNode->getOperands(), nodeTypeId);
+    visitChildren(nodeName, timeShiftNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
@@ -146,7 +144,7 @@ void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
     std::string nodeName = "timeIndex";
     std::type_index nodeTypeId = typeIndexOf<TimeIndexNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, timeIndexNode->getOperands(), nodeTypeId);
+    visitChildren(nodeName, timeIndexNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const TimeSumNode* timeSumNode)
@@ -154,7 +152,7 @@ void NodeChecker::visit(const TimeSumNode* timeSumNode)
     std::string nodeName = "sum";
     std::type_index nodeTypeId = typeIndexOf<TimeSumNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, timeSumNode->getOperands(), nodeTypeId);
+    visitChildren(nodeName, timeSumNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
@@ -162,17 +160,14 @@ void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
     std::string nodeName = "sum";
     std::type_index nodeTypeId = typeIndexOf<AllTimeSumNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, allTimeSumNode->getOperands(), nodeTypeId);
+    visitChildren(nodeName, allTimeSumNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const FunctionNode* functionNode)
 {
-    const std::string nodeName = functionNode->typeToString();
-    const auto& operands = functionNode->getOperands();
-    const FunctionNodeType type = functionNode->type();
     std::type_index nodeTypeId(typeid(int) /* has to be default constructed here */);
 
-    switch (type)
+    switch (functionNode->type())
     {
     case FunctionNodeType::reduced_cost:
         nodeTypeId = typeIndexOf<FunctionNodeType::reduced_cost>();
@@ -196,8 +191,10 @@ void NodeChecker::visit(const FunctionNode* functionNode)
         break;
     }
 
+    const std::string nodeName = functionNode->typeToString();
+
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, operands, nodeTypeId);
+    visitChildren(nodeName, functionNode, nodeTypeId);
 }
 
 void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId,
@@ -218,11 +215,11 @@ void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId,
 }
 
 void NodeChecker::visitChildren(const std::string& nodeName,
-                                const std::vector<Expressions::Nodes::Node*>& children,
+                                const Expressions::Nodes::ParentNode* node,
                                 const std::type_index& nodeTypeId)
 {
     parentsStack_.emplace_back(nodeName, nodeTypeId);
-    for (const auto* child: children)
+    for (const auto* child: node->getOperands())
     {
         dispatch(child);
     }

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -25,8 +25,8 @@ using namespace Antares::Expressions::Nodes;
 
 namespace Antares::IO::Inputs::ModelConverter
 {
-NodeChecker::NodeChecker(const ForbiddenNodes& forbid, const std::string& expression):
-    forbid_(forbid),
+NodeChecker::NodeChecker(const ForbiddenNodes& forbiddenNodes, const std::string& expression):
+    forbiddenNodes_(forbiddenNodes),
     expression_(expression)
 {
 }
@@ -38,37 +38,37 @@ std::string NodeChecker::name() const
 
 void NodeChecker::visit(const SumNode* sumNode)
 {
-    checkChildren<SumNode>("sum", sumNode->getOperands(), false);
+    visitChildren<SumNode>("sum", sumNode->getOperands(), false);
 }
 
 void NodeChecker::visit(const SubtractionNode* subtractionNode)
 {
-    checkChildren<SubtractionNode>("subtraction", subtractionNode->getOperands(), false);
+    visitChildren<SubtractionNode>("subtraction", subtractionNode->getOperands(), false);
 }
 
 void NodeChecker::visit(const MultiplicationNode* multiplicationNode)
 {
-    checkChildren<MultiplicationNode>("multiplication", multiplicationNode->getOperands(), false);
+    visitChildren<MultiplicationNode>("multiplication", multiplicationNode->getOperands(), false);
 }
 
 void NodeChecker::visit(const DivisionNode* divisionNode)
 {
-    checkChildren<DivisionNode>("division", divisionNode->getOperands(), false);
+    visitChildren<DivisionNode>("division", divisionNode->getOperands(), false);
 }
 
 void NodeChecker::visit(const EqualNode* equalNode)
 {
-    handleComparisonNode<EqualNode>("=", equalNode->getOperands());
+    visitComparisonNode<EqualNode>("=", equalNode->getOperands());
 }
 
 void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
 {
-    handleComparisonNode<LessThanOrEqualNode>("<=", lessThanOrEqualNode->getOperands());
+    visitComparisonNode<LessThanOrEqualNode>("<=", lessThanOrEqualNode->getOperands());
 }
 
 void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
 {
-    handleComparisonNode<GreaterThanOrEqualNode>(">=", greaterThanOrEqualNode->getOperands());
+    visitComparisonNode<GreaterThanOrEqualNode>(">=", greaterThanOrEqualNode->getOperands());
 }
 
 void NodeChecker::visit(const NegationNode* negationNode)
@@ -104,22 +104,22 @@ void NodeChecker::visit(const PortFieldSumNode*)
 
 void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
 {
-    checkChildren<TimeShiftNode>("timeShift", timeShiftNode->getOperands(), true);
+    visitChildren<TimeShiftNode>("timeShift", timeShiftNode->getOperands(), true);
 }
 
 void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
 {
-    checkChildren<TimeIndexNode>("timeIndex", timeIndexNode->getOperands(), true);
+    visitChildren<TimeIndexNode>("timeIndex", timeIndexNode->getOperands(), true);
 }
 
 void NodeChecker::visit(const TimeSumNode* timeSumNode)
 {
-    checkChildren<TimeSumNode>("sum", timeSumNode->getOperands(), true);
+    visitChildren<TimeSumNode>("sum", timeSumNode->getOperands(), true);
 }
 
 void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 {
-    checkChildren<AllTimeSumNode>("sum", allTimeSumNode->getOperands(), true);
+    visitChildren<AllTimeSumNode>("sum", allTimeSumNode->getOperands(), true);
 }
 
 void NodeChecker::visit(const FunctionNode* functionNode)
@@ -127,31 +127,28 @@ void NodeChecker::visit(const FunctionNode* functionNode)
     switch (functionNode->type())
     {
     case FunctionNodeType::reduced_cost:
-        checkChildren<FunctionNodeType::reduced_cost>(functionNode->typeToString(),
+        visitChildren<FunctionNodeType::reduced_cost>(functionNode->typeToString(),
                                                       functionNode->getOperands(),
                                                       true);
         break;
     case FunctionNodeType::dual:
-        checkChildren<FunctionNodeType::dual>(functionNode->typeToString(),
+        visitChildren<FunctionNodeType::dual>(functionNode->typeToString(),
                                               functionNode->getOperands(),
                                               true);
         break;
 
     case FunctionNodeType::min:
-
-        checkChildren<FunctionNodeType::min>(functionNode->typeToString(),
+        visitChildren<FunctionNodeType::min>(functionNode->typeToString(),
                                              functionNode->getOperands(),
                                              true);
         break;
     case FunctionNodeType::max:
-
-        checkChildren<FunctionNodeType::max>(functionNode->typeToString(),
+        visitChildren<FunctionNodeType::max>(functionNode->typeToString(),
                                              functionNode->getOperands(),
                                              true);
         break;
     case FunctionNodeType::pow:
-
-        checkChildren<FunctionNodeType::pow>(functionNode->typeToString(),
+        visitChildren<FunctionNodeType::pow>(functionNode->typeToString(),
                                              functionNode->getOperands(),
                                              true);
         break;

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -190,4 +190,21 @@ void NodeChecker::visit(const FunctionNode* functionNode)
         break;
     }
 }
+
+void NodeChecker::checkIsForbidden(std::type_index& typeId, const std::string& nodeName) const
+{
+    if (forbiddenNodes_.isGloballyForbidden(typeId))
+    {
+        throw ForbiddenNodeFound(expression_, nodeName);
+    }
+
+    for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
+    {
+        if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, typeId))
+        {
+            throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
+        }
+    }
+}
+
 } // namespace Antares::IO::Inputs::ModelConverter

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -77,21 +77,21 @@ void NodeChecker::visit(const DivisionNode* divisionNode)
 void NodeChecker::visit(const EqualNode* equalNode)
 {
     std::string nodeName = "expression with =";
-    checkIsForbidden<EqualNode>(nodeName);
+    checkIsForbidden(typeIndexOf<EqualNode>(), nodeName);
     visitChildren<EqualNode>(nodeName, equalNode->getOperands());
 }
 
 void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
 {
     std::string nodeName = "expression with <=";
-    checkIsForbidden<LessThanOrEqualNode>(nodeName);
+    checkIsForbidden(typeIndexOf<LessThanOrEqualNode>(), nodeName);
     visitChildren<LessThanOrEqualNode>(nodeName, lessThanOrEqualNode->getOperands());
 }
 
 void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
 {
     std::string nodeName = "expression with >=";
-    checkIsForbidden<GreaterThanOrEqualNode>(nodeName);
+    checkIsForbidden(typeIndexOf<GreaterThanOrEqualNode>(), nodeName);
     visitChildren<GreaterThanOrEqualNode>(nodeName, greaterThanOrEqualNode->getOperands());
 }
 
@@ -107,7 +107,8 @@ void NodeChecker::visit(const LiteralNode*)
 
 void NodeChecker::visit(const VariableNode* variableNode)
 {
-    checkIsForbidden<VariableNode>("variable(" + variableNode->value() + ")");
+    std::string nodeName = "variable(" + variableNode->value() + ")";
+    checkIsForbidden(typeIndexOf<VariableNode>(), nodeName);
 }
 
 void NodeChecker::visit(const ParameterNode*)
@@ -117,81 +118,91 @@ void NodeChecker::visit(const ParameterNode*)
 
 void NodeChecker::visit(const PortFieldNode* portFieldNode)
 {
-    checkIsForbidden<PortFieldNode>("port field (" + portFieldNode->getPortName() + "."
-                                    + portFieldNode->getFieldName() + ")");
+    std::string nodeName = "port field (" + portFieldNode->getPortName() + "."
+                           + portFieldNode->getFieldName() + ")";
+    checkIsForbidden(typeIndexOf<PortFieldNode>(),nodeName);
 }
 
 void NodeChecker::visit(const PortFieldSumNode*)
 {
-    checkIsForbidden<PortFieldSumNode>("sum_connections");
+    checkIsForbidden(typeIndexOf<PortFieldSumNode>(), "sum_connections");
 }
 
 void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
 {
     std::string nodeName = "timeShift";
-    checkIsForbidden<TimeShiftNode>(nodeName);
+    checkIsForbidden(typeIndexOf<TimeShiftNode>(), nodeName);
     visitChildren<TimeShiftNode>(nodeName, timeShiftNode->getOperands());
 }
 
 void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
 {
     std::string nodeName = "timeIndex";
-    checkIsForbidden<TimeIndexNode>(nodeName);
+    checkIsForbidden(typeIndexOf<TimeIndexNode>(), nodeName);
     visitChildren<TimeIndexNode>(nodeName, timeIndexNode->getOperands());
 }
 
 void NodeChecker::visit(const TimeSumNode* timeSumNode)
 {
     std::string nodeName = "sum";
-    checkIsForbidden<TimeIndexNode>(nodeName);
+    std::type_index typeId = typeIndexOf<TimeSumNode>();
+    checkIsForbidden(typeId, nodeName);
     visitChildren<TimeSumNode>(nodeName, timeSumNode->getOperands());
 }
 
 void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 {
     std::string nodeName = "sum";
-    checkIsForbidden<AllTimeSumNode>(nodeName);
+    std::type_index typeId = typeIndexOf<AllTimeSumNode>();
+    checkIsForbidden(typeId, nodeName);
     visitChildren<AllTimeSumNode>(nodeName, allTimeSumNode->getOperands());
 }
 
 void NodeChecker::visit(const FunctionNode* functionNode)
 {
-    const std::string type_str = functionNode->typeToString();
+    const std::string nodeName = functionNode->typeToString();
     const auto& operands = functionNode->getOperands();
     const FunctionNodeType type = functionNode->type();
+    std::type_index typeId(typeid(int) /* has to be default constructed here */);
 
     switch (type)
     {
     case FunctionNodeType::reduced_cost:
-        checkIsForbidden<FunctionNodeType::reduced_cost>(type_str);
-        visitChildren<FunctionNodeType::reduced_cost>(type_str, operands);
+        typeId = typeIndexOf<FunctionNodeType::reduced_cost>();
+        checkIsForbidden(typeId, nodeName);
+        visitChildren<FunctionNodeType::reduced_cost>(nodeName, operands);
         break;
     case FunctionNodeType::dual:
-        checkIsForbidden<FunctionNodeType::dual>(type_str);
-        visitChildren<FunctionNodeType::dual>(type_str, operands);
+        typeId = typeIndexOf<FunctionNodeType::dual>();
+        checkIsForbidden(typeId, nodeName);
+        visitChildren<FunctionNodeType::dual>(nodeName, operands);
         break;
     case FunctionNodeType::min:
-        checkIsForbidden<FunctionNodeType::min>(type_str);
-        visitChildren<FunctionNodeType::min>(type_str, operands);
+        typeId = typeIndexOf<FunctionNodeType::min>();
+        checkIsForbidden(typeId, nodeName);
+        visitChildren<FunctionNodeType::min>(nodeName, operands);
         break;
     case FunctionNodeType::max:
-        checkIsForbidden<FunctionNodeType::max>(type_str);
-        visitChildren<FunctionNodeType::max>(type_str, operands);
+        typeId = typeIndexOf<FunctionNodeType::max>();
+        checkIsForbidden(typeId, nodeName);
+        visitChildren<FunctionNodeType::max>(nodeName, operands);
         break;
     case FunctionNodeType::pow:
-        checkIsForbidden<FunctionNodeType::pow>(type_str);
-        visitChildren<FunctionNodeType::pow>(type_str, operands);
+        typeId = typeIndexOf<FunctionNodeType::pow>();
+        checkIsForbidden(typeId, nodeName);
+        visitChildren<FunctionNodeType::pow>(nodeName, operands);
         break;
     case FunctionNodeType::floor:
-        checkIsForbidden<FunctionNodeType::floor>(type_str);
-        visitChildren<FunctionNodeType::floor>(type_str, operands);
+        typeId = typeIndexOf<FunctionNodeType::floor>();
+        checkIsForbidden(typeId, nodeName);
+        visitChildren<FunctionNodeType::floor>(nodeName, operands);
         break;
     default:
         break;
     }
 }
 
-void NodeChecker::checkIsForbidden(std::type_index& typeId, const std::string& nodeName) const
+void NodeChecker::checkIsForbidden(const std::type_index& typeId, const std::string& nodeName) const
 {
     if (forbiddenNodes_.isGloballyForbidden(typeId))
     {

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -30,10 +30,10 @@ std::string ErrorMessage(const std::string expr, const std::string node, const s
 {
     if (!parent.empty())
     {
-        std::string format_str = "'{}' is not allowed to contain '{}' in this context '{}'";
+        std::string format_str = "'{}' is not allowed to contain '{}' in expression '{}'";
         return fmt::format(fmt::runtime(format_str), parent, node, expr);
     }
-    return fmt::format("'{}' is not allowed in this context '{}'", node, expr);
+    return fmt::format("'{}' is not allowed in expression '{}'", node, expr);
 }
 
 ForbiddenNodeFound::ForbiddenNodeFound(const std::string expr,
@@ -56,46 +56,43 @@ std::string NodeChecker::name() const
 
 void NodeChecker::visit(const SumNode* sumNode)
 {
-    visitChildren("sum", sumNode, typeIndexOf<SumNode>());
+    visitChildren(sumNode, typeIndexOf<SumNode>());
 }
 
 void NodeChecker::visit(const SubtractionNode* subtractionNode)
 {
-    visitChildren("subtraction", subtractionNode, typeIndexOf<SubtractionNode>());
+    visitChildren(subtractionNode, typeIndexOf<SubtractionNode>());
 }
 
 void NodeChecker::visit(const MultiplicationNode* multiplicationNode)
 {
-    visitChildren("multiplication", multiplicationNode, typeIndexOf<MultiplicationNode>());
+    visitChildren(multiplicationNode, typeIndexOf<MultiplicationNode>());
 }
 
 void NodeChecker::visit(const DivisionNode* divisionNode)
 {
-    visitChildren("division", divisionNode, typeIndexOf<DivisionNode>());
+    visitChildren(divisionNode, typeIndexOf<DivisionNode>());
 }
 
 void NodeChecker::visit(const EqualNode* equalNode)
 {
-    std::string nodeName = "expression with =";
     std::type_index nodeTypeId = typeIndexOf<EqualNode>();
-    checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, equalNode, nodeTypeId);
+    checkIsForbidden(nodeTypeId, equalNode);
+    visitChildren(equalNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
 {
-    std::string nodeName = "expression with <=";
     std::type_index nodeTypeId = typeIndexOf<LessThanOrEqualNode>();
-    checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, lessThanOrEqualNode, nodeTypeId);
+    checkIsForbidden(nodeTypeId, lessThanOrEqualNode);
+    visitChildren(lessThanOrEqualNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
 {
-    std::string nodeName = "expression with >=";
     std::type_index nodeTypeId = typeIndexOf<GreaterThanOrEqualNode>();
-    checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, greaterThanOrEqualNode, nodeTypeId);
+    checkIsForbidden(nodeTypeId, greaterThanOrEqualNode);
+    visitChildren(greaterThanOrEqualNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const NegationNode* negationNode)
@@ -110,8 +107,7 @@ void NodeChecker::visit(const LiteralNode*)
 
 void NodeChecker::visit(const VariableNode* variableNode)
 {
-    std::string nodeName = "variable(" + variableNode->value() + ")";
-    checkIsForbidden(typeIndexOf<VariableNode>(), nodeName);
+    checkIsForbidden(typeIndexOf<VariableNode>(), variableNode);
 }
 
 void NodeChecker::visit(const ParameterNode*)
@@ -121,46 +117,40 @@ void NodeChecker::visit(const ParameterNode*)
 
 void NodeChecker::visit(const PortFieldNode* portFieldNode)
 {
-    std::string nodeName = "port field (" + portFieldNode->getPortName() + "."
-                           + portFieldNode->getFieldName() + ")";
-    checkIsForbidden(typeIndexOf<PortFieldNode>(), nodeName);
+    checkIsForbidden(typeIndexOf<PortFieldNode>(), portFieldNode);
 }
 
-void NodeChecker::visit(const PortFieldSumNode*)
+void NodeChecker::visit(const PortFieldSumNode* portFieldSumNode)
 {
-    checkIsForbidden(typeIndexOf<PortFieldSumNode>(), "sum_connections");
+    checkIsForbidden(typeIndexOf<PortFieldSumNode>(), portFieldSumNode);
 }
 
 void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
 {
-    std::string nodeName = "timeShift";
     std::type_index nodeTypeId = typeIndexOf<TimeShiftNode>();
-    checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, timeShiftNode, nodeTypeId);
+    checkIsForbidden(nodeTypeId, timeShiftNode);
+    visitChildren(timeShiftNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
 {
-    std::string nodeName = "timeIndex";
     std::type_index nodeTypeId = typeIndexOf<TimeIndexNode>();
-    checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, timeIndexNode, nodeTypeId);
+    checkIsForbidden(nodeTypeId, timeIndexNode);
+    visitChildren(timeIndexNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const TimeSumNode* timeSumNode)
 {
-    std::string nodeName = "sum";
     std::type_index nodeTypeId = typeIndexOf<TimeSumNode>();
-    checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, timeSumNode, nodeTypeId);
+    checkIsForbidden(nodeTypeId, timeSumNode);
+    visitChildren(timeSumNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 {
-    std::string nodeName = "sum";
     std::type_index nodeTypeId = typeIndexOf<AllTimeSumNode>();
-    checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, allTimeSumNode, nodeTypeId);
+    checkIsForbidden(nodeTypeId, allTimeSumNode);
+    visitChildren(allTimeSumNode, nodeTypeId);
 }
 
 void NodeChecker::visit(const FunctionNode* functionNode)
@@ -191,37 +181,33 @@ void NodeChecker::visit(const FunctionNode* functionNode)
         break;
     }
 
-    const std::string nodeName = functionNode->typeToString();
-
-    checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren(nodeName, functionNode, nodeTypeId);
+    checkIsForbidden(nodeTypeId, functionNode);
+    visitChildren(functionNode, nodeTypeId);
 }
 
-void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId,
-                                   const std::string& nodeName) const
+void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId, const Node* node) const
 {
     if (forbiddenNodes_.isGloballyForbidden(nodeTypeId))
     {
-        throw ForbiddenNodeFound(expression_, nodeName);
+        throw ForbiddenNodeFound(expression_, node->name());
     }
 
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
         if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, nodeTypeId))
         {
-            throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
+            throw ForbiddenNodeFound(expression_, node->name(), parentNodeName);
         }
     }
 }
 
-void NodeChecker::visitChildren(const std::string& nodeName,
-                                const Expressions::Nodes::ParentNode* node,
+void NodeChecker::visitChildren(const Expressions::Nodes::ParentNode* node,
                                 const std::type_index& nodeTypeId)
 {
-    parentsStack_.emplace_back(nodeName, nodeTypeId);
-    for (const auto* child: node->getOperands())
+    parentsStack_.emplace_back(node->name(), nodeTypeId);
+    for (const auto* childNode: node->getOperands())
     {
-        dispatch(child);
+        dispatch(childNode);
     }
     parentsStack_.pop_back();
 }

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -56,22 +56,24 @@ std::string NodeChecker::name() const
 
 void NodeChecker::visit(const SumNode* sumNode)
 {
-    visitChildren<SumNode>("sum", sumNode->getOperands());
+    visitChildren("sum", sumNode->getOperands(), typeIndexOf<SumNode>());
 }
 
 void NodeChecker::visit(const SubtractionNode* subtractionNode)
 {
-    visitChildren<SubtractionNode>("subtraction", subtractionNode->getOperands());
+    visitChildren("subtraction", subtractionNode->getOperands(), typeIndexOf<SubtractionNode>());
 }
 
 void NodeChecker::visit(const MultiplicationNode* multiplicationNode)
 {
-    visitChildren<MultiplicationNode>("multiplication", multiplicationNode->getOperands());
+    visitChildren("multiplication",
+                  multiplicationNode->getOperands(),
+                  typeIndexOf<MultiplicationNode>());
 }
 
 void NodeChecker::visit(const DivisionNode* divisionNode)
 {
-    visitChildren<DivisionNode>("division", divisionNode->getOperands());
+    visitChildren("division", divisionNode->getOperands(), typeIndexOf<DivisionNode>());
 }
 
 void NodeChecker::visit(const EqualNode* equalNode)
@@ -79,7 +81,7 @@ void NodeChecker::visit(const EqualNode* equalNode)
     std::string nodeName = "expression with =";
     std::type_index nodeTypeId = typeIndexOf<EqualNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren<EqualNode>(nodeName, equalNode->getOperands());
+    visitChildren(nodeName, equalNode->getOperands(), nodeTypeId);
 }
 
 void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
@@ -87,7 +89,7 @@ void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
     std::string nodeName = "expression with <=";
     std::type_index nodeTypeId = typeIndexOf<LessThanOrEqualNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren<LessThanOrEqualNode>(nodeName, lessThanOrEqualNode->getOperands());
+    visitChildren(nodeName, lessThanOrEqualNode->getOperands(), nodeTypeId);
 }
 
 void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
@@ -95,7 +97,7 @@ void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
     std::string nodeName = "expression with >=";
     std::type_index nodeTypeId = typeIndexOf<GreaterThanOrEqualNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren<GreaterThanOrEqualNode>(nodeName, greaterThanOrEqualNode->getOperands());
+    visitChildren(nodeName, greaterThanOrEqualNode->getOperands(), nodeTypeId);
 }
 
 void NodeChecker::visit(const NegationNode* negationNode)
@@ -123,7 +125,7 @@ void NodeChecker::visit(const PortFieldNode* portFieldNode)
 {
     std::string nodeName = "port field (" + portFieldNode->getPortName() + "."
                            + portFieldNode->getFieldName() + ")";
-    checkIsForbidden(typeIndexOf<PortFieldNode>(),nodeName);
+    checkIsForbidden(typeIndexOf<PortFieldNode>(), nodeName);
 }
 
 void NodeChecker::visit(const PortFieldSumNode*)
@@ -136,7 +138,7 @@ void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
     std::string nodeName = "timeShift";
     std::type_index nodeTypeId = typeIndexOf<TimeShiftNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren<TimeShiftNode>(nodeName, timeShiftNode->getOperands());
+    visitChildren(nodeName, timeShiftNode->getOperands(), nodeTypeId);
 }
 
 void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
@@ -144,7 +146,7 @@ void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
     std::string nodeName = "timeIndex";
     std::type_index nodeTypeId = typeIndexOf<TimeIndexNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren<TimeIndexNode>(nodeName, timeIndexNode->getOperands());
+    visitChildren(nodeName, timeIndexNode->getOperands(), nodeTypeId);
 }
 
 void NodeChecker::visit(const TimeSumNode* timeSumNode)
@@ -152,7 +154,7 @@ void NodeChecker::visit(const TimeSumNode* timeSumNode)
     std::string nodeName = "sum";
     std::type_index nodeTypeId = typeIndexOf<TimeSumNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren<TimeSumNode>(nodeName, timeSumNode->getOperands());
+    visitChildren(nodeName, timeSumNode->getOperands(), nodeTypeId);
 }
 
 void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
@@ -160,7 +162,7 @@ void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
     std::string nodeName = "sum";
     std::type_index nodeTypeId = typeIndexOf<AllTimeSumNode>();
     checkIsForbidden(nodeTypeId, nodeName);
-    visitChildren<AllTimeSumNode>(nodeName, allTimeSumNode->getOperands());
+    visitChildren(nodeName, allTimeSumNode->getOperands(), nodeTypeId);
 }
 
 void NodeChecker::visit(const FunctionNode* functionNode)
@@ -174,40 +176,32 @@ void NodeChecker::visit(const FunctionNode* functionNode)
     {
     case FunctionNodeType::reduced_cost:
         nodeTypeId = typeIndexOf<FunctionNodeType::reduced_cost>();
-        checkIsForbidden(nodeTypeId, nodeName);
-        visitChildren<FunctionNodeType::reduced_cost>(nodeName, operands);
         break;
     case FunctionNodeType::dual:
         nodeTypeId = typeIndexOf<FunctionNodeType::dual>();
-        checkIsForbidden(nodeTypeId, nodeName);
-        visitChildren<FunctionNodeType::dual>(nodeName, operands);
         break;
     case FunctionNodeType::min:
         nodeTypeId = typeIndexOf<FunctionNodeType::min>();
-        checkIsForbidden(nodeTypeId, nodeName);
-        visitChildren<FunctionNodeType::min>(nodeName, operands);
         break;
     case FunctionNodeType::max:
         nodeTypeId = typeIndexOf<FunctionNodeType::max>();
-        checkIsForbidden(nodeTypeId, nodeName);
-        visitChildren<FunctionNodeType::max>(nodeName, operands);
         break;
     case FunctionNodeType::pow:
         nodeTypeId = typeIndexOf<FunctionNodeType::pow>();
-        checkIsForbidden(nodeTypeId, nodeName);
-        visitChildren<FunctionNodeType::pow>(nodeName, operands);
         break;
     case FunctionNodeType::floor:
         nodeTypeId = typeIndexOf<FunctionNodeType::floor>();
-        checkIsForbidden(nodeTypeId, nodeName);
-        visitChildren<FunctionNodeType::floor>(nodeName, operands);
         break;
     default:
         break;
     }
+
+    checkIsForbidden(nodeTypeId, nodeName);
+    visitChildren(nodeName, operands, nodeTypeId);
 }
 
-void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId, const std::string& nodeName) const
+void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId,
+                                   const std::string& nodeName) const
 {
     if (forbiddenNodes_.isGloballyForbidden(nodeTypeId))
     {
@@ -221,6 +215,18 @@ void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId, const std:
             throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }
     }
+}
+
+void NodeChecker::visitChildren(const std::string& nodeName,
+                                const std::vector<Expressions::Nodes::Node*>& children,
+                                const std::type_index& nodeTypeId)
+{
+    parentsStack_.emplace_back(nodeName, nodeTypeId);
+    for (const auto* child: children)
+    {
+        dispatch(child);
+    }
+    parentsStack_.pop_back();
 }
 
 } // namespace Antares::IO::Inputs::ModelConverter

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -77,21 +77,24 @@ void NodeChecker::visit(const DivisionNode* divisionNode)
 void NodeChecker::visit(const EqualNode* equalNode)
 {
     std::string nodeName = "expression with =";
-    checkIsForbidden(typeIndexOf<EqualNode>(), nodeName);
+    std::type_index nodeTypeId = typeIndexOf<EqualNode>();
+    checkIsForbidden(nodeTypeId, nodeName);
     visitChildren<EqualNode>(nodeName, equalNode->getOperands());
 }
 
 void NodeChecker::visit(const LessThanOrEqualNode* lessThanOrEqualNode)
 {
     std::string nodeName = "expression with <=";
-    checkIsForbidden(typeIndexOf<LessThanOrEqualNode>(), nodeName);
+    std::type_index nodeTypeId = typeIndexOf<LessThanOrEqualNode>();
+    checkIsForbidden(nodeTypeId, nodeName);
     visitChildren<LessThanOrEqualNode>(nodeName, lessThanOrEqualNode->getOperands());
 }
 
 void NodeChecker::visit(const GreaterThanOrEqualNode* greaterThanOrEqualNode)
 {
     std::string nodeName = "expression with >=";
-    checkIsForbidden(typeIndexOf<GreaterThanOrEqualNode>(), nodeName);
+    std::type_index nodeTypeId = typeIndexOf<GreaterThanOrEqualNode>();
+    checkIsForbidden(nodeTypeId, nodeName);
     visitChildren<GreaterThanOrEqualNode>(nodeName, greaterThanOrEqualNode->getOperands());
 }
 
@@ -131,30 +134,32 @@ void NodeChecker::visit(const PortFieldSumNode*)
 void NodeChecker::visit(const TimeShiftNode* timeShiftNode)
 {
     std::string nodeName = "timeShift";
-    checkIsForbidden(typeIndexOf<TimeShiftNode>(), nodeName);
+    std::type_index nodeTypeId = typeIndexOf<TimeShiftNode>();
+    checkIsForbidden(nodeTypeId, nodeName);
     visitChildren<TimeShiftNode>(nodeName, timeShiftNode->getOperands());
 }
 
 void NodeChecker::visit(const TimeIndexNode* timeIndexNode)
 {
     std::string nodeName = "timeIndex";
-    checkIsForbidden(typeIndexOf<TimeIndexNode>(), nodeName);
+    std::type_index nodeTypeId = typeIndexOf<TimeIndexNode>();
+    checkIsForbidden(nodeTypeId, nodeName);
     visitChildren<TimeIndexNode>(nodeName, timeIndexNode->getOperands());
 }
 
 void NodeChecker::visit(const TimeSumNode* timeSumNode)
 {
     std::string nodeName = "sum";
-    std::type_index typeId = typeIndexOf<TimeSumNode>();
-    checkIsForbidden(typeId, nodeName);
+    std::type_index nodeTypeId = typeIndexOf<TimeSumNode>();
+    checkIsForbidden(nodeTypeId, nodeName);
     visitChildren<TimeSumNode>(nodeName, timeSumNode->getOperands());
 }
 
 void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 {
     std::string nodeName = "sum";
-    std::type_index typeId = typeIndexOf<AllTimeSumNode>();
-    checkIsForbidden(typeId, nodeName);
+    std::type_index nodeTypeId = typeIndexOf<AllTimeSumNode>();
+    checkIsForbidden(nodeTypeId, nodeName);
     visitChildren<AllTimeSumNode>(nodeName, allTimeSumNode->getOperands());
 }
 
@@ -163,38 +168,38 @@ void NodeChecker::visit(const FunctionNode* functionNode)
     const std::string nodeName = functionNode->typeToString();
     const auto& operands = functionNode->getOperands();
     const FunctionNodeType type = functionNode->type();
-    std::type_index typeId(typeid(int) /* has to be default constructed here */);
+    std::type_index nodeTypeId(typeid(int) /* has to be default constructed here */);
 
     switch (type)
     {
     case FunctionNodeType::reduced_cost:
-        typeId = typeIndexOf<FunctionNodeType::reduced_cost>();
-        checkIsForbidden(typeId, nodeName);
+        nodeTypeId = typeIndexOf<FunctionNodeType::reduced_cost>();
+        checkIsForbidden(nodeTypeId, nodeName);
         visitChildren<FunctionNodeType::reduced_cost>(nodeName, operands);
         break;
     case FunctionNodeType::dual:
-        typeId = typeIndexOf<FunctionNodeType::dual>();
-        checkIsForbidden(typeId, nodeName);
+        nodeTypeId = typeIndexOf<FunctionNodeType::dual>();
+        checkIsForbidden(nodeTypeId, nodeName);
         visitChildren<FunctionNodeType::dual>(nodeName, operands);
         break;
     case FunctionNodeType::min:
-        typeId = typeIndexOf<FunctionNodeType::min>();
-        checkIsForbidden(typeId, nodeName);
+        nodeTypeId = typeIndexOf<FunctionNodeType::min>();
+        checkIsForbidden(nodeTypeId, nodeName);
         visitChildren<FunctionNodeType::min>(nodeName, operands);
         break;
     case FunctionNodeType::max:
-        typeId = typeIndexOf<FunctionNodeType::max>();
-        checkIsForbidden(typeId, nodeName);
+        nodeTypeId = typeIndexOf<FunctionNodeType::max>();
+        checkIsForbidden(nodeTypeId, nodeName);
         visitChildren<FunctionNodeType::max>(nodeName, operands);
         break;
     case FunctionNodeType::pow:
-        typeId = typeIndexOf<FunctionNodeType::pow>();
-        checkIsForbidden(typeId, nodeName);
+        nodeTypeId = typeIndexOf<FunctionNodeType::pow>();
+        checkIsForbidden(nodeTypeId, nodeName);
         visitChildren<FunctionNodeType::pow>(nodeName, operands);
         break;
     case FunctionNodeType::floor:
-        typeId = typeIndexOf<FunctionNodeType::floor>();
-        checkIsForbidden(typeId, nodeName);
+        nodeTypeId = typeIndexOf<FunctionNodeType::floor>();
+        checkIsForbidden(nodeTypeId, nodeName);
         visitChildren<FunctionNodeType::floor>(nodeName, operands);
         break;
     default:
@@ -202,16 +207,16 @@ void NodeChecker::visit(const FunctionNode* functionNode)
     }
 }
 
-void NodeChecker::checkIsForbidden(const std::type_index& typeId, const std::string& nodeName) const
+void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId, const std::string& nodeName) const
 {
-    if (forbiddenNodes_.isGloballyForbidden(typeId))
+    if (forbiddenNodes_.isGloballyForbidden(nodeTypeId))
     {
         throw ForbiddenNodeFound(expression_, nodeName);
     }
 
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, typeId))
+        if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, nodeTypeId))
         {
             throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -187,11 +187,22 @@ void NodeChecker::visit(const FunctionNode* functionNode)
 
 void NodeChecker::checkIsForbidden(const std::type_index& nodeTypeId, const Node* node) const
 {
+    checkIGloballyForbidden(nodeTypeId, node);
+    checkIsForbiddenByParent(nodeTypeId, node);
+}
+
+void NodeChecker::checkIGloballyForbidden(const std::type_index& nodeTypeId,
+                                          const Antares::Expressions::Nodes::Node* node) const
+{
     if (forbiddenNodes_.isGloballyForbidden(nodeTypeId))
     {
         throw ForbiddenNodeFound(expression_, node->name());
     }
+}
 
+void NodeChecker::checkIsForbiddenByParent(const std::type_index& nodeTypeId,
+                                           const Antares::Expressions::Nodes::Node* node) const
+{
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
         if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, nodeTypeId))

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -155,7 +155,7 @@ void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 
 void NodeChecker::visit(const FunctionNode* functionNode)
 {
-    std::type_index nodeTypeId(typeid(int) /* has to be default constructed here */);
+    std::type_index nodeTypeId(typeid(int)); // Must be default constructed here
 
     switch (functionNode->type())
     {

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -26,20 +26,20 @@ using namespace Antares::Expressions::Nodes;
 namespace Antares::IO::Inputs::ModelConverter
 {
 
-std::string ErrorMessage(const std::string expr, const std::string child, const std::string parent)
+std::string ErrorMessage(const std::string expr, const std::string node, const std::string parent)
 {
     if (!parent.empty())
     {
         std::string format_str = "'{}' is not allowed to contain '{}' in this context '{}'";
-        return fmt::format(fmt::runtime(format_str), parent, child, expr);
+        return fmt::format(fmt::runtime(format_str), parent, node, expr);
     }
-    return fmt::format("'{}' is not allowed in this context '{}'", child, expr);
+    return fmt::format("'{}' is not allowed in this context '{}'", node, expr);
 }
 
 ForbiddenNodeFound::ForbiddenNodeFound(const std::string expr,
-                                       const std::string child,
+                                       const std::string node,
                                        const std::string parent):
-    invalid_argument(ErrorMessage(expr, child, parent))
+    invalid_argument(ErrorMessage(expr, node, parent))
 {
 }
 
@@ -143,7 +143,7 @@ void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 void NodeChecker::visit(const FunctionNode* functionNode)
 {
     const std::string type_str = functionNode->typeToString();
-    const auto operands = functionNode->getOperands();
+    const auto& operands = functionNode->getOperands();
     const FunctionNodeType type = functionNode->type();
 
     switch (type)
@@ -162,6 +162,9 @@ void NodeChecker::visit(const FunctionNode* functionNode)
         break;
     case FunctionNodeType::pow:
         visitChildren<FunctionNodeType::pow>(type_str, operands);
+        break;
+    case FunctionNodeType::floor:
+        visitChildren<FunctionNodeType::floor>(type_str, operands);
         break;
     default:
         break;

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -25,6 +25,24 @@ using namespace Antares::Expressions::Nodes;
 
 namespace Antares::IO::Inputs::ModelConverter
 {
+
+std::string ErrorMessage(const std::string expr, const std::string child, const std::string parent)
+{
+    if (!parent.empty())
+    {
+        std::string format_str = "'{}' is not allowed to contain '{}' in this context '{}'";
+        return fmt::format(fmt::runtime(format_str), parent, child, expr);
+    }
+    return fmt::format("'{}' is not allowed in this context '{}'", child, expr);
+}
+
+ForbiddenNodeFound::ForbiddenNodeFound(const std::string expr,
+                                       const std::string child,
+                                       const std::string parent):
+    invalid_argument(ErrorMessage(expr, child, parent))
+{
+}
+
 NodeChecker::NodeChecker(const ForbiddenNodes& forbiddenNodes, const std::string& expression):
     forbiddenNodes_(forbiddenNodes),
     expression_(expression)

--- a/src/io/inputs/model-converter/NodeChecker.cpp
+++ b/src/io/inputs/model-converter/NodeChecker.cpp
@@ -142,33 +142,26 @@ void NodeChecker::visit(const AllTimeSumNode* allTimeSumNode)
 
 void NodeChecker::visit(const FunctionNode* functionNode)
 {
-    switch (functionNode->type())
+    const std::string type_str = functionNode->typeToString();
+    const auto operands = functionNode->getOperands();
+    const FunctionNodeType type = functionNode->type();
+
+    switch (type)
     {
     case FunctionNodeType::reduced_cost:
-        visitChildren<FunctionNodeType::reduced_cost>(functionNode->typeToString(),
-                                                      functionNode->getOperands(),
-                                                      true);
+        visitChildren<FunctionNodeType::reduced_cost>(type_str, operands);
         break;
     case FunctionNodeType::dual:
-        visitChildren<FunctionNodeType::dual>(functionNode->typeToString(),
-                                              functionNode->getOperands(),
-                                              true);
+        visitChildren<FunctionNodeType::dual>(type_str, operands);
         break;
-
     case FunctionNodeType::min:
-        visitChildren<FunctionNodeType::min>(functionNode->typeToString(),
-                                             functionNode->getOperands(),
-                                             true);
+        visitChildren<FunctionNodeType::min>(type_str, operands);
         break;
     case FunctionNodeType::max:
-        visitChildren<FunctionNodeType::max>(functionNode->typeToString(),
-                                             functionNode->getOperands(),
-                                             true);
+        visitChildren<FunctionNodeType::max>(type_str, operands);
         break;
     case FunctionNodeType::pow:
-        visitChildren<FunctionNodeType::pow>(functionNode->typeToString(),
-                                             functionNode->getOperands(),
-                                             true);
+        visitChildren<FunctionNodeType::pow>(type_str, operands);
         break;
     default:
         break;

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -33,17 +33,17 @@ namespace Antares::IO::Inputs::ModelConverter
 {
 
 template<typename NodeType>
-std::type_index forbiddenNodeKey()
+std::type_index typeIndexOf()
 {
     static_assert(!std::is_same_v<NodeType, Expressions::Nodes::FunctionNode>,
                   "Use Expressions::Nodes::FunctionNodeType enum values or "
-                  "forbiddenNodeKey(Expressions::Nodes::FunctionNodeType) "
+                  "typeIndexOf(Expressions::Nodes::FunctionNodeType) "
                   "instead of FunctionNode for forbidden rules.");
     return std::type_index(typeid(NodeType));
 }
 
 template<Expressions::Nodes::FunctionNodeType T>
-std::type_index forbiddenNodeKey()
+std::type_index typeIndexOf()
 {
     using Tag = std::integral_constant<Expressions::Nodes::FunctionNodeType, T>;
     return std::type_index(typeid(Tag));
@@ -56,13 +56,13 @@ public:
     template<typename... NodeType>
     void addGlobalForbidden()
     {
-        (global_.insert(forbiddenNodeKey<NodeType>()), ...);
+        (global_.insert(typeIndexOf<NodeType>()), ...);
     }
 
     template<Expressions::Nodes::FunctionNodeType... NodeType>
     void addGlobalForbidden()
     {
-        (global_.insert(forbiddenNodeKey<NodeType>()), ...);
+        (global_.insert(typeIndexOf<NodeType>()), ...);
     }
 
     // ---------------------- PARENT -> CHILD --------------------
@@ -70,60 +70,59 @@ public:
     requires(!std::is_same_v<Child, Expressions::Nodes::FunctionNodeType>)
     void addForbiddenFor()
     {
-        rules_[forbiddenNodeKey<Parent>()].insert(forbiddenNodeKey<Child>());
+        rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
     template<Expressions::Nodes::FunctionNodeType Parent,
              Expressions::Nodes::FunctionNodeType Child>
     void addForbiddenFor()
     {
-        rules_[forbiddenNodeKey<Parent>()].insert(forbiddenNodeKey<Child>());
+        rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
     template<typename Parent, Expressions::Nodes::FunctionNodeType Child>
     void addForbiddenFor()
     {
-        rules_[forbiddenNodeKey<Parent>()].insert(forbiddenNodeKey<Child>());
+        rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
     // ---------------------- COMPILE-TIME CHECK ----------------------
     template<typename Parent, Expressions::Nodes::FunctionNodeType Child>
     [[nodiscard]] bool isForbiddenFor() const
     {
-        return check(forbiddenNodeKey<Parent>(), forbiddenNodeKey<Child>());
+        return check(typeIndexOf<Parent>(), typeIndexOf<Child>());
     }
 
     template<typename Parent, typename Child>
     [[nodiscard]] bool isForbiddenFor() const
     {
-        return check(forbiddenNodeKey<Parent>(), forbiddenNodeKey<Child>());
+        return check(typeIndexOf<Parent>(), typeIndexOf<Child>());
     }
 
     // ---------------------- RUNTIME CHECK ----------------------
     template<Expressions::Nodes::FunctionNodeType Child>
     [[nodiscard]] bool isForbiddenFor(const std::type_index& parentKey) const
     {
-        return check(parentKey, forbiddenNodeKey<Child>());
+        return check(parentKey, typeIndexOf<Child>());
     }
 
     template<typename Child>
     [[nodiscard]] bool isForbiddenFor(const std::type_index& parentKey) const
     {
-        return check(parentKey, forbiddenNodeKey<Child>());
+        return check(parentKey, typeIndexOf<Child>());
     }
 
     // ---------------------- GLOBALLY FORBIDDEN ----------------------
-
     template<typename NodeType>
-    [[nodiscard]] bool isForbidden() const
+    [[nodiscard]] bool isGloballyForbidden() const
     {
-        return global_.contains(forbiddenNodeKey<NodeType>());
+        return global_.contains(typeIndexOf<NodeType>());
     }
 
     template<Expressions::Nodes::FunctionNodeType NodeType>
-    [[nodiscard]] bool isForbidden() const
+    [[nodiscard]] bool isGloballyForbidden() const
     {
-        return global_.contains(forbiddenNodeKey<NodeType>());
+        return global_.contains(typeIndexOf<NodeType>());
     }
 
 private:

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -49,40 +49,10 @@ std::type_index forbiddenNodeKey()
     return std::type_index(typeid(Tag));
 }
 
-inline std::type_index forbiddenNodeKey(const Expressions::Nodes::FunctionNodeType& funcType)
-{
-    switch (funcType)
-    {
-        using NT = Expressions::Nodes::FunctionNodeType;
-    case NT::max:
-        return forbiddenNodeKey<NT::max>();
-    case NT::min:
-        return forbiddenNodeKey<NT::min>();
-    case NT::pow:
-        return forbiddenNodeKey<NT::pow>();
-    case NT::dual:
-        return forbiddenNodeKey<NT::dual>();
-    case NT::reduced_cost:
-        return forbiddenNodeKey<NT::reduced_cost>();
-    default:
-        throw std::runtime_error("ForbiddenNodeKey is not implemented");
-    }
-}
-
-inline std::type_index forbiddenNodeKey(const Expressions::Nodes::Node& node)
-{
-    if (auto* funcNode = dynamic_cast<const Expressions::Nodes::FunctionNode*>(&node))
-    {
-        return forbiddenNodeKey(funcNode->type());
-    }
-    return {typeid(node)};
-}
-
 class ForbiddenNodes
 {
 public:
     // ------------------------- GLOBAL -------------------------
-
     template<typename... NodeType>
     void addGlobalForbidden()
     {
@@ -130,7 +100,6 @@ public:
     }
 
     // ---------------------- RUNTIME CHECK ----------------------
-
     template<Expressions::Nodes::FunctionNodeType Child>
     [[nodiscard]] bool isForbiddenFor(const std::type_index& parentKey) const
     {

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -54,13 +54,13 @@ class ForbiddenNodes
 public:
     // ------------------------- GLOBAL -------------------------
     template<typename... NodeType>
-    void addGlobalForbidden()
+    void forbidGlobally()
     {
         (global_.insert(typeIndexOf<NodeType>()), ...);
     }
 
     template<Expressions::Nodes::FunctionNodeType... NodeType>
-    void addGlobalForbidden()
+    void forbidGlobally()
     {
         (global_.insert(typeIndexOf<NodeType>()), ...);
     }

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -88,13 +88,13 @@ public:
 
     // ---------------------- RUNTIME CHECK ----------------------
     template<Expressions::Nodes::FunctionNodeType functionNodeType>
-    [[nodiscard]] bool isForbiddenFor(const std::type_index& parentTypeId) const
+    [[nodiscard]] bool isForbiddenByParent(const std::type_index& parentTypeId) const
     {
         return isForbidden(parentTypeId, typeIndexOf<functionNodeType>());
     }
 
     template<typename Node>
-    [[nodiscard]] bool isForbiddenFor(const std::type_index& parentTypeId) const
+    [[nodiscard]] bool isForbiddenByParent(const std::type_index& parentTypeId) const
     {
         return isForbidden(parentTypeId, typeIndexOf<Node>());
     }

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -87,10 +87,10 @@ public:
     }
 
     // ---------------------- RUNTIME CHECK ----------------------
-    template<Expressions::Nodes::FunctionNodeType func>
+    template<Expressions::Nodes::FunctionNodeType functionNodeType>
     [[nodiscard]] bool isForbiddenFor(const std::type_index& parentTypeId) const
     {
-        return isForbidden(parentTypeId, typeIndexOf<func>());
+        return isForbidden(parentTypeId, typeIndexOf<functionNodeType>());
     }
 
     template<typename Node>

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -32,19 +32,17 @@
 namespace Antares::IO::Inputs::ModelConverter
 {
 
-using namespace Antares::Expressions;
-
 template<typename NodeType>
-requires(!std::is_same_v<NodeType, Nodes::FunctionNodeType>)
+requires(!std::is_same_v<NodeType, Expressions::Nodes::FunctionNodeType>)
 std::type_index typeIndexOf()
 {
     return std::type_index(typeid(NodeType));
 }
 
-template<Nodes::FunctionNodeType item>
+template<Expressions::Nodes::FunctionNodeType item>
 std::type_index typeIndexOf()
 {
-    using enum_item_as_type = std::integral_constant<Nodes::FunctionNodeType, item>;
+    using enum_item_as_type = std::integral_constant<Expressions::Nodes::FunctionNodeType, item>;
     return std::type_index(typeid(enum_item_as_type));
 }
 
@@ -58,28 +56,28 @@ public:
         (global_.insert(typeIndexOf<NodeType>()), ...);
     }
 
-    template<Nodes::FunctionNodeType... NodeType>
+    template<Expressions::Nodes::FunctionNodeType... NodeType>
     void forbidGlobally()
     {
         (global_.insert(typeIndexOf<NodeType>()), ...);
     }
 
     // ---------------------- PARENT -> CHILD --------------------
-    template<Nodes::FunctionNodeType Parent, typename Child>
-    requires(!std::is_same_v<Child, Nodes::FunctionNodeType>)
+    template<Expressions::Nodes::FunctionNodeType Parent, typename Child>
+    requires(!std::is_same_v<Child, Expressions::Nodes::FunctionNodeType>)
     void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
-    template<Nodes::FunctionNodeType Parent,
-             Nodes::FunctionNodeType Child>
+    template<Expressions::Nodes::FunctionNodeType Parent,
+             Expressions::Nodes::FunctionNodeType Child>
     void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
-    template<typename Parent, Nodes::FunctionNodeType Child>
+    template<typename Parent, Expressions::Nodes::FunctionNodeType Child>
     void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -100,16 +100,10 @@ public:
     }
 
     // ---------------------- GLOBALLY FORBIDDEN ----------------------
-    template<typename NodeType>
-    [[nodiscard]] bool isGloballyForbidden() const
+    
+    [[nodiscard]] bool isGloballyForbidden(const std::type_index& typeId) const
     {
-        return global_.contains(typeIndexOf<NodeType>());
-    }
-
-    template<Expressions::Nodes::FunctionNodeType NodeType>
-    [[nodiscard]] bool isGloballyForbidden() const
-    {
-        return global_.contains(typeIndexOf<NodeType>());
+        return global_.contains(typeId);
     }
 
 private:

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -32,21 +32,20 @@
 namespace Antares::IO::Inputs::ModelConverter
 {
 
+using namespace Antares::Expressions;
+
 template<typename NodeType>
+requires(!std::is_same_v<NodeType, Nodes::FunctionNodeType>)
 std::type_index typeIndexOf()
 {
-    static_assert(!std::is_same_v<NodeType, Expressions::Nodes::FunctionNode>,
-                  "Use Expressions::Nodes::FunctionNodeType enum values or "
-                  "typeIndexOf(Expressions::Nodes::FunctionNodeType) "
-                  "instead of FunctionNode for forbidden rules.");
     return std::type_index(typeid(NodeType));
 }
 
-template<Expressions::Nodes::FunctionNodeType T>
+template<Nodes::FunctionNodeType item>
 std::type_index typeIndexOf()
 {
-    using Tag = std::integral_constant<Expressions::Nodes::FunctionNodeType, T>;
-    return std::type_index(typeid(Tag));
+    using enum_item_as_type = std::integral_constant<Nodes::FunctionNodeType, item>;
+    return std::type_index(typeid(enum_item_as_type));
 }
 
 class ForbiddenNodes
@@ -59,28 +58,28 @@ public:
         (global_.insert(typeIndexOf<NodeType>()), ...);
     }
 
-    template<Expressions::Nodes::FunctionNodeType... NodeType>
+    template<Nodes::FunctionNodeType... NodeType>
     void forbidGlobally()
     {
         (global_.insert(typeIndexOf<NodeType>()), ...);
     }
 
     // ---------------------- PARENT -> CHILD --------------------
-    template<Expressions::Nodes::FunctionNodeType Parent, typename Child>
-    requires(!std::is_same_v<Child, Expressions::Nodes::FunctionNodeType>)
+    template<Nodes::FunctionNodeType Parent, typename Child>
+    requires(!std::is_same_v<Child, Nodes::FunctionNodeType>)
     void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
-    template<Expressions::Nodes::FunctionNodeType Parent,
-             Expressions::Nodes::FunctionNodeType Child>
+    template<Nodes::FunctionNodeType Parent,
+             Nodes::FunctionNodeType Child>
     void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
-    template<typename Parent, Expressions::Nodes::FunctionNodeType Child>
+    template<typename Parent, Nodes::FunctionNodeType Child>
     void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
@@ -99,6 +98,7 @@ public:
     }
 
 private:
+    // gp : we originally used unordered set and map, do we restore these types ?
     std::set<std::type_index> global_;
     std::map<std::type_index, std::set<std::type_index>> rules_; // Parent --> set of children
 };

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -114,12 +114,10 @@ public:
 
 private:
     std::set<std::type_index> global_;
+    std::map<std::type_index, std::set<std::type_index>> rules_; // Parent --> set of children
 
-    // Parent --> set of children
-    std::map<std::type_index, std::set<std::type_index>> rules_;
-
-    [[nodiscard]] bool isForbiddenByParent(const std::type_index& parentTypeId,
-                                           const std::type_index& nodeTypeId) const
+    bool isForbiddenByParent(const std::type_index& parentTypeId,
+                             const std::type_index& nodeTypeId) const
     {
         const auto& it = rules_.find(parentTypeId);
         return (it != rules_.end()) && it->second.contains(nodeTypeId);

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -21,10 +21,10 @@
 
 #pragma once
 
+#include <map>
+#include <set>
 #include <stdexcept>
 #include <typeindex>
-#include <unordered_map>
-#include <unordered_set>
 
 #include "antares/expressions/nodes/FunctionNode.h"
 #include "antares/expressions/nodes/Node.h"
@@ -101,15 +101,15 @@ public:
 
     // ---------------------- RUNTIME CHECK ----------------------
     template<Expressions::Nodes::FunctionNodeType Child>
-    [[nodiscard]] bool isForbiddenFor(const std::type_index& parentKey) const
+    [[nodiscard]] bool isForbiddenFor(const std::type_index& parentTypeId) const
     {
-        return check(parentKey, typeIndexOf<Child>());
+        return check(parentTypeId, typeIndexOf<Child>());
     }
 
     template<typename Child>
-    [[nodiscard]] bool isForbiddenFor(const std::type_index& parentKey) const
+    [[nodiscard]] bool isForbiddenFor(const std::type_index& parentTypeId) const
     {
-        return check(parentKey, typeIndexOf<Child>());
+        return check(parentTypeId, typeIndexOf<Child>());
     }
 
     // ---------------------- GLOBALLY FORBIDDEN ----------------------
@@ -126,28 +126,28 @@ public:
     }
 
 private:
-    std::unordered_set<std::type_index> global_;
-    std::unordered_map<std::type_index /* parent */,
-                       std::unordered_set<std::type_index> /* children */>
-      rules_;
+    std::set<std::type_index> global_;
 
-    [[nodiscard]] bool check(const std::type_index& parentKey,
-                             const std::type_index& childKey) const
+    // Parent --> set of children 
+    std::map<std::type_index, std::set<std::type_index>> rules_;
+
+    [[nodiscard]] bool check(const std::type_index& parentTypeId,
+                             const std::type_index& childTypeId) const
     {
-        // global forbidden child?
-        if (global_.contains(childKey))
+        // global forbidden child ?
+        if (global_.contains(childTypeId))
         {
             return true;
         }
 
-        // parent-specific forbidden child?
-        const auto& it = rules_.find(parentKey);
+        // parent-specific forbidden child ?
+        const auto& it = rules_.find(parentTypeId);
         if (it == rules_.end())
         {
             return false;
         }
 
-        return it->second.contains(childKey);
+        return it->second.contains(childTypeId);
     }
 };
 

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -68,20 +68,20 @@ public:
     // ---------------------- PARENT -> CHILD --------------------
     template<Expressions::Nodes::FunctionNodeType Parent, typename Child>
     requires(!std::is_same_v<Child, Expressions::Nodes::FunctionNodeType>)
-    void addForbiddenFor()
+    void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
     template<Expressions::Nodes::FunctionNodeType Parent,
              Expressions::Nodes::FunctionNodeType Child>
-    void addForbiddenFor()
+    void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
     template<typename Parent, Expressions::Nodes::FunctionNodeType Child>
-    void addForbiddenFor()
+    void parentForbidsChild()
     {
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -83,17 +83,9 @@ public:
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
+    bool isGloballyForbidden(const std::type_index& typeId) const;
     bool isForbiddenByParent(const std::type_index& parentTypeId,
-                             const std::type_index& nodeTypeId) const
-    {
-        const auto& it = rules_.find(parentTypeId);
-        return (it != rules_.end()) && it->second.contains(nodeTypeId);
-    }
-
-    bool isGloballyForbidden(const std::type_index& typeId) const
-    {
-        return global_.contains(typeId);
-    }
+                             const std::type_index& nodeTypeId) const;
 
 private:
     // gp : we originally used unordered set and map, do we restore these types ?

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -86,30 +86,17 @@ public:
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
-    // ---------------------- COMPILE-TIME CHECK ----------------------
-    template<typename Parent, Expressions::Nodes::FunctionNodeType Child>
-    [[nodiscard]] bool isForbiddenFor() const
-    {
-        return check(typeIndexOf<Parent>(), typeIndexOf<Child>());
-    }
-
-    template<typename Parent, typename Child>
-    [[nodiscard]] bool isForbiddenFor() const
-    {
-        return check(typeIndexOf<Parent>(), typeIndexOf<Child>());
-    }
-
     // ---------------------- RUNTIME CHECK ----------------------
-    template<Expressions::Nodes::FunctionNodeType Child>
+    template<Expressions::Nodes::FunctionNodeType func>
     [[nodiscard]] bool isForbiddenFor(const std::type_index& parentTypeId) const
     {
-        return check(parentTypeId, typeIndexOf<Child>());
+        return isForbidden(parentTypeId, typeIndexOf<func>());
     }
 
-    template<typename Child>
+    template<typename Node>
     [[nodiscard]] bool isForbiddenFor(const std::type_index& parentTypeId) const
     {
-        return check(parentTypeId, typeIndexOf<Child>());
+        return isForbidden(parentTypeId, typeIndexOf<Node>());
     }
 
     // ---------------------- GLOBALLY FORBIDDEN ----------------------
@@ -128,26 +115,18 @@ public:
 private:
     std::set<std::type_index> global_;
 
-    // Parent --> set of children 
+    // Parent --> set of children
     std::map<std::type_index, std::set<std::type_index>> rules_;
 
-    [[nodiscard]] bool check(const std::type_index& parentTypeId,
-                             const std::type_index& childTypeId) const
+    [[nodiscard]] bool isForbidden(const std::type_index& parentTypeId,
+                                   const std::type_index& nodeTypeId) const
     {
-        // global forbidden child ?
-        if (global_.contains(childTypeId))
-        {
-            return true;
-        }
+        bool isGloballyForbidden = global_.contains(nodeTypeId);
 
-        // parent-specific forbidden child ?
         const auto& it = rules_.find(parentTypeId);
-        if (it == rules_.end())
-        {
-            return false;
-        }
+        bool isForbiddenByParent = (it != rules_.end()) && it->second.contains(nodeTypeId);
 
-        return it->second.contains(childTypeId);
+        return isGloballyForbidden || isForbiddenByParent;
     }
 };
 

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -86,22 +86,14 @@ public:
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
-    // ---------------------- FORBIDDEN BY PARENT ----------------------
-    template<Expressions::Nodes::FunctionNodeType functionNodeType>
-    [[nodiscard]] bool isForbiddenByParent(const std::type_index& parentTypeId) const
+    bool isForbiddenByParent(const std::type_index& parentTypeId,
+                             const std::type_index& nodeTypeId) const
     {
-        return isForbiddenByParent(parentTypeId, typeIndexOf<functionNodeType>());
+        const auto& it = rules_.find(parentTypeId);
+        return (it != rules_.end()) && it->second.contains(nodeTypeId);
     }
 
-    template<typename Node>
-    [[nodiscard]] bool isForbiddenByParent(const std::type_index& parentTypeId) const
-    {
-        return isForbiddenByParent(parentTypeId, typeIndexOf<Node>());
-    }
-
-    // ---------------------- GLOBALLY FORBIDDEN ----------------------
-    
-    [[nodiscard]] bool isGloballyForbidden(const std::type_index& typeId) const
+    bool isGloballyForbidden(const std::type_index& typeId) const
     {
         return global_.contains(typeId);
     }
@@ -109,13 +101,6 @@ public:
 private:
     std::set<std::type_index> global_;
     std::map<std::type_index, std::set<std::type_index>> rules_; // Parent --> set of children
-
-    bool isForbiddenByParent(const std::type_index& parentTypeId,
-                             const std::type_index& nodeTypeId) const
-    {
-        const auto& it = rules_.find(parentTypeId);
-        return (it != rules_.end()) && it->second.contains(nodeTypeId);
-    }
 };
 
 } // namespace Antares::IO::Inputs::ModelConverter

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -86,17 +86,17 @@ public:
         rules_[typeIndexOf<Parent>()].insert(typeIndexOf<Child>());
     }
 
-    // ---------------------- RUNTIME CHECK ----------------------
+    // ---------------------- FORBIDDEN BY PARENT ----------------------
     template<Expressions::Nodes::FunctionNodeType functionNodeType>
     [[nodiscard]] bool isForbiddenByParent(const std::type_index& parentTypeId) const
     {
-        return isForbidden(parentTypeId, typeIndexOf<functionNodeType>());
+        return isForbiddenByParent(parentTypeId, typeIndexOf<functionNodeType>());
     }
 
     template<typename Node>
     [[nodiscard]] bool isForbiddenByParent(const std::type_index& parentTypeId) const
     {
-        return isForbidden(parentTypeId, typeIndexOf<Node>());
+        return isForbiddenByParent(parentTypeId, typeIndexOf<Node>());
     }
 
     // ---------------------- GLOBALLY FORBIDDEN ----------------------
@@ -118,15 +118,11 @@ private:
     // Parent --> set of children
     std::map<std::type_index, std::set<std::type_index>> rules_;
 
-    [[nodiscard]] bool isForbidden(const std::type_index& parentTypeId,
-                                   const std::type_index& nodeTypeId) const
+    [[nodiscard]] bool isForbiddenByParent(const std::type_index& parentTypeId,
+                                           const std::type_index& nodeTypeId) const
     {
-        bool isGloballyForbidden = global_.contains(nodeTypeId);
-
         const auto& it = rules_.find(parentTypeId);
-        bool isForbiddenByParent = (it != rules_.end()) && it->second.contains(nodeTypeId);
-
-        return isGloballyForbidden || isForbiddenByParent;
+        return (it != rules_.end()) && it->second.contains(nodeTypeId);
     }
 };
 

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -33,7 +33,6 @@ namespace Antares::IO::Inputs::ModelConverter
 {
 
 template<typename NodeType>
-requires(!std::is_same_v<NodeType, Expressions::Nodes::FunctionNodeType>)
 std::type_index typeIndexOf()
 {
     return std::type_index(typeid(NodeType));

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodes.h
@@ -48,7 +48,7 @@ std::type_index typeIndexOf()
 class ForbiddenNodes
 {
 public:
-    // ------------------------- GLOBAL -------------------------
+    // ------ GLOBALLY FORBIDDEN -------
     template<typename... NodeType>
     void forbidGlobally()
     {
@@ -61,7 +61,7 @@ public:
         (global_.insert(typeIndexOf<NodeType>()), ...);
     }
 
-    // ---------------------- PARENT -> CHILD --------------------
+    // ------ A PARENT FORBIDS A CHILD ------
     template<Expressions::Nodes::FunctionNodeType Parent, typename Child>
     requires(!std::is_same_v<Child, Expressions::Nodes::FunctionNodeType>)
     void parentForbidsChild()

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodesVisitor.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodesVisitor.h
@@ -66,8 +66,8 @@ public:
 
 private:
     // Member functions
-    void checkIsForbidden(const std::type_index& nodeTypeId,
-                          const Expressions::Nodes::Node* node) const;
+    void checkIsForbidden(const Expressions::Nodes::Node* node,
+                          const std::type_index& nodeTypeId) const;
 
     void checkIGloballyForbidden(const std::type_index& nodeTypeId,
                                  const Antares::Expressions::Nodes::Node* node) const;

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodesVisitor.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/ForbiddenNodesVisitor.h
@@ -39,10 +39,10 @@ public:
                                 const std::string parent = "");
 };
 
-class NodeChecker final: public Expressions::Visitors::NodeVisitor<void>
+class ForbiddenNodesVisitor final: public Expressions::Visitors::NodeVisitor<void>
 {
 public:
-    explicit NodeChecker(const ForbiddenNodes& forbid, const std::string& expression);
+    explicit ForbiddenNodesVisitor(const ForbiddenNodes& forbid, const std::string& expression);
     [[nodiscard]] std::string name() const override;
 
     void visit(const Expressions::Nodes::SumNode*) override;

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -30,6 +30,15 @@
 
 namespace Antares::IO::Inputs::ModelConverter
 {
+
+class ForbiddenNodeFound final: public std::invalid_argument
+{
+public:
+    explicit ForbiddenNodeFound(const std::string expr,
+                                const std::string node,
+                                const std::string parent = "");
+};
+
 class NodeChecker final: public Expressions::Visitors::NodeVisitor<void>
 {
 public:
@@ -59,50 +68,14 @@ private:
     // Member functions
     void checkIsForbidden(const std::type_index& nodeTypeId, const std::string& nodeName) const;
 
-    template<class Node>
     void visitChildren(const std::string& nodeName,
-                       const std::vector<Expressions::Nodes::Node*>& children);
-
-    template<Expressions::Nodes::FunctionNodeType>
-    void visitChildren(const std::string& parentName,
-                       const std::vector<Expressions::Nodes::Node*>& children);
+                       const std::vector<Expressions::Nodes::Node*>& children,
+                       const std::type_index& nodeTypeId);
 
     // Data members
     const ForbiddenNodes& forbiddenNodes_;
     std::vector<std::pair<std::string, std::type_index>> parentsStack_;
     const std::string& expression_;
 };
-
-class ForbiddenNodeFound final: public std::invalid_argument
-{
-public:
-    explicit ForbiddenNodeFound(const std::string expr,
-                                const std::string node,
-                                const std::string parent = "");
-};
-
-template<typename Node>
-void NodeChecker::visitChildren(const std::string& nodeName,
-                                const std::vector<Expressions::Nodes::Node*>& children)
-{
-    parentsStack_.emplace_back(nodeName, typeIndexOf<Node>());
-    for (const auto* child: children)
-    {
-        dispatch(child);
-    }
-    parentsStack_.pop_back();
-}
-
-template<Expressions::Nodes::FunctionNodeType functionNodeType>
-void NodeChecker::visitChildren(const std::string& nodeName,
-                                const std::vector<Expressions::Nodes::Node*>& children)
-{
-    parentsStack_.emplace_back(nodeName, typeIndexOf<functionNodeType>());
-    for (const auto* child: children)
-    {
-        dispatch(child);
-    }
-    parentsStack_.pop_back();
-}
 
 } // namespace Antares::IO::Inputs::ModelConverter

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -63,6 +63,8 @@ private:
     template<class Node>
     void checkIsForbidden(const std::string& childName) const;
 
+    void checkIsForbidden(std::type_index& typeId, const std::string& nodeName) const;
+
     template<class Node>
     void visitChildren(const std::string& nodeName,
                        const std::vector<Expressions::Nodes::Node*>& children);
@@ -89,38 +91,14 @@ template<typename Node>
 void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 {
     std::type_index typeId = typeIndexOf<Node>();
-
-    if (forbiddenNodes_.isGloballyForbidden(typeId))
-    {
-        throw ForbiddenNodeFound(expression_, nodeName);
-    }
-
-    for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
-    {
-        if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, typeId))
-        {
-            throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
-        }
-    }
+    checkIsForbidden(typeId, nodeName);
 }
 
 template<Expressions::Nodes::FunctionNodeType functionNodeType>
 void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 {
     std::type_index typeId = typeIndexOf<functionNodeType>();
-    
-    if (forbiddenNodes_.isGloballyForbidden(typeId))
-    {
-        throw ForbiddenNodeFound(expression_, nodeName);
-    }
-
-    for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
-    {
-        if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, typeId))
-        {
-            throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
-        }
-    }
+    checkIsForbidden(typeId, nodeName);
 }
 
 template<typename Node>

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -86,22 +86,9 @@ private:
 class ForbiddenNodeFound final: public std::invalid_argument
 {
 public:
-    static std::string ErrorMessage(const std::string expr,
-                             const std::string child,
-                             const std::string parent)
-    {
-        if (!parent.empty())
-        {
-            std::string format_str = "'{}' is not allowed to contain '{}' in this context '{}'";
-            return fmt::format(fmt::runtime(format_str), parent, child, expr);
-        }
-        return fmt::format("'{}' is not allowed in this context '{}'", child, expr);
-    }
-
-    explicit ForbiddenNodeFound(std::string expr, std::string child, std::string parent = ""):
-        invalid_argument(ErrorMessage(expr, child, parent))
-    {
-    }
+    explicit ForbiddenNodeFound(const std::string expr,
+                                const std::string child,
+                                const std::string parent = "");
 };
 
 template<typename Child>

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -100,7 +100,7 @@ void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
 
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbiddenNodes_.isForbiddenFor<Node>(parentTypeIndex))
+        if (forbiddenNodes_.isForbiddenByParent<Node>(parentTypeIndex))
         {
             throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }
@@ -117,7 +117,7 @@ void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
 
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbiddenNodes_.isForbiddenFor<functionNodeType>(parentTypeIndex))
+        if (forbiddenNodes_.isForbiddenByParent<functionNodeType>(parentTypeIndex))
         {
             throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -65,16 +65,11 @@ private:
 
     template<class Node>
     void visitChildren(const std::string& nodeName,
-                       const std::vector<Expressions::Nodes::Node*>& children,
-                       bool validateConsistencyWithParents);
+                       const std::vector<Expressions::Nodes::Node*>& children);
 
     template<Expressions::Nodes::FunctionNodeType>
     void visitChildren(const std::string& parentName,
                        const std::vector<Expressions::Nodes::Node*>& children);
-
-    template<class Node>
-    void visitComparisonNode(const std::string& op,
-                             const std::vector<Expressions::Nodes::Node*>& children);
 
     // Data members
     const ForbiddenNodes& forbiddenNodes_;
@@ -126,14 +121,8 @@ void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
 
 template<typename Node>
 void NodeChecker::visitChildren(const std::string& nodeName,
-                                const std::vector<Expressions::Nodes::Node*>& children,
-                                bool validateConsistencyWithParents)
+                                const std::vector<Expressions::Nodes::Node*>& children)
 {
-    if (validateConsistencyWithParents)
-    {
-        checkConsistencyWithParents<Node>(nodeName);
-    }
-
     parentsStack_.emplace_back(nodeName, typeIndexOf<Node>());
     for (const auto* child: children)
     {
@@ -154,13 +143,6 @@ void NodeChecker::visitChildren(const std::string& nodeName,
         dispatch(child);
     }
     parentsStack_.pop_back();
-}
-
-template<typename Node>
-void NodeChecker::visitComparisonNode(const std::string& sign,
-                                      const std::vector<Expressions::Nodes::Node*>& children)
-{
-    visitChildren<Node>("expression with " + sign, children, true);
 }
 
 } // namespace Antares::IO::Inputs::ModelConverter

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -88,14 +88,16 @@ public:
 template<typename Node>
 void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 {
-    if (forbiddenNodes_.isGloballyForbidden(typeIndexOf<Node>()))
+    std::type_index typeId = typeIndexOf<Node>();
+
+    if (forbiddenNodes_.isGloballyForbidden(typeId))
     {
         throw ForbiddenNodeFound(expression_, nodeName);
     }
 
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbiddenNodes_.isForbiddenByParent<Node>(parentTypeIndex))
+        if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, typeId))
         {
             throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }
@@ -105,14 +107,16 @@ void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 template<Expressions::Nodes::FunctionNodeType functionNodeType>
 void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 {
-    if (forbiddenNodes_.isGloballyForbidden(typeIndexOf<functionNodeType>()))
+    std::type_index typeId = typeIndexOf<functionNodeType>();
+    
+    if (forbiddenNodes_.isGloballyForbidden(typeId))
     {
         throw ForbiddenNodeFound(expression_, nodeName);
     }
 
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbiddenNodes_.isForbiddenByParent<functionNodeType>(parentTypeIndex))
+        if (forbiddenNodes_.isForbiddenByParent(parentTypeIndex, typeId))
         {
             throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -83,32 +83,23 @@ private:
     const std::string& expression_;
 };
 
-struct ErrorInfo
-{
-    std::string expression;
-    std::string childName;
-    std::optional<std::string> parentName;
-};
-
 class ForbiddenNodeFound final: public std::invalid_argument
 {
 public:
-    std::string ErrorMessage(const ErrorInfo& errorInfo)
+    static std::string ErrorMessage(const std::string expr,
+                             const std::string child,
+                             const std::string parent)
     {
-        if (errorInfo.parentName.has_value())
+        if (!parent.empty())
         {
-            return fmt::format("'{}' is not allowed to contain '{}' in this context '{}'",
-                               errorInfo.parentName.value(),
-                               errorInfo.childName,
-                               errorInfo.expression);
+            std::string format_str = "'{}' is not allowed to contain '{}' in this context '{}'";
+            return fmt::format(fmt::runtime(format_str), parent, child, expr);
         }
-        return fmt::format("'{}' is not allowed in this context '{}'",
-                           errorInfo.childName,
-                           errorInfo.expression);
+        return fmt::format("'{}' is not allowed in this context '{}'", child, expr);
     }
 
-    explicit ForbiddenNodeFound(const ErrorInfo& errorInfo):
-        invalid_argument(ErrorMessage(errorInfo))
+    explicit ForbiddenNodeFound(std::string expr, std::string child, std::string parent = ""):
+        invalid_argument(ErrorMessage(expr, child, parent))
     {
     }
 };
@@ -118,14 +109,14 @@ void NodeChecker::checkConsistencyWithParents(const std::string& childName) cons
 {
     if (forbiddenNodes_.isGloballyForbidden<Child>())
     {
-        throw ForbiddenNodeFound({.expression = expression_, .childName = childName});
+        throw ForbiddenNodeFound(expression_, childName);
     }
 
     for (const auto& [parentName, typeIndex]: std::ranges::reverse_view(parentsStack_))
     {
         if (forbiddenNodes_.isForbiddenFor<Child>(typeIndex))
         {
-            throw ForbiddenNodeFound({expression_, childName, parentName});
+            throw ForbiddenNodeFound(expression_, childName, parentName);
         }
     }
 }
@@ -135,14 +126,14 @@ void NodeChecker::checkConsistencyWithParents(const std::string& childName) cons
 {
     if (forbiddenNodes_.isGloballyForbidden<func>())
     {
-        throw ForbiddenNodeFound({.expression = expression_, .childName = childName});
+        throw ForbiddenNodeFound(expression_, childName);
     }
 
     for (const auto& [parentName, typeIndex]: std::ranges::reverse_view(parentsStack_))
     {
         if (forbiddenNodes_.isForbiddenFor<func>(typeIndex))
         {
-            throw ForbiddenNodeFound({expression_, childName, parentName});
+            throw ForbiddenNodeFound(expression_, childName, parentName);
         }
     }
 }

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -70,8 +70,7 @@ private:
 
     template<Expressions::Nodes::FunctionNodeType func>
     void visitChildren(const std::string& parentName,
-                       const std::vector<Expressions::Nodes::Node*>& children,
-                       bool validateConsistencyWithParents);
+                       const std::vector<Expressions::Nodes::Node*>& children);
 
     template<class NodeType>
     void visitComparisonNode(const std::string& op,
@@ -145,13 +144,9 @@ void NodeChecker::visitChildren(const std::string& parentName,
 
 template<Expressions::Nodes::FunctionNodeType func>
 void NodeChecker::visitChildren(const std::string& parentName,
-                                const std::vector<Expressions::Nodes::Node*>& children,
-                                bool validateConsistencyWithParents)
+                                const std::vector<Expressions::Nodes::Node*>& children)
 {
-    if (validateConsistencyWithParents)
-    {
-        checkConsistencyWithParents<func>(parentName);
-    }
+    checkConsistencyWithParents<func>(parentName);
 
     parentsStack_.emplace_back(parentName, typeIndexOf<func>());
     for (const auto* child: children)

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -58,10 +58,10 @@ public:
 private:
     // Member functions
     template<Expressions::Nodes::FunctionNodeType>
-    void checkConsistencyWithParents(const std::string& childName) const;
+    void checkIsForbidden(const std::string& childName) const;
 
     template<class Node>
-    void checkConsistencyWithParents(const std::string& childName) const;
+    void checkIsForbidden(const std::string& childName) const;
 
     template<class Node>
     void visitChildren(const std::string& nodeName,
@@ -86,7 +86,7 @@ public:
 };
 
 template<typename Node>
-void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
+void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 {
     if (forbiddenNodes_.isGloballyForbidden<Node>())
     {
@@ -103,7 +103,7 @@ void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
 }
 
 template<Expressions::Nodes::FunctionNodeType functionNodeType>
-void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
+void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 {
     if (forbiddenNodes_.isGloballyForbidden<functionNodeType>())
     {
@@ -135,8 +135,6 @@ template<Expressions::Nodes::FunctionNodeType functionNodeType>
 void NodeChecker::visitChildren(const std::string& nodeName,
                                 const std::vector<Expressions::Nodes::Node*>& children)
 {
-    checkConsistencyWithParents<functionNodeType>(nodeName);
-
     parentsStack_.emplace_back(nodeName, typeIndexOf<functionNodeType>());
     for (const auto* child: children)
     {

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -57,13 +57,7 @@ public:
 
 private:
     // Member functions
-    template<Expressions::Nodes::FunctionNodeType>
-    void checkIsForbidden(const std::string& childName) const;
-
-    template<class Node>
-    void checkIsForbidden(const std::string& childName) const;
-
-    void checkIsForbidden(std::type_index& typeId, const std::string& nodeName) const;
+    void checkIsForbidden(const std::type_index& typeId, const std::string& nodeName) const;
 
     template<class Node>
     void visitChildren(const std::string& nodeName,
@@ -86,20 +80,6 @@ public:
                                 const std::string node,
                                 const std::string parent = "");
 };
-
-template<typename Node>
-void NodeChecker::checkIsForbidden(const std::string& nodeName) const
-{
-    std::type_index typeId = typeIndexOf<Node>();
-    checkIsForbidden(typeId, nodeName);
-}
-
-template<Expressions::Nodes::FunctionNodeType functionNodeType>
-void NodeChecker::checkIsForbidden(const std::string& nodeName) const
-{
-    std::type_index typeId = typeIndexOf<functionNodeType>();
-    checkIsForbidden(typeId, nodeName);
-}
 
 template<typename Node>
 void NodeChecker::visitChildren(const std::string& nodeName,

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -66,10 +66,10 @@ public:
 
 private:
     // Member functions
-    void checkIsForbidden(const std::type_index& nodeTypeId, const std::string& nodeName) const;
+    void checkIsForbidden(const std::type_index& nodeTypeId,
+                          const Expressions::Nodes::Node* node) const;
 
-    void visitChildren(const std::string& nodeName,
-                       const Expressions::Nodes::ParentNode* node,
+    void visitChildren(const Expressions::Nodes::ParentNode* node,
                        const std::type_index& nodeTypeId);
 
     // Data members

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -57,7 +57,7 @@ public:
 
 private:
     // Member functions
-    void checkIsForbidden(const std::type_index& typeId, const std::string& nodeName) const;
+    void checkIsForbidden(const std::type_index& nodeTypeId, const std::string& nodeName) const;
 
     template<class Node>
     void visitChildren(const std::string& nodeName,

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -134,8 +134,8 @@ void NodeChecker::visitChildren(const std::string& parentName,
     {
         checkConsistencyWithParents<Parent>(parentName);
     }
-    parentsStack_.emplace_back(parentName, typeid(Parent));
 
+    parentsStack_.emplace_back(parentName, typeIndexOf<Parent>());
     for (const auto* child: children)
     {
         dispatch(child);
@@ -152,10 +152,8 @@ void NodeChecker::visitChildren(const std::string& parentName,
     {
         checkConsistencyWithParents<func>(parentName);
     }
-    parentsStack_.emplace_back(
-      parentName,
-      typeid(std::integral_constant<Expressions::Nodes::FunctionNodeType, func>));
 
+    parentsStack_.emplace_back(parentName, typeIndexOf<func>());
     for (const auto* child: children)
     {
         dispatch(child);

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -113,7 +113,7 @@ public:
 template<typename Child>
 void NodeChecker::checkConsistencyWithParents(const std::string& childName) const
 {
-    if (forbid_.isForbidden<Child>())
+    if (forbid_.isGloballyForbidden<Child>())
     {
         throw BadContextComposition(
           {.expression = expression_, .childName = childName, .parentName = std::nullopt});
@@ -131,7 +131,7 @@ void NodeChecker::checkConsistencyWithParents(const std::string& childName) cons
 template<Expressions::Nodes::FunctionNodeType func>
 void NodeChecker::checkConsistencyWithParents(const std::string& childName) const
 {
-    if (forbid_.isForbidden<func>())
+    if (forbid_.isGloballyForbidden<func>())
     {
         throw BadContextComposition(
           {.expression = expression_, .childName = childName, .parentName = std::nullopt});

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -60,11 +60,11 @@ private:
     template<Expressions::Nodes::FunctionNodeType func>
     void checkConsistencyWithParents(const std::string& childName) const;
 
-    template<class Child>
+    template<class Node>
     void checkConsistencyWithParents(const std::string& childName) const;
 
-    template<class Parent>
-    void visitChildren(const std::string& parentName,
+    template<class Node>
+    void visitChildren(const std::string& nodeName,
                        const std::vector<Expressions::Nodes::Node*>& children,
                        bool validateConsistencyWithParents);
 
@@ -72,7 +72,7 @@ private:
     void visitChildren(const std::string& parentName,
                        const std::vector<Expressions::Nodes::Node*>& children);
 
-    template<class NodeType>
+    template<class Node>
     void visitComparisonNode(const std::string& op,
                              const std::vector<Expressions::Nodes::Node*>& children);
 
@@ -86,55 +86,55 @@ class ForbiddenNodeFound final: public std::invalid_argument
 {
 public:
     explicit ForbiddenNodeFound(const std::string expr,
-                                const std::string child,
+                                const std::string node,
                                 const std::string parent = "");
 };
 
-template<typename Child>
-void NodeChecker::checkConsistencyWithParents(const std::string& childName) const
+template<typename Node>
+void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
 {
-    if (forbiddenNodes_.isGloballyForbidden<Child>())
+    if (forbiddenNodes_.isGloballyForbidden<Node>())
     {
-        throw ForbiddenNodeFound(expression_, childName);
+        throw ForbiddenNodeFound(expression_, nodeName);
     }
 
-    for (const auto& [parentName, typeIndex]: std::ranges::reverse_view(parentsStack_))
+    for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbiddenNodes_.isForbiddenFor<Child>(typeIndex))
+        if (forbiddenNodes_.isForbiddenFor<Node>(parentTypeIndex))
         {
-            throw ForbiddenNodeFound(expression_, childName, parentName);
+            throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }
     }
 }
 
 template<Expressions::Nodes::FunctionNodeType func>
-void NodeChecker::checkConsistencyWithParents(const std::string& childName) const
+void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
 {
     if (forbiddenNodes_.isGloballyForbidden<func>())
     {
-        throw ForbiddenNodeFound(expression_, childName);
+        throw ForbiddenNodeFound(expression_, nodeName);
     }
 
-    for (const auto& [parentName, typeIndex]: std::ranges::reverse_view(parentsStack_))
+    for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbiddenNodes_.isForbiddenFor<func>(typeIndex))
+        if (forbiddenNodes_.isForbiddenFor<func>(parentTypeIndex))
         {
-            throw ForbiddenNodeFound(expression_, childName, parentName);
+            throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }
     }
 }
 
-template<typename Parent>
-void NodeChecker::visitChildren(const std::string& parentName,
+template<typename Node>
+void NodeChecker::visitChildren(const std::string& nodeName,
                                 const std::vector<Expressions::Nodes::Node*>& children,
                                 bool validateConsistencyWithParents)
 {
     if (validateConsistencyWithParents)
     {
-        checkConsistencyWithParents<Parent>(parentName);
+        checkConsistencyWithParents<Node>(nodeName);
     }
 
-    parentsStack_.emplace_back(parentName, typeIndexOf<Parent>());
+    parentsStack_.emplace_back(nodeName, typeIndexOf<Node>());
     for (const auto* child: children)
     {
         dispatch(child);
@@ -143,12 +143,12 @@ void NodeChecker::visitChildren(const std::string& parentName,
 }
 
 template<Expressions::Nodes::FunctionNodeType func>
-void NodeChecker::visitChildren(const std::string& parentName,
+void NodeChecker::visitChildren(const std::string& nodeName,
                                 const std::vector<Expressions::Nodes::Node*>& children)
 {
-    checkConsistencyWithParents<func>(parentName);
+    checkConsistencyWithParents<func>(nodeName);
 
-    parentsStack_.emplace_back(parentName, typeIndexOf<func>());
+    parentsStack_.emplace_back(nodeName, typeIndexOf<func>());
     for (const auto* child: children)
     {
         dispatch(child);
@@ -156,11 +156,11 @@ void NodeChecker::visitChildren(const std::string& parentName,
     parentsStack_.pop_back();
 }
 
-template<typename NodeType>
+template<typename Node>
 void NodeChecker::visitComparisonNode(const std::string& sign,
                                       const std::vector<Expressions::Nodes::Node*>& children)
 {
-    visitChildren<NodeType>("expression with " + sign, children, true);
+    visitChildren<Node>("expression with " + sign, children, true);
 }
 
 } // namespace Antares::IO::Inputs::ModelConverter

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -83,32 +83,32 @@ private:
     const std::string& expression_;
 };
 
-struct BadExpression
+struct ErrorInfo
 {
     std::string expression;
     std::string childName;
     std::optional<std::string> parentName;
 };
 
-class BadContextComposition final: public std::invalid_argument
+class ForbiddenNodeFound final: public std::invalid_argument
 {
 public:
-    static std::string BuildMessage(const BadExpression& context)
+    std::string ErrorMessage(const ErrorInfo& errorInfo)
     {
-        if (context.parentName.has_value())
+        if (errorInfo.parentName.has_value())
         {
             return fmt::format("'{}' is not allowed to contain '{}' in this context '{}'",
-                               context.parentName.value(),
-                               context.childName,
-                               context.expression);
+                               errorInfo.parentName.value(),
+                               errorInfo.childName,
+                               errorInfo.expression);
         }
         return fmt::format("'{}' is not allowed in this context '{}'",
-                           context.childName,
-                           context.expression);
+                           errorInfo.childName,
+                           errorInfo.expression);
     }
 
-    explicit BadContextComposition(const BadExpression& context):
-        invalid_argument(BuildMessage(context))
+    explicit ForbiddenNodeFound(const ErrorInfo& errorInfo):
+        invalid_argument(ErrorMessage(errorInfo))
     {
     }
 };
@@ -118,15 +118,14 @@ void NodeChecker::checkConsistencyWithParents(const std::string& childName) cons
 {
     if (forbiddenNodes_.isGloballyForbidden<Child>())
     {
-        throw BadContextComposition(
-          {.expression = expression_, .childName = childName, .parentName = std::nullopt});
+        throw ForbiddenNodeFound({.expression = expression_, .childName = childName});
     }
+
     for (const auto& [parentName, typeIndex]: std::ranges::reverse_view(parentsStack_))
     {
         if (forbiddenNodes_.isForbiddenFor<Child>(typeIndex))
         {
-            throw BadContextComposition(
-              {.expression = expression_, .childName = childName, .parentName = parentName});
+            throw ForbiddenNodeFound({expression_, childName, parentName});
         }
     }
 }
@@ -136,15 +135,14 @@ void NodeChecker::checkConsistencyWithParents(const std::string& childName) cons
 {
     if (forbiddenNodes_.isGloballyForbidden<func>())
     {
-        throw BadContextComposition(
-          {.expression = expression_, .childName = childName, .parentName = std::nullopt});
+        throw ForbiddenNodeFound({.expression = expression_, .childName = childName});
     }
+
     for (const auto& [parentName, typeIndex]: std::ranges::reverse_view(parentsStack_))
     {
         if (forbiddenNodes_.isForbiddenFor<func>(typeIndex))
         {
-            throw BadContextComposition(
-              {.expression = expression_, .childName = childName, .parentName = parentName});
+            throw ForbiddenNodeFound({expression_, childName, parentName});
         }
     }
 }

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -57,7 +57,7 @@ public:
 
 private:
     // Member functions
-    template<Expressions::Nodes::FunctionNodeType func>
+    template<Expressions::Nodes::FunctionNodeType>
     void checkConsistencyWithParents(const std::string& childName) const;
 
     template<class Node>
@@ -68,7 +68,7 @@ private:
                        const std::vector<Expressions::Nodes::Node*>& children,
                        bool validateConsistencyWithParents);
 
-    template<Expressions::Nodes::FunctionNodeType func>
+    template<Expressions::Nodes::FunctionNodeType>
     void visitChildren(const std::string& parentName,
                        const std::vector<Expressions::Nodes::Node*>& children);
 
@@ -107,17 +107,17 @@ void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
     }
 }
 
-template<Expressions::Nodes::FunctionNodeType func>
+template<Expressions::Nodes::FunctionNodeType functionNodeType>
 void NodeChecker::checkConsistencyWithParents(const std::string& nodeName) const
 {
-    if (forbiddenNodes_.isGloballyForbidden<func>())
+    if (forbiddenNodes_.isGloballyForbidden<functionNodeType>())
     {
         throw ForbiddenNodeFound(expression_, nodeName);
     }
 
     for (const auto& [parentNodeName, parentTypeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbiddenNodes_.isForbiddenFor<func>(parentTypeIndex))
+        if (forbiddenNodes_.isForbiddenFor<functionNodeType>(parentTypeIndex))
         {
             throw ForbiddenNodeFound(expression_, nodeName, parentNodeName);
         }
@@ -142,13 +142,13 @@ void NodeChecker::visitChildren(const std::string& nodeName,
     parentsStack_.pop_back();
 }
 
-template<Expressions::Nodes::FunctionNodeType func>
+template<Expressions::Nodes::FunctionNodeType functionNodeType>
 void NodeChecker::visitChildren(const std::string& nodeName,
                                 const std::vector<Expressions::Nodes::Node*>& children)
 {
-    checkConsistencyWithParents<func>(nodeName);
+    checkConsistencyWithParents<functionNodeType>(nodeName);
 
-    parentsStack_.emplace_back(nodeName, typeIndexOf<func>());
+    parentsStack_.emplace_back(nodeName, typeIndexOf<functionNodeType>());
     for (const auto* child: children)
     {
         dispatch(child);

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -69,7 +69,7 @@ private:
     void checkIsForbidden(const std::type_index& nodeTypeId, const std::string& nodeName) const;
 
     void visitChildren(const std::string& nodeName,
-                       const std::vector<Expressions::Nodes::Node*>& children,
+                       const Expressions::Nodes::ParentNode* node,
                        const std::type_index& nodeTypeId);
 
     // Data members

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -56,26 +56,29 @@ public:
     void visit(const Expressions::Nodes::FunctionNode*) override;
 
 private:
+    // Member functions
     template<Expressions::Nodes::FunctionNodeType func>
     void checkConsistencyWithParents(const std::string& childName) const;
+
     template<class Child>
     void checkConsistencyWithParents(const std::string& childName) const;
 
     template<class Parent>
-    void checkChildren(const std::string& parentName,
+    void visitChildren(const std::string& parentName,
                        const std::vector<Expressions::Nodes::Node*>& children,
                        bool validateConsistencyWithParents);
+
     template<Expressions::Nodes::FunctionNodeType func>
-    void checkChildren(const std::string& parentName,
+    void visitChildren(const std::string& parentName,
                        const std::vector<Expressions::Nodes::Node*>& children,
                        bool validateConsistencyWithParents);
+
     template<class NodeType>
-    void handleComparisonNode(const std::string& op,
-                              const std::vector<Expressions::Nodes::Node*>& children);
+    void visitComparisonNode(const std::string& op,
+                             const std::vector<Expressions::Nodes::Node*>& children);
 
-    //--
-
-    const ForbiddenNodes& forbid_;
+    // Data members
+    const ForbiddenNodes& forbiddenNodes_;
     std::vector<std::pair<std::string, std::type_index>> parentsStack_;
     const std::string& expression_;
 };
@@ -113,14 +116,14 @@ public:
 template<typename Child>
 void NodeChecker::checkConsistencyWithParents(const std::string& childName) const
 {
-    if (forbid_.isGloballyForbidden<Child>())
+    if (forbiddenNodes_.isGloballyForbidden<Child>())
     {
         throw BadContextComposition(
           {.expression = expression_, .childName = childName, .parentName = std::nullopt});
     }
     for (const auto& [parentName, typeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbid_.isForbiddenFor<Child>(typeIndex))
+        if (forbiddenNodes_.isForbiddenFor<Child>(typeIndex))
         {
             throw BadContextComposition(
               {.expression = expression_, .childName = childName, .parentName = parentName});
@@ -131,14 +134,14 @@ void NodeChecker::checkConsistencyWithParents(const std::string& childName) cons
 template<Expressions::Nodes::FunctionNodeType func>
 void NodeChecker::checkConsistencyWithParents(const std::string& childName) const
 {
-    if (forbid_.isGloballyForbidden<func>())
+    if (forbiddenNodes_.isGloballyForbidden<func>())
     {
         throw BadContextComposition(
           {.expression = expression_, .childName = childName, .parentName = std::nullopt});
     }
     for (const auto& [parentName, typeIndex]: std::ranges::reverse_view(parentsStack_))
     {
-        if (forbid_.isForbiddenFor<func>(typeIndex))
+        if (forbiddenNodes_.isForbiddenFor<func>(typeIndex))
         {
             throw BadContextComposition(
               {.expression = expression_, .childName = childName, .parentName = parentName});
@@ -147,7 +150,7 @@ void NodeChecker::checkConsistencyWithParents(const std::string& childName) cons
 }
 
 template<typename Parent>
-void NodeChecker::checkChildren(const std::string& parentName,
+void NodeChecker::visitChildren(const std::string& parentName,
                                 const std::vector<Expressions::Nodes::Node*>& children,
                                 bool validateConsistencyWithParents)
 {
@@ -165,7 +168,7 @@ void NodeChecker::checkChildren(const std::string& parentName,
 }
 
 template<Expressions::Nodes::FunctionNodeType func>
-void NodeChecker::checkChildren(const std::string& parentName,
+void NodeChecker::visitChildren(const std::string& parentName,
                                 const std::vector<Expressions::Nodes::Node*>& children,
                                 bool validateConsistencyWithParents)
 {
@@ -185,10 +188,10 @@ void NodeChecker::checkChildren(const std::string& parentName,
 }
 
 template<typename NodeType>
-void NodeChecker::handleComparisonNode(const std::string& op,
-                                       const std::vector<Expressions::Nodes::Node*>& children)
+void NodeChecker::visitComparisonNode(const std::string& sign,
+                                      const std::vector<Expressions::Nodes::Node*>& children)
 {
-    checkChildren<NodeType>("expression with " + op, children, true);
+    visitChildren<NodeType>("expression with " + sign, children, true);
 }
 
 } // namespace Antares::IO::Inputs::ModelConverter

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -69,6 +69,12 @@ private:
     void checkIsForbidden(const std::type_index& nodeTypeId,
                           const Expressions::Nodes::Node* node) const;
 
+    void checkIGloballyForbidden(const std::type_index& nodeTypeId,
+                                 const Antares::Expressions::Nodes::Node* node) const;
+
+    void checkIsForbiddenByParent(const std::type_index& nodeTypeId,
+                                  const Antares::Expressions::Nodes::Node* node) const;
+
     void visitChildren(const Expressions::Nodes::ParentNode* node,
                        const std::type_index& nodeTypeId);
 

--- a/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
+++ b/src/io/inputs/model-converter/include/antares/io/inputs/model-converter/NodeChecker.h
@@ -88,7 +88,7 @@ public:
 template<typename Node>
 void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 {
-    if (forbiddenNodes_.isGloballyForbidden<Node>())
+    if (forbiddenNodes_.isGloballyForbidden(typeIndexOf<Node>()))
     {
         throw ForbiddenNodeFound(expression_, nodeName);
     }
@@ -105,7 +105,7 @@ void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 template<Expressions::Nodes::FunctionNodeType functionNodeType>
 void NodeChecker::checkIsForbidden(const std::string& nodeName) const
 {
-    if (forbiddenNodes_.isGloballyForbidden<functionNodeType>())
+    if (forbiddenNodes_.isGloballyForbidden(typeIndexOf<functionNodeType>()))
     {
         throw ForbiddenNodeFound(expression_, nodeName);
     }

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -78,13 +78,21 @@ static void CommonPreSolve(ForbiddenNodes& f)
 {
     // constraint, objective and variable bounds should not contain dual or reduced_cost
     f.addGlobalForbidden<FunctionNodeType::reduced_cost, FunctionNodeType::dual>();
-    // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in max and min
+
+    // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in max(...)
     f.addForbiddenFor<FunctionNodeType::max, VariableNode>();
-    f.addForbiddenFor<FunctionNodeType::min, VariableNode>();
     f.addForbiddenFor<FunctionNodeType::max, PortFieldNode>();
-    f.addForbiddenFor<FunctionNodeType::min, PortFieldNode>();
     f.addForbiddenFor<FunctionNodeType::max, PortFieldSumNode>();
+
+    // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in min(...)
+    f.addForbiddenFor<FunctionNodeType::min, VariableNode>();
+    f.addForbiddenFor<FunctionNodeType::min, PortFieldNode>();
     f.addForbiddenFor<FunctionNodeType::min, PortFieldSumNode>();
+
+    // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in floor(node)
+    f.addForbiddenFor<FunctionNodeType::floor, VariableNode>();
+    f.addForbiddenFor<FunctionNodeType::floor, PortFieldNode>();
+    f.addForbiddenFor<FunctionNodeType::floor, PortFieldSumNode>();
 }
 
 static ForbiddenNodes ForbiddenInConstraint()

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -80,7 +80,7 @@ PortInDefinition::PortInDefinition(const std::string& portId, const std::string&
 static void CommonPreSolve(ForbiddenNodes& f)
 {
     // constraint, objective and variable bounds should not contain dual or reduced_cost
-    f.addGlobalForbidden<FunctionNodeType::reduced_cost, FunctionNodeType::dual>();
+    f.forbidGlobally<FunctionNodeType::reduced_cost, FunctionNodeType::dual>();
 
     // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in max(...)
     f.addForbiddenFor<FunctionNodeType::max, VariableNode>();
@@ -105,7 +105,7 @@ static ForbiddenNodes ForbiddenInConstraint()
         // Initialization code executed ONCE
         ForbiddenNodes f;
         CommonPreSolve(f);
-        f.addGlobalForbidden<PortFieldSumNode>();
+        f.forbidGlobally<PortFieldSumNode>();
         return f;
     }();
     return forbidden;
@@ -130,7 +130,7 @@ static ForbiddenNodes PreSolveNonConstraint()
         // Initialization code executed ONCE
         ForbiddenNodes f;
         CommonPreSolve(f);
-        f.addGlobalForbidden<ComparisonNode,
+        f.forbidGlobally<ComparisonNode,
                              EqualNode,
                              LessThanOrEqualNode,
                              GreaterThanOrEqualNode,
@@ -146,7 +146,7 @@ static ForbiddenNodes ForbiddenInExtraOutput()
     {
         // Initialization code executed ONCE
         ForbiddenNodes f;
-        // TODO check        //   f.addGlobalForbidden<PortFieldSumNode>();
+        // TODO check        //   f.forbidGlobally<PortFieldSumNode>();
         return f;
     }();
     return forbidden;

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -83,19 +83,19 @@ static void CommonPreSolve(ForbiddenNodes& f)
     f.forbidGlobally<FunctionNodeType::reduced_cost, FunctionNodeType::dual>();
 
     // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in max(...)
-    f.addForbiddenFor<FunctionNodeType::max, VariableNode>();
-    f.addForbiddenFor<FunctionNodeType::max, PortFieldNode>();
-    f.addForbiddenFor<FunctionNodeType::max, PortFieldSumNode>();
+    f.parentForbidsChild<FunctionNodeType::max, VariableNode>();
+    f.parentForbidsChild<FunctionNodeType::max, PortFieldNode>();
+    f.parentForbidsChild<FunctionNodeType::max, PortFieldSumNode>();
 
     // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in min(...)
-    f.addForbiddenFor<FunctionNodeType::min, VariableNode>();
-    f.addForbiddenFor<FunctionNodeType::min, PortFieldNode>();
-    f.addForbiddenFor<FunctionNodeType::min, PortFieldSumNode>();
+    f.parentForbidsChild<FunctionNodeType::min, VariableNode>();
+    f.parentForbidsChild<FunctionNodeType::min, PortFieldNode>();
+    f.parentForbidsChild<FunctionNodeType::min, PortFieldSumNode>();
 
     // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in floor(node)
-    f.addForbiddenFor<FunctionNodeType::floor, VariableNode>();
-    f.addForbiddenFor<FunctionNodeType::floor, PortFieldNode>();
-    f.addForbiddenFor<FunctionNodeType::floor, PortFieldSumNode>();
+    f.parentForbidsChild<FunctionNodeType::floor, VariableNode>();
+    f.parentForbidsChild<FunctionNodeType::floor, PortFieldNode>();
+    f.parentForbidsChild<FunctionNodeType::floor, PortFieldSumNode>();
 }
 
 static ForbiddenNodes ForbiddenInConstraint()
@@ -131,10 +131,10 @@ static ForbiddenNodes PreSolveNonConstraint()
         ForbiddenNodes f;
         CommonPreSolve(f);
         f.forbidGlobally<ComparisonNode,
-                             EqualNode,
-                             LessThanOrEqualNode,
-                             GreaterThanOrEqualNode,
-                             PortFieldSumNode>();
+                         EqualNode,
+                         LessThanOrEqualNode,
+                         GreaterThanOrEqualNode,
+                         PortFieldSumNode>();
         return f;
     }();
     return forbidden;

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -256,21 +256,19 @@ std::vector<Variable> convertVariables(const YmlModel::Model& model)
 {
     std::vector<Variable> variables;
     variables.reserve(model.variables.size());
-    const auto& whatIsForbiddenInVariableBound = PreSolveNonConstraint();
+    const auto& forbiddenNodesInVarBounds = PreSolveNonConstraint();
 
     for (const auto& variable: model.variables)
     {
         Expression lb(variable.lower_bound, convertExpressionToNode(variable.lower_bound, model));
         if (lb.RootNode())
         {
-            NodeChecker(whatIsForbiddenInVariableBound, variable.lower_bound)
-              .dispatch(lb.RootNode());
+            NodeChecker(forbiddenNodesInVarBounds, variable.lower_bound).dispatch(lb.RootNode());
         }
         Expression ub(variable.upper_bound, convertExpressionToNode(variable.upper_bound, model));
         if (ub.RootNode())
         {
-            NodeChecker(whatIsForbiddenInVariableBound, variable.upper_bound)
-              .dispatch(ub.RootNode());
+            NodeChecker(forbiddenNodesInVarBounds, variable.upper_bound).dispatch(ub.RootNode());
         }
         variables.emplace_back(variable.id,
                                std::move(lb),

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -24,7 +24,7 @@
 #include <antares/expressions/iterators/pre-order.h>
 #include <antares/expressions/nodes/ExpressionsNodes.h>
 #include "antares/expressions/expression.h"
-#include "antares/io/inputs/model-converter/NodeChecker.h"
+#include "antares/io/inputs/model-converter/ForbiddenNodesVisitor.h"
 #include "antares/io/inputs/model-converter/convertorVisitor.h"
 #include "antares/study/system-model/constraint.h"
 #include "antares/study/system-model/library.h"
@@ -263,12 +263,14 @@ std::vector<Variable> convertVariables(const YmlModel::Model& model)
         Expression lb(variable.lower_bound, convertExpressionToNode(variable.lower_bound, model));
         if (lb.RootNode())
         {
-            NodeChecker(forbiddenNodesInVarBounds, variable.lower_bound).dispatch(lb.RootNode());
+            ForbiddenNodesVisitor(forbiddenNodesInVarBounds, variable.lower_bound)
+              .dispatch(lb.RootNode());
         }
         Expression ub(variable.upper_bound, convertExpressionToNode(variable.upper_bound, model));
         if (ub.RootNode())
         {
-            NodeChecker(forbiddenNodesInVarBounds, variable.upper_bound).dispatch(ub.RootNode());
+            ForbiddenNodesVisitor(forbiddenNodesInVarBounds, variable.upper_bound)
+              .dispatch(ub.RootNode());
         }
         variables.emplace_back(variable.id,
                                std::move(lb),
@@ -351,7 +353,8 @@ std::vector<PortFieldDefinition> convertPortFieldDefinitions(const YmlModel::Mod
             throw PortInDefinition(pfdefinition.port,
                                    dynamic_cast<const PortFieldNode&>(*it).getPortName());
         }
-        NodeChecker(PreSolveNonConstraint(), pfdefinition.definition).dispatch(nodeRegistry.node);
+        ForbiddenNodesVisitor(PreSolveNonConstraint(), pfdefinition.definition)
+          .dispatch(nodeRegistry.node);
         portFieldDefinitions.emplace_back(*itPort,
                                           *itField,
                                           Expression(pfdefinition.definition,
@@ -366,7 +369,7 @@ static void addSingleConstraint(std::vector<Constraint>& constraints,
                                 const ForbiddenNodes& forbiddenNodes)
 {
     auto nodeRegistry = convertExpressionToNode(constraint.expression, model);
-    NodeChecker(forbiddenNodes, constraint.expression).dispatch(nodeRegistry.node);
+    ForbiddenNodesVisitor(forbiddenNodes, constraint.expression).dispatch(nodeRegistry.node);
     constraints.emplace_back(constraint.id,
                              Expression{constraint.expression, std::move(nodeRegistry)},
                              convertLocation(constraint.location));
@@ -409,7 +412,8 @@ std::vector<ExtraOutput> convertExtraOutputs(const YmlModel::Model& model)
     for (const auto& extraOutput: model.extra_outputs)
     {
         auto nodeRegistry = convertExpressionToNode(extraOutput.expression, model);
-        NodeChecker(ForbiddenInExtraOutput(), extraOutput.expression).dispatch(nodeRegistry.node);
+        ForbiddenNodesVisitor(ForbiddenInExtraOutput(), extraOutput.expression)
+          .dispatch(nodeRegistry.node);
         extraOutputs.emplace_back(extraOutput.id,
                                   Expression{extraOutput.expression, std::move(nodeRegistry)});
     }
@@ -429,7 +433,8 @@ std::vector<Objective> convertObjectives(const YmlModel::Model& model)
     for (const auto& objective: model.objectives)
     {
         auto nodeRegistry = convertExpressionToNode(objective.expression, model);
-        NodeChecker(PreSolveNonConstraint(), objective.expression).dispatch(nodeRegistry.node);
+        ForbiddenNodesVisitor(PreSolveNonConstraint(), objective.expression)
+          .dispatch(nodeRegistry.node);
         objectives.emplace_back(objective.id,
                                 Expression{objective.expression, std::move(nodeRegistry)},
                                 convertLocation(objective.location));

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -32,7 +32,10 @@
 #include "antares/study/system-model/port.h"
 #include "antares/study/system-model/portType.h"
 #include "antares/study/system-model/variable.h"
+
 using namespace Antares::Expressions::Nodes;
+using namespace Antares::ModelerStudy::SystemModel;
+using namespace Antares::IO::Inputs;
 
 namespace Antares::IO::Inputs::ModelConverter
 {
@@ -149,11 +152,9 @@ static ForbiddenNodes ForbiddenInExtraOutput()
     return forbidden;
 }
 
-/// Convert portTypes to Antares::ModelerStudy::SystemModel::PortType
-std::vector<ModelerStudy::SystemModel::PortType> convertTypes(
-  const IO::Inputs::YmlModel::Library& library)
+std::vector<PortType> convertTypes(const ::YmlModel::Library& library)
 {
-    std::vector<ModelerStudy::SystemModel::PortType> out;
+    std::vector<PortType> out;
     out.reserve(library.port_types.size());
     for (const auto& portType: library.port_types)
     {
@@ -161,7 +162,7 @@ std::vector<ModelerStudy::SystemModel::PortType> convertTypes(
         {
             throw PortTypeDoesntContainsFields(portType.id);
         }
-        std::vector<ModelerStudy::SystemModel::PortField> fields;
+        std::vector<PortField> fields;
         for (const auto& field: portType.fields)
         {
             fields.emplace_back(field);
@@ -174,9 +175,9 @@ std::vector<ModelerStudy::SystemModel::PortType> convertTypes(
             throw PortTypeWithThisIdAlreadyExists(portType.id);
         }
 
-        ModelerStudy::SystemModel::PortType portTypeModel(portType.id,
-                                                          std::move(fields),
-                                                          portType.area_connection_injection_field);
+        PortType portTypeModel(portType.id,
+                               std::move(fields),
+                               portType.area_connection_injection_field);
         out.emplace_back(std::move(portTypeModel));
     }
     return out;
@@ -188,8 +189,7 @@ std::vector<ModelerStudy::SystemModel::PortType> convertTypes(
  * \param model The YmlModel::Model object containing parameters.
  * \return A vector of SystemModel::Parameter objects.
  */
-std::vector<ModelerStudy::SystemModel::Parameter> convertParameters(
-  const IO::Inputs::YmlModel::Model& model)
+std::vector<Parameter> convertParameters(const YmlModel::Model& model)
 {
     namespace SM = ModelerStudy::SystemModel;
     std::vector<SM::Parameter> parameters;
@@ -230,19 +230,19 @@ Modeler::Config::Location convertLocation(const std::string& locationStr)
  * \return The corresponding SystemModel::ValueType.
  * \throws UnknownType if the type is unknown.
  */
-ModelerStudy::SystemModel::ValueType convertType(IO::Inputs::YmlModel::ValueType type)
+ValueType convertType(YmlModel::ValueType type)
 {
     using namespace std::string_literals;
     switch (type)
     {
-    case IO::Inputs::YmlModel::ValueType::CONTINUOUS:
-        return ModelerStudy::SystemModel::ValueType::FLOAT;
-    case IO::Inputs::YmlModel::ValueType::INTEGER:
-        return ModelerStudy::SystemModel::ValueType::INTEGER;
-    case IO::Inputs::YmlModel::ValueType::BOOL:
-        return ModelerStudy::SystemModel::ValueType::BOOL;
+    case YmlModel::ValueType::CONTINUOUS:
+        return ValueType::FLOAT;
+    case YmlModel::ValueType::INTEGER:
+        return ValueType::INTEGER;
+    case YmlModel::ValueType::BOOL:
+        return ValueType::BOOL;
     default:
-        throw UnknownTypeException(IO::Inputs::YmlModel::toString(type));
+        throw UnknownTypeException(YmlModel::toString(type));
     }
 }
 
@@ -252,24 +252,21 @@ ModelerStudy::SystemModel::ValueType convertType(IO::Inputs::YmlModel::ValueType
  * \param model The YmlModel::Model object containing variables.
  * \return A vector of SystemModel::Variable objects.
  */
-std::vector<ModelerStudy::SystemModel::Variable> convertVariables(const YmlModel::Model& model)
+std::vector<Variable> convertVariables(const YmlModel::Model& model)
 {
-    namespace SM = Antares::ModelerStudy::SystemModel;
-
-    std::vector<SM::Variable> variables;
+    std::vector<Variable> variables;
     variables.reserve(model.variables.size());
+    const auto& whatIsForbiddenInVariableBound = PreSolveNonConstraint();
+
     for (const auto& variable: model.variables)
     {
-        const auto& whatIsForbiddenInVariableBound = PreSolveNonConstraint();
-        SM::Expression lb(variable.lower_bound,
-                          convertExpressionToNode(variable.lower_bound, model));
+        Expression lb(variable.lower_bound, convertExpressionToNode(variable.lower_bound, model));
         if (lb.RootNode())
         {
             NodeChecker(whatIsForbiddenInVariableBound, variable.lower_bound)
               .dispatch(lb.RootNode());
         }
-        SM::Expression ub(variable.upper_bound,
-                          convertExpressionToNode(variable.upper_bound, model));
+        Expression ub(variable.upper_bound, convertExpressionToNode(variable.upper_bound, model));
         if (ub.RootNode())
         {
             NodeChecker(whatIsForbiddenInVariableBound, variable.upper_bound)
@@ -279,8 +276,8 @@ std::vector<ModelerStudy::SystemModel::Variable> convertVariables(const YmlModel
                                std::move(lb),
                                std::move(ub),
                                convertType(variable.variable_type),
-                               SM::fromBool<SM::TimeDependent>(variable.time_dependent),
-                               SM::fromBool<SM::ScenarioDependent>(variable.scenario_dependent),
+                               fromBool<TimeDependent>(variable.time_dependent),
+                               fromBool<ScenarioDependent>(variable.scenario_dependent),
                                convertLocation(variable.location));
     }
 
@@ -293,11 +290,9 @@ std::vector<ModelerStudy::SystemModel::Variable> convertVariables(const YmlModel
  * \param model The YmlModel::Model object containing ports.
  * \return A vector of SystemModel::Port objects.
  */
-std::vector<ModelerStudy::SystemModel::Port> convertPorts(
-  const IO::Inputs::YmlModel::Model& model,
-  const std::vector<ModelerStudy::SystemModel::PortType>& portTypes)
+std::vector<Port> convertPorts(const YmlModel::Model& model, const std::vector<PortType>& portTypes)
 {
-    std::vector<ModelerStudy::SystemModel::Port> ports;
+    std::vector<Port> ports;
     ports.reserve(model.ports.size());
     for (const auto& port: model.ports)
     {
@@ -319,11 +314,10 @@ std::vector<ModelerStudy::SystemModel::Port> convertPorts(
  * \param model The YmlModel::Model object containing port field definitions.
  * \return A vector of SystemModel::PortFieldDefinition objects.
  */
-std::vector<ModelerStudy::SystemModel::PortFieldDefinition> convertPortFieldDefinitions(
-  const IO::Inputs::YmlModel::Model& model,
-  const std::vector<ModelerStudy::SystemModel::Port>& ports)
+std::vector<PortFieldDefinition> convertPortFieldDefinitions(const YmlModel::Model& model,
+                                                             const std::vector<Port>& ports)
 {
-    std::vector<ModelerStudy::SystemModel::PortFieldDefinition> portFieldDefinitions;
+    std::vector<PortFieldDefinition> portFieldDefinitions;
     portFieldDefinitions.reserve(model.port_field_definitions.size());
     for (const auto& pfdefinition: model.port_field_definitions)
     {
@@ -360,24 +354,23 @@ std::vector<ModelerStudy::SystemModel::PortFieldDefinition> convertPortFieldDefi
                                    dynamic_cast<const PortFieldNode&>(*it).getPortName());
         }
         NodeChecker(PreSolveNonConstraint(), pfdefinition.definition).dispatch(nodeRegistry.node);
-        portFieldDefinitions.emplace_back(
-          *itPort,
-          *itField,
-          ModelerStudy::SystemModel::Expression(pfdefinition.definition, std::move(nodeRegistry)));
+        portFieldDefinitions.emplace_back(*itPort,
+                                          *itField,
+                                          Expression(pfdefinition.definition,
+                                                     std::move(nodeRegistry)));
     }
     return portFieldDefinitions;
 }
 
-static void addSingleConstraint(std::vector<ModelerStudy::SystemModel::Constraint>& constraints,
-                                const IO::Inputs::YmlModel::Constraint& constraint,
-                                const IO::Inputs::YmlModel::Model& model,
+static void addSingleConstraint(std::vector<Constraint>& constraints,
+                                const YmlModel::Constraint& constraint,
+                                const YmlModel::Model& model,
                                 const ForbiddenNodes& forbiddenNodes)
 {
     auto nodeRegistry = convertExpressionToNode(constraint.expression, model);
     NodeChecker(forbiddenNodes, constraint.expression).dispatch(nodeRegistry.node);
     constraints.emplace_back(constraint.id,
-                             ModelerStudy::SystemModel::Expression{constraint.expression,
-                                                                   std::move(nodeRegistry)},
+                             Expression{constraint.expression, std::move(nodeRegistry)},
                              convertLocation(constraint.location));
 }
 
@@ -387,10 +380,9 @@ static void addSingleConstraint(std::vector<ModelerStudy::SystemModel::Constrain
  * \param model The YmlModel::Model object containing constraints.
  * \return A vector of SystemModel::Constraint objects.
  */
-std::vector<ModelerStudy::SystemModel::Constraint> convertConstraints(
-  const IO::Inputs::YmlModel::Model& model)
+std::vector<Constraint> convertConstraints(const YmlModel::Model& model)
 {
-    std::vector<ModelerStudy::SystemModel::Constraint> constraints;
+    std::vector<Constraint> constraints;
     constraints.reserve(model.constraints.size());
 
     for (const auto& constraint: model.constraints)
@@ -411,10 +403,9 @@ std::vector<ModelerStudy::SystemModel::Constraint> convertConstraints(
  * \param model The YmlModel::Model object containing extra outputs.
  * \return A vector of SystemModel::ExtraOutput objects.
  */
-std::vector<ModelerStudy::SystemModel::ExtraOutput> convertExtraOutputs(
-  const IO::Inputs::YmlModel::Model& model)
+std::vector<ExtraOutput> convertExtraOutputs(const YmlModel::Model& model)
 {
-    std::vector<ModelerStudy::SystemModel::ExtraOutput> extraOutputs;
+    std::vector<ExtraOutput> extraOutputs;
     extraOutputs.reserve(model.extra_outputs.size());
 
     for (const auto& extraOutput: model.extra_outputs)
@@ -422,8 +413,7 @@ std::vector<ModelerStudy::SystemModel::ExtraOutput> convertExtraOutputs(
         auto nodeRegistry = convertExpressionToNode(extraOutput.expression, model);
         NodeChecker(ForbiddenInExtraOutput(), extraOutput.expression).dispatch(nodeRegistry.node);
         extraOutputs.emplace_back(extraOutput.id,
-                                  ModelerStudy::SystemModel::Expression{extraOutput.expression,
-                                                                        std::move(nodeRegistry)});
+                                  Expression{extraOutput.expression, std::move(nodeRegistry)});
     }
     return extraOutputs;
 }
@@ -434,18 +424,16 @@ std::vector<ModelerStudy::SystemModel::ExtraOutput> convertExtraOutputs(
  * \param model The YmlModel::Model object containing objectives.
  * \return A vector of SystemModel::Expression objects.
  */
-std::vector<ModelerStudy::SystemModel::Objective> convertObjectives(
-  const IO::Inputs::YmlModel::Model& model)
+std::vector<Objective> convertObjectives(const YmlModel::Model& model)
 {
-    std::vector<ModelerStudy::SystemModel::Objective> objectives;
+    std::vector<Objective> objectives;
     objectives.reserve(model.objectives.size());
     for (const auto& objective: model.objectives)
     {
         auto nodeRegistry = convertExpressionToNode(objective.expression, model);
         NodeChecker(PreSolveNonConstraint(), objective.expression).dispatch(nodeRegistry.node);
         objectives.emplace_back(objective.id,
-                                ModelerStudy::SystemModel::Expression{objective.expression,
-                                                                      std::move(nodeRegistry)},
+                                Expression{objective.expression, std::move(nodeRegistry)},
                                 convertLocation(objective.location));
     }
     return objectives;
@@ -457,24 +445,22 @@ std::vector<ModelerStudy::SystemModel::Objective> convertObjectives(
  * \param library The YmlModel::Library object containing models.
  * \return A vector of SystemModel::Model objects.
  */
-std::vector<ModelerStudy::SystemModel::Model> convertModels(
-  const IO::Inputs::YmlModel::Library& library,
-  const std::vector<ModelerStudy::SystemModel::PortType>& portTypes)
+std::vector<Model> convertModels(const YmlModel::Library& library,
+                                 const std::vector<PortType>& portTypes)
 {
-    std::vector<ModelerStudy::SystemModel::Model> models;
+    std::vector<Model> models;
     models.reserve(library.models.size());
     for (const auto& model: library.models)
     {
-        ModelerStudy::SystemModel::ModelBuilder modelBuilder;
-        std::vector<ModelerStudy::SystemModel::Parameter> parameters = convertParameters(model);
-        std::vector<ModelerStudy::SystemModel::Variable> variables = convertVariables(model);
-        std::vector<ModelerStudy::SystemModel::Port> ports = convertPorts(model, portTypes);
-        std::vector<ModelerStudy::SystemModel::PortFieldDefinition>
-          portFieldDefinitions = convertPortFieldDefinitions(model, ports);
-        std::vector<ModelerStudy::SystemModel::Constraint> constraints = convertConstraints(model);
-        std::vector<ModelerStudy::SystemModel::ExtraOutput> extraOutputs = convertExtraOutputs(
-          model);
-        std::vector<ModelerStudy::SystemModel::Objective> objectives = convertObjectives(model);
+        ModelBuilder modelBuilder;
+        std::vector<Parameter> parameters = convertParameters(model);
+        std::vector<Variable> variables = convertVariables(model);
+        std::vector<Port> ports = convertPorts(model, portTypes);
+        std::vector<PortFieldDefinition> portFieldDefinitions = convertPortFieldDefinitions(model,
+                                                                                            ports);
+        std::vector<Constraint> constraints = convertConstraints(model);
+        std::vector<ExtraOutput> extraOutputs = convertExtraOutputs(model);
+        std::vector<Objective> objectives = convertObjectives(model);
 
         auto modelObj = modelBuilder.withId(model.id)
                           .withObjectives(std::move(objectives))
@@ -496,17 +482,17 @@ std::vector<ModelerStudy::SystemModel::Model> convertModels(
  * \param library The YmlModel::Library object to convert.
  * \return The corresponding SystemModel::Library object.
  */
-ModelerStudy::SystemModel::Library convert(const IO::Inputs::YmlModel::Library& library)
+Library convert(const YmlModel::Library& library)
 {
-    std::vector<ModelerStudy::SystemModel::PortType> portTypes = convertTypes(library);
-    std::vector<ModelerStudy::SystemModel::Model> models = convertModels(library, portTypes);
+    std::vector<PortType> portTypes = convertTypes(library);
+    std::vector<Model> models = convertModels(library, portTypes);
 
-    ModelerStudy::SystemModel::LibraryBuilder builder;
-    ModelerStudy::SystemModel::Library lib = builder.withId(library.id)
-                                               .withDescription(library.description)
-                                               .withPortTypes(std::move(portTypes))
-                                               .withModels(std::move(models))
-                                               .build();
+    LibraryBuilder builder;
+    Library lib = builder.withId(library.id)
+                    .withDescription(library.description)
+                    .withPortTypes(std::move(portTypes))
+                    .withModels(std::move(models))
+                    .build();
     return lib;
 }
 } // namespace Antares::IO::Inputs::ModelConverter

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -117,18 +117,6 @@ void ComponentToAreaConnectionFiller::addExpressionToConstraint(
     }
 }
 
-// TODO remove and use proper scenario
-class DefaultScenario final: public IScenario
-{
-public:
-    using IScenario::IScenario;
-
-    [[nodiscard]] TimeSeriesNumber getData(Year) const override
-    {
-        return 1; // Default rank for empty groupId
-    }
-};
-
 void ComponentToAreaConnectionFiller::addComponentPortContributionToArea(
   ILinearProblem& pb,
   const FillContext& ctx,

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -634,7 +634,6 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignGT, SupplyModelFor
 
     auto node = convertExpressionToNode(expression, model);
 
-    // Forbid <= Globally
     forbidden.addGlobalForbidden<Nodes::GreaterThanOrEqualNode>();
 
     std::string err_msg = "'expression with >=' is not allowed in this context '" + expression

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -460,7 +460,7 @@ struct SupplyModelForFunctionalOperator
       .objectives = {{"objective-id", ""}},
       .extra_outputs = {}};
 
-    ForbiddenNodes forbidden;
+    ForbiddenNodes forbiddenNodes;
 };
 
 BOOST_FIXTURE_TEST_CASE(reducedCostExpression, SupplyModelForFunctionalOperator)
@@ -587,11 +587,11 @@ BOOST_FIXTURE_TEST_CASE(MinWithForbiddenNode, SupplyModelForFunctionalOperator)
     auto node = convertExpressionToNode(expression, model);
 
     // Forbid variable in min
-    forbidden.addForbiddenFor<Nodes::FunctionNodeType::min, Nodes::VariableNode>();
+    forbiddenNodes.addForbiddenFor<Nodes::FunctionNodeType::min, Nodes::VariableNode>();
 
     auto err_msg = "'min' is not allowed to contain 'variable(varB)' in this context '" + expression
                    + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
@@ -603,11 +603,11 @@ BOOST_FIXTURE_TEST_CASE(MaxWithForbiddenNode, SupplyModelForFunctionalOperator)
     auto node = convertExpressionToNode(expression, model);
 
     // Forbid variable in max
-    forbidden.addForbiddenFor<Nodes::FunctionNodeType::max, Nodes::VariableNode>();
+    forbiddenNodes.addForbiddenFor<Nodes::FunctionNodeType::max, Nodes::VariableNode>();
 
     std::string err_msg = "'max' is not allowed to contain 'variable(varB)' in this context '"
                           + expression + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
@@ -619,11 +619,11 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignLT, SupplyModelFor
     auto node = convertExpressionToNode(expression, model);
 
     // Forbid <= Globally
-    forbidden.addGlobalForbidden<Nodes::LessThanOrEqualNode>();
+    forbiddenNodes.forbidGlobally<Nodes::LessThanOrEqualNode>();
 
     std::string err_msg = "'expression with <=' is not allowed in this context '" + expression
                           + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
@@ -634,11 +634,11 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignGT, SupplyModelFor
 
     auto node = convertExpressionToNode(expression, model);
 
-    forbidden.addGlobalForbidden<Nodes::GreaterThanOrEqualNode>();
+    forbiddenNodes.forbidGlobally<Nodes::GreaterThanOrEqualNode>();
 
     std::string err_msg = "'expression with >=' is not allowed in this context '" + expression
                           + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
@@ -650,10 +650,10 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainEqualSign, SupplyModelForFunctio
     auto node = convertExpressionToNode(expression, model);
 
     // Forbid <= Globally
-    forbidden.addGlobalForbidden<Nodes::EqualNode>();
+    forbiddenNodes.forbidGlobally<Nodes::EqualNode>();
 
     std::string err_msg = "'expression with =' is not allowed in this context '" + expression + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -587,7 +587,7 @@ BOOST_FIXTURE_TEST_CASE(MinWithForbiddenNode, SupplyModelForFunctionalOperator)
     auto node = convertExpressionToNode(expression, model);
 
     // Forbid variable in min
-    forbiddenNodes.addForbiddenFor<Nodes::FunctionNodeType::min, Nodes::VariableNode>();
+    forbiddenNodes.parentForbidsChild<Nodes::FunctionNodeType::min, Nodes::VariableNode>();
 
     auto err_msg = "'min' is not allowed to contain 'variable(varB)' in this context '" + expression
                    + "'";
@@ -603,7 +603,7 @@ BOOST_FIXTURE_TEST_CASE(MaxWithForbiddenNode, SupplyModelForFunctionalOperator)
     auto node = convertExpressionToNode(expression, model);
 
     // Forbid variable in max
-    forbiddenNodes.addForbiddenFor<Nodes::FunctionNodeType::max, Nodes::VariableNode>();
+    forbiddenNodes.parentForbidsChild<Nodes::FunctionNodeType::max, Nodes::VariableNode>();
 
     std::string err_msg = "'max' is not allowed to contain 'variable(varB)' in this context '"
                           + expression + "'";

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -618,7 +618,6 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignLT, SupplyModelFor
 
     auto node = convertExpressionToNode(expression, model);
 
-    // Forbid <= Globally
     forbiddenNodes.forbidGlobally<Nodes::LessThanOrEqualNode>();
 
     std::string err_msg = "'expression with <=' is not allowed in this context '" + expression
@@ -649,7 +648,6 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainEqualSign, SupplyModelForFunctio
 
     auto node = convertExpressionToNode(expression, model);
 
-    // Forbid <= Globally
     forbiddenNodes.forbidGlobally<Nodes::EqualNode>();
 
     std::string err_msg = "'expression with =' is not allowed in this context '" + expression + "'";

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -35,7 +35,7 @@
 #include <unit_test_utils.h>
 
 #include "antares/io/inputs/model-converter/ForbiddenNodes.h"
-#include "antares/io/inputs/model-converter/NodeChecker.h"
+#include "antares/io/inputs/model-converter/ForbiddenNodesVisitor.h"
 // clang-format on
 
 using namespace Antares::Expressions;
@@ -591,7 +591,7 @@ BOOST_FIXTURE_TEST_CASE(MinWithForbiddenNode, SupplyModelForFunctionalOperator)
 
     auto err_msg = "'FunctionNode::min' is not allowed to contain 'VariableNode' in expression '"
                    + expression + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(ForbiddenNodesVisitor(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
@@ -605,9 +605,9 @@ BOOST_FIXTURE_TEST_CASE(MaxWithForbiddenNode, SupplyModelForFunctionalOperator)
     // Forbid variable in max
     forbiddenNodes.parentForbidsChild<Nodes::FunctionNodeType::max, Nodes::VariableNode>();
 
-    std::string err_msg = "'FunctionNode::max' is not allowed to contain 'VariableNode' in "
-                          "expression '" + expression + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
+    std::string err_msg = "'FunctionNode::max' is not allowed to contain 'VariableNode' in ";
+    err_msg += "expression '" + expression + "'";
+    BOOST_CHECK_EXCEPTION(ForbiddenNodesVisitor(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
@@ -621,7 +621,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignLT, SupplyModelFor
     forbiddenNodes.forbidGlobally<Nodes::LessThanOrEqualNode>();
 
     std::string err_msg = "'LessThanOrEqualNode' is not allowed in expression '" + expression + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(ForbiddenNodesVisitor(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
@@ -636,7 +636,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignGT, SupplyModelFor
 
     std::string err_msg = "'GreaterThanOrEqualNode' is not allowed in expression '" + expression
                           + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(ForbiddenNodesVisitor(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
@@ -650,7 +650,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainEqualSign, SupplyModelForFunctio
     forbiddenNodes.forbidGlobally<Nodes::EqualNode>();
 
     std::string err_msg = "'EqualNode' is not allowed in expression '" + expression + "'";
-    BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
+    BOOST_CHECK_EXCEPTION(ForbiddenNodesVisitor(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
 }

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -589,8 +589,8 @@ BOOST_FIXTURE_TEST_CASE(MinWithForbiddenNode, SupplyModelForFunctionalOperator)
     // Forbid variable in min
     forbiddenNodes.parentForbidsChild<Nodes::FunctionNodeType::min, Nodes::VariableNode>();
 
-    auto err_msg = "'min' is not allowed to contain 'variable(varB)' in this context '" + expression
-                   + "'";
+    auto err_msg = "'FunctionNode::min' is not allowed to contain 'VariableNode' in expression '"
+                   + expression + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
@@ -605,8 +605,8 @@ BOOST_FIXTURE_TEST_CASE(MaxWithForbiddenNode, SupplyModelForFunctionalOperator)
     // Forbid variable in max
     forbiddenNodes.parentForbidsChild<Nodes::FunctionNodeType::max, Nodes::VariableNode>();
 
-    std::string err_msg = "'max' is not allowed to contain 'variable(varB)' in this context '"
-                          + expression + "'";
+    std::string err_msg = "'FunctionNode::max' is not allowed to contain 'VariableNode' in "
+                          "expression '" + expression + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
@@ -620,8 +620,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignLT, SupplyModelFor
 
     forbiddenNodes.forbidGlobally<Nodes::LessThanOrEqualNode>();
 
-    std::string err_msg = "'expression with <=' is not allowed in this context '" + expression
-                          + "'";
+    std::string err_msg = "'LessThanOrEqualNode' is not allowed in expression '" + expression + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));
@@ -635,7 +634,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignGT, SupplyModelFor
 
     forbiddenNodes.forbidGlobally<Nodes::GreaterThanOrEqualNode>();
 
-    std::string err_msg = "'expression with >=' is not allowed in this context '" + expression
+    std::string err_msg = "'GreaterThanOrEqualNode' is not allowed in expression '" + expression
                           + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
@@ -650,7 +649,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainEqualSign, SupplyModelForFunctio
 
     forbiddenNodes.forbidGlobally<Nodes::EqualNode>();
 
-    std::string err_msg = "'expression with =' is not allowed in this context '" + expression + "'";
+    std::string err_msg = "'EqualNode' is not allowed in expression '" + expression + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbiddenNodes, expression).dispatch(node.node),
                           ForbiddenNodeFound,
                           checkMessage(err_msg));

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -592,7 +592,7 @@ BOOST_FIXTURE_TEST_CASE(MinWithForbiddenNode, SupplyModelForFunctionalOperator)
     auto err_msg = "'min' is not allowed to contain 'variable(varB)' in this context '" + expression
                    + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
-                          BadContextComposition,
+                          ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
 
@@ -608,7 +608,7 @@ BOOST_FIXTURE_TEST_CASE(MaxWithForbiddenNode, SupplyModelForFunctionalOperator)
     std::string err_msg = "'max' is not allowed to contain 'variable(varB)' in this context '"
                           + expression + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
-                          BadContextComposition,
+                          ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
 
@@ -624,7 +624,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignLT, SupplyModelFor
     std::string err_msg = "'expression with <=' is not allowed in this context '" + expression
                           + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
-                          BadContextComposition,
+                          ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
 
@@ -640,7 +640,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainComparisonSignGT, SupplyModelFor
     std::string err_msg = "'expression with >=' is not allowed in this context '" + expression
                           + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
-                          BadContextComposition,
+                          ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
 
@@ -655,7 +655,7 @@ BOOST_FIXTURE_TEST_CASE(ExpressionThatNotContainEqualSign, SupplyModelForFunctio
 
     std::string err_msg = "'expression with =' is not allowed in this context '" + expression + "'";
     BOOST_CHECK_EXCEPTION(NodeChecker(forbidden, expression).dispatch(node.node),
-                          BadContextComposition,
+                          ForbiddenNodeFound,
                           checkMessage(err_msg));
 }
 


### PR DESCRIPTION
This PR is the 2nd PR out of 3 PR about adding operators **ceil** and **floor** : 
- [PR 3316](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/3316) (the main work on adding these operators)
- [PR 3329](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/3329), (the current one)
- [PR 3335](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/3335) 

It intends to simplify and make more readable code about forbidden nodes. 

**What was done** :  some PR comments were left below. Please read them.   