### PR TITLE
fix(ci): sonar cloud scan

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -240,6 +240,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       with:
+        scannerVersion: 7.3.0.5189 #8.0.1.6346 hangs
         args: >
           --define sonar.host.url=${{ env.SONAR_SERVER_URL }} --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
 


### PR DESCRIPTION
Version 8.0.1.6346 hangs indefinitely after "Load/download plugins"
Setting the scanner to a prior version