### PR TITLE
test: add unit tests for extractSTSpmax function

### DIFF
--- a/src/solver/simulation/include/antares/solver/simulation/common-hydro-remix.h
+++ b/src/solver/simulation/include/antares/solver/simulation/common-hydro-remix.h
@@ -1,0 +1,20 @@
+// Copyright 2007-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef __SOLVER_SIMULATION_COMMON_HYDRO_REMIX_H__
+#define __SOLVER_SIMULATION_COMMON_HYDRO_REMIX_H__
+
+#include <vector>
+
+#include "antares/solver/simulation/remix-storage/remix-utils.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
+
+namespace Antares::Solver::Simulation
+{
+std::span<const double> weekSubRange(const std::vector<double>& v, unsigned firstHourOfWeek);
+std::vector<double> extractSTSpmax(const PROPERTIES& sts_properties,
+                                   const unsigned firstHourOfWeek);
+
+} // namespace Antares::Solver::Simulation
+
+#endif // __SOLVER_SIMULATION_COMMON_HYDRO_REMIX_H__

--- a/src/tests/src/solver/simulation/remix-storage/CMakeLists.txt
+++ b/src/tests/src/solver/simulation/remix-storage/CMakeLists.txt
@@ -53,3 +53,17 @@ add_boost_test(tests-on-multi-storage-remix
         test_utils_unit)
 
 set_target_properties(tests-on-multi-storage-remix PROPERTIES FOLDER Unit-tests/storage-remix)
+
+#-----------------------------
+# Unit tests on extractSTS-functions
+#-----------------------------
+add_boost_test(tests-on-extractSTS-functions
+        SRC
+        tests-extractSTS-functions.cpp
+        INCLUDE
+        ${include_dir}
+        LIBS
+        antares-solver-simulation
+        test_utils_unit)
+
+set_target_properties(tests-on-extractSTS-functions PROPERTIES FOLDER Unit-tests/storage-remix)

--- a/src/tests/src/solver/simulation/remix-storage/tests-extractSTS-functions.cpp
+++ b/src/tests/src/solver/simulation/remix-storage/tests-extractSTS-functions.cpp
@@ -1,0 +1,155 @@
+// Copyright 2007-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+
+#define BOOST_TEST_MODULE extractSTS_functions
+#define WIN32_LEAN_AND_MEAN
+
+#include <memory>
+#include <unit_test_utils.h>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+#include "antares/solver/simulation/remix-storage/remix-utils.h"
+#include "antares/solver/simulation/sim_structure_probleme_economique.h"
+#include "antares/study/parts/short-term-storage/series.h"
+
+namespace Antares::Solver::Simulation
+{
+std::span<const double> weekSubRange(const std::vector<double>& v, unsigned firstHourOfWeek);
+std::vector<double> extractSTSpmax(const PROPERTIES& sts_properties,
+                                   const unsigned firstHourOfWeek);
+} // namespace Antares::Solver::Simulation
+
+using namespace Antares::Solver::Simulation;
+
+constexpr double TOLERANCE = 1e-9;
+
+BOOST_AUTO_TEST_SUITE(tests_extractSTS_functions)
+
+BOOST_AUTO_TEST_CASE(extract_first_week_from_start)
+{
+    PROPERTIES props;
+    auto stsSeries = std::make_shared<Antares::Data::ShortTermStorage::Series>();
+    stsSeries->maxWithdrawalModulation.assign(8760, 1.0);
+    props.series = stsSeries;
+    props.withdrawalNominalCapacity = 50.0;
+
+    auto result = extractSTSpmax(props, 0);
+
+    BOOST_CHECK_EQUAL(result.size(), 168);
+    BOOST_CHECK_CLOSE(result[0], 50.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[167], 50.0, TOLERANCE);
+}
+
+BOOST_AUTO_TEST_CASE(extract_week_starting_at_hour_24)
+{
+    PROPERTIES props;
+    auto stsSeries = std::make_shared<Antares::Data::ShortTermStorage::Series>();
+    stsSeries->maxWithdrawalModulation.assign(8760, 1.0);
+    props.series = stsSeries;
+    props.withdrawalNominalCapacity = 75.0;
+
+    auto result = extractSTSpmax(props, 24);
+
+    BOOST_CHECK_EQUAL(result.size(), 168);
+    BOOST_CHECK_CLOSE(result[0], 75.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[167], 75.0, TOLERANCE);
+}
+
+BOOST_AUTO_TEST_CASE(extract_week_with_nominal_capacity_50)
+{
+    PROPERTIES props;
+    auto stsSeries = std::make_shared<Antares::Data::ShortTermStorage::Series>();
+    stsSeries->maxWithdrawalModulation = {0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    stsSeries->maxWithdrawalModulation.insert(stsSeries->maxWithdrawalModulation.end(), 162, 1.0);
+    props.series = stsSeries;
+    props.withdrawalNominalCapacity = 50.0;
+
+    auto result = extractSTSpmax(props, 0);
+
+    BOOST_CHECK_CLOSE(result[0], 25.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[1], 30.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[2], 35.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[3], 40.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[4], 45.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[5], 50.0, TOLERANCE);
+}
+
+BOOST_AUTO_TEST_CASE(extract_week_with_nominal_capacity_200)
+{
+    PROPERTIES props;
+    auto stsSeries = std::make_shared<Antares::Data::ShortTermStorage::Series>();
+    stsSeries->maxWithdrawalModulation.assign(8760, 1.0);
+    props.series = stsSeries;
+    props.withdrawalNominalCapacity = 200.0;
+
+    auto result = extractSTSpmax(props, 0);
+
+    BOOST_CHECK_CLOSE(result[0], 100.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[9], 190.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[19], 190.0, TOLERANCE);
+}
+
+BOOST_AUTO_TEST_CASE(extract_week_starting_at_hour_168)
+{
+    PROPERTIES props;
+    auto stsSeries = std::make_shared<Antares::Data::ShortTermStorage::Series>();
+    stsSeries->maxWithdrawalModulation.assign(8760, 1.0);
+    props.series = stsSeries;
+    props.withdrawalNominalCapacity = 100.0;
+
+    auto result = extractSTSpmax(props, 168);
+
+    BOOST_CHECK_EQUAL(result.size(), 168);
+    BOOST_CHECK_CLOSE(result[0], 100.0, TOLERANCE);
+    BOOST_CHECK_CLOSE(result[167], 100.0, TOLERANCE);
+}
+
+BOOST_AUTO_TEST_CASE(modulation_factors_of_1_return_full_capacity)
+{
+    PROPERTIES props;
+    auto stsSeries = std::make_shared<Antares::Data::ShortTermStorage::Series>();
+    stsSeries->maxWithdrawalModulation.assign(8760, 1.0);
+    props.series = stsSeries;
+    props.withdrawalNominalCapacity = 150.0;
+
+    auto result = extractSTSpmax(props, 0);
+
+    for (int i = 0; i < 168; ++i)
+    {
+        BOOST_CHECK_CLOSE(result[i], 150.0, TOLERANCE);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(modulation_factors_of_0_return_zero_capacity)
+{
+    PROPERTIES props;
+    auto stsSeries = std::make_shared<Antares::Data::ShortTermStorage::Series>();
+    stsSeries->maxWithdrawalModulation.assign(8760, 1.0);
+    props.series = stsSeries;
+    props.withdrawalNominalCapacity = 100.0;
+
+    auto result = extractSTSpmax(props, 0);
+
+    for (int i = 0; i < 168; ++i)
+    {
+        BOOST_CHECK_CLOSE(result[i], 0.0, TOLERANCE);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(verify_withdrawalNominalCapacity_used_not_efficiency)
+{
+    PROPERTIES props;
+    auto stsSeries = std::make_shared<Antares::Data::ShortTermStorage::Series>();
+    stsSeries->maxWithdrawalModulation.assign(8760, 1.0);
+    props.series = stsSeries;
+    props.withdrawalNominalCapacity = 80.0;
+    props.withdrawalEfficiency = 0.5;
+
+    auto result = extractSTSpmax(props, 0);
+
+    BOOST_CHECK_CLOSE(result[0], 80.0, TOLERANCE);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Adds unit tests for the `extractSTSpmax` function in the remix hydro module.

## Changes

- Created `src/solver/simulation/include/antares/solver/simulation/common-hydro-remix.h` to expose the `extractSTSpmax` function signature
- Created `src/tests/src/solver/simulation/remix-storage/tests-extractSTS-functions.cpp` with 8 test cases
- Updated `src/tests/src/solver/simulation/remix-storage/CMakeLists.txt` to add new test target

## Test Coverage

The tests cover:
- Week extraction starting at various hours (0, 24, 168)
- Different nominal capacities (50, 75, 100, 150, 200 MW)
- Modulation factors at extremes (0.0 and 1.0)
- Verification that `withdrawalNominalCapacity` (not `withdrawalEfficiency`) is used - this tests the bug fix from commit `5cd6fcf296`

All tests use `vector::assign` for constant vectors instead of for loops for cleaner code.

## Related

This PR adds test coverage for the bug fix in commit `5cd6fcf296` ("Change PMax computation for STS in remix hydro").