### PR TITLE
chore: better handle testNR

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -180,9 +180,17 @@ jobs:
       run: |
         echo "SIMTEST=${{ fromJson(env.SIMTEST_JSON).version }}" >> $GITHUB_ENV
 
-    - name: Init submodule Antares_Simulator_Tests_NR
+    # Get latest Test NR
+    - name: Init submodule Antares_Simulator_Tests_NR on top of main
+      if: ${{ env.IS_RELEASE == 'false' }}
       run: |
         git submodule update --init --remote --recursive src/tests/resources/Antares_Simulator_Tests_NR
+
+    # Get test NR of submodule commit for reproductibility
+    - name: Init submodule Antares_Simulator_Tests_NR at submodule commit
+      if: ${{ env.IS_RELEASE == 'true' }}
+      run: |
+        git submodule update --init --depth 1 -- src/tests/resources/Antares_Simulator_Tests_NR
 
     - name: Run named mps tests
       if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -184,9 +184,17 @@ jobs:
       run: |
         echo "SIMTEST=${{ fromJson(env.SIMTEST_JSON).version }}" >> $GITHUB_ENV
 
-    - name: Init submodule Antares_Simulator_Tests_NR
+    # Get latest Test NR
+    - name: Init submodule Antares_Simulator_Tests_NR on top of main
+      if: ${{ env.IS_RELEASE == 'false' }}
       run: |
-        git submodule update --init --remote src/tests/resources/Antares_Simulator_Tests_NR
+        git submodule update --init --remote --recursive src/tests/resources/Antares_Simulator_Tests_NR
+
+    # Get test NR of submodule commit for reproductibility
+    - name: Init submodule Antares_Simulator_Tests_NR at submodule commit
+      if: ${{ env.IS_RELEASE == 'true' }}
+      run: |
+        git submodule update --init --depth 1 -- src/tests/resources/Antares_Simulator_Tests_NR
 
     - name: Run named mps tests
       if: ${{ env.RUN_SIMPLE_TESTS == 'true' && ! cancelled() }}

--- a/docs/Architecture_Decision_Records/2025-03-02-submodule-version-pinning.md
+++ b/docs/Architecture_Decision_Records/2025-03-02-submodule-version-pinning.md
@@ -1,0 +1,141 @@
+# ADR: Management of Antares_Simulator_Tests_NR submodule version during releases
+
+## Status
+
+Accepted
+
+## Date
+
+2025-03-02
+
+## Context
+
+The repository uses a Git submodule at `src/tests/resources/Antares_Simulator_Tests_NR` which contains test data used by
+CI workflows.
+Historically some workflows used `git submodule update --init --remote` which follows the remote branch and therefore
+may
+pull a newer submodule head than the commit recorded in the superproject. This can lead to non-reproducible CI runs and
+unexpected test differences between releases.
+
+### Problem
+
+If a release (for example v10.0) is created when the superproject records the submodule at commit `abc123`, but the
+submodule remote later advances to `def456`, then running a workflow that uses `--remote` may fetch `def456` instead of
+`abc123`. Re-running or re-building a release may therefore use different test inputs and yield different results.
+
+## Decision
+
+We adopt a clear, two-case policy for how the `Antares_Simulator_Tests_NR` submodule is initialized in CI workflows:
+
+Policy
+------
+
+- Release builds (tagged releases, explicit release workflow runs): use the commit SHA recorded in the superproject
+  (the pinned commit). This guarantees reproducibility for releases.
+- Non-release builds (development branches such as `develop`, `feature/*`, CI runs outside release context): use the
+  top of the `main` branch of the submodule (the latest tests on `origin/main`). This provides test teams quick access
+  to the latest test data during development.
+
+This policy strikes a balance: releases stay reproducible and traceable, while developers get fresh test data during
+active development.
+
+### How to detect a release in workflows
+
+Workflows should consider a run to be a release when at least one of the following is true:
+
+- the workflow is triggered on a tag (GITHUB_REF like `refs/tags/*`),
+- the workflow event name is `release`,
+- the workflow is called by the repository's explicit release workflow and receives an input `is_release: true`.
+
+Workflows should treat other runs as development runs and checkout the top of `origin/main` in the submodule.
+
+Implementation
+--------------
+Replace any use of `--remote` and enforce the two-case logic. Recommended pattern (bash) for a workflow step:
+
+```bash
+set -euo pipefail
+SUBMODULE_PATH=src/tests/resources/Antares_Simulator_Tests_NR
+
+# Initialize shallow by default (fast)
+git submodule update --init --depth 1 -- "$SUBMODULE_PATH" || true
+
+# Decision: release vs development
+# prefer an explicit workflow input `is_release` when available
+IS_RELEASE_INPUT=${{ inputs.is_release || 'false' }}
+if [ "${IS_RELEASE_INPUT}" = "true" ] || [[ "$GITHUB_REF" == refs/tags/* ]] || [[ "$GITHUB_EVENT_NAME" == release ]]; then
+  # Release: pin to the commit recorded in the superproject
+  RECORDED_SHA=$(git ls-tree HEAD "$SUBMODULE_PATH" | awk '{print $3}')
+  pushd "$SUBMODULE_PATH"
+  if ! git rev-parse --verify "$RECORDED_SHA" >/dev/null 2>&1; then
+    # If shallow clone doesn't have the object, fetch full history
+    git fetch --unshallow || git fetch --all --tags --prune
+  fi
+  git checkout "$RECORDED_SHA"
+  popd
+else
+  # Development: use the latest main from the submodule remote
+  pushd "$SUBMODULE_PATH"
+  git fetch origin main --depth=1 || git fetch --all --tags --prune
+  if git show-ref --verify --quiet refs/remotes/origin/main; then
+    git checkout origin/main
+  elif git show-ref --verify --quiet refs/heads/main; then
+    git checkout main
+  elif git show-ref --verify --quiet refs/heads/master; then
+    git checkout master
+  fi
+  popd
+fi
+```
+
+Notes:
+
+- When `is_release` is available as a workflow input (for reusable workflows invoked by the release orchestration), it
+  should be honored.
+- The shallow `--depth 1` clone is a performance optimization; if the pinned commit is missing from the shallow clone,
+  a full fetch is attempted as a fallback.
+
+## Consequences
+
+### Positive
+
+- Reproducibility for releases: release builds use the exact submodule commit recorded in the superproject.
+- Fresh test data for development: developers and CI on non-release branches get the latest tests from `origin/main`.
+- Traceability: release runs and artifacts can be traced back to exact submodule SHAs.
+
+### Negative / trade-offs
+
+- Developers get different test data between development and release contexts; this is intentional but should be
+  documented so expectations are clear.
+- If the submodule history is rewritten upstream and a recorded commit is removed, the release checkout will fail. The
+  mitigation is to avoid force-pushes on the submodule's important branches and to pin releases to tags when possible.
+
+## Procedure to update the submodule (maintainer action)
+
+When you want a release (or a branch) to include a newer version of the tests, update the submodule HEAD in the
+superproject and commit the change before tagging/releasing:
+
+```bash
+cd src/tests/resources/Antares_Simulator_Tests_NR
+git fetch origin
+git checkout origin/main   # or git checkout vX.Y.Z to pin a tag
+cd ../../../..
+
+# Record the new submodule state in the superproject
+git add src/tests/resources/Antares_Simulator_Tests_NR
+git commit -m "chore(tests): update Antares_Simulator_Tests_NR to <ref>"
+```
+
+For release preparation, ensure the superproject commit that you tag contains the expected submodule SHA.
+
+## Alternatives considered
+
+- Continue using `--remote`: rejected because it breaks reproducibility for releases.
+- Always pin to the recorded commit (never use origin/main): rejected because developers lose easy access to the
+  latest tests during development; the chosen two-case policy keeps development convenient.
+- Publish test data as external artifact: valid long-term approach but requires infrastructure and convention changes.
+
+## References
+
+- Git Submodules Documentation: https://git-scm.com/book/en/v2/Git-Tools-Submodules
+- Original issue: divergence of versions between consecutive releases


### PR DESCRIPTION
This pull request introduces a clear policy for managing the version of the `Antares_Simulator_Tests_NR` submodule in CI workflows, ensuring reproducibility for releases while providing developers with up-to-date test data during development. The workflows for both Ubuntu and Windows now initialize the submodule differently based on whether the run is a release or a development build. Additionally, an Architecture Decision Record (ADR) documents this strategy for future maintainers.

**Submodule management improvements:**

* CI workflows (`.github/workflows/ubuntu.yml` and `.github/workflows/windows-vcpkg.yml`) now initialize the `Antares_Simulator_Tests_NR` submodule to the recorded commit for release builds, and to the latest `main` branch for development builds, ensuring reproducibility and developer convenience. [[1]](diffhunk://#diff-6640e8c668a6deeb426558faaa2b0f535d95814c09a05c044a1df27a008dd544L183-R194) [[2]](diffhunk://#diff-8e86046c750ae789851a44583d756b322d7908feaafb4776eb93ac4e331d1d13L187-R197)
* The submodule pointer in `src/tests/resources/Antares_Simulator_Tests_NR` has been updated to a new commit, reflecting the latest test data.

**Documentation:**

* Added a comprehensive ADR (`docs/Architecture_Decision_Records/2025-03-02-submodule-version-pinning.md`) describing the rationale, implementation details, and consequences of the new submodule management policy.