### PR TITLE
Legacy modeler : adding a new constraint to maximize unsupplied energy [ANT-4033]

### DIFF
--- a/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md
+++ b/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md
@@ -1,0 +1,39 @@
+# Adding expressions from GEMS into legacy LP constraints
+
+Every time we want to add an expressions from GEMS into an existing legacy LP constaint, this expression 
+is evaluated into a time-dependent linear expression.
+A time-dependent linear expression is a vector of linear expressions (one for each time step).
+A linear expression is comprises a linear combination of variables and a unique constant term.
+In a linear expression, each variable is associated to a constant coefficient.
+
+So when adding an expression from GEMS into a LP constraint, we merely add coefficients or constants to the constraint.
+
+In the following, writting constraints often implies gathering constant-in-time terms in the RHS, 
+and variable terms to the LHS.
+
+## Balance constraint
+
+In Antares legacy modeler code, balance constraint is actually written as follows :
+ **-P = -(L-Fatal)**, with **P** being productions, **L** being loads and **L-Fatal** being the residual load.
+An equivalent form is : **L - P = Fatal**.
+Now, let's break P into Pv (production variable in time) and Pc (production constant in time) :
+**L - Pv = Fatal + Pc**
+As a consequence, variable productions from GEMS are added negatively, and constant productions are added positively. 
+
+
+## Fictitious load constraint
+
+This constraint can be written as follows : 
+
+**Spillage - Thermal - Hydro < Fatal**.  
+
+As previously, adding time-variable productions from GEMS is done negatively, and adding time-constant production is done positively.
+
+## Bounding unsupplied enegy constraint
+
+This constraint can be written as follows :
+
+**unsupE - Lv < Lc + Fatal**, **Lv** being variables loads, **Lc** being constant loads.
+
+
+adding time-variable loads from GEMS is done negatively, and adding time-constant loads is done positively.

--- a/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-problem.md
+++ b/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-problem.md
@@ -1,0 +1,37 @@
+# Adding expressions from GEMS into legacy LP constraints
+
+Every time we want to add an expression from GEMS into an existing legacy LP constaint, this expression 
+is evaluated into a time-dependent linear expression.
+A time-dependent linear expression is a vector of linear expressions (one for each time step).
+A linear expression comprises a linear combination of variables and a unique constant term.
+In a linear expression, each variable is associated to a constant coefficient.
+
+So when adding an expression from GEMS into a LP constraint, we merely add coefficients or constants to the constraint.
+
+In the following, writing constraints often implies gathering constant terms in the RHS, 
+and variable terms to the LHS.
+
+## Balance constraint
+
+In Antares legacy modeler code, balance constraint is actually written as follows :
+ **-P = -(L-Fatal)**, with **P** being productions, **L** being loads and **L-Fatal** being the residual load.
+An equivalent form is : **L - P = Fatal**.
+Now, let's break **P** into **Pv** (production given as a variable of optimization) and **Pc** (production as parameter, e.g. fatal production) :
+**L - Pv = Fatal + Pc**
+As a consequence, variable productions from GEMS are added negatively, and constant productions are added positively.
+
+## Fictitious load constraint
+
+This constraint can be written as follows : 
+
+**Spillage - Thermal - Hydro < Fatal**.
+
+As previously, adding variable productions from GEMS is done negatively, and adding constant production is done positively.
+
+## Bounding unsupplied energy constraint
+
+This constraint can be written as follows :
+
+**unsupE - Lv < Lc + Fatal**, **Lv** being variables loads, **Lc** being constant loads.
+
+adding variable loads from GEMS is done negatively, and adding constant loads is done positively.

--- a/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-problem.md
+++ b/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-problem.md
@@ -16,7 +16,7 @@ and variable terms to the LHS.
 In Antares legacy modeler code, balance constraint is actually written as follows :
  **-P = -(L-Fatal)**, with **P** being productions, **L** being loads and **L-Fatal** being the residual load.
 An equivalent form is : **L - P = Fatal**.
-Now, let's break P into Pv (production given as a variable of optimization) and Pc (production as parameter, e.g. fatal production) :
+Now, let's break **P** into **Pv** (production given as a variable of optimization) and **Pc** (production as parameter, e.g. fatal production) :
 **L - Pv = Fatal + Pc**
 As a consequence, variable productions from GEMS are added negatively, and constant productions are added positively.
 

--- a/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-problem.md
+++ b/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-problem.md
@@ -8,7 +8,7 @@ In a linear expression, each variable is associated to a constant coefficient.
 
 So when adding an expression from GEMS into a LP constraint, we merely add coefficients or constants to the constraint.
 
-In the following, writting constraints often implies gathering constant-in-time terms in the RHS, 
+In the following, writing constraints often implies gathering constant terms in the RHS, 
 and variable terms to the LHS.
 
 ## Balance constraint
@@ -16,24 +16,22 @@ and variable terms to the LHS.
 In Antares legacy modeler code, balance constraint is actually written as follows :
  **-P = -(L-Fatal)**, with **P** being productions, **L** being loads and **L-Fatal** being the residual load.
 An equivalent form is : **L - P = Fatal**.
-Now, let's break P into Pv (production variable in time) and Pc (production constant in time) :
+Now, let's break P into Pv (production given as a variable of optimization) and Pc (production as parameter, e.g. fatal production) :
 **L - Pv = Fatal + Pc**
-As a consequence, variable productions from GEMS are added negatively, and constant productions are added positively. 
-
+As a consequence, variable productions from GEMS are added negatively, and constant productions are added positively.
 
 ## Fictitious load constraint
 
 This constraint can be written as follows : 
 
-**Spillage - Thermal - Hydro < Fatal**.  
+**Spillage - Thermal - Hydro < Fatal**.
 
-As previously, adding time-variable productions from GEMS is done negatively, and adding time-constant production is done positively.
+As previously, adding variable productions from GEMS is done negatively, and adding constant production is done positively.
 
-## Bounding unsupplied enegy constraint
+## Bounding unsupplied energy constraint
 
 This constraint can be written as follows :
 
 **unsupE - Lv < Lc + Fatal**, **Lv** being variables loads, **Lc** being constant loads.
 
-
-adding time-variable loads from GEMS is done negatively, and adding time-constant loads is done positively.
+adding variable loads from GEMS is done negatively, and adding constant loads is done positively.

--- a/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-problem.md
+++ b/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-problem.md
@@ -1,9 +1,9 @@
 # Adding expressions from GEMS into legacy LP constraints
 
-Every time we want to add an expressions from GEMS into an existing legacy LP constaint, this expression 
+Every time we want to add an expression from GEMS into an existing legacy LP constaint, this expression 
 is evaluated into a time-dependent linear expression.
 A time-dependent linear expression is a vector of linear expressions (one for each time step).
-A linear expression is comprises a linear combination of variables and a unique constant term.
+A linear expression comprises a linear combination of variables and a unique constant term.
 In a linear expression, each variable is associated to a constant coefficient.
 
 So when adding an expression from GEMS into a LP constraint, we merely add coefficients or constants to the constraint.

--- a/docs/user-guide/solver/08-hybrid-studies.md
+++ b/docs/user-guide/solver/08-hybrid-studies.md
@@ -29,9 +29,11 @@ Hybrid studies offer the following features.
 
 ### Connecting modeler components to legacy areas
 One of the most useful use cases is the added ability to define new types of system components with custom behavior, 
-using the new [modelling language](../modeler/05-model.md), and inserting them into existing studies, 
-by connecting them to "areas". This has the effect of adding generation or consumption to an existing area, thus 
-modifying its [balance constraint](05-model.md#balance-between-load-and-generation).  
+using the new [modelling language](../modeler/05-model.md), and inserting these system components into existing studies, 
+by connecting them to "areas". 
+Such connections allow : 
+- adding generation or consumption to an existing area, thus modifying its [balance constraint](05-model.md#balance-between-load-and-generation).
+- bounding unsupplied energy or spillage with linear expressions coming from modeler components.
 
 This is implemented in Antares thanks to the [ports](../modeler/05-model.md#ports-and-connections) concept.  
 In order to connect new components to existing areas, you must follow two steps:
@@ -43,23 +45,23 @@ In order to connect new components to existing areas, you must follow two steps:
 To connect a component to an area, you must define a connection in the **area-connections** section of the 
 [system file](../modeler/02-inputs.md#system-file). 
 This section has been specifically created for this use case. Every element in this section represents a connection 
-between a component defined in the same system file, and an existing area defined in the antares-solver study.  
+between a component (defined in the same system file) and an existing area defined in the antares-solver study.  
 
 Example:
 ~~~yaml
 area-connections:
  - component: generator1
-   port: injection
+   port: injection-port
    area: area1
  - component: generator2
-   port: injection
+   port: injection-port
    area: area1
  - component: consumer1
-   port: consumption
+   port: consumption-port
    area: area2
 ~~~
 
-- **component1**: the IDs of the component to connect to the area, as defined in the [components section](../modeler/02-inputs.md#components)
+- **component**: the IDs of the component to connect to the area, as defined in the [components section](../modeler/02-inputs.md#components)
 - **port**: the ID of the component's port to connect to the area (as defined by the model of the component). This port 
   must be of a type that defines an area-connection injection field (see [next paragraph](#selecting-the-area-connection-port-fields))
 - **area**: the ID of the area to connect the component to, as defined in the [antares-solver input files](02-inputs.md).
@@ -73,30 +75,137 @@ This is done in the [model library](../modeler/02-inputs.md#model-libraries), in
 Example:
 ~~~yaml
 port-type:
-   id: ac_link
+   id: port-to-area
    fields:
-      - id: flow
+      - id: field_to_balance
       - id: angle
+	  - id: to-area-bound
+      - id: from-area-bound
    area-connection:
-      - injection-field: flow
+      - injection-field: field_to_balance
+	  - spillage-bound: to-area-bound
+      - unsupplied-energy-bound: from-area-bound
 ~~~
 
 **area-connection** is the name of the optional section to use. It is mandatory if you want to use such a port type to 
-connect modeler components to solver areas.  
+connect modeler components to solver areas.
+Here we describe the role of each field contained in **area-connection**. The value for each of them
+must be an existing port name in the same port type.
+All components connected to this port and area (via an **area-connections** system section entry, 
+see previous paragraph [Defining the connections](#defining-the-connections)) will have their corresponding linear 
+expression contributing to a constraint of the linear problem.
+The nature of this contribution depends on the field : 
 
-  - **injection-field**: the field to use when adding the contribution of this port bearer to a connected area, were the 
-    component to be connected to an area
+  - **injection-field**: the linear expression is injected in the balance constraint of the area.
+	This is done with respect to a convention (see next [Optimization model](#optimization-model)).
+	
+  - **spillage-bound**: the linear expression is added to the sum of all variables or linear expressions already used 
+    to bound the spillage in the constraint called "fictitious load".
+	
+  - **unsupplied-energy-bound** : the linear expression is added to any linear expression already used to bound the unsupplied energy.
 
-#### Optimization model
-The linear expression defined by the connected component's port field definition is simply added to the **left-hand side** 
-of the area's [balance constraint](05-model.md#balance-between-load-and-generation).  
+These fields are independent : you don't have to define the 3 of them at the same time, you can define only one (as long as its value is an existing port in the same port type).
+ 
+#### Adding a linear expression in optimization model
+When you connect a component to an area via a port (containing an **area-connection** section), you must respect conventions on the GEMS side.
 
-???+ warning
-    
-    The current convention of this constraint is:  
-      - Generation contributions to the balance should be **positive**  
-      - Load contributions to the balance should be **negative**  
-    Take this into account when defining the connection port value.
+In examples below, for simplicity, we make productions and loads expressions some paramaters with a constant value.
+  
+- **Connecting to balance constraint**
+
+If you need to involve a production (defined in a component), make it positive and don't prefix it with a - sign.
+Typically, you would defined it like this : 
+~~~yaml
+  # library.yml
+  port-type:
+     id: port-to-area
+     fields:
+       - id: field_to_balance
+     area-connection:
+       - injection-field: field_to_balance
+
+  models:
+    - id: my-production
+      parameters:
+        - id: flat_production # Here is positive production
+      ports:
+        - id: balance_port
+          type: port-to-area
+      port-field-definitions:
+        - port: balance_port
+          field: field_to_balance
+          definition: flat_production
+~~~
+
+Reversely, if you need to involve a load in the balance constaint, make it negative :
+~~~yaml
+  models:
+    - id: my-load
+      parameters:
+        - id: flat_load # Here is positive load
+      ports:
+        - id: port-to-area
+          type: field_to_balance
+      port-field-definitions:
+        - port: port-to-area
+          field: field_to_balance
+          definition: -flat_load
+~~~
+
+- **Connecting to fictitious load constraint**
+
+This kind of connection is specifically made to connect a production from a GEMS component, because it's about limiting spillage optimization variable.
+The convention is the same as the connection to balance constraint : make the production positive and don't prefix it with a - sign.
+~~~yaml
+  # library.yml
+  port-type:
+     id: port-to-area
+     fields:
+       - id: to-area-bound
+     area-connection:
+       - spillage-bound: to-area-bound
+
+  models:
+    - id: my-production
+      parameters:
+        - id: flat_production # Here is positive production
+      ports:
+        - id: spillage_port
+          type: port-to-area
+      port-field-definitions:
+        - port: spillage_port
+          field: to-area-bound
+          definition: flat_production
+~~~
+
+- **Connectiong to bounding unsupplied energy constraint**
+
+This kind of connection is specifically made to connect a loads from a GEMS component, because it's about limiting the unsupplied energy optimization variable.
+The convention is to make the loads positive and don't prefix it with a - sign.
+~~~yaml
+  # library.yml
+  port-type:
+     id: port-to-area
+     fields:
+       - id: from-area-bound
+     area-connection:
+       - unsupplied-energy-bound: from-area-bound
+
+  models:
+    - id: my-load
+      parameters:
+        - id: flat_load # Here is positive load
+      ports:
+        - id: unsup_energy_port
+          type: port-to-area
+      port-field-definitions:
+        - port: unsup_energy_port
+          field: from-area-bound
+          definition: flat_production
+~~~
+
+
+For more details why we adpot these conventions, please read [this article](https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/develop/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md)
 
 ## Limitations
 

--- a/docs/user-guide/solver/08-hybrid-studies.md
+++ b/docs/user-guide/solver/08-hybrid-studies.md
@@ -103,7 +103,7 @@ The nature of this contribution depends on the field :
 	
   - **unsupplied-energy-bound** : the linear expression is added to any linear expression already used to bound the unsupplied energy.
 
-#### Adding a linear expreesion in optimization model
+#### Adding a linear expression in optimization model
 
 For more details about how to add a contribution of a component from GEMS to the leagcy linear problem, and 
 which sign (positive / negative) to give them in the constraint, read [this article](https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/develop/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md)

--- a/docs/user-guide/solver/08-hybrid-studies.md
+++ b/docs/user-guide/solver/08-hybrid-studies.md
@@ -29,9 +29,11 @@ Hybrid studies offer the following features.
 
 ### Connecting modeler components to legacy areas
 One of the most useful use cases is the added ability to define new types of system components with custom behavior, 
-using the new [modelling language](../modeler/05-model.md), and inserting them into existing studies, 
-by connecting them to "areas". This has the effect of adding generation or consumption to an existing area, thus 
-modifying its [balance constraint](05-model.md#balance-between-load-and-generation).  
+using the new [modelling language](../modeler/05-model.md), and inserting these system components into existing studies, 
+by connecting them to "areas". 
+Such connections allow : 
+- adding generation or consumption to an existing area, thus modifying its [balance constraint](05-model.md#balance-between-load-and-generation).
+- bounding unsupplied energy or spillage with linear expressions coming from modeler components.
 
 This is implemented in Antares thanks to the [ports](../modeler/05-model.md#ports-and-connections) concept.  
 In order to connect new components to existing areas, you must follow two steps:
@@ -43,23 +45,23 @@ In order to connect new components to existing areas, you must follow two steps:
 To connect a component to an area, you must define a connection in the **area-connections** section of the 
 [system file](../modeler/02-inputs.md#system-file). 
 This section has been specifically created for this use case. Every element in this section represents a connection 
-between a component defined in the same system file, and an existing area defined in the antares-solver study.  
+between a component (defined in the same system file) and an existing area defined in the antares-solver study.  
 
 Example:
 ~~~yaml
 area-connections:
  - component: generator1
-   port: injection
+   port: injection-port
    area: area1
  - component: generator2
-   port: injection
+   port: injection-port
    area: area1
  - component: consumer1
-   port: consumption
+   port: consumption-port
    area: area2
 ~~~
 
-- **component1**: the IDs of the component to connect to the area, as defined in the [components section](../modeler/02-inputs.md#components)
+- **component**: the IDs of the component to connect to the area, as defined in the [components section](../modeler/02-inputs.md#components)
 - **port**: the ID of the component's port to connect to the area (as defined by the model of the component). This port 
   must be of a type that defines an area-connection injection field (see [next paragraph](#selecting-the-area-connection-port-fields))
 - **area**: the ID of the area to connect the component to, as defined in the [antares-solver input files](02-inputs.md).
@@ -77,15 +79,28 @@ port-type:
    fields:
       - id: flow
       - id: angle
+	  - id: to-area-bound
+      - id: from-area-bound
    area-connection:
       - injection-field: flow
+	  - spillage-bound: to-area-bound
+      - unsupplied-energy-bound: from-area-bound
 ~~~
 
 **area-connection** is the name of the optional section to use. It is mandatory if you want to use such a port type to 
-connect modeler components to solver areas.  
-
-  - **injection-field**: the field to use when adding the contribution of this port bearer to a connected area, were the 
-    component to be connected to an area
+connect modeler components to solver areas.
+Here we describe the role of each field the **area-connection** can contain. The value for each of them
+must be an existing port name in the same port type.
+All components connected to this port and area (via an **area-connections** system section entry, 
+see previous paragraph [Defining the connections](#defining-the-connections)) will have their corresponding linear 
+expression contributing to a constraint of the linear problem.
+The nature of this contribution depends on the field : 
+  - **injection-field**: the linear expression is injected in the balance constraint of the area.
+	This is done with respect to a convention (see next [Optimization model](#optimization-model)).
+	
+  - **spillage-bound**: the linear expression is added to the sum of all variables or linear expressions already used 
+    to bound the spillage in the constraint called "fictitious load".
+  - **unsupplied-energy-bound** : the linear expression is added to any linear expression already used to bound the unsupplied ennergy.
 
 #### Optimization model
 The linear expression defined by the connected component's port field definition is simply added to the **left-hand side** 

--- a/docs/user-guide/solver/08-hybrid-studies.md
+++ b/docs/user-guide/solver/08-hybrid-studies.md
@@ -89,7 +89,7 @@ port-type:
 
 **area-connection** is the name of the optional section to use. It is mandatory if you want to use such a port type to 
 connect modeler components to solver areas.
-Here we describe the role of each field the **area-connection** can contain. The value for each of them
+Here we describe the role of each field contained in **area-connection**. The value for each of them
 must be an existing port name in the same port type.
 All components connected to this port and area (via an **area-connections** system section entry, 
 see previous paragraph [Defining the connections](#defining-the-connections)) will have their corresponding linear 
@@ -100,18 +100,14 @@ The nature of this contribution depends on the field :
 	
   - **spillage-bound**: the linear expression is added to the sum of all variables or linear expressions already used 
     to bound the spillage in the constraint called "fictitious load".
-  - **unsupplied-energy-bound** : the linear expression is added to any linear expression already used to bound the unsupplied ennergy.
+	
+  - **unsupplied-energy-bound** : the linear expression is added to any linear expression already used to bound the unsupplied energy.
 
-#### Optimization model
-The linear expression defined by the connected component's port field definition is simply added to the **left-hand side** 
-of the area's [balance constraint](05-model.md#balance-between-load-and-generation).  
+#### Adding a linear expreesion in optimization model
 
-???+ warning
-    
-    The current convention of this constraint is:  
-      - Generation contributions to the balance should be **positive**  
-      - Load contributions to the balance should be **negative**  
-    Take this into account when defining the connection port value.
+For more details about how to add a contribution of a component from GEMS to the leagcy linear problem, and 
+which sign (positive / negative) to give them in the constraint, please downlaod the Antares repository and read file :
+**docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md**
 
 ## Limitations
 

--- a/docs/user-guide/solver/08-hybrid-studies.md
+++ b/docs/user-guide/solver/08-hybrid-studies.md
@@ -75,14 +75,14 @@ This is done in the [model library](../modeler/02-inputs.md#model-libraries), in
 Example:
 ~~~yaml
 port-type:
-   id: ac_link
+   id: port-to-area
    fields:
-      - id: flow
+      - id: field_to_balance
       - id: angle
 	  - id: to-area-bound
       - id: from-area-bound
    area-connection:
-      - injection-field: flow
+      - injection-field: field_to_balance
 	  - spillage-bound: to-area-bound
       - unsupplied-energy-bound: from-area-bound
 ~~~
@@ -95,6 +95,7 @@ All components connected to this port and area (via an **area-connections** syst
 see previous paragraph [Defining the connections](#defining-the-connections)) will have their corresponding linear 
 expression contributing to a constraint of the linear problem.
 The nature of this contribution depends on the field : 
+
   - **injection-field**: the linear expression is injected in the balance constraint of the area.
 	This is done with respect to a convention (see next [Optimization model](#optimization-model)).
 	
@@ -103,10 +104,108 @@ The nature of this contribution depends on the field :
 	
   - **unsupplied-energy-bound** : the linear expression is added to any linear expression already used to bound the unsupplied energy.
 
+These fields are independent : you don't have to define the 3 of them at the same time, you can define only one (as long as its value is an existing port in the same port type).
+ 
 #### Adding a linear expression in optimization model
+When you connect a component to an area via a port (containing an **area-connection** section), you must respect conventions on the GEMS side.
 
-For more details about how to add a contribution of a component from GEMS to the leagcy linear problem, and 
-which sign (positive / negative) to give them in the constraint, read [this article](https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/develop/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md)
+In examples below, for simplicity, we make productions and loads expressions some paramaters with a constant value.
+  
+- **Connecting to balance constraint**
+
+If you need to involve a production (defined in a component), make it positive and don't prefix it with a - sign.
+Typically, you would defined it like this : 
+~~~yaml
+  # library.yml
+  port-type:
+     id: port-to-area
+     fields:
+       - id: field_to_balance
+     area-connection:
+       - injection-field: field_to_balance
+
+  models:
+    - id: my-production
+      parameters:
+        - id: flat_production # Here is positive production
+      ports:
+        - id: balance_port
+          type: port-to-area
+      port-field-definitions:
+        - port: balance_port
+          field: field_to_balance
+          definition: flat_production
+~~~
+
+Reversely, if you need to involve a load in the balance constaint, make it negative :
+~~~yaml
+  models:
+    - id: my-load
+      parameters:
+        - id: flat_load # Here is positive load
+      ports:
+        - id: port-to-area
+          type: field_to_balance
+      port-field-definitions:
+        - port: port-to-area
+          field: field_to_balance
+          definition: -flat_load
+~~~
+
+- **Connecting to fictitious load constraint**
+
+This kind of connection is specifically made to connect a production from a GEMS component, because it's about limiting spillage optimization variable.
+The convention is the same as the connection to balance constraint : make the production positive and don't prefix it with a - sign.
+~~~yaml
+  # library.yml
+  port-type:
+     id: port-to-area
+     fields:
+       - id: to-area-bound
+     area-connection:
+       - spillage-bound: to-area-bound
+
+  models:
+    - id: my-production
+      parameters:
+        - id: flat_production # Here is positive production
+      ports:
+        - id: spillage_port
+          type: port-to-area
+      port-field-definitions:
+        - port: spillage_port
+          field: to-area-bound
+          definition: flat_production
+~~~
+
+- **Connectiong to bounding unsupplied energy constraint**
+
+This kind of connection is specifically made to connect a loads from a GEMS component, because it's about limiting the unsupplied energy optimization variable.
+The convention is to make the loads positive and don't prefix it with a - sign.
+~~~yaml
+  # library.yml
+  port-type:
+     id: port-to-area
+     fields:
+       - id: from-area-bound
+     area-connection:
+       - unsupplied-energy-bound: from-area-bound
+
+  models:
+    - id: my-load
+      parameters:
+        - id: flat_load # Here is positive load
+      ports:
+        - id: unsup_energy_port
+          type: port-to-area
+      port-field-definitions:
+        - port: unsup_energy_port
+          field: from-area-bound
+          definition: flat_production
+~~~
+
+
+For more details why we adpot these conventions, please read [this article](https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/develop/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md)
 
 ## Limitations
 

--- a/docs/user-guide/solver/08-hybrid-studies.md
+++ b/docs/user-guide/solver/08-hybrid-studies.md
@@ -106,8 +106,7 @@ The nature of this contribution depends on the field :
 #### Adding a linear expreesion in optimization model
 
 For more details about how to add a contribution of a component from GEMS to the leagcy linear problem, and 
-which sign (positive / negative) to give them in the constraint, please downlaod the Antares repository and read file :
-**docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md**
+which sign (positive / negative) to give them in the constraint, read [this article](https://github.com/AntaresSimulatorTeam/Antares_Simulator/blob/develop/docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md)
 
 ## Limitations
 

--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -141,7 +141,7 @@ static ForbiddenNodes ForbiddenInExtraOutput()
 
 AreaConnection convert_to_system(const YmlModel::AreaConnection& ac)
 {
-    return {ac.injection, ac.to_area_bound, ac.from_area_bound};
+    return {ac.injection, ac.spillage_bound, ac.unsupplied_energy_bound};
 }
 
 std::vector<PortType> convertPortTypes(const ::YmlModel::Library& library)

--- a/src/io/inputs/yml-model/decoders.hxx
+++ b/src/io/inputs/yml-model/decoders.hxx
@@ -242,8 +242,9 @@ struct convert<Antares::IO::Inputs::YmlModel::PortType>
                 return false;
             }
             rhs.area_connection.injection = findValue("injection-field", node);
-            rhs.area_connection.to_area_bound = findValue("to-area-bound-field", node);
-            rhs.area_connection.from_area_bound = findValue("from-area-bound-field", node);
+            rhs.area_connection.spillage_bound = findValue("spillage-bound", node);
+            rhs.area_connection.unsupplied_energy_bound = findValue("unsupplied-energy-bound",
+                                                                    node);
         }
         return true;
     }

--- a/src/io/inputs/yml-model/include/antares/io/inputs/yml-model/Library.h
+++ b/src/io/inputs/yml-model/include/antares/io/inputs/yml-model/Library.h
@@ -101,8 +101,8 @@ struct Model
 struct AreaConnection
 {
     std::string injection;
-    std::string to_area_bound;
-    std::string from_area_bound;
+    std::string spillage_bound;
+    std::string unsupplied_energy_bound;
 };
 
 struct PortType

--- a/src/solver/optim-model-filler/TimeDependentLinearExpression.cpp
+++ b/src/solver/optim-model-filler/TimeDependentLinearExpression.cpp
@@ -35,6 +35,22 @@ TimeDependentLinearExpression::TimeDependentLinearExpression(
 {
 }
 
+TimeDependentLinearExpression::TimeDependentLinearExpression(
+  std::vector<LinearExpression>&& linearExpressions):
+    v_(std::move(linearExpressions))
+{
+}
+
+TimeDependentLinearExpression TimeDependentLinearExpression::expandToSize(unsigned size)
+{
+    if (isConstant())
+    {
+        std::vector<LinearExpression> v(size, v_[0]);
+        return TimeDependentLinearExpression(std::move(v));
+    }
+    return *this;
+}
+
 void TimeDependentLinearExpression::expandTo(std::size_t nbTimesteps)
 {
     v_.resize(nbTimesteps, v_[0]);

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/TimeDependentLinearExpression.h
@@ -20,6 +20,7 @@ public:
     explicit TimeDependentLinearExpression(LinearExpression&& expr);
     explicit TimeDependentLinearExpression(const std::vector<std::pair<int, double>>& coefs,
                                            double constant);
+    explicit TimeDependentLinearExpression(std::vector<LinearExpression>&& linearExpressions);
 
     std::vector<double> constant() const;
 
@@ -39,6 +40,8 @@ public:
 
     LinearExpression& operator[](std::size_t idx);
     const LinearExpression& operator[](std::size_t idx) const;
+
+    TimeDependentLinearExpression expandToSize(unsigned size);
 
     TimeDependentLinearExpression& operator+=(const TimeDependentLinearExpression& other);
     TimeDependentLinearExpression& operator-=(const TimeDependentLinearExpression& other);

--- a/src/solver/optimisation/CMakeLists.txt
+++ b/src/solver/optimisation/CMakeLists.txt
@@ -76,6 +76,8 @@ set(RTESOLVER_OPT
         constraints/AreaBalance.cpp
         include/antares/solver/optimisation/constraints/FictitiousLoad.h
         constraints/FictitiousLoad.cpp
+        include/antares/solver/optimisation/constraints/MaxUnsuppliedEnergy.h
+        constraints/MaxUnsuppliedEnergy.cpp
         include/antares/solver/optimisation/constraints/ShortTermStorageLevel.h
         constraints/ShortTermStorageLevel.cpp
         include/antares/solver/optimisation/constraints/ShortTermStorageCostVariation.h

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -163,9 +163,9 @@ TimeDependentLinearExpression ComponentToAreaConnectionFiller::linearExpressionA
 }
 
 void ComponentToAreaConnectionFiller::addInjectionPortToLinearPb(const FillContext& ctx,
-                                                                      const Component& component,
-                                                                      const std::string& portId,
-                                                                      const unsigned& areaIndex)
+                                                                 const Component& component,
+                                                                 const std::string& portId,
+                                                                 const unsigned& areaIndex)
 {
     std::string portField = componentInjectionField(component, portId);
     if (portField.empty())

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -18,9 +18,19 @@ std::string componentInjectionField(const Component& component, const std::strin
     return component.getModel()->Ports().at(portId).Type().areaConnection()->injection;
 }
 
-std::string componentToAreaBoundField(const Component& component, const std::string& portId)
+std::string componentSpillageBound(const Component& component, const std::string& portId)
 {
-    return component.getModel()->Ports().at(portId).Type().areaConnection()->to_area_bound;
+    return component.getModel()->Ports().at(portId).Type().areaConnection()->spillage_bound;
+}
+
+std::string componentUnsupEnergyBound(const Component& component, const std::string& portId)
+{
+    return component.getModel()
+      ->Ports()
+      .at(portId)
+      .Type()
+      .areaConnection()
+      ->unsupplied_energy_bound;
 }
 
 std::map<std::string, unsigned> associateIndicesToAreas(const PROBLEME_HEBDO* problemeHebdo_)
@@ -94,6 +104,19 @@ std::vector<unsigned> ComponentToAreaConnectionFiller::fictitiousLoadConstraintI
     return indices;
 }
 
+std::vector<unsigned> ComponentToAreaConnectionFiller::maxUnsupEnergyConstraintIndices(
+  const FillContext& ctx,
+  const unsigned& areaIndex) const
+{
+    std::vector<unsigned> indices(ctx.getLocalNumberOfTimeSteps());
+    for (auto h(0); h <= ctx.getLocalLastTimeStep(); ++h)
+    {
+        indices[h] = problemeHebdo_->CorrespondanceCntNativesCntOptim[h]
+                       .NumeroDeContraintePourBornerLaDefaillance[areaIndex];
+    }
+    return indices;
+}
+
 void ComponentToAreaConnectionFiller::addExpressionToConstraint(
   const TimeDependentLinearExpression& linearExpression,
   const FillContext& ctx,
@@ -136,7 +159,7 @@ TimeDependentLinearExpression ComponentToAreaConnectionFiller::linearExpressionA
     ReadLinearExpressionVisitor visitor(optimEntityContainer_, ctx, component);
 
     Nodes::Node* expression = component.nodeAtPortField(portId, fieldId);
-    return visitor.visitMergeDuplicates(expression);
+    return visitor.visitMergeDuplicates(expression).expandToSize(ctx.getLocalNumberOfTimeSteps());
 }
 
 void ComponentToAreaConnectionFiller::addInjectionPortToLinearProblem(const FillContext& ctx,
@@ -145,39 +168,69 @@ void ComponentToAreaConnectionFiller::addInjectionPortToLinearProblem(const Fill
                                                                       const unsigned& areaIndex)
 {
     std::string portField = componentInjectionField(component, portId);
-    if (portField.empty()) // area connection does not know this port field
+    if (portField.empty())
     {
+        // area connection does not specify this port field
         return;
     }
 
-    // 1. Get time-dependent linear expression at a component port field
+    // 1. GEMS side : get time-dependent linear expression at a component port field
     auto linearExpression = linearExpressionAtPortField(portId, portField, component, ctx);
-    // 2. Get the set of LP constraints to be modified with previous linear expression
+    // 2. Legacy LP side : get the set of LP constraints to be modified
     std::vector<unsigned> constaintsIndices = balanceConstraintIndices(ctx, areaIndex);
     auto constraints = fetchConstraints(ctx, constaintsIndices);
     // 3. Add the linear expression to LP constraints
     addExpressionToConstraint(linearExpression, ctx, constraints);
 }
 
-void ComponentToAreaConnectionFiller::addToAreaBoundPortInLinearProblem(const FillContext& ctx,
-                                                                        const Component& component,
-                                                                        const std::string& portId,
-                                                                        const unsigned& areaIndex)
+void ComponentToAreaConnectionFiller::addToLinearPbSpillageBound(const FillContext& ctx,
+                                                                 const Component& component,
+                                                                 const std::string& portId,
+                                                                 const unsigned& areaIndex)
 {
-    std::string portField = componentToAreaBoundField(component, portId);
-    if (portField.empty()) // area connection does not know this field
+    std::string portField = componentSpillageBound(component, portId);
+    if (portField.empty())
     {
+        // area connection does not specify this port field
         return;
     }
 
-    // 1. Get time-dependent linear expression at a component port field
+    // 1. GEMS side : get time-dependent linear expression at a component port field
     auto linearExpression = linearExpressionAtPortField(portId, portField, component, ctx);
-    // 2. Get the set of LP constraints to be modified with previous linear expression
+    // 2. Legacy LP side : get the set of LP constraints to be modified
     std::vector<unsigned> constaintsIndices = fictitiousLoadConstraintIndices(ctx, areaIndex);
     auto constraints = fetchConstraints(ctx, constaintsIndices);
     // 3. Add the linear expression to LP constraints
     addExpressionToConstraint(linearExpression, ctx, constraints);
 }
+
+void ComponentToAreaConnectionFiller::addToLinearPbUnsupEnergyBound(const FillContext& ctx,
+                                                                    const Component& component,
+                                                                    const std::string& portId,
+                                                                    const unsigned& areaIndex)
+{
+    std::string portField = componentUnsupEnergyBound(component, portId);
+    if (portField.empty())
+    {
+        // area connection does not specify this port field
+        return;
+    }
+
+    // 1. GEMS side : get time-dependent linear expression at a component port field
+    auto linearExpression = linearExpressionAtPortField(portId, portField, component, ctx);
+    // 2. Legacy LP side : get the set of LP constraints to be modified
+    std::vector<unsigned> constaintsIndices = maxUnsupEnergyConstraintIndices(ctx, areaIndex);
+    auto constraints = fetchConstraints(ctx, constaintsIndices);
+    // 3. Add the linear expression to Legacy LP constraints
+    addExpressionToConstraint(linearExpression, ctx, constraints);
+}
+
+// This function is used to add terms (from GEMS modeler) to legacy linear problem constraints.
+// For each constraint involved we add variable terms as negative terms
+// and constant terms as positive terms.
+// For details on reason why, see file :
+//   docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md
+// Please update this file in case of change.
 
 void ComponentToAreaConnectionFiller::addConstraints(const FillContext& ctx)
 {
@@ -187,7 +240,8 @@ void ComponentToAreaConnectionFiller::addConstraints(const FillContext& ctx)
         {
             auto areaIndex = areaIndices_.at(areaId);
             addInjectionPortToLinearProblem(ctx, component, portId, areaIndex);
-            addToAreaBoundPortInLinearProblem(ctx, component, portId, areaIndex);
+            addToLinearPbSpillageBound(ctx, component, portId, areaIndex);
+            addToLinearPbUnsupEnergyBound(ctx, component, portId, areaIndex);
         }
     }
 }

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -225,6 +225,13 @@ void ComponentToAreaConnectionFiller::addToLinearPbUnsupEnergyBound(const FillCo
     addExpressionToConstraint(linearExpression, ctx, constraints);
 }
 
+// This function is used to add terms (from GEMS modeler) to legacy linear problem constraints.
+// For each constraint involved we add variable terms as negative terms
+// and constant terms as positive terms.
+// For details on reason why, see file :
+//   docs/Architecture_Decision_Records/from-GEMS-to-legacy-linear-preblem.md
+// Please update this file in case of change.
+
 void ComponentToAreaConnectionFiller::addConstraints(const FillContext& ctx)
 {
     for (const auto& component: modelerSystem_->Components())

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -159,7 +159,7 @@ TimeDependentLinearExpression ComponentToAreaConnectionFiller::linearExpressionA
     ReadLinearExpressionVisitor visitor(optimEntityContainer_, ctx, component);
 
     Nodes::Node* expression = component.nodeAtPortField(portId, fieldId);
-    return visitor.visitMergeDuplicates(expression);
+    return visitor.visitMergeDuplicates(expression).expandToSize(ctx.getLocalNumberOfTimeSteps());
 }
 
 void ComponentToAreaConnectionFiller::addInjectionPortToLinearProblem(const FillContext& ctx,

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -23,6 +23,11 @@ std::string componentToAreaBoundField(const Component& component, const std::str
     return component.getModel()->Ports().at(portId).Type().areaConnection()->to_area_bound;
 }
 
+std::string componentFromAreaBoundField(const Component& component, const std::string& portId)
+{
+    return component.getModel()->Ports().at(portId).Type().areaConnection()->from_area_bound;
+}
+
 std::map<std::string, unsigned> associateIndicesToAreas(const PROBLEME_HEBDO* problemeHebdo_)
 {
     std::map<std::string, unsigned> areaIndices;
@@ -94,6 +99,19 @@ std::vector<unsigned> ComponentToAreaConnectionFiller::fictitiousLoadConstraintI
     return indices;
 }
 
+std::vector<unsigned> ComponentToAreaConnectionFiller::maxUnsupEnergyConstraintIndices(
+  const FillContext& ctx,
+  const unsigned& areaIndex) const
+{
+    std::vector<unsigned> indices(ctx.getLocalNumberOfTimeSteps());
+    for (auto h(0); h <= ctx.getLocalLastTimeStep(); ++h)
+    {
+        indices[h] = problemeHebdo_->CorrespondanceCntNativesCntOptim[h]
+                       .NumeroDeContraintePourBornerLaDefaillance[areaIndex];
+    }
+    return indices;
+}
+
 void ComponentToAreaConnectionFiller::addExpressionToConstraint(
   const TimeDependentLinearExpression& linearExpression,
   const FillContext& ctx,
@@ -145,14 +163,15 @@ void ComponentToAreaConnectionFiller::addInjectionPortToLinearProblem(const Fill
                                                                       const unsigned& areaIndex)
 {
     std::string portField = componentInjectionField(component, portId);
-    if (portField.empty()) // area connection does not know this port field
+    if (portField.empty())
     {
+        // area connection does not specify this port field
         return;
     }
 
-    // 1. Get time-dependent linear expression at a component port field
+    // 1. GEMS side : get time-dependent linear expression at a component port field
     auto linearExpression = linearExpressionAtPortField(portId, portField, component, ctx);
-    // 2. Get the set of LP constraints to be modified with previous linear expression
+    // 2. Legacy LP side : get the set of LP constraints to be modified
     std::vector<unsigned> constaintsIndices = balanceConstraintIndices(ctx, areaIndex);
     auto constraints = fetchConstraints(ctx, constaintsIndices);
     // 3. Add the linear expression to LP constraints
@@ -165,17 +184,40 @@ void ComponentToAreaConnectionFiller::addToAreaBoundPortInLinearProblem(const Fi
                                                                         const unsigned& areaIndex)
 {
     std::string portField = componentToAreaBoundField(component, portId);
-    if (portField.empty()) // area connection does not know this field
+    if (portField.empty())
     {
+        // area connection does not specify this port field
         return;
     }
 
-    // 1. Get time-dependent linear expression at a component port field
+    // 1. GEMS side : get time-dependent linear expression at a component port field
     auto linearExpression = linearExpressionAtPortField(portId, portField, component, ctx);
-    // 2. Get the set of LP constraints to be modified with previous linear expression
+    // 2. Legacy LP side : get the set of LP constraints to be modified
     std::vector<unsigned> constaintsIndices = fictitiousLoadConstraintIndices(ctx, areaIndex);
     auto constraints = fetchConstraints(ctx, constaintsIndices);
     // 3. Add the linear expression to LP constraints
+    addExpressionToConstraint(linearExpression, ctx, constraints);
+}
+
+void ComponentToAreaConnectionFiller::addFromAreaBoundPortToLinearProblem(
+  const FillContext& ctx,
+  const Component& component,
+  const std::string& portId,
+  const unsigned& areaIndex)
+{
+    std::string portField = componentFromAreaBoundField(component, portId);
+    if (portField.empty())
+    {
+        // area connection does not specify this port field
+        return;
+    }
+
+    // 1. GEMS side : get time-dependent linear expression at a component port field
+    auto linearExpression = linearExpressionAtPortField(portId, portField, component, ctx);
+    // 2. Legacy LP side : get the set of LP constraints to be modified
+    std::vector<unsigned> constaintsIndices = maxUnsupEnergyConstraintIndices(ctx, areaIndex);
+    auto constraints = fetchConstraints(ctx, constaintsIndices);
+    // 3. Add the linear expression to Legacy LP constraints
     addExpressionToConstraint(linearExpression, ctx, constraints);
 }
 
@@ -188,6 +230,7 @@ void ComponentToAreaConnectionFiller::addConstraints(const FillContext& ctx)
             auto areaIndex = areaIndices_.at(areaId);
             addInjectionPortToLinearProblem(ctx, component, portId, areaIndex);
             addToAreaBoundPortInLinearProblem(ctx, component, portId, areaIndex);
+            addFromAreaBoundPortToLinearProblem(ctx, component, portId, areaIndex);
         }
     }
 }

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -178,10 +178,10 @@ void ComponentToAreaConnectionFiller::addInjectionPortToLinearProblem(const Fill
     addExpressionToConstraint(linearExpression, ctx, constraints);
 }
 
-void ComponentToAreaConnectionFiller::addToAreaBoundPortInLinearProblem(const FillContext& ctx,
-                                                                        const Component& component,
-                                                                        const std::string& portId,
-                                                                        const unsigned& areaIndex)
+void ComponentToAreaConnectionFiller::addToLinearPbSpillageBound(const FillContext& ctx,
+                                                                 const Component& component,
+                                                                 const std::string& portId,
+                                                                 const unsigned& areaIndex)
 {
     std::string portField = componentToAreaBoundField(component, portId);
     if (portField.empty())
@@ -199,11 +199,10 @@ void ComponentToAreaConnectionFiller::addToAreaBoundPortInLinearProblem(const Fi
     addExpressionToConstraint(linearExpression, ctx, constraints);
 }
 
-void ComponentToAreaConnectionFiller::addFromAreaBoundPortToLinearProblem(
-  const FillContext& ctx,
-  const Component& component,
-  const std::string& portId,
-  const unsigned& areaIndex)
+void ComponentToAreaConnectionFiller::addToLinearPbUnsupEnergyBound(const FillContext& ctx,
+                                                                    const Component& component,
+                                                                    const std::string& portId,
+                                                                    const unsigned& areaIndex)
 {
     std::string portField = componentFromAreaBoundField(component, portId);
     if (portField.empty())
@@ -229,8 +228,8 @@ void ComponentToAreaConnectionFiller::addConstraints(const FillContext& ctx)
         {
             auto areaIndex = areaIndices_.at(areaId);
             addInjectionPortToLinearProblem(ctx, component, portId, areaIndex);
-            addToAreaBoundPortInLinearProblem(ctx, component, portId, areaIndex);
-            addFromAreaBoundPortToLinearProblem(ctx, component, portId, areaIndex);
+            addToLinearPbSpillageBound(ctx, component, portId, areaIndex);
+            addToLinearPbUnsupEnergyBound(ctx, component, portId, areaIndex);
         }
     }
 }

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -18,12 +18,12 @@ std::string componentInjectionField(const Component& component, const std::strin
     return component.getModel()->Ports().at(portId).Type().areaConnection()->injection;
 }
 
-std::string componentToAreaBoundField(const Component& component, const std::string& portId)
+std::string componentSpillageBound(const Component& component, const std::string& portId)
 {
     return component.getModel()->Ports().at(portId).Type().areaConnection()->spillage_bound;
 }
 
-std::string componentFromAreaBoundField(const Component& component, const std::string& portId)
+std::string componentUnsupEnergyBound(const Component& component, const std::string& portId)
 {
     return component.getModel()
       ->Ports()
@@ -188,7 +188,7 @@ void ComponentToAreaConnectionFiller::addToLinearPbSpillageBound(const FillConte
                                                                  const std::string& portId,
                                                                  const unsigned& areaIndex)
 {
-    std::string portField = componentToAreaBoundField(component, portId);
+    std::string portField = componentSpillageBound(component, portId);
     if (portField.empty())
     {
         // area connection does not specify this port field
@@ -209,7 +209,7 @@ void ComponentToAreaConnectionFiller::addToLinearPbUnsupEnergyBound(const FillCo
                                                                     const std::string& portId,
                                                                     const unsigned& areaIndex)
 {
-    std::string portField = componentFromAreaBoundField(component, portId);
+    std::string portField = componentUnsupEnergyBound(component, portId);
     if (portField.empty())
     {
         // area connection does not specify this port field

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -162,7 +162,7 @@ TimeDependentLinearExpression ComponentToAreaConnectionFiller::linearExpressionA
     return visitor.visitMergeDuplicates(expression).expandToSize(ctx.getLocalNumberOfTimeSteps());
 }
 
-void ComponentToAreaConnectionFiller::addInjectionPortToLinearProblem(const FillContext& ctx,
+void ComponentToAreaConnectionFiller::addInjectionPortToLinearPb(const FillContext& ctx,
                                                                       const Component& component,
                                                                       const std::string& portId,
                                                                       const unsigned& areaIndex)
@@ -183,7 +183,7 @@ void ComponentToAreaConnectionFiller::addInjectionPortToLinearProblem(const Fill
     addExpressionToConstraint(linearExpression, ctx, constraints);
 }
 
-void ComponentToAreaConnectionFiller::addToLinearPbSpillageBound(const FillContext& ctx,
+void ComponentToAreaConnectionFiller::addSpillageBoundToLinearPb(const FillContext& ctx,
                                                                  const Component& component,
                                                                  const std::string& portId,
                                                                  const unsigned& areaIndex)
@@ -204,7 +204,7 @@ void ComponentToAreaConnectionFiller::addToLinearPbSpillageBound(const FillConte
     addExpressionToConstraint(linearExpression, ctx, constraints);
 }
 
-void ComponentToAreaConnectionFiller::addToLinearPbUnsupEnergyBound(const FillContext& ctx,
+void ComponentToAreaConnectionFiller::addUnsupEnergyBoundToLinearPb(const FillContext& ctx,
                                                                     const Component& component,
                                                                     const std::string& portId,
                                                                     const unsigned& areaIndex)
@@ -239,9 +239,9 @@ void ComponentToAreaConnectionFiller::addConstraints(const FillContext& ctx)
         for (auto [portId, areaId]: component.portToAreaConnections())
         {
             auto areaIndex = areaIndices_.at(areaId);
-            addInjectionPortToLinearProblem(ctx, component, portId, areaIndex);
-            addToLinearPbSpillageBound(ctx, component, portId, areaIndex);
-            addToLinearPbUnsupEnergyBound(ctx, component, portId, areaIndex);
+            addInjectionPortToLinearPb(ctx, component, portId, areaIndex);
+            addSpillageBoundToLinearPb(ctx, component, portId, areaIndex);
+            addUnsupEnergyBoundToLinearPb(ctx, component, portId, areaIndex);
         }
     }
 }

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -20,12 +20,17 @@ std::string componentInjectionField(const Component& component, const std::strin
 
 std::string componentToAreaBoundField(const Component& component, const std::string& portId)
 {
-    return component.getModel()->Ports().at(portId).Type().areaConnection()->to_area_bound;
+    return component.getModel()->Ports().at(portId).Type().areaConnection()->spillage_bound;
 }
 
 std::string componentFromAreaBoundField(const Component& component, const std::string& portId)
 {
-    return component.getModel()->Ports().at(portId).Type().areaConnection()->from_area_bound;
+    return component.getModel()
+      ->Ports()
+      .at(portId)
+      .Type()
+      .areaConnection()
+      ->unsupplied_energy_bound;
 }
 
 std::map<std::string, unsigned> associateIndicesToAreas(const PROBLEME_HEBDO* problemeHebdo_)

--- a/src/solver/optimisation/constraints/Group1.cpp
+++ b/src/solver/optimisation/constraints/Group1.cpp
@@ -24,6 +24,11 @@ FictitiousLoadData Group1::GetFictitiousLoadData()
             .DefaillanceNegativeUtiliserHydro = problemeHebdo_->DefaillanceNegativeUtiliserHydro};
 }
 
+MaxUnsupEnergyData Group1::GetMaxUnsupEnergyData()
+{
+    return {.CorrespondanceCntNativesCntOptim = problemeHebdo_->CorrespondanceCntNativesCntOptim};
+}
+
 ShortTermStorageData Group1::GetShortTermStorageData()
 {
     return {
@@ -64,6 +69,9 @@ void Group1::BuildConstraints()
     auto fictitiousLoadData = GetFictitiousLoadData();
     FictitiousLoad fictitiousLoad(builder_, fictitiousLoadData);
 
+    //auto maxUnsupEnergyData = GetMaxUnsupEnergyData();
+    //MaxUnsuppliedEnergy maxUnsuppliedEnergy(builder_, maxUnsupEnergyData);
+
     auto shortTermStorageData = GetShortTermStorageData();
     ShortTermStorageLevel shortTermStorageLevel(builder_, shortTermStorageData);
 
@@ -99,6 +107,7 @@ void Group1::BuildConstraints()
         {
             areaBalance.add(pdt, pays);
             fictitiousLoad.add(pdt, pays);
+            // maxUnsuppliedEnergy.add(pdt, pays);
             shortTermStorageLevel.add(pdt, pays);
             shortTermStorageCostVariationInjectionBackward.add(pdt, pays);
             shortTermStorageCostVariationInjectionForward.add(pdt, pays);

--- a/src/solver/optimisation/constraints/Group1.cpp
+++ b/src/solver/optimisation/constraints/Group1.cpp
@@ -69,8 +69,8 @@ void Group1::BuildConstraints()
     auto fictitiousLoadData = GetFictitiousLoadData();
     FictitiousLoad fictitiousLoad(builder_, fictitiousLoadData);
 
-    //auto maxUnsupEnergyData = GetMaxUnsupEnergyData();
-    //MaxUnsuppliedEnergy maxUnsuppliedEnergy(builder_, maxUnsupEnergyData);
+    // auto maxUnsupEnergyData = GetMaxUnsupEnergyData();
+    // MaxUnsuppliedEnergy maxUnsuppliedEnergy(builder_, maxUnsupEnergyData);
 
     auto shortTermStorageData = GetShortTermStorageData();
     ShortTermStorageLevel shortTermStorageLevel(builder_, shortTermStorageData);

--- a/src/solver/optimisation/constraints/Group1.cpp
+++ b/src/solver/optimisation/constraints/Group1.cpp
@@ -69,8 +69,8 @@ void Group1::BuildConstraints()
     auto fictitiousLoadData = GetFictitiousLoadData();
     FictitiousLoad fictitiousLoad(builder_, fictitiousLoadData);
 
-    // auto maxUnsupEnergyData = GetMaxUnsupEnergyData();
-    // MaxUnsuppliedEnergy maxUnsuppliedEnergy(builder_, maxUnsupEnergyData);
+    auto maxUnsupEnergyData = GetMaxUnsupEnergyData();
+    MaxUnsuppliedEnergy maxUnsuppliedEnergy(builder_, maxUnsupEnergyData);
 
     auto shortTermStorageData = GetShortTermStorageData();
     ShortTermStorageLevel shortTermStorageLevel(builder_, shortTermStorageData);
@@ -107,7 +107,7 @@ void Group1::BuildConstraints()
         {
             areaBalance.add(pdt, pays);
             fictitiousLoad.add(pdt, pays);
-            // maxUnsuppliedEnergy.add(pdt, pays);
+            maxUnsuppliedEnergy.add(pdt, pays);
             shortTermStorageLevel.add(pdt, pays);
             shortTermStorageCostVariationInjectionBackward.add(pdt, pays);
             shortTermStorageCostVariationInjectionForward.add(pdt, pays);

--- a/src/solver/optimisation/constraints/MaxUnsuppliedEnergy.cpp
+++ b/src/solver/optimisation/constraints/MaxUnsuppliedEnergy.cpp
@@ -1,0 +1,19 @@
+#include "antares/solver/optimisation/constraints/MaxUnsuppliedEnergy.h"
+
+void MaxUnsuppliedEnergy::add(int pdt, int pays)
+{
+    data.CorrespondanceCntNativesCntOptim[pdt].NumeroDeContraintePourBornerLaDefaillance[pays]
+      = builder.data.nombreDeContraintes;
+
+    ConstraintNamer namer(builder.data.NomDesContraintes);
+
+    namer.UpdateTimeStep(builder.data.weekInTheYear * 168 + pdt);
+    namer.UpdateArea(builder.data.NomsDesPays[pays]);
+    namer.MaxUnsuppliedEnergy(builder.data.nombreDeContraintes);
+
+    builder.updateHourWithinWeek(pdt);
+    builder.UnsuppliedEnergy(pays, 1.0);
+
+    builder.lessThan();
+    builder.build();
+}

--- a/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
@@ -82,14 +82,14 @@ private:
                                          const ModelerStudy::SystemModel::Component& component,
                                          const std::string& portId,
                                          const unsigned& areaIndex);
-    void addToAreaBoundPortInLinearProblem(const Optimisation::LinearProblemApi::FillContext& ctx,
-                                           const ModelerStudy::SystemModel::Component& component,
-                                           const std::string& portId,
-                                           const unsigned& areaIndex);
-    void addFromAreaBoundPortToLinearProblem(const Optimisation::LinearProblemApi::FillContext& ctx,
-                                             const ModelerStudy::SystemModel::Component& component,
-                                             const std::string& portId,
-                                             const unsigned& areaIndex);
+    void addToLinearPbSpillageBound(const Optimisation::LinearProblemApi::FillContext& ctx,
+                                    const ModelerStudy::SystemModel::Component& component,
+                                    const std::string& portId,
+                                    const unsigned& areaIndex);
+    void addToLinearPbUnsupEnergyBound(const Optimisation::LinearProblemApi::FillContext& ctx,
+                                       const ModelerStudy::SystemModel::Component& component,
+                                       const std::string& portId,
+                                       const unsigned& areaIndex);
 };
 
 } // namespace Antares::Optimization

--- a/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
@@ -78,15 +78,15 @@ private:
       const ModelerStudy::SystemModel::Component& component,
       const Optimisation::LinearProblemApi::FillContext& ctx);
 
-    void addInjectionPortToLinearProblem(const Optimisation::LinearProblemApi::FillContext& ctx,
+    void addInjectionPortToLinearPb(const Optimisation::LinearProblemApi::FillContext& ctx,
                                          const ModelerStudy::SystemModel::Component& component,
                                          const std::string& portId,
                                          const unsigned& areaIndex);
-    void addToLinearPbSpillageBound(const Optimisation::LinearProblemApi::FillContext& ctx,
+    void addSpillageBoundToLinearPb(const Optimisation::LinearProblemApi::FillContext& ctx,
                                     const ModelerStudy::SystemModel::Component& component,
                                     const std::string& portId,
                                     const unsigned& areaIndex);
-    void addToLinearPbUnsupEnergyBound(const Optimisation::LinearProblemApi::FillContext& ctx,
+    void addUnsupEnergyBoundToLinearPb(const Optimisation::LinearProblemApi::FillContext& ctx,
                                        const ModelerStudy::SystemModel::Component& component,
                                        const std::string& portId,
                                        const unsigned& areaIndex);

--- a/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
@@ -63,6 +63,10 @@ private:
       const Optimisation::LinearProblemApi::FillContext& ctx,
       const unsigned& areaIndex) const;
 
+    std::vector<unsigned> maxUnsupEnergyConstraintIndices(
+      const Optimisation::LinearProblemApi::FillContext& ctx,
+      const unsigned& areaIndex) const;
+
     void addExpressionToConstraint(
       const Antares::Optimization::TimeDependentLinearExpression& linearExpression,
       const Optimisation::LinearProblemApi::FillContext& ctx,
@@ -78,10 +82,14 @@ private:
                                          const ModelerStudy::SystemModel::Component& component,
                                          const std::string& portId,
                                          const unsigned& areaIndex);
-    void addToAreaBoundPortInLinearProblem(const Optimisation::LinearProblemApi::FillContext& ctx,
-                                           const ModelerStudy::SystemModel::Component& component,
-                                           const std::string& portId,
-                                           const unsigned& areaIndex);
+    void addToLinearPbSpillageBound(const Optimisation::LinearProblemApi::FillContext& ctx,
+                                    const ModelerStudy::SystemModel::Component& component,
+                                    const std::string& portId,
+                                    const unsigned& areaIndex);
+    void addToLinearPbUnsupEnergyBound(const Optimisation::LinearProblemApi::FillContext& ctx,
+                                       const ModelerStudy::SystemModel::Component& component,
+                                       const std::string& portId,
+                                       const unsigned& areaIndex);
 };
 
 } // namespace Antares::Optimization

--- a/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
@@ -63,6 +63,10 @@ private:
       const Optimisation::LinearProblemApi::FillContext& ctx,
       const unsigned& areaIndex) const;
 
+    std::vector<unsigned> maxUnsupEnergyConstraintIndices(
+      const Optimisation::LinearProblemApi::FillContext& ctx,
+      const unsigned& areaIndex) const;
+
     void addExpressionToConstraint(
       const Antares::Optimization::TimeDependentLinearExpression& linearExpression,
       const Optimisation::LinearProblemApi::FillContext& ctx,
@@ -82,6 +86,10 @@ private:
                                            const ModelerStudy::SystemModel::Component& component,
                                            const std::string& portId,
                                            const unsigned& areaIndex);
+    void addFromAreaBoundPortToLinearProblem(const Optimisation::LinearProblemApi::FillContext& ctx,
+                                             const ModelerStudy::SystemModel::Component& component,
+                                             const std::string& portId,
+                                             const unsigned& areaIndex);
 };
 
 } // namespace Antares::Optimization

--- a/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
@@ -79,9 +79,9 @@ private:
       const Optimisation::LinearProblemApi::FillContext& ctx);
 
     void addInjectionPortToLinearPb(const Optimisation::LinearProblemApi::FillContext& ctx,
-                                         const ModelerStudy::SystemModel::Component& component,
-                                         const std::string& portId,
-                                         const unsigned& areaIndex);
+                                    const ModelerStudy::SystemModel::Component& component,
+                                    const std::string& portId,
+                                    const unsigned& areaIndex);
     void addSpillageBoundToLinearPb(const Optimisation::LinearProblemApi::FillContext& ctx,
                                     const ModelerStudy::SystemModel::Component& component,
                                     const std::string& portId,

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/Group1.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/Group1.h
@@ -6,8 +6,8 @@
 #include "BindingConstraintHour.h"
 #include "ConstraintGroup.h"
 #include "FictitiousLoad.h"
-#include "MaxUnsuppliedEnergy.h"
 #include "FlowDissociation.h"
+#include "MaxUnsuppliedEnergy.h"
 #include "ShortTermStorageLevel.h"
 
 class Group1 final: public ConstraintGroup

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/Group1.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/Group1.h
@@ -6,6 +6,7 @@
 #include "BindingConstraintHour.h"
 #include "ConstraintGroup.h"
 #include "FictitiousLoad.h"
+#include "MaxUnsuppliedEnergy.h"
 #include "FlowDissociation.h"
 #include "ShortTermStorageLevel.h"
 
@@ -19,10 +20,9 @@ public:
 private:
     AreaBalanceData GetAreaBalanceData();
     FictitiousLoadData GetFictitiousLoadData();
+    MaxUnsupEnergyData GetMaxUnsupEnergyData();
     ShortTermStorageData GetShortTermStorageData();
-
     ShortTermStorageCumulativeConstraintData GetShortTermStorageCumulativeConstraintData();
-
     FlowDissociationData GetFlowDissociationData();
     BindingConstraintHourData GetBindingConstraintHourData();
 };

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxUnsuppliedEnergy.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxUnsuppliedEnergy.h
@@ -33,6 +33,3 @@ public:
 private:
     MaxUnsupEnergyData& data;
 };
-
-
-

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxUnsuppliedEnergy.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/MaxUnsuppliedEnergy.h
@@ -1,0 +1,38 @@
+// Copyright 2007-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include "ConstraintBuilder.h"
+
+struct MaxUnsupEnergyData
+{
+    std::vector<CORRESPONDANCES_DES_CONTRAINTES>& CorrespondanceCntNativesCntOptim;
+};
+
+/*!
+ * Purpose of this constraint : be able to maximize the unsupplied energy variable with
+ * other variables of optimization.
+ */
+class MaxUnsuppliedEnergy final: private ConstraintFactory
+{
+public:
+    MaxUnsuppliedEnergy(ConstraintBuilder& builder, MaxUnsupEnergyData& data):
+        ConstraintFactory(builder),
+        data(data)
+    {
+    }
+
+    /*!
+     * @brief Add variables to the constraint and update constraints Matrix
+     * @param pdt : timestep
+     * @param pays : area
+     */
+    void add(int pdt, int pays);
+
+private:
+    MaxUnsupEnergyData& data;
+};
+
+
+

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -82,6 +82,7 @@ public:
     void FlowDissociation(unsigned constrIndex);
     void AreaBalance(unsigned constrIndex);
     void FictiveLoads(unsigned constrIndex);
+    void MaxUnsuppliedEnergy(unsigned constrIndex);
     void HydroPower(unsigned constrIndex);
     void HydroPowerSmoothingUsingVariationSum(unsigned constrIndex);
     void HydroPowerSmoothingUsingVariationMaxDown(unsigned constrIndex);

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -66,13 +66,17 @@ void setBoundsForUnsuppliedEnergy(PROBLEME_HEBDO* problemeHebdo,
     std::vector<double*>& AdresseOuPlacerLaValeurDesVariablesOptimisees
       = problemeHebdo->ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees;
 
+    // gp : to remove
     const bool reserveJm1 = (problemeHebdo->YaDeLaReserveJmoins1);
     const bool opt1 = (optimizationNumber == PREMIERE_OPTIMISATION);
+
     auto variableManager = VariableManagerFromProblemHebdo(problemeHebdo);
 
     for (int pdtHebdo = PremierPdtDeLIntervalle, pdtJour = 0; pdtHebdo < DernierPdtDeLIntervalle;
          pdtHebdo++, pdtJour++)
     {
+        
+        // gp : to remove
         const ALL_MUST_RUN_GENERATION& AllMustRunGeneration = problemeHebdo
                                                                 ->AllMustRunGeneration[pdtHebdo];
         const CONSOMMATIONS_ABATTUES& ConsommationsAbattues = problemeHebdo
@@ -80,16 +84,19 @@ void setBoundsForUnsuppliedEnergy(PROBLEME_HEBDO* problemeHebdo,
 
         for (uint32_t pays = 0; pays < problemeHebdo->NombreDePays; pays++)
         {
-            double ResidualLoadInArea = ConsommationsAbattues.ConsommationAbattueDuPays[pays];
+            int var = variableManager.UnsuppliedEnergy(pays, pdtJour);
+            Xmin[var] = 0.0;
 
+            // Unsupplied energy lower bound
+            // ---------------------------------
+            // Xmax[var] = LINFINI_ANTARES; // gp : to be added back
+
+            double ResidualLoadInArea = ConsommationsAbattues.ConsommationAbattueDuPays[pays];
             if (reserveJm1 && opt1)
             {
                 ResidualLoadInArea += problemeHebdo->ReserveJMoins1[pays]
                                         .ReserveHoraireJMoins1[pdtHebdo];
             }
-
-            int var = variableManager.UnsuppliedEnergy(pays, pdtJour);
-            Xmin[var] = 0.0;
 
             double MaxAllMustRunGenerationOfArea = 0.;
             if (AllMustRunGeneration.AllMustRunGenerationOfArea[pays] > 0.)
@@ -108,6 +115,7 @@ void setBoundsForUnsuppliedEnergy(PROBLEME_HEBDO* problemeHebdo,
                 Xmax[var] = 0.;
             }
 
+            // Unsuplied energy results after optimization
             problemeHebdo->ResultatsHoraires[pays].ValeursHorairesDeDefaillancePositive[pdtHebdo]
               = 0.0;
 

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -66,55 +66,17 @@ void setBoundsForUnsuppliedEnergy(PROBLEME_HEBDO* problemeHebdo,
     std::vector<double*>& AdresseOuPlacerLaValeurDesVariablesOptimisees
       = problemeHebdo->ProblemeAResoudre->AdresseOuPlacerLaValeurDesVariablesOptimisees;
 
-    // gp : to remove
-    const bool reserveJm1 = (problemeHebdo->YaDeLaReserveJmoins1);
-    const bool opt1 = (optimizationNumber == PREMIERE_OPTIMISATION);
-
     auto variableManager = VariableManagerFromProblemHebdo(problemeHebdo);
 
     for (int pdtHebdo = PremierPdtDeLIntervalle, pdtJour = 0; pdtHebdo < DernierPdtDeLIntervalle;
          pdtHebdo++, pdtJour++)
     {
-        // gp : to remove
-        const ALL_MUST_RUN_GENERATION& AllMustRunGeneration = problemeHebdo
-                                                                ->AllMustRunGeneration[pdtHebdo];
-        const CONSOMMATIONS_ABATTUES& ConsommationsAbattues = problemeHebdo
-                                                                ->ConsommationsAbattues[pdtHebdo];
-
         for (uint32_t pays = 0; pays < problemeHebdo->NombreDePays; pays++)
         {
             int var = variableManager.UnsuppliedEnergy(pays, pdtJour);
             Xmin[var] = 0.0;
+            Xmax[var] = LINFINI_ANTARES;
 
-            // Unsupplied energy lower bound
-            // ---------------------------------
-            // Xmax[var] = LINFINI_ANTARES; // gp : to be added back
-
-            double ResidualLoadInArea = ConsommationsAbattues.ConsommationAbattueDuPays[pays];
-            if (reserveJm1 && opt1)
-            {
-                ResidualLoadInArea += problemeHebdo->ReserveJMoins1[pays]
-                                        .ReserveHoraireJMoins1[pdtHebdo];
-            }
-
-            double MaxAllMustRunGenerationOfArea = 0.;
-            if (AllMustRunGeneration.AllMustRunGenerationOfArea[pays] > 0.)
-            {
-                MaxAllMustRunGenerationOfArea = AllMustRunGeneration
-                                                  .AllMustRunGenerationOfArea[pays];
-            }
-
-            ResidualLoadInArea += MaxAllMustRunGenerationOfArea;
-            if (ResidualLoadInArea >= 0.)
-            {
-                Xmax[var] = ResidualLoadInArea + 1e-5;
-            }
-            else
-            {
-                Xmax[var] = 0.;
-            }
-
-            // Unsuplied energy results after optimization
             problemeHebdo->ResultatsHoraires[pays].ValeursHorairesDeDefaillancePositive[pdtHebdo]
               = 0.0;
 

--- a/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_des_bornes_cas_lineaire.cpp
@@ -75,7 +75,6 @@ void setBoundsForUnsuppliedEnergy(PROBLEME_HEBDO* problemeHebdo,
     for (int pdtHebdo = PremierPdtDeLIntervalle, pdtJour = 0; pdtHebdo < DernierPdtDeLIntervalle;
          pdtHebdo++, pdtJour++)
     {
-        
         // gp : to remove
         const ALL_MUST_RUN_GENERATION& AllMustRunGeneration = problemeHebdo
                                                                 ->AllMustRunGeneration[pdtHebdo];

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -92,6 +92,9 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
     const std::vector<bool>& DefaillanceNegativeUtiliserPMinThermique
       = problemeHebdo->DefaillanceNegativeUtiliserPMinThermique;
 
+    bool reserveJm1 = (problemeHebdo->YaDeLaReserveJmoins1);
+    bool opt1 = (optimizationNumber == PREMIERE_OPTIMISATION);
+
     for (int i = 0; i < ProblemeAResoudre->NombreDeContraintes; i++)
     {
         AdresseOuPlacerLaValeurDesCoutsMarginaux[i] = nullptr;
@@ -110,40 +113,40 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
                                                                 ->AllMustRunGeneration[pdtHebdo];
         for (uint32_t pays = 0; pays < problemeHebdo->NombreDePays; pays++)
         {
-            int cnt = CorrespondanceCntNativesCntOptim.NumeroDeContrainteDesBilansPays[pays];
-            SecondMembre[cnt] = -ConsommationsAbattues.ConsommationAbattueDuPays[pays];
+            double ResidualLoadInArea = ConsommationsAbattues.ConsommationAbattueDuPays[pays];
+            double reserveHoraireJmoins1 = problemeHebdo->ReserveJMoins1[pays]
+                                             .ReserveHoraireJMoins1[pdtHebdo];
+            double mustRunGenOfArea = AllMustRunGeneration.AllMustRunGenerationOfArea[pays];
 
-            bool reserveJm1 = (problemeHebdo->YaDeLaReserveJmoins1);
-            bool opt1 = (optimizationNumber == PREMIERE_OPTIMISATION);
+            // ---------------------------------------
+            // RHS for area balance constraint set
+            // ---------------------------------------
+            int cnt = CorrespondanceCntNativesCntOptim.NumeroDeContrainteDesBilansPays[pays];
+
+            SecondMembre[cnt] = -ResidualLoadInArea;
             if (reserveJm1 && opt1)
             {
-                SecondMembre[cnt] -= problemeHebdo->ReserveJMoins1[pays]
-                                       .ReserveHoraireJMoins1[pdtHebdo];
+                SecondMembre[cnt] -= reserveHoraireJmoins1;
             }
 
             double* adresseDuResultat = &(
               problemeHebdo->ResultatsHoraires[pays].CoutsMarginauxHoraires[pdtHebdo]);
             AdresseOuPlacerLaValeurDesCoutsMarginaux[cnt] = adresseDuResultat;
 
+            // ---------------------------------------
+            // RHS for avoiding fictitious loads
+            // ---------------------------------------
             cnt = CorrespondanceCntNativesCntOptim
                     .NumeroDeContraintePourEviterLesChargesFictives[pays];
             SecondMembre[cnt] = 0.0;
 
             double MaxAllMustRunGeneration = 0.0;
-            if (AllMustRunGeneration.AllMustRunGenerationOfArea[pays] > 0.0)
+            if (mustRunGenOfArea > 0.0)
             {
-                MaxAllMustRunGeneration = AllMustRunGeneration.AllMustRunGenerationOfArea[pays];
+                MaxAllMustRunGeneration = mustRunGenOfArea;
             }
 
-            double MaxMoinsConsommationBrute = 0.0;
-            if (-(ConsommationsAbattues.ConsommationAbattueDuPays[pays]
-                  + AllMustRunGeneration.AllMustRunGenerationOfArea[pays])
-                > 0.0)
-            {
-                MaxMoinsConsommationBrute = -(
-                  ConsommationsAbattues.ConsommationAbattueDuPays[pays]
-                  + AllMustRunGeneration.AllMustRunGenerationOfArea[pays]);
-            }
+            double MaxMoinsConsommationBrute = -std::min(0., ResidualLoadInArea + mustRunGenOfArea);
 
             SecondMembre[cnt] = DefaillanceNegativeUtiliserConsoAbattue[pays]
                                 * (MaxAllMustRunGeneration + MaxMoinsConsommationBrute);
@@ -152,6 +155,31 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
             {
                 SecondMembre[cnt] -= OPT_SommeDesPminThermiques(problemeHebdo, pays, pdtHebdo);
             }
+
+            // ---------------------------------------
+            // RHS for maximizing unsupplied energy
+            // ---------------------------------------
+            //cnt = CorrespondanceCntNativesCntOptim.NumeroDeContraintePourBornerLaDefaillance[pays];
+            //SecondMembre[cnt] = 0.;
+
+            //if (reserveJm1 && opt1)
+            //{
+            //    ResidualLoadInArea += reserveHoraireJmoins1;
+            //}
+
+            //double MaxAllMustRunGenerationOfArea = 0.;
+            //if (mustRunGenOfArea > 0.)
+            //{
+            //    MaxAllMustRunGenerationOfArea = AllMustRunGeneration
+            //                                      .AllMustRunGenerationOfArea[pays];
+            //}
+
+            //ResidualLoadInArea += MaxAllMustRunGenerationOfArea;
+            //if (ResidualLoadInArea >= 0.)
+            //{
+            //    SecondMembre[cnt] = ResidualLoadInArea + 1e-5;
+            //}
+            // ---------------------------------------
 
             AdresseOuPlacerLaValeurDesCoutsMarginaux[cnt] = nullptr;
         }

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -114,8 +114,14 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
         for (uint32_t pays = 0; pays < problemeHebdo->NombreDePays; pays++)
         {
             double ResidualLoadInArea = ConsommationsAbattues.ConsommationAbattueDuPays[pays];
-            double reserveHoraireJmoins1 = problemeHebdo->ReserveJMoins1[pays]
-                                             .ReserveHoraireJMoins1[pdtHebdo];
+
+            double reserveHoraireJmoins1 = 0;
+            if (reserveJm1 && opt1)
+            {
+                reserveHoraireJmoins1 = problemeHebdo->ReserveJMoins1[pays]
+                                          .ReserveHoraireJMoins1[pdtHebdo];
+            }
+
             double mustRunGenOfArea = AllMustRunGeneration.AllMustRunGenerationOfArea[pays];
 
             // ---------------------------------------
@@ -123,11 +129,7 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
             // ---------------------------------------
             int cnt = CorrespondanceCntNativesCntOptim.NumeroDeContrainteDesBilansPays[pays];
 
-            SecondMembre[cnt] = -ResidualLoadInArea;
-            if (reserveJm1 && opt1)
-            {
-                SecondMembre[cnt] -= reserveHoraireJmoins1;
-            }
+            SecondMembre[cnt] -= ResidualLoadInArea + reserveHoraireJmoins1;
 
             double* adresseDuResultat = &(
               problemeHebdo->ResultatsHoraires[pays].CoutsMarginauxHoraires[pdtHebdo]);
@@ -159,27 +161,18 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
             // ---------------------------------------
             // RHS for maximizing unsupplied energy
             // ---------------------------------------
-            //cnt = CorrespondanceCntNativesCntOptim.NumeroDeContraintePourBornerLaDefaillance[pays];
-            //SecondMembre[cnt] = 0.;
+            // cnt =
+            // CorrespondanceCntNativesCntOptim.NumeroDeContraintePourBornerLaDefaillance[pays];
+            // SecondMembre[cnt] = 0.;
 
-            //if (reserveJm1 && opt1)
-            //{
-            //    ResidualLoadInArea += reserveHoraireJmoins1;
-            //}
+            // double MaxMustRunGenOfArea = std::max(0, mustRunGenOfArea);
 
-            //double MaxAllMustRunGenerationOfArea = 0.;
-            //if (mustRunGenOfArea > 0.)
-            //{
-            //    MaxAllMustRunGenerationOfArea = AllMustRunGeneration
-            //                                      .AllMustRunGenerationOfArea[pays];
-            //}
-
-            //ResidualLoadInArea += MaxAllMustRunGenerationOfArea;
-            //if (ResidualLoadInArea >= 0.)
-            //{
-            //    SecondMembre[cnt] = ResidualLoadInArea + 1e-5;
-            //}
-            // ---------------------------------------
+            // ResidualLoadInArea += MaxMustRunGenOfArea + reserveHoraireJmoins1;
+            // if (ResidualLoadInArea >= 0.)
+            // {
+            //     SecondMembre[cnt] = ResidualLoadInArea + 1e-5;
+            // }
+            //  ---------------------------------------
 
             AdresseOuPlacerLaValeurDesCoutsMarginaux[cnt] = nullptr;
         }

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -113,17 +113,18 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
                                                                 ->AllMustRunGeneration[pdtHebdo];
         for (uint32_t pays = 0; pays < problemeHebdo->NombreDePays; pays++)
         {
-            double ResidualLoadInArea = ConsommationsAbattues.ConsommationAbattueDuPays[pays];
-
+            // Useful variables for the current scope
+            // --------------------------------------
             double reserveHoraireJmoins1 = 0;
             if (reserveJm1 && opt1)
             {
                 reserveHoraireJmoins1 = problemeHebdo->ReserveJMoins1[pays]
                                           .ReserveHoraireJMoins1[pdtHebdo];
             }
-
+            double ResidualLoadInArea = ConsommationsAbattues.ConsommationAbattueDuPays[pays];
             double mustRunGenOfArea = AllMustRunGeneration.AllMustRunGenerationOfArea[pays];
             double MaxMustRunGenOfArea = std::max(0., mustRunGenOfArea);
+            double MaxMoinsConsoBrute = -std::min(0., ResidualLoadInArea + mustRunGenOfArea);
 
             // ---------------------------------------
             // RHS for area balance constraint set
@@ -141,9 +142,6 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
             // ---------------------------------------
             cnt = CorrespondanceCntNativesCntOptim
                     .NumeroDeContraintePourEviterLesChargesFictives[pays];
-            SecondMembre[cnt] = 0.0;
-
-            double MaxMoinsConsoBrute = -std::min(0., ResidualLoadInArea + mustRunGenOfArea);
 
             SecondMembre[cnt] = DefaillanceNegativeUtiliserConsoAbattue[pays]
                                 * (MaxMustRunGenOfArea + MaxMoinsConsoBrute);
@@ -153,21 +151,18 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
                 SecondMembre[cnt] -= OPT_SommeDesPminThermiques(problemeHebdo, pays, pdtHebdo);
             }
 
+            AdresseOuPlacerLaValeurDesCoutsMarginaux[cnt] = nullptr;
+
             // ---------------------------------------
             // RHS for maximizing unsupplied energy
             // ---------------------------------------
-            // cnt =
-            // CorrespondanceCntNativesCntOptim.NumeroDeContraintePourBornerLaDefaillance[pays];
-            // SecondMembre[cnt] = 0.;
+            ResidualLoadInArea += MaxMustRunGenOfArea + reserveHoraireJmoins1;
 
-            // ResidualLoadInArea += MaxMustRunGenOfArea + reserveHoraireJmoins1;
-            // if (ResidualLoadInArea >= 0.)
-            // {
-            //     SecondMembre[cnt] = ResidualLoadInArea + 1e-5;
-            // }
-            //  ---------------------------------------
-
-            AdresseOuPlacerLaValeurDesCoutsMarginaux[cnt] = nullptr;
+            cnt = CorrespondanceCntNativesCntOptim.NumeroDeContraintePourBornerLaDefaillance[pays];
+            if (ResidualLoadInArea >= 0.)
+            {
+                SecondMembre[cnt] = ResidualLoadInArea + 1e-5;
+            }
         }
 
         int hourInTheYear = weekFirstHour + pdtHebdo;

--- a/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
+++ b/src/solver/optimisation/opt_gestion_second_membre_cas_lineaire.cpp
@@ -123,6 +123,7 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
             }
 
             double mustRunGenOfArea = AllMustRunGeneration.AllMustRunGenerationOfArea[pays];
+            double MaxMustRunGenOfArea = std::max(0., mustRunGenOfArea);
 
             // ---------------------------------------
             // RHS for area balance constraint set
@@ -142,16 +143,10 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
                     .NumeroDeContraintePourEviterLesChargesFictives[pays];
             SecondMembre[cnt] = 0.0;
 
-            double MaxAllMustRunGeneration = 0.0;
-            if (mustRunGenOfArea > 0.0)
-            {
-                MaxAllMustRunGeneration = mustRunGenOfArea;
-            }
-
-            double MaxMoinsConsommationBrute = -std::min(0., ResidualLoadInArea + mustRunGenOfArea);
+            double MaxMoinsConsoBrute = -std::min(0., ResidualLoadInArea + mustRunGenOfArea);
 
             SecondMembre[cnt] = DefaillanceNegativeUtiliserConsoAbattue[pays]
-                                * (MaxAllMustRunGeneration + MaxMoinsConsommationBrute);
+                                * (MaxMustRunGenOfArea + MaxMoinsConsoBrute);
 
             if (DefaillanceNegativeUtiliserPMinThermique[pays] == 0)
             {
@@ -164,8 +159,6 @@ void OPT_InitialiserLeSecondMembreDuProblemeLineaire(PROBLEME_HEBDO* problemeHeb
             // cnt =
             // CorrespondanceCntNativesCntOptim.NumeroDeContraintePourBornerLaDefaillance[pays];
             // SecondMembre[cnt] = 0.;
-
-            // double MaxMustRunGenOfArea = std::max(0, mustRunGenOfArea);
 
             // ResidualLoadInArea += MaxMustRunGenOfArea + reserveHoraireJmoins1;
             // if (ResidualLoadInArea >= 0.)

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -292,6 +292,11 @@ void ConstraintNamer::FictiveLoads(unsigned constrIndex)
     SetAreaElementNameHour(constrIndex, "FictiveLoads");
 }
 
+void ConstraintNamer::MaxUnsuppliedEnergy(unsigned constrIndex)
+{
+    SetAreaElementNameHour(constrIndex, "MaxUnsupEnergy");
+}
+
 void ConstraintNamer::HydroPower(unsigned constrIndex)
 {
     SetAreaElementNameWeek(constrIndex, "HydroPower");

--- a/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
@@ -35,11 +35,9 @@ struct CORRESPONDANCES_DES_VARIABLES
     std::vector<int> NumeroDeVariablesDeDebordement;
 
     std::vector<int> NumeroDeVariableDefaillancePositive;
-
     std::vector<int> NumeroDeVariableDefaillanceNegative;
 
     std::vector<int> NumeroDeVariablesVariationHydALaBaisse;
-
     std::vector<int> NumeroDeVariablesVariationHydALaHausse;
 
     std::vector<int> NumeroDeVariableDuNombreDeGroupesEnMarcheDuPalierThermique;
@@ -67,6 +65,7 @@ struct CORRESPONDANCES_DES_CONTRAINTES
 
     std::vector<int> NumeroDeContrainteDesBilansPays;
     std::vector<int> NumeroDeContraintePourEviterLesChargesFictives;
+    std::vector<int> NumeroDeContraintePourBornerLaDefaillance;
 
     std::vector<int> NumeroPremiereContrainteDeReserveParZone;
     std::vector<int> NumeroDeuxiemeContrainteDeReserveParZone;

--- a/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
+++ b/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
@@ -179,6 +179,8 @@ void SIM_AllocationProblemePasDeTemps(PROBLEME_HEBDO& problem,
           .NumeroDeContraintePourEviterLesChargesFictives.assign(nbPays, 0);
         problem.CorrespondanceCntNativesCntOptim[k].NumeroDeContrainteDesNiveauxPays.assign(nbPays,
                                                                                             0);
+        problem.CorrespondanceCntNativesCntOptim[k]
+          .NumeroDeContraintePourBornerLaDefaillance.assign(nbPays, 0);
 
         problem.CorrespondanceCntNativesCntOptim[k]
           .ShortTermStorageLevelConstraint.assign(shortTermStorageCount, 0);

--- a/src/study/system-model/component.cpp
+++ b/src/study/system-model/component.cpp
@@ -160,7 +160,9 @@ void Component::addAreaConnection(const std::string& localPortId, std::string ar
 
     checkPortFieldDefinitionExists(localPortId, area_connection->injection, errMsgPrefix);
     checkPortFieldDefinitionExists(localPortId, area_connection->spillage_bound, errMsgPrefix);
-    checkPortFieldDefinitionExists(localPortId, area_connection->unsupplied_energy_bound, errMsgPrefix);
+    checkPortFieldDefinitionExists(localPortId,
+                                   area_connection->unsupplied_energy_bound,
+                                   errMsgPrefix);
 
     if (portToAreaConnections_.contains(localPortId))
     {

--- a/src/study/system-model/component.cpp
+++ b/src/study/system-model/component.cpp
@@ -159,8 +159,10 @@ void Component::addAreaConnection(const std::string& localPortId, std::string ar
     }
 
     checkPortFieldDefinitionExists(localPortId, area_connection->injection, errMsgPrefix);
-    checkPortFieldDefinitionExists(localPortId, area_connection->to_area_bound, errMsgPrefix);
-    checkPortFieldDefinitionExists(localPortId, area_connection->from_area_bound, errMsgPrefix);
+    checkPortFieldDefinitionExists(localPortId, area_connection->spillage_bound, errMsgPrefix);
+    checkPortFieldDefinitionExists(localPortId,
+                                   area_connection->unsupplied_energy_bound,
+                                   errMsgPrefix);
 
     if (portToAreaConnections_.contains(localPortId))
     {

--- a/src/study/system-model/component.cpp
+++ b/src/study/system-model/component.cpp
@@ -159,8 +159,8 @@ void Component::addAreaConnection(const std::string& localPortId, std::string ar
     }
 
     checkPortFieldDefinitionExists(localPortId, area_connection->injection, errMsgPrefix);
-    checkPortFieldDefinitionExists(localPortId, area_connection->to_area_bound, errMsgPrefix);
-    checkPortFieldDefinitionExists(localPortId, area_connection->from_area_bound, errMsgPrefix);
+    checkPortFieldDefinitionExists(localPortId, area_connection->spillage_bound, errMsgPrefix);
+    checkPortFieldDefinitionExists(localPortId, area_connection->unsupplied_energy_bound, errMsgPrefix);
 
     if (portToAreaConnections_.contains(localPortId))
     {

--- a/src/study/system-model/include/antares/study/system-model/portType.h
+++ b/src/study/system-model/include/antares/study/system-model/portType.h
@@ -14,8 +14,8 @@ namespace Antares::ModelerStudy::SystemModel
 struct AreaConnection
 {
     std::string injection;
-    std::string to_area_bound;
-    std::string from_area_bound;
+    std::string spillage_bound;
+    std::string unsupplied_energy_bound;
 };
 
 class PortType final

--- a/src/study/system-model/portType.cpp
+++ b/src/study/system-model/portType.cpp
@@ -10,7 +10,7 @@ namespace Antares::ModelerStudy::SystemModel
 // -----------------
 bool isEmpty(const AreaConnection& ac)
 {
-    return ac.injection.empty() && ac.to_area_bound.empty() && ac.from_area_bound.empty();
+    return ac.injection.empty() && ac.spillage_bound.empty() && ac.unsupplied_energy_bound.empty();
 }
 
 void checkNonEmptyFieldExist(const std::string& field,
@@ -40,8 +40,8 @@ bool operator==(const std::optional<AreaConnection>& a, const std::optional<Area
 
     if (a.has_value())
     {
-        return a->injection == b->injection && a->to_area_bound == b->to_area_bound
-               && a->from_area_bound == b->from_area_bound;
+        return a->injection == b->injection && a->spillage_bound == b->spillage_bound
+               && a->unsupplied_energy_bound == b->unsupplied_energy_bound;
     }
 
     return true; // both are std::nullopt
@@ -59,8 +59,8 @@ PortType::PortType(const std::string& id,
     if (!isEmpty(areaConnection))
     {
         checkNonEmptyFieldExist(areaConnection.injection, fields_, id_);
-        checkNonEmptyFieldExist(areaConnection.to_area_bound, fields_, id_);
-        checkNonEmptyFieldExist(areaConnection.from_area_bound, fields_, id_);
+        checkNonEmptyFieldExist(areaConnection.spillage_bound, fields_, id_);
+        checkNonEmptyFieldExist(areaConnection.unsupplied_energy_bound, fields_, id_);
         areaConnection_ = areaConnection;
     }
 }

--- a/src/tests/src/io/yml-importers/test-system-with-connexions.cpp
+++ b/src/tests/src/io/yml-importers/test-system-with-connexions.cpp
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE(port_type_area_connection_is_read_correctly)
     auto area_connection = portType.areaConnection();
     BOOST_CHECK(area_connection.has_value());
     BOOST_CHECK_EQUAL(area_connection->injection, "flow");
-    BOOST_CHECK(area_connection->to_area_bound.empty());
-    BOOST_CHECK(area_connection->from_area_bound.empty());
+    BOOST_CHECK(area_connection->spillage_bound.empty());
+    BOOST_CHECK(area_connection->unsupplied_energy_bound.empty());
 }
 
 // This yaml lib contains only a port type, but with a more complete area connection.
@@ -69,8 +69,8 @@ library:
         - id: from-area-bound
       area-connection:
         - injection-field: flow
-        - to-area-bound-field: to-area-bound
-        - from-area-bound-field: from-area-bound
+        - spillage-bound: to-area-bound
+        - unsupplied-energy-bound: from-area-bound
 
   models:
     - id: empty model
@@ -95,8 +95,8 @@ BOOST_AUTO_TEST_CASE(port_type_area_connection_is_more_complete_and_is_still_rea
     auto area_connection = portType.areaConnection();
     BOOST_CHECK(area_connection.has_value());
     BOOST_CHECK_EQUAL(area_connection->injection, "flow");
-    BOOST_CHECK_EQUAL(area_connection->to_area_bound, "to-area-bound");
-    BOOST_CHECK_EQUAL(area_connection->from_area_bound, "from-area-bound");
+    BOOST_CHECK_EQUAL(area_connection->spillage_bound, "to-area-bound");
+    BOOST_CHECK_EQUAL(area_connection->unsupplied_energy_bound, "from-area-bound");
 }
 
 static const auto libraryYaml = R"(

--- a/src/tests/src/solver/optimisation/constraints/constraints_builder.cpp
+++ b/src/tests/src/solver/optimisation/constraints/constraints_builder.cpp
@@ -173,6 +173,8 @@ struct ConstraintBuilderFixture: public STScumulativeConstaintFixture,
 {
 };
 
+BOOST_AUTO_TEST_SUITE(_constraint_builder_test_suite_)
+
 BOOST_FIXTURE_TEST_CASE(AddWithdrawalConstraint, ConstraintBuilderFixture)
 {
     ConstraintBuilderData constraint_builder_data = makeConstraintBuilderData();
@@ -714,3 +716,5 @@ BOOST_AUTO_TEST_CASE(TestMultipleStoragesSameArea)
         BOOST_CHECK_CLOSE(problemeAResoudre.SecondMembre[constraint_index], expected_rhs, 0.001);
     }
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
+++ b/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
@@ -220,7 +220,7 @@ BOOST_FIXTURE_TEST_CASE(injecting_spillage_and_unsupplied_energy_bounds, AreaCon
     // Checks
     // ---------
     const auto* var1_t0 = linearProblem.lookupVariable("component_with_vars.var_1_t0");
-    
+
     const auto* fictive_load_ct_t0 = linearProblem.lookupConstraint(fictiveLoadsConstrName);
     BOOST_CHECK_EQUAL(fictive_load_ct_t0->getCoefficient(var1_t0), -2.);
     BOOST_CHECK_EQUAL(fictive_load_ct_t0->getLb(), 0. + 30.);

--- a/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
+++ b/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
@@ -35,8 +35,8 @@ library:
         - id: to-area-bound
         - id: from-area-bound
       area-connection:
-        - to-area-bound-field: to-area-bound
-        - from-area-bound-field: from-area-bound
+        - spillage-bound: to-area-bound
+        - unsupplied-energy-bound: from-area-bound
 
   models:
     - id: model_with_vars

--- a/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
+++ b/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
@@ -169,10 +169,11 @@ void AreaConnectionFixture::addConstraintsToLinearProblem(std::vector<std::strin
     }
 }
 
-BOOST_AUTO_TEST_SUITE(_area_connections___spillage_)
+BOOST_AUTO_TEST_SUITE(_area_connections___injecting_spillage_and_unsupplied_energy_bounds)
 
 BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
 {
+    // ------------------------------------------
     // Linear problem before addition from GEMS
     // ------------------------------------------
     // 1. LP is filled with constraints before GEMS comes into play.
@@ -198,6 +199,7 @@ BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
     problemeHebdo->CorrespondanceCntNativesCntOptim[0]
       .NumeroDeContraintePourBornerLaDefaillance.push_back(3);
 
+    // -------------------------------------------------------
     // Adding GEMS variables and constraints to linear problem
     // -------------------------------------------------------
     // 1. Adding variables (replaces the work of ComponentFiller, but for variables)

--- a/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
+++ b/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
@@ -33,8 +33,10 @@ library:
       description: some port type for area connection
       fields:
         - id: to-area-bound
+        - id: from-area-bound
       area-connection:
         - to-area-bound-field: to-area-bound
+        - from-area-bound-field: from-area-bound
 
   models:
     - id: model_with_vars
@@ -50,6 +52,9 @@ library:
         - port: area_conn_port
           field: to-area-bound
           definition: 2 * var_1
+        - port: area_conn_port
+          field: from-area-bound
+          definition: var_1 / 2
 )"s;
 
 static const auto systemYaml = R"(
@@ -172,17 +177,26 @@ BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
     // ------------------------------------------
     // 1. LP is filled with constraints before GEMS comes into play.
     std::vector<std::string> constraintNames;
+    std::string fictiveLoadsConstrName = "FictiveLoads::area<area1>::hour<0>";
+    std::string maxUnsupEconstrName = "MaxUnsupEnergy::area<area1>::hour<0>";
+
     constraintNames.push_back("dummy constaint");
-    constraintNames.push_back("FictiveLoads::area<area1>::hour<0>");
+    constraintNames.push_back(fictiveLoadsConstrName);
+    constraintNames.push_back("another dummy constaint");
+    constraintNames.push_back(maxUnsupEconstrName);
 
     addNamedConstraintsToLP(constraintNames, 10 /* rhs */);
 
-    // 2. Contraints numbering in linear problem before GEMS commes into play.
+    // 2. Contraints numbering in linear problem before GEMS comes into play.
     problemeHebdo->NomsDesPays.push_back("area1");
     problemeHebdo->CorrespondanceCntNativesCntOptim.push_back({});
-    // In LP, fictive loads constraints are contiguous. The start number for them is 1.
+    // ... In LP, fictive loads constraints are contiguous. 
+    //     The start number for fictive loads is 1.
     problemeHebdo->CorrespondanceCntNativesCntOptim[0]
       .NumeroDeContraintePourEviterLesChargesFictives.push_back(1);
+    // ... The start number for upper-bounding the unsupplied energy is 3.
+    problemeHebdo->CorrespondanceCntNativesCntOptim[0]
+      .NumeroDeContraintePourBornerLaDefaillance.push_back(3);
 
     // Adding GEMS variables and constraints to linear problem
     // -------------------------------------------------------
@@ -198,14 +212,18 @@ BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
     // ---------
     // Checks
     // ---------
-    const auto* fictive_ct_t0 = linearProblem.lookupConstraint(
-      "FictiveLoads::area<area1>::hour<0>");
+    const auto* fictive_load_ct_t0 = linearProblem.lookupConstraint(fictiveLoadsConstrName);
+    const auto* max_unsupE_ct_t0 = linearProblem.lookupConstraint(maxUnsupEconstrName);
+
     const auto* var1_t0 = linearProblem.lookupVariable("component_with_vars.var_1_t0");
 
-    BOOST_CHECK_EQUAL(fictive_ct_t0->getCoefficient(var1_t0), -2.);
+    BOOST_CHECK_EQUAL(fictive_load_ct_t0->getCoefficient(var1_t0), -2.);
+    BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getCoefficient(var1_t0), -0.5);
 
-    auto other_ct = linearProblem.lookupConstraint("dummy constaint");
-    BOOST_CHECK_EQUAL(other_ct->getCoefficient(var1_t0), 0);
+    auto dummy_ct = linearProblem.lookupConstraint("dummy constaint");
+    auto other_dummy_ct = linearProblem.lookupConstraint("dummy constaint");
+    BOOST_CHECK_EQUAL(dummy_ct->getCoefficient(var1_t0), 0);
+    BOOST_CHECK_EQUAL(other_dummy_ct->getCoefficient(var1_t0), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
+++ b/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
@@ -129,7 +129,6 @@ std::unique_ptr<Solver::ModelerData> AreaConnectionFixture::buildModelerSystem()
     auto system = IO::Inputs::SystemConverter::convert(ymlSystem, libraries);
 
     to_return->system = std::make_unique<System>(std::move(system));
-    // std::string id = to_return->system->Id();
     return to_return;
 }
 

--- a/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
+++ b/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
@@ -33,8 +33,10 @@ library:
       description: some port type for area connection
       fields:
         - id: to-area-bound
+        - id: from-area-bound
       area-connection:
-        - to-area-bound-field: to-area-bound
+        - spillage-bound: to-area-bound
+        - unsupplied-energy-bound: from-area-bound
 
   models:
     - id: model_with_vars
@@ -49,7 +51,10 @@ library:
       port-field-definitions:
         - port: area_conn_port
           field: to-area-bound
-          definition: 2 * var_1
+          definition: 2 * var_1 + 30
+        - port: area_conn_port
+          field: from-area-bound
+          definition: var_1 / 2 - 10
 )"s;
 
 static const auto systemYaml = R"(
@@ -74,7 +79,9 @@ struct AreaConnectionFixture
     AreaConnectionFixture();
     std::unique_ptr<Solver::ModelerData> buildModelerSystem();
     void addComponentsVariablesToLP();
-    void addNamedConstraintsToLP(std::vector<std::string>& constraintNames, double rhs);
+    void addNamedConstraintsToLP(std::vector<std::string>& constraintNames,
+                                 const double low_bound,
+                                 const double up_bound);
 
     // public data members :
     // -------------------
@@ -92,7 +99,9 @@ struct AreaConnectionFixture
     std::unique_ptr<OptimEntityContainer> optimContainer;
 
 private:
-    void addConstraintsToLinearProblem(std::vector<std::string>& names, double rhs);
+    void addConstraintsToLinearProblem(std::vector<std::string>& names,
+                                       const double low_bound,
+                                       const double up_bound);
 };
 
 AreaConnectionFixture::AreaConnectionFixture():
@@ -124,7 +133,6 @@ std::unique_ptr<Solver::ModelerData> AreaConnectionFixture::buildModelerSystem()
     auto system = IO::Inputs::SystemConverter::convert(ymlSystem, libraries);
 
     to_return->system = std::make_unique<System>(std::move(system));
-    // std::string id = to_return->system->Id();
     return to_return;
 }
 
@@ -147,43 +155,56 @@ void AreaConnectionFixture::addComponentsVariablesToLP()
 }
 
 void AreaConnectionFixture::addNamedConstraintsToLP(std::vector<std::string>& constraintNames,
-                                                    double rhs)
+                                                    const double low_bound,
+                                                    const double up_bound)
 {
     problemeHebdo->ProblemeAResoudre->NomDesContraintes = constraintNames;
     problemeHebdo->ProblemeAResoudre->NombreDeContraintes = constraintNames.size();
 
-    addConstraintsToLinearProblem(constraintNames, rhs);
+    addConstraintsToLinearProblem(constraintNames, low_bound, up_bound);
 }
 
 void AreaConnectionFixture::addConstraintsToLinearProblem(std::vector<std::string>& names,
-                                                          double rhs)
+                                                          const double low_bound,
+                                                          const double up_bound)
 {
     for (const auto& name: names)
     {
-        linearProblem.addConstraint(rhs, rhs, name);
+        linearProblem.addConstraint(low_bound, up_bound, name);
     }
 }
 
-BOOST_AUTO_TEST_SUITE(_area_connections___spillage_)
+BOOST_AUTO_TEST_SUITE(_area_connections___injecting_spillage_and_unsupplied_energy_bounds)
 
-BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
+BOOST_FIXTURE_TEST_CASE(injecting_spillage_and_unsupplied_energy_bounds, AreaConnectionFixture)
 {
+    // ------------------------------------------
     // Linear problem before addition from GEMS
     // ------------------------------------------
     // 1. LP is filled with constraints before GEMS comes into play.
     std::vector<std::string> constraintNames;
+    std::string fictiveLoadsConstrName = "FictiveLoads::area<area1>::hour<0>";
+    std::string maxUnsupEconstrName = "MaxUnsupEnergy::area<area1>::hour<0>";
+
     constraintNames.push_back("dummy constaint");
-    constraintNames.push_back("FictiveLoads::area<area1>::hour<0>");
+    constraintNames.push_back(fictiveLoadsConstrName);
+    constraintNames.push_back("another dummy constaint");
+    constraintNames.push_back(maxUnsupEconstrName);
 
-    addNamedConstraintsToLP(constraintNames, 10 /* rhs */);
+    addNamedConstraintsToLP(constraintNames, 0. /* low rhs */, 50. /* up rhs */);
 
-    // 2. Contraints numbering in linear problem before GEMS commes into play.
+    // 2. Contraints numbering in linear problem before GEMS comes into play.
     problemeHebdo->NomsDesPays.push_back("area1");
     problemeHebdo->CorrespondanceCntNativesCntOptim.push_back({});
-    // In LP, fictive loads constraints are contiguous. The start number for them is 1.
+    // ... In LP, fictive loads constraints are contiguous.
+    //     The start number for fictive loads is 1.
     problemeHebdo->CorrespondanceCntNativesCntOptim[0]
       .NumeroDeContraintePourEviterLesChargesFictives.push_back(1);
+    // ... The start number for upper-bounding the unsupplied energy is 3.
+    problemeHebdo->CorrespondanceCntNativesCntOptim[0]
+      .NumeroDeContraintePourBornerLaDefaillance.push_back(3);
 
+    // -------------------------------------------------------
     // Adding GEMS variables and constraints to linear problem
     // -------------------------------------------------------
     // 1. Adding variables (replaces the work of ComponentFiller, but for variables)
@@ -198,14 +219,22 @@ BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
     // ---------
     // Checks
     // ---------
-    const auto* fictive_ct_t0 = linearProblem.lookupConstraint(
-      "FictiveLoads::area<area1>::hour<0>");
     const auto* var1_t0 = linearProblem.lookupVariable("component_with_vars.var_1_t0");
 
-    BOOST_CHECK_EQUAL(fictive_ct_t0->getCoefficient(var1_t0), -2.);
+    const auto* fictive_load_ct_t0 = linearProblem.lookupConstraint(fictiveLoadsConstrName);
+    BOOST_CHECK_EQUAL(fictive_load_ct_t0->getCoefficient(var1_t0), -2.);
+    BOOST_CHECK_EQUAL(fictive_load_ct_t0->getLb(), 0. + 30.);
+    BOOST_CHECK_EQUAL(fictive_load_ct_t0->getUb(), 50. + 30.);
 
-    auto other_ct = linearProblem.lookupConstraint("dummy constaint");
-    BOOST_CHECK_EQUAL(other_ct->getCoefficient(var1_t0), 0);
+    const auto* max_unsupE_ct_t0 = linearProblem.lookupConstraint(maxUnsupEconstrName);
+    BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getCoefficient(var1_t0), -0.5);
+    BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getLb(), 0. - 10.);
+    BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getUb(), 50. - 10.);
+
+    auto dummy_ct = linearProblem.lookupConstraint("dummy constaint");
+    auto other_dummy_ct = linearProblem.lookupConstraint("dummy constaint");
+    BOOST_CHECK_EQUAL(dummy_ct->getCoefficient(var1_t0), 0);
+    BOOST_CHECK_EQUAL(other_dummy_ct->getCoefficient(var1_t0), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
+++ b/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
@@ -51,10 +51,10 @@ library:
       port-field-definitions:
         - port: area_conn_port
           field: to-area-bound
-          definition: 2 * var_1
+          definition: 2 * var_1 + 30
         - port: area_conn_port
           field: from-area-bound
-          definition: var_1 / 2
+          definition: var_1 / 2 - 10
 )"s;
 
 static const auto systemYaml = R"(
@@ -79,7 +79,9 @@ struct AreaConnectionFixture
     AreaConnectionFixture();
     std::unique_ptr<Solver::ModelerData> buildModelerSystem();
     void addComponentsVariablesToLP();
-    void addNamedConstraintsToLP(std::vector<std::string>& constraintNames, double rhs);
+    void addNamedConstraintsToLP(std::vector<std::string>& constraintNames,
+                                 const double low_bound,
+                                 const double up_bound);
 
     // public data members :
     // -------------------
@@ -97,7 +99,9 @@ struct AreaConnectionFixture
     std::unique_ptr<OptimEntityContainer> optimContainer;
 
 private:
-    void addConstraintsToLinearProblem(std::vector<std::string>& names, double rhs);
+    void addConstraintsToLinearProblem(std::vector<std::string>& names,
+                                       const double low_bound,
+                                       const double up_bound);
 };
 
 AreaConnectionFixture::AreaConnectionFixture():
@@ -151,26 +155,28 @@ void AreaConnectionFixture::addComponentsVariablesToLP()
 }
 
 void AreaConnectionFixture::addNamedConstraintsToLP(std::vector<std::string>& constraintNames,
-                                                    double rhs)
+                                                    const double low_bound,
+                                                    const double up_bound)
 {
     problemeHebdo->ProblemeAResoudre->NomDesContraintes = constraintNames;
     problemeHebdo->ProblemeAResoudre->NombreDeContraintes = constraintNames.size();
 
-    addConstraintsToLinearProblem(constraintNames, rhs);
+    addConstraintsToLinearProblem(constraintNames, low_bound, up_bound);
 }
 
 void AreaConnectionFixture::addConstraintsToLinearProblem(std::vector<std::string>& names,
-                                                          double rhs)
+                                                          const double low_bound,
+                                                          const double up_bound)
 {
     for (const auto& name: names)
     {
-        linearProblem.addConstraint(rhs, rhs, name);
+        linearProblem.addConstraint(low_bound, up_bound, name);
     }
 }
 
 BOOST_AUTO_TEST_SUITE(_area_connections___injecting_spillage_and_unsupplied_energy_bounds)
 
-BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
+BOOST_FIXTURE_TEST_CASE(injecting_spillage_and_unsupplied_energy_bounds, AreaConnectionFixture)
 {
     // ------------------------------------------
     // Linear problem before addition from GEMS
@@ -185,12 +191,12 @@ BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
     constraintNames.push_back("another dummy constaint");
     constraintNames.push_back(maxUnsupEconstrName);
 
-    addNamedConstraintsToLP(constraintNames, 10 /* rhs */);
+    addNamedConstraintsToLP(constraintNames, 0. /* low rhs */, 50. /* up rhs */);
 
     // 2. Contraints numbering in linear problem before GEMS comes into play.
     problemeHebdo->NomsDesPays.push_back("area1");
     problemeHebdo->CorrespondanceCntNativesCntOptim.push_back({});
-    // ... In LP, fictive loads constraints are contiguous. 
+    // ... In LP, fictive loads constraints are contiguous.
     //     The start number for fictive loads is 1.
     problemeHebdo->CorrespondanceCntNativesCntOptim[0]
       .NumeroDeContraintePourEviterLesChargesFictives.push_back(1);
@@ -213,13 +219,17 @@ BOOST_FIXTURE_TEST_CASE(dummy_test, AreaConnectionFixture)
     // ---------
     // Checks
     // ---------
-    const auto* fictive_load_ct_t0 = linearProblem.lookupConstraint(fictiveLoadsConstrName);
-    const auto* max_unsupE_ct_t0 = linearProblem.lookupConstraint(maxUnsupEconstrName);
-
     const auto* var1_t0 = linearProblem.lookupVariable("component_with_vars.var_1_t0");
-
+    
+    const auto* fictive_load_ct_t0 = linearProblem.lookupConstraint(fictiveLoadsConstrName);
     BOOST_CHECK_EQUAL(fictive_load_ct_t0->getCoefficient(var1_t0), -2.);
+    BOOST_CHECK_EQUAL(fictive_load_ct_t0->getLb(), 0. + 30.);
+    BOOST_CHECK_EQUAL(fictive_load_ct_t0->getUb(), 50. + 30.);
+
+    const auto* max_unsupE_ct_t0 = linearProblem.lookupConstraint(maxUnsupEconstrName);
     BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getCoefficient(var1_t0), -0.5);
+    BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getLb(), 0. - 10.);
+    BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getUb(), 50. - 10.);
 
     auto dummy_ct = linearProblem.lookupConstraint("dummy constaint");
     auto other_dummy_ct = linearProblem.lookupConstraint("dummy constaint");

--- a/src/tests/src/study/system-model/test_library.cpp
+++ b/src/tests/src/study/system-model/test_library.cpp
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(port_type_with_area_connection_having_all_fields_defined)
 
     AreaConnection areaConnection = portType.areaConnection().value();
     BOOST_CHECK_EQUAL(areaConnection.injection, "field-3");
-    BOOST_CHECK_EQUAL(areaConnection.to_area_bound, "field-2");
-    BOOST_CHECK_EQUAL(areaConnection.from_area_bound, "field-1");
+    BOOST_CHECK_EQUAL(areaConnection.spillage_bound, "field-2");
+    BOOST_CHECK_EQUAL(areaConnection.unsupplied_energy_bound, "field-1");
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This work is about **part 2** of ticket [ANT-4033](https://gopro-tickets.rte-france.com/browse/ANT-4033).
This work follows [this part 1 PR](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/3355).
See [PR part 1](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/3355) for an overview of the 3 parts.

This PR is about adding a new constraint to set an upper bound for **unsupplied energy** variable.
**Why ?** 
In optimization, variable bounds remain constant, and cannot be impacted by other variables value.
Make a new constraint like `myVar < someConstant` replaces an upper bound for **myVar** and then allows to make other variables to come into play when limiting **myVar**, like in :  `myVar < someConstant + otherVar` (can also be written  `myVar - otherVar < someConstant`)
 