### PR TITLE
fix(ci): free disk before SonarCloud scan

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,7 +20,7 @@ jobs:
       ORTOOLS_DIR: ${{ github.workspace }}/or-tools
       # Caching strategy of VCPKG dependencies
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
-      BUILD_WRAPPER_OUT_DIR: ${{ github.workspace }}/_build/output # Directory where build-wrapper output will be placed
+      BUILD_WRAPPER_OUT_DIR: ${{ github.workspace }}/sonar-build-wrapper # Directory where build-wrapper output will be placed
       #config in env to be accessible at each step
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_COMPILERCHECK: content
@@ -232,6 +232,15 @@ jobs:
       if: ${{ !cancelled() }}
       run: |
         gcovr --sonarqube --output coverage.xml
+
+    - name: Cleanup disk space before SonarQube Scan
+      if: ${{ !cancelled() }}
+      run: |
+        df -h
+        du -sh "$GITHUB_WORKSPACE/_build" || true
+        du -sh "${{ env.BUILD_WRAPPER_OUT_DIR }}" || true
+        rm -rf "$GITHUB_WORKSPACE/_build"
+        df -h
 
     - name: SonarQube Scan
       if: ${{ !cancelled() }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,7 +38,6 @@ jobs:
       uses: easimon/maximize-build-space@v10
       with:
         root-reserve-mb: 5120
-        temp-reserve-mb: 8192
         swap-size-mb: 1024
         remove-dotnet: true
         remove-android: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,6 +21,10 @@ jobs:
       # Caching strategy of VCPKG dependencies
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
       BUILD_WRAPPER_OUT_DIR: ${{ github.workspace }}/sonar-build-wrapper # Directory where build-wrapper output will be placed
+      SONAR_USER_HOME: ${{ github.workspace }}/.sonar
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
+      TMPDIR: ${{ github.workspace }}/tmp
+      SONAR_SCANNER_JAVA_OPTS: -Djava.io.tmpdir=${{ github.workspace }}/tmp
       #config in env to be accessible at each step
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_COMPILERCHECK: content
@@ -34,6 +38,7 @@ jobs:
       uses: easimon/maximize-build-space@v10
       with:
         root-reserve-mb: 5120
+        temp-reserve-mb: 8192
         swap-size-mb: 1024
         remove-dotnet: true
         remove-android: true
@@ -236,11 +241,14 @@ jobs:
     - name: Cleanup disk space before SonarQube Scan
       if: ${{ !cancelled() }}
       run: |
-        df -h
+        mkdir -p "${{ env.SONAR_USER_HOME }}" "${{ env.XDG_CACHE_HOME }}" "${{ env.TMPDIR }}"
+        df -h / "$GITHUB_WORKSPACE"
         du -sh "$GITHUB_WORKSPACE/_build" || true
         du -sh "${{ env.BUILD_WRAPPER_OUT_DIR }}" || true
+        du -sh "${{ env.SONAR_USER_HOME }}" || true
+        du -sh "${{ env.TMPDIR }}" || true
         rm -rf "$GITHUB_WORKSPACE/_build"
-        df -h
+        df -h / "$GITHUB_WORKSPACE"
 
     - name: SonarQube Scan
       if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary
- move Sonar build-wrapper output outside `_build` so the job can delete the build directory before the scan
- add a cleanup step before SonarCloud to log disk usage and remove `_build` once coverage has been generated
- keep the existing test coverage scope and scanner pin while targeting the actual runner disk exhaustion seen on recent SonarCloud failures