### PR TITLE
Add robustness for MPS API export, minor fixes

### DIFF
--- a/src/api/main.cpp
+++ b/src/api/main.cpp
@@ -100,8 +100,7 @@ void writeWeekMPS(const std::unique_ptr<Optimisation::LinearProblemApi::ILinearP
     // logs.info() << "******************************** END MPS ********************************";
     if (!outputPath.empty())
     {
-        static std::once_flag once;
-        std::call_once(once, [&outputPath] { std::filesystem::create_directories(outputPath); });
+        std::filesystem::create_directories(outputPath);
         IO::Outputs::MPSFileWriter::write(outputPath / (name + ".mps"), mps);
     }
 }
@@ -117,8 +116,7 @@ void writeMasterAndStructure(ModelerData* data, const std::filesystem::path& out
 
     if (!outputDir.empty())
     {
-        static std::once_flag once;
-        std::call_once(once, [&outputDir] { std::filesystem::create_directories(outputDir); });
+        std::filesystem::create_directories(outputDir);
     }
 
     FillContext fillContext = {0, 167, 0, 167, 0};

--- a/src/modeler/modeler/Modeler.cpp
+++ b/src/modeler/modeler/Modeler.cpp
@@ -4,6 +4,7 @@
 #include "antares/solver/modeler/Modeler.h"
 
 #include <fstream>
+#include <stdexcept>
 
 #include <antares/logs/logs.h>
 #include <antares/optimisation/linear-problem-api/StructuredLinearProblem.h>
@@ -123,6 +124,11 @@ std::unique_ptr<ILinearProblem> getProblem(bool isMip,
 {
     if (resolutionMode == ResolutionMode::SEQUENTIAL_SUBPROBLEMS)
     {
+        if (!solver)
+        {
+            throw std::invalid_argument(
+              "Please provide a solver for sequential subproblem resolution");
+        }
         return std::make_unique<OrtoolsLinearProblem>(isMip, solver.value());
     }
     return std::make_unique<StructuredLinearProblem>();

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/StructuredLinearProblem.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/StructuredLinearProblem.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <limits>
 
 #include <antares/optimisation/linear-problem-api/linearProblem.h>
 #include <antares/optimisation/linear-problem-api/mipConstraint.h>

--- a/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/StructuredLinearProblem.h
+++ b/src/optimisation/linear-problem-api/include/antares/optimisation/linear-problem-api/StructuredLinearProblem.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
-#include <limits>
 
 #include <antares/optimisation/linear-problem-api/linearProblem.h>
 #include <antares/optimisation/linear-problem-api/mipConstraint.h>

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -165,9 +165,9 @@ static SimplexResult OPT_TryToCallSimplex(const SingleOptimOptions& options,
     const ILinearProblemData* modelerDataSeries = hasModelerData ? modelerData->dataSeries.get()
                                                                  : nullptr;
     const ScenarioGroupRepository* modelerScenarioGroupRepository = hasModelerData
-                                                                       ? &modelerData
-                                                                            ->scenarioGroupRepository
-                                                                       : nullptr;
+                                                                      ? &modelerData
+                                                                           ->scenarioGroupRepository
+                                                                      : nullptr;
 
     OptimEntityContainer optimEntityContainer(ortoolsProblem,
                                               modelerDataSeries,
@@ -344,11 +344,7 @@ bool OPT_AppelDuSimplexe(const SingleOptimOptions& options,
                                                                           ->bendersDecomposition
                                                                      : nullptr;
 
-        fillLinearProblem(fillCtx,
-                          problemeHebdo,
-                          optimEntityContainer,
-                          true,
-                          bendersDecomposition);
+        fillLinearProblem(fillCtx, problemeHebdo, optimEntityContainer, true, bendersDecomposition);
         auto MPproblem = infeasibleProblem.getMpSolver();
         auto analyzer = makeUnfeasiblePbAnalyzer();
         analyzer->run(MPproblem.get());

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -165,19 +165,24 @@ static SimplexResult OPT_TryToCallSimplex(const SingleOptimOptions& options,
     const ILinearProblemData* modelerDataSeries = hasModelerData ? modelerData->dataSeries.get()
                                                                  : nullptr;
     const ScenarioGroupRepository* modelerScenarioGroupRepository = hasModelerData
-                                                                      ? &modelerData
-                                                                           ->scenarioGroupRepository
-                                                                      : nullptr;
+                                                                       ? &modelerData
+                                                                            ->scenarioGroupRepository
+                                                                       : nullptr;
 
     OptimEntityContainer optimEntityContainer(ortoolsProblem,
                                               modelerDataSeries,
                                               modelerScenarioGroupRepository);
 
+    Optimisation::BendersDecomposition* bendersDecomposition = hasModelerData
+                                                                 ? &modelerData
+                                                                      ->bendersDecomposition
+                                                                 : nullptr;
+
     fillLinearProblem(fillCtx,
                       problemeHebdo,
                       optimEntityContainer,
                       problemeHebdo->NamedProblems,
-                      &problemeHebdo->modelerData->bendersDecomposition);
+                      bendersDecomposition);
     auto solver = ortoolsProblem.getMpSolver();
     ProblemeAResoudre->ProblemesSpx[NumIntervalle] = solver;
 
@@ -334,11 +339,16 @@ bool OPT_AppelDuSimplexe(const SingleOptimOptions& options,
         OptimEntityContainer optimEntityContainer(infeasibleProblem,
                                                   modelerDataSeries,
                                                   modelerScenarioGroupRepository);
+        Optimisation::BendersDecomposition* bendersDecomposition = hasModelerData
+                                                                     ? &modelerData
+                                                                          ->bendersDecomposition
+                                                                     : nullptr;
+
         fillLinearProblem(fillCtx,
                           problemeHebdo,
                           optimEntityContainer,
                           true,
-                          &problemeHebdo->modelerData->bendersDecomposition);
+                          bendersDecomposition);
         auto MPproblem = infeasibleProblem.getMpSolver();
         auto analyzer = makeUnfeasiblePbAnalyzer();
         analyzer->run(MPproblem.get());


### PR DESCRIPTION
- Sometimes `modelerData` can be `nullptr`
- `std::filesystem::create_directory` does not return an error if the directory already exists