### PR TITLE
Fix naming for daily binding constraints

### DIFF
--- a/src/solver/optimisation/constraints/BindingConstraintDay.cpp
+++ b/src/solver/optimisation/constraints/BindingConstraintDay.cpp
@@ -63,8 +63,9 @@ void BindingConstraintDay::add(int cntCouplante)
 
         builder.SetOperator(MatriceDesContraintesCouplantes.SensDeLaContrainteCouplante);
         {
+            const auto dayInTheYear = builder.data.weekInTheYear * 7 + jour;
             ConstraintNamer namer(builder.data.NomDesContraintes);
-            namer.UpdateTimeStep(jour);
+            namer.UpdateTimeStep(dayInTheYear);
             namer.BindingConstraintDay(builder.data.nombreDeContraintes,
                                        MatriceDesContraintesCouplantes.NomDeLaContrainteCouplante);
         }


### PR DESCRIPTION

daily bc name is now updated to print the day number in the year instead of always 0-6
<img width="1492" height="532" alt="image" src="https://github.com/user-attachments/assets/e2ee805b-2d23-4511-b5fc-9b0cf5a95a9a" />
