### PR TITLE
Add docs & tests on the floor operator [ANT-4295]

### DIFF
--- a/docs/user-guide/modeler/09-expressions.md
+++ b/docs/user-guide/modeler/09-expressions.md
@@ -216,6 +216,46 @@ models:
     expression: myVar^(2 + myParam)
 ```
 
+### Floor and ceil operators
+
+The unary operators **floor(X)** and **ceil(X)** return, respectively, the greatest integer less
+than or equal to `X` and the smallest integer greater than or equal to `X`. When `X` is
+ time-dependent (a parameter, variable, or port field with time dimension), the operators apply
+pointwise on the underlying time-series.
+
+In the context of a linear problem construction (any context but **extra-output**), the argument of
+`floor` or `ceil` must not depend on decision variables: it must be a literal, a parameter, or any
+combination of them. In those contexts the optimizer works with the already-rounded, constant
+expression produced by `floor`/`ceil`.
+
+Within an **extra-output expression**, `floor` and `ceil` can be applied to expressions involving
+variables as well. In that case, the operators are evaluated after optimization using the numerical
+solution.
+
+_Examples :_
+
+```yaml
+models:
+- id: myModel
+  parameters:
+  - id: myParam
+  variables:
+  - id: x
+    lower_bound: 0
+    upper_bound: 10
+  constraints:
+  - id: c1
+    # Allowed: argument only depends on parameters and literals
+    expression: x <= floor(myParam)
+  - id: c2
+    expression: x >= ceil(myParam / 2)
+  extra-outputs:
+  - id: rounded_output_floor
+    expression: floor(x)
+  - id: rounded_output_ceil
+    expression: ceil(x)
+```
+
 ### max (or min) operator
 
 This n-ary operator **max(u, v, ...)** can be used within any expression, with following restrictions.

--- a/docs/user-guide/modeler/09-expressions.md
+++ b/docs/user-guide/modeler/09-expressions.md
@@ -216,6 +216,41 @@ models:
     expression: myVar^(2 + myParam)
 ```
 
+### Floor operator
+
+This unary operator **floor(X)** returns the greatest integer less than or equal to its argument.
+When `X` is time-dependent (a parameter, variable, or port field with time dimension), the operator
+applies pointwise on the underlying time-series.
+
+In the context of a linear problem construction (any context but **extra-output**), the argument of
+`floor` must not depend on decision variables: it must be a literal, a parameter, or any
+combination of them. In those contexts the optimizer works with the already-rounded, constant
+expression produced by `floor`.
+
+Within an **extra-output expression**, `floor` can be applied to expressions involving variables as
+well. In that case, the operator is evaluated after optimization using the numerical solution.
+
+_Examples :_
+
+```yaml
+models:
+- id: myModel
+  parameters:
+  - id: myParam
+  variables:
+  - id: x
+    lower_bound: 0
+    upper_bound: 10
+  constraints:
+  - id: myConstraint
+    # Allowed: argument only depends on parameters and literals
+    expression: x <= floor(myParam)
+  extra-outputs:
+  - id: rounded_output
+    # Allowed in extra-output: argument can depend on variables
+    expression: floor(x)
+```
+
 ### max (or min) operator
 
 This n-ary operator **max(u, v, ...)** can be used within any expression, with following restrictions.

--- a/src/expressions/include/antares/expressions/nodes/FunctionNode.h
+++ b/src/expressions/include/antares/expressions/nodes/FunctionNode.h
@@ -38,6 +38,7 @@ enum class FunctionNodeType
     min,          ///< Minimum of multiple expressions.
     pow,          ///< Exponentiation: base^exponent.
     floor,        ///< Rounds a number to closest smaller int
+    ceil,         ///< Rounds a number to closest greater or equal int
 };
 
 /**
@@ -60,6 +61,7 @@ std::string FunctionNodeTypeToString(FunctionNodeType type);
  * - reduced_cost(var) -> FunctionNode(FunctionNodeType::reduced_cost, VariableNode("var"))
  * - dual(constraint) -> FunctionNode(FunctionNodeType::dual, ParameterNode("constraint"))
  * - floor(p) -> FunctionNode(FunctionNodeType::floor, ParameterNode(param))
+ * - ceil(p) -> FunctionNode(FunctionNodeType::ceil, ParameterNode(param))
  */
 class FunctionNode final: public ParentNode
 {

--- a/src/expressions/include/antares/expressions/visitors/EvalVisitor.h
+++ b/src/expressions/include/antares/expressions/visitors/EvalVisitor.h
@@ -360,5 +360,6 @@ private:
     EvaluationResult visitDual(const Nodes::FunctionNode* node);
     EvaluationResult visitPow(const Nodes::FunctionNode* node);
     EvaluationResult visitFloor(const Nodes::FunctionNode* node);
+    EvaluationResult visitCeil(const Nodes::FunctionNode* node);
 };
 } // namespace Antares::Expressions::Visitors

--- a/src/expressions/nodes/FunctionNode.cpp
+++ b/src/expressions/nodes/FunctionNode.cpp
@@ -39,6 +39,8 @@ std::string FunctionNodeTypeToString(FunctionNodeType type)
         return "pow";
     case FunctionNodeType::floor:
         return "floor";
+    case FunctionNodeType::ceil:
+        return "ceil";
     default:
         return "Unknown function";
     }

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -236,6 +236,7 @@ EvaluationResult EvalVisitor::visitDual(const Nodes::FunctionNode* node)
 
 auto PowerOp = [](const auto& a, const auto& b) { return std::pow(a, b); };
 auto FloorOp = [](double d) { return std::floor(d); };
+auto CeilOp = [](double d) { return std::ceil(d); };
 
 EvaluationResult EvalVisitor::visitPow(const Nodes::FunctionNode* node)
 {
@@ -249,6 +250,12 @@ EvaluationResult EvalVisitor::visitFloor(const Nodes::FunctionNode* node)
 {
     auto* floor_arg = node->getOperands()[0];
     return dispatch(floor_arg).evaluateUnaryOperation(FloorOp);
+}
+
+EvaluationResult EvalVisitor::visitCeil(const Nodes::FunctionNode* node)
+{
+    auto* ceil_arg = node->getOperands()[0];
+    return dispatch(ceil_arg).evaluateUnaryOperation(CeilOp);
 }
 
 EvaluationResult EvalVisitor::visit(const Nodes::FunctionNode* node)
@@ -269,6 +276,8 @@ EvaluationResult EvalVisitor::visit(const Nodes::FunctionNode* node)
         return visitPow(node);
     case Nodes::FunctionNodeType::floor:
         return visitFloor(node);
+    case Nodes::FunctionNodeType::ceil:
+        return visitCeil(node);
     default:
         return EvaluationResult(0);
     }

--- a/src/expressions/visitors/VariabilityVisitor.cpp
+++ b/src/expressions/visitors/VariabilityVisitor.cpp
@@ -182,6 +182,7 @@ VariabilityType VariabilityVisitor::visit(const Nodes::FunctionNode* node)
     case Nodes::FunctionNodeType::max:
     case Nodes::FunctionNodeType::min:
     case Nodes::FunctionNodeType::floor:
+    case Nodes::FunctionNodeType::ceil:
         return visitChildrenNodes(node);
     case Nodes::FunctionNodeType::pow:
         return visitPow(node);

--- a/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
+++ b/src/io/inputs/model-converter/ForbiddenNodesVisitor.cpp
@@ -170,6 +170,8 @@ std::type_index functionNodeTypeIndex(const FunctionNode* functionNode)
         return typeIndexOf<FunctionNodeType::pow>();
     case FunctionNodeType::floor:
         return typeIndexOf<FunctionNodeType::floor>();
+    case FunctionNodeType::ceil:
+        return typeIndexOf<FunctionNodeType::ceil>();
     default:
         return typeid(int); // Supposed to be dead code (never reached)
     }

--- a/src/io/inputs/model-converter/convertorVisitor.cpp
+++ b/src/io/inputs/model-converter/convertorVisitor.cpp
@@ -85,6 +85,7 @@ private:
     std::any visitMax(ExprParser::ArgListContext* context);
     std::any visitMin(ExprParser::ArgListContext* arglist);
     std::any visitFloor(ExprParser::ArgListContext* context);
+    std::any visitCeil(ExprParser::ArgListContext* context);
     std::any buildShiftNode(Node* shifted_expr, ExprParser::ShiftContext* context);
     Node* NodeFromShiftContext(ExprParser::Shift_exprContext* shift_expr);
     PortFieldNode* processPortRule(ExprParser::PortFieldExprContext* context);
@@ -491,6 +492,17 @@ std::any ConvertorVisitor::visitFloor(ExprParser::ArgListContext* context)
     return static_cast<Node*>(registry_.create<FunctionNode>(FunctionNodeType::floor, nodes[0]));
 }
 
+std::any ConvertorVisitor::visitCeil(ExprParser::ArgListContext* context)
+{
+    const auto nodes = std::any_cast<std::vector<Node*>>(context->accept(this));
+    if (size_t size = nodes.size(); size > 1)
+    {
+        std::string err_msg = "ceil() expects 1 argument, but has " + std::to_string(size);
+        throw std::invalid_argument(err_msg);
+    }
+    return static_cast<Node*>(registry_.create<FunctionNode>(FunctionNodeType::ceil, nodes[0]));
+}
+
 std::any ConvertorVisitor::visitFunction(ExprParser::FunctionContext* context)
 {
     const auto functionName = context->IDENTIFIER()->getText();
@@ -521,6 +533,10 @@ std::any ConvertorVisitor::visitFunction(ExprParser::FunctionContext* context)
     else if (functionName == "floor")
     {
         return visitFloor(arglist);
+    }
+    else if (functionName == "ceil")
+    {
+        return visitCeil(arglist);
     }
 
     throw std::invalid_argument("Invalid function: '" + functionName + "'");

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -96,6 +96,11 @@ static void CommonPreSolve(ForbiddenNodes& f)
     f.parentForbidsChild<FunctionNodeType::floor, VariableNode>();
     f.parentForbidsChild<FunctionNodeType::floor, PortFieldNode>();
     f.parentForbidsChild<FunctionNodeType::floor, PortFieldSumNode>();
+
+    // Forbid VariableNode, PortFieldNode, and PortFieldSumNode in ceil(node)
+    f.parentForbidsChild<FunctionNodeType::ceil, VariableNode>();
+    f.parentForbidsChild<FunctionNodeType::ceil, PortFieldNode>();
+    f.parentForbidsChild<FunctionNodeType::ceil, PortFieldSumNode>();
 }
 
 static ForbiddenNodes ForbiddenInConstraint()

--- a/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
@@ -311,6 +311,22 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visitFloor(
     return expressions;
 }
 
+TimeDependentLinearExpression ReadLinearExpressionVisitor::visitCeil(
+  const Nodes::FunctionNode* node)
+{
+    auto expressions = dispatch(node->getOperands()[0]);
+    for (auto& expression: expressions)
+    {
+        if (expression.hasCoefs())
+        {
+            std::string err_msg = "ceil operator: its argument is not constant, but has to be.";
+            throw std::invalid_argument(err_msg);
+        }
+        expression.constant(std::ceil(expression.constant()));
+    }
+    return expressions;
+}
+
 TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Nodes::FunctionNode* node)
 {
     switch (node->type())
@@ -333,6 +349,8 @@ TimeDependentLinearExpression ReadLinearExpressionVisitor::visit(const Nodes::Fu
         return visitPower(node);
     case Nodes::FunctionNodeType::floor:
         return visitFloor(node);
+    case Nodes::FunctionNodeType::ceil:
+        return visitCeil(node);
     default:
         throw std::runtime_error("Function " + node->typeToString() + " is not implemented.");
     }

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
@@ -116,6 +116,7 @@ public:
 private:
     Optimization::TimeDependentLinearExpression visitPower(const Nodes::FunctionNode* node);
     Optimization::TimeDependentLinearExpression visitFloor(const Nodes::FunctionNode* node);
+    Optimization::TimeDependentLinearExpression visitCeil(const Nodes::FunctionNode* node);
 
     const Antares::Optimisation::OptimEntityContainer& optimEntityContainer_;
     const Antares::ModelerStudy::SystemModel::Component& component_;

--- a/src/tests/src/expressions/test_VariabilityVisitor.cpp
+++ b/src/tests/src/expressions/test_VariabilityVisitor.cpp
@@ -256,6 +256,24 @@ BOOST_AUTO_TEST_CASE(variability_of_floor_operator___case_varying_in_scenario_on
                       VariabilityType::VARYING_IN_SCENARIO_ONLY);
 }
 
+BOOST_AUTO_TEST_CASE(variability_of_ceil_operator___case_constant)
+{
+    LiteralNode literalNode(2.3);
+    FunctionNode ceil(FunctionNodeType::ceil, &literalNode);
+
+    BOOST_CHECK_EQUAL(variabilityVisitor->dispatch(&ceil),
+                      VariabilityType::CONSTANT_IN_TIME_AND_SCENARIO);
+}
+
+BOOST_AUTO_TEST_CASE(variability_of_ceil_operator___case_varying_in_scenario_only)
+{
+    ParameterNode paramNode = ParameterNode("param", VariabilityType::VARYING_IN_TIME_ONLY);
+    FunctionNode ceil(FunctionNodeType::ceil, &paramNode);
+
+    BOOST_CHECK_EQUAL(variabilityVisitor->dispatch(&ceil),
+                      VariabilityType::VARYING_IN_SCENARIO_ONLY);
+}
+
 template<class T>
 static Node* singleNode(Registry<Node>& registry)
 {

--- a/src/tests/src/expressions/test_evaluate-function-operators.cpp
+++ b/src/tests/src/expressions/test_evaluate-function-operators.cpp
@@ -28,6 +28,7 @@ struct CreateAST
     Node* literal(double value);
     Node* parameter(const std::string& name, const VariabilityType variability);
     Node* floor(Node* node);
+    Node* ceil(Node* node);
 
 private:
     Registry<Nodes::Node> registry_;
@@ -46,6 +47,11 @@ Node* CreateAST::parameter(const std::string& name, const VariabilityType variab
 Node* CreateAST::floor(Node* node)
 {
     return registry_.create<FunctionNode>(FunctionNodeType::floor, node);
+}
+
+Node* CreateAST::ceil(Node* node)
+{
+    return registry_.create<FunctionNode>(FunctionNodeType::ceil, node);
 }
 
 // =================================

--- a/src/tests/src/expressions/test_evaluate-function-operators.cpp
+++ b/src/tests/src/expressions/test_evaluate-function-operators.cpp
@@ -148,3 +148,41 @@ BOOST_FIXTURE_TEST_CASE(floor_applied_to_a_constant_parameter, eval_function_op_
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(test_ceil_operator)
+
+BOOST_FIXTURE_TEST_CASE(ceil_applied_to_a_time_dependent_parameter, eval_function_op_fixture)
+{
+    // Expression : ceil(p), where p = {1.5, 2.3, 3.7}
+    Node* p = parameter("p", VariabilityType::VARYING_IN_TIME_ONLY);
+    Node* ceil_node = ceil(p);
+
+    auto evalResult = evalVisitor->dispatch(ceil_node);
+
+    std::vector<double> expected_result = {2., 3., 4.};
+    BOOST_CHECK(evalResult.valuesAsVector() == expected_result);
+}
+
+BOOST_FIXTURE_TEST_CASE(ceil_applied_to_a_literal, eval_function_op_fixture)
+{
+    // Expression : ceil(2.3)
+    Node* p = literal(2.3);
+    Node* ceil_node = ceil(p);
+
+    auto evalResult = evalVisitor->dispatch(ceil_node);
+
+    BOOST_CHECK_EQUAL(evalResult.valueAsDouble(), 3.);
+}
+
+BOOST_FIXTURE_TEST_CASE(ceil_applied_to_a_constant_parameter, eval_function_op_fixture)
+{
+    // Expression : ceil(p), where p = {4.5, 4.5, 4.5}
+    Node* p = parameter("p-const", VariabilityType::CONSTANT_IN_TIME_AND_SCENARIO);
+    Node* ceil_node = ceil(p);
+
+    auto evalResult = evalVisitor->dispatch(ceil_node);
+
+    BOOST_CHECK_EQUAL(evalResult.valueAsDouble(), 5.);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -726,15 +726,22 @@ BOOST_FIXTURE_TEST_CASE(floor_operator_should_not_take_more_than_one_arg,
                           checkMessage(err_msg));
 }
 
-// BOOST_FIXTURE_TEST_CASE(floor_operator_should_not_take_more_a_var_as_arg,
-//                         SupplyModelForFunctionalOperator)
-//{
-//     std::string expression = "floor(varA)";
-//
-//     std::string err_msg = "floor()'s argument is neither a parameter or a literal.";
-//     BOOST_CHECK_EXCEPTION(convertExpressionToNode(expression, model),
-//                           std::invalid_argument,
-//                           checkMessage(err_msg));
-// }
+BOOST_FIXTURE_TEST_CASE(floor_operator_forbidden_on_variable_with_forbidden_nodes,
+                        SupplyModelForFunctionalOperator)
+{
+    std::string expression = "floor(varA)";
+
+    auto node = convertExpressionToNode(expression, model);
+
+    // Forbid variables as children of floor
+    forbiddenNodes.parentForbidsChild<Nodes::FunctionNodeType::floor, Nodes::VariableNode>();
+
+    std::string err_msg = "'FunctionNode::floor' is not allowed to contain 'VariableNode' in "
+                          "expression '"
+                          + expression + "'";
+    BOOST_CHECK_EXCEPTION(ForbiddenNodesVisitor(forbiddenNodes, expression).dispatch(node.node),
+                          ForbiddenNodeFound,
+                          checkMessage(err_msg));
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -726,15 +726,83 @@ BOOST_FIXTURE_TEST_CASE(floor_operator_should_not_take_more_than_one_arg,
                           checkMessage(err_msg));
 }
 
-// BOOST_FIXTURE_TEST_CASE(floor_operator_should_not_take_more_a_var_as_arg,
-//                         SupplyModelForFunctionalOperator)
-//{
-//     std::string expression = "floor(varA)";
-//
-//     std::string err_msg = "floor()'s argument is neither a parameter or a literal.";
-//     BOOST_CHECK_EXCEPTION(convertExpressionToNode(expression, model),
-//                           std::invalid_argument,
-//                           checkMessage(err_msg));
-// }
+BOOST_FIXTURE_TEST_CASE(ceil_operator___nominal_case, SupplyModelForFunctionalOperator)
+{
+    std::string expression = "ceil(pmin)";
+
+    auto expr = convertExpressionToNode(expression, model);
+
+    // Root node is a 'ceil' node
+    BOOST_CHECK_EQUAL(expr.node->name(), "FunctionNode::ceil");
+
+    auto ceilNode = dynamic_cast<Nodes::FunctionNode*>(expr.node);
+    BOOST_CHECK_EQUAL(ceilNode->typeToString(), "ceil");
+
+    // Child node must be unique, and be the parameter node 'pmin' from the model
+    BOOST_CHECK_EQUAL(ceilNode->getOperands().size(), 1);
+    auto* childNode = ceilNode->getOperands()[0];
+
+    const auto* paramNode = dynamic_cast<Nodes::ParameterNode*>(childNode);
+    BOOST_CHECK(paramNode);
+    BOOST_CHECK_EQUAL(paramNode->value(), "pmin");
+}
+
+BOOST_FIXTURE_TEST_CASE(ceil_operator_applied_to_a_literal, SupplyModelForFunctionalOperator)
+{
+    std::string expression = "ceil(3.7)";
+
+    auto expr = convertExpressionToNode(expression, model);
+
+    BOOST_CHECK_EQUAL(expr.node->name(), "FunctionNode::ceil");
+
+    auto ceilNode = dynamic_cast<Nodes::FunctionNode*>(expr.node);
+    BOOST_CHECK_EQUAL(ceilNode->typeToString(), "ceil");
+
+    BOOST_CHECK_EQUAL(ceilNode->getOperands().size(), 1);
+    auto* childNode = ceilNode->getOperands()[0];
+
+    const auto* literalNode = dynamic_cast<Nodes::LiteralNode*>(childNode);
+    BOOST_CHECK(literalNode);
+    BOOST_CHECK_EQUAL(literalNode->value(), 3.7);
+}
+
+BOOST_FIXTURE_TEST_CASE(ceil_operator_should_not_take_no_arg, SupplyModelForFunctionalOperator)
+{
+    std::string expression = "ceil()";
+
+    std::string err_msg = "ceil operator expects an argument, got nothing";
+    BOOST_CHECK_EXCEPTION(convertExpressionToNode(expression, model),
+                          std::invalid_argument,
+                          checkMessage(err_msg));
+}
+
+BOOST_FIXTURE_TEST_CASE(ceil_operator_should_not_take_more_than_one_arg,
+                        SupplyModelForFunctionalOperator)
+{
+    std::string expression = "ceil(pmin, 5)";
+
+    std::string err_msg = "ceil() expects 1 argument, but has 2";
+    BOOST_CHECK_EXCEPTION(convertExpressionToNode(expression, model),
+                          std::invalid_argument,
+                          checkMessage(err_msg));
+}
+
+BOOST_FIXTURE_TEST_CASE(ceil_operator_forbidden_on_variable_with_forbidden_nodes,
+                        SupplyModelForFunctionalOperator)
+{
+    std::string expression = "ceil(varA)";
+
+    auto node = convertExpressionToNode(expression, model);
+
+    // Forbid variables as children of ceil
+    forbiddenNodes.parentForbidsChild<Nodes::FunctionNodeType::ceil, Nodes::VariableNode>();
+
+    std::string err_msg = "'FunctionNode::ceil' is not allowed to contain 'VariableNode' in "
+                          "expression '"
+                          + expression + "'";
+    BOOST_CHECK_EXCEPTION(ForbiddenNodesVisitor(forbiddenNodes, expression).dispatch(node.node),
+                          ForbiddenNodeFound,
+                          checkMessage(err_msg));
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/optim-model-filler/test_readLinearExpressionVisitor.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_readLinearExpressionVisitor.cpp
@@ -188,6 +188,20 @@ BOOST_FIXTURE_TEST_CASE(linear_expr_from_floor_of_a_constant_param,
     BOOST_CHECK_EQUAL(linear_expression[0].hasCoefs(), false); // Not variable
 }
 
+BOOST_FIXTURE_TEST_CASE(linear_expr_from_floor_of_a_variable_throws,
+                        VisitorFixture<ReadLinearExpressionVisitor>)
+{
+    // floor(7 * var) is not linear: argument has non-zero coefficients
+    Node* var = create<VariableNode>("var", 0);
+    Node* product = create<MultiplicationNode>(create<LiteralNode>(7.), var);
+    Node* floorNode = create<FunctionNode>(FunctionNodeType::floor, product);
+
+    BOOST_CHECK_EXCEPTION(visitor().dispatch(floorNode),
+                          std::invalid_argument,
+                          checkMessage(
+                            "floor operator: its argument is not constant, but has to be."));
+}
+
 BOOST_FIXTURE_TEST_CASE(visit_literal_plus_param_plus_var,
                         VisitorFixture<ReadLinearExpressionVisitor>)
 {

--- a/src/tests/src/solver/optim-model-filler/test_readLinearExpressionVisitor.cpp
+++ b/src/tests/src/solver/optim-model-filler/test_readLinearExpressionVisitor.cpp
@@ -188,6 +188,47 @@ BOOST_FIXTURE_TEST_CASE(linear_expr_from_floor_of_a_constant_param,
     BOOST_CHECK_EQUAL(linear_expression[0].hasCoefs(), false); // Not variable
 }
 
+BOOST_FIXTURE_TEST_CASE(linear_expr_from_ceil_of_a_literal,
+                        VisitorFixture<ReadLinearExpressionVisitor>)
+{
+    // ceil(4.5) = 5
+    Node* ceilNode = create<FunctionNode>(FunctionNodeType::ceil, create<LiteralNode>(4.5));
+
+    auto linear_expression = visitor().dispatch(ceilNode);
+
+    BOOST_REQUIRE_EQUAL(linear_expression.size(), 1);
+    BOOST_CHECK_EQUAL(linear_expression[0].constant(), 5.);
+    BOOST_CHECK_EQUAL(linear_expression[0].hasCoefs(), false); // Not variable
+}
+
+BOOST_FIXTURE_TEST_CASE(linear_expr_from_ceil_of_a_constant_param,
+                        VisitorFixture<ReadLinearExpressionVisitor>)
+{
+    // ceil(param(4.5)) = 5
+    Node* ceilNode = create<FunctionNode>(FunctionNodeType::ceil,
+                                          create<ParameterNode>("four.five"));
+
+    auto linear_expression = visitor().dispatch(ceilNode);
+
+    BOOST_REQUIRE_EQUAL(linear_expression.size(), 1);
+    BOOST_CHECK_EQUAL(linear_expression[0].constant(), 5.);
+    BOOST_CHECK_EQUAL(linear_expression[0].hasCoefs(), false); // Not variable
+}
+
+BOOST_FIXTURE_TEST_CASE(linear_expr_from_ceil_of_a_variable_throws,
+                        VisitorFixture<ReadLinearExpressionVisitor>)
+{
+    // ceil(7 * var) is not linear: argument has non-zero coefficients
+    Node* var = create<VariableNode>("var", 0);
+    Node* product = create<MultiplicationNode>(create<LiteralNode>(7.), var);
+    Node* ceilNode = create<FunctionNode>(FunctionNodeType::ceil, product);
+
+    BOOST_CHECK_EXCEPTION(visitor().dispatch(ceilNode),
+                          std::invalid_argument,
+                          checkMessage(
+                            "ceil operator: its argument is not constant, but has to be."));
+}
+
 BOOST_FIXTURE_TEST_CASE(visit_literal_plus_param_plus_var,
                         VisitorFixture<ReadLinearExpressionVisitor>)
 {


### PR DESCRIPTION
- Add a test to ensure `ReadLinearExpressionVisitor` rejects floor when its argument has non-zero coefficients (i.e. depends on variables)
- Add a test to ensure `floor(variable)` is rejected through `ForbiddenNodes`
- Update the user documentation to mention the `floor` operator