### PR TITLE
fix: hourly PMax not clamped up to PMax Hydro Ecretee

### DIFF
--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -239,6 +239,8 @@ WeeklyDataFromAntares SingleProblemGetter::getWeeklyData(WeeklyProblemId id)
         OPT_InitialiserNombreMinEtMaxDeGroupesCoutsDeDemarrage(&pb_);
     }
 
+    OPT_RestaurerLesDonnees(&pb_);
+
     OPT_InitialiserLesBornesDesVariablesDuProblemeLineaire(&pb_,
                                                            PremierPdtDeLIntervalle,
                                                            DernierPdtDeLIntervalle,


### PR DESCRIPTION
With SingleProblemGetter API _OPT_RestaurerLesDonnees_ wasn't called.

I'm not entirely sure why it is necessary to "restore data" during optimisation but one thing is sure there is a trap inside _OPT_RestaurerLesDonnees_. It does more than its name implies since it also ceil the value of **PMax** to eith **PMax** or **Hydro ecretee**