### PR TITLE
Remove `addScratchpadToEachArea` function

### DIFF
--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -43,17 +43,6 @@ Antares::Data::ShortTermStorage::STStorageCluster* addSTSToArea(Area* area,
     return &storages.back();
 }
 
-void addScratchpadToEachArea(Study& study)
-{
-    for (auto& [_, area]: study.areas)
-    {
-        for (unsigned i = 0; i < study.maxNbYearsInParallel; ++i)
-        {
-            area->scratchpad.emplace_back(study.runtime, *area);
-        }
-    }
-}
-
 TimeSeriesConfigurer& TimeSeriesConfigurer::setDimensions(unsigned columnCount, unsigned rowCount)
 {
     ts_->resize(columnCount, rowCount);
@@ -325,7 +314,6 @@ void TestingSimulationObserver::notifyHebdoProblem(const PROBLEME_HEBDO& problem
 void SimulationHandler::create()
 {
     study_.initializeRuntimeInfos();
-    addScratchpadToEachArea(study_);
     simulation_ = std::make_shared<ISimulation<Economy>>(study_,
                                                          settings_,
                                                          durationCollector_,

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -147,8 +147,6 @@ std::shared_ptr<ThermalCluster> addClusterToArea(Area* area, const std::string& 
 Antares::Data::ShortTermStorage::STStorageCluster* addSTSToArea(Area* area,
                                                                 const std::string& stsName);
 
-void addScratchpadToEachArea(Data::Study& study);
-
 // -------------------------------
 // Simulation results retrieval
 // -------------------------------

--- a/src/tests/src/api_lib/test_single_problem_api.cpp
+++ b/src/tests/src/api_lib/test_single_problem_api.cpp
@@ -71,10 +71,9 @@ std::unique_ptr<Study> buildStudy(bool thermal, bool hydro)
     }
 
     // TODO StudyBuilder should have a `run` method that
-    // calls addScratchpadToEachArea and initializeRuntimeInfos
+    // initializeRuntimeInfos
     // auto study = builder.run();
     builder.study->initializeRuntimeInfos();
-    addScratchpadToEachArea(*builder.study);
 
     // TODO this is HORRIBLE
     // more specifically, this resize is usually done when loading from files. It's all good, except
@@ -580,7 +579,6 @@ BOOST_AUTO_TEST_CASE(weeks_independent_multiple_areas_all_compliant)
     loadTSconfig2.setDimensions(1).fillColumnWith(0, 120.);
 
     builder.study->initializeRuntimeInfos();
-    addScratchpadToEachArea(*builder.study);
     area1->hydro.deltaBetweenFinalAndInitialLevels.resize(builder.study->parameters.nbYears);
     area2->hydro.deltaBetweenFinalAndInitialLevels.resize(builder.study->parameters.nbYears);
 
@@ -635,7 +633,6 @@ BOOST_AUTO_TEST_CASE(weeks_not_independent_multiple_areas_one_non_compliant)
     loadTSconfig2.setDimensions(1).fillColumnWith(0, 120.);
 
     builder.study->initializeRuntimeInfos();
-    addScratchpadToEachArea(*builder.study);
     area1->hydro.deltaBetweenFinalAndInitialLevels.resize(builder.study->parameters.nbYears);
     area2->hydro.deltaBetweenFinalAndInitialLevels.resize(builder.study->parameters.nbYears);
 


### PR DESCRIPTION
Initialize runtime infos which already prepares per-area scratchpads `StudyRuntimeInfos::loadFromStudy` creates the per-numspace scratchpad.

Avoid possible memory violations
```
unknown location(0): fatal error: in "ONE_AREA__ONE_THERMAL_CLUSTER/parallel2": memory access violation at address: 0x10: no mapping at fault address
/home/runner/work/Antares_Simulator/Antares_Simulator/src/tests/end-to-end/simple_study/simple-study.cpp(240): last checkpoint: "parallel2" test entry
```
https://github.com/AntaresSimulatorTeam/Antares_Simulator/actions/runs/23195374391/job/67402200831?pr=3497