### PR TITLE
Fix digest [ANT-4630]

### DIFF
--- a/src/solver/variable/include/antares/solver/variable/variable.hxx
+++ b/src/solver/variable/include/antares/solver/variable/variable.hxx
@@ -320,12 +320,6 @@ inline void IVariable<ChildT, NextT, VCardT>::buildDigest(SurveyResults& results
             || VCardType::categoryDataLevel & Category::DataLevel::area
             || VCardType::categoryDataLevel & Category::DataLevel::link))
     {
-        // Skip STS by-cluster variables (categoryFileLevel = de_sts only) from digest
-        if (VCardType::categoryFileLevel == Category::FileLevel::de_sts)
-        {
-            return;
-        }
-
         // Initializing pointer on variable non applicable and print stati arrays to beginning
         results.isPrinted = isPrinted;
         results.isCurrentVarNA = isNonApplicable;


### PR DESCRIPTION
The return condition would cause the digest generation to stop after encountering STS var, thus the missing variables.