### PR TITLE
Use emplace_back instead of push_back where possible

### DIFF
--- a/src/io/inputs/model-converter/modelConverter.cpp
+++ b/src/io/inputs/model-converter/modelConverter.cpp
@@ -102,11 +102,10 @@ std::vector<PortType> convertPortTypes(const ::YmlModel::Library& library)
             throw PortTypeWithThisIdAlreadyExists(ymlPortType.id);
         }
 
-        PortType portType(ymlPortType.id,
-                          std::move(fields),
-                          convert_to_system(ymlPortType.area_connection),
-                          ymlPortType.thermal_capacity_connection_field);
-        out.emplace_back(std::move(portType));
+        out.emplace_back(ymlPortType.id,
+                         std::move(fields),
+                         convert_to_system(ymlPortType.area_connection),
+                         ymlPortType.thermal_capacity_connection_field);
     }
     return out;
 }

--- a/src/libs/antares/utils/utils.cpp
+++ b/src/libs/antares/utils/utils.cpp
@@ -63,7 +63,7 @@ std::vector<std::pair<std::string, std::string>> splitStringIntoPairs(const std:
         {
             std::string begin = token.substr(0, pos);
             std::string end = token.substr(pos + 1);
-            pairs.push_back({begin, end});
+            pairs.emplace_back(begin, end);
         }
         else
         {

--- a/src/solver/simulation/remix-storage/storage-for-remix-list-sort.cpp
+++ b/src/solver/simulation/remix-storage/storage-for-remix-list-sort.cpp
@@ -7,7 +7,7 @@ namespace Antares::Solver::Simulation
 {
 void StorageListSort::add(const double capacity, const std::shared_ptr<IStorageForRemix> sts)
 {
-    pairs_capa_storage_.push_back({capacity, sts});
+    pairs_capa_storage_.emplace_back(capacity, sts);
 }
 
 ListStorageForRemix StorageListSort::makeSortedList()


### PR DESCRIPTION
Use `emplace_back` to construct elements **in-place** within the container, while `push_back` requires a temporary object.