### PR TITLE
APIv2 - Fix wrong size for TS numbers

### DIFF
--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -64,6 +64,8 @@ SingleProblemGetter::SingleProblemGetter(std::unique_ptr<Antares::Data::Study>&&
 
     study_->computePThetaInfForThermalClusters(); // PthetaInf
 
+    study_->resizeAllTimeseriesNumbers(1 + study_->runtime.rangeLimits.year[Data::rangeEnd]);
+
     // TODO duplication
     if (!pb_.LeProblemeADejaEteInstancie)
     {

--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -64,8 +64,6 @@ SingleProblemGetter::SingleProblemGetter(std::unique_ptr<Antares::Data::Study>&&
 
     study_->computePThetaInfForThermalClusters(); // PthetaInf
 
-    study_->resizeAllTimeseriesNumbers(1 + study_->runtime.rangeLimits.year[Data::rangeEnd]);
-
     // TODO duplication
     if (!pb_.LeProblemeADejaEteInstancie)
     {

--- a/src/libs/antares/writer/immediate_file_writer.cpp
+++ b/src/libs/antares/writer/immediate_file_writer.cpp
@@ -63,12 +63,12 @@ void ImmediateFileResultWriter::addEntryFromFile(const fs::path& entryPath,
     }
     catch (const fs::filesystem_error& exc)
     {
-        logs.error() << exc.what();
+        logs.error() << "Error writing " << filePath << " (exception message " << exc.what() << ")";
     }
 
     if (ec)
     {
-        logs.error() << "Error: " << ec.message();
+        logs.error() << "Error writing " << filePath << " (message " << ec.message() << ")";
     }
 }
 

--- a/src/tests/src/api_lib/test_single_problem_api.cpp
+++ b/src/tests/src/api_lib/test_single_problem_api.cpp
@@ -74,6 +74,9 @@ std::unique_ptr<Study> buildStudy(bool thermal, bool hydro)
     // more specifically, this resize is usually done when loading from files. It's all good, except
     // when you DON'T LOAD FILES.
     area->hydro.deltaBetweenFinalAndInitialLevels.resize(builder.study->parameters.nbYears);
+    builder.study->resizeAllTimeseriesNumbers(
+      1 + builder.study->runtime.rangeLimits.year[Antares::Data::rangeEnd]);
+
     return std::move(builder.study);
 }
 BOOST_AUTO_TEST_SUITE(in_memory_check_problem_contents)


### PR DESCRIPTION
~~This bug was found out when releasing 9.4.0-rc1. New rule curves impose reading TS numbers. It seems none of these were properly initialized~~

### There are 2 cases
- Study loaded from files. `FileTreeStudyLoader` is used and initialized TS numbers properly. We **must not** reset TS numbers
- Study built in memory. TS not initialized, must be initialized **only in this case**