### PR TITLE
Remove `JIT::usedFromGUI`

### DIFF
--- a/src/libs/antares/correlation/correlation.cpp
+++ b/src/libs/antares/correlation/correlation.cpp
@@ -400,7 +400,7 @@ bool Correlation::internalLoadFromINITry(Study& study, const IniFile& ini, bool 
         return false;
     }
 
-    if (JIT::usedFromGUI or pMode == modeAnnual)
+    if (pMode == modeAnnual)
     {
         annual.clear();
         annual.resize(study.areas.size(), study.areas.size());
@@ -413,7 +413,7 @@ bool Correlation::internalLoadFromINITry(Study& study, const IniFile& ini, bool 
         }
     }
 
-    if (JIT::usedFromGUI or pMode == modeMonthly)
+    if (pMode == modeMonthly)
     {
         monthly.resize(12);
         for (uint i = 0; i < 12; ++i)
@@ -452,27 +452,9 @@ void Correlation::reset(Study& study)
     clear();
 
     pMode = modeAnnual;
-    if (JIT::usedFromGUI)
-    {
-        // Reset
-        annual.clear();
-        annual.resize(study.areas.size(), study.areas.size());
-        annual.fillUnit();
-
-        // Preparing the monthly correlation matrices
-        monthly.resize(12);
-        for (int i = 0; i < 12; ++i)
-        {
-            monthly[i].resize(study.areas.size(), study.areas.size());
-            monthly[i].fillUnit();
-        }
-    }
-    else
-    {
-        annual.clear();
-        annual.resize(study.areas.size(), study.areas.size());
-        annual.fillUnit();
-    }
+    annual.clear();
+    annual.resize(study.areas.size(), study.areas.size());
+    annual.fillUnit();
 }
 
 void Correlation::clear()
@@ -489,17 +471,6 @@ bool Correlation::internalLoadFromINI(Study& study, const IniFile& ini, bool war
     {
         // The loading has failed - fallback
         pMode = modeAnnual;
-        if (JIT::usedFromGUI)
-        {
-            // Preparing the monthly correlation matrices
-            monthly.resize(12);
-            for (int i = 0; i < 12; ++i)
-            {
-                monthly[i].resize(study.areas.size(), study.areas.size());
-                monthly[i].fillUnit();
-            }
-        }
-
         annual.clear();
         annual.resize(study.areas.size(), study.areas.size());
         annual.fillUnit();

--- a/src/libs/antares/jit/include/antares/jit/jit.h
+++ b/src/libs/antares/jit/include/antares/jit/jit.h
@@ -161,11 +161,6 @@ public:
     */
     static bool enabled;
 
-    /*!
-    ** \brief Flag to know if the library is called from the User interface
-    */
-    static bool usedFromGUI;
-
 }; // class JIT
 
 #include "jit.hxx"

--- a/src/libs/antares/jit/jit.cpp
+++ b/src/libs/antares/jit/jit.cpp
@@ -9,8 +9,6 @@
 
 bool JIT::enabled = false;
 
-bool JIT::usedFromGUI = false;
-
 JIT::Informations::Informations():
     alreadyLoaded(false),
     modified(false),

--- a/src/libs/antares/study/xcast/xcast.cpp
+++ b/src/libs/antares/study/xcast/xcast.cpp
@@ -265,22 +265,20 @@ bool XCast::loadFromFolder(const fs::path& folder)
     p = folder / "translation.txt";
 
     ret = translation.loadFromCSVFile(p.string(), 1, HOURS_PER_YEAR, opts, &readBuffer) && ret;
-    if (!JIT::usedFromGUI)
+
+    if (translation.empty())
     {
-        if (translation.empty())
+        // This is not really an error
+        useTranslation = tsTranslationNone;
+        translation.reset(1, HOURS_PER_YEAR);
+    }
+    else
+    {
+        if (translation.width != 1 || translation.height != HOURS_PER_YEAR)
         {
-            // This is not really an error
+            logs.warning() << folder << ": invalid size for the time-series translation.";
+            translation.resizeWithoutDataLost(1, HOURS_PER_YEAR);
             useTranslation = tsTranslationNone;
-            translation.reset(1, HOURS_PER_YEAR);
-        }
-        else
-        {
-            if (translation.width != 1 || translation.height != HOURS_PER_YEAR)
-            {
-                logs.warning() << folder << ": invalid size for the time-series translation.";
-                translation.resizeWithoutDataLost(1, HOURS_PER_YEAR);
-                useTranslation = tsTranslationNone;
-            }
         }
     }
 


### PR DESCRIPTION
Assume that
```cpp
bool JIT::usedFromGUI = false;
```
and remove all instances of it.