### PR TITLE
Don't use package managers to install boost, use vcpkg

### DIFF
--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install libraries
         run: |
           dnf install -y epel-release git cmake wget rpm-build redhat-lsb-core
-          dnf install -y unzip libuuid-devel boost-test boost-devel gcc-toolset-11 zlib-devel
+          dnf install -y unzip libuuid-devel gcc-toolset-11 zlib-devel
 
       - name: Checkout
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -47,7 +47,7 @@ jobs:
         echo "ORTOOLS_URL=https://github.com/rte-france/or-tools-rte/releases/download/$(cat ortools_tag)/ortools_cxx_ubuntu-22.04_static_sirius.zip" >> $GITHUB_ENV
 
     - name: Install ccache
-      run: sudo apt-get install -y ccache
+      run: sudo apt-get install -y ccache uuid-dev
 
       # Can't use ubuntu cache. Cache hit is only single digit %
     - name: Restore ccache cache
@@ -72,12 +72,6 @@ jobs:
 
     - name: Install Build Wrapper
       uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7.0.0
-
-    - name: Install libraries
-      run: |
-        sudo apt-get update
-        sudo apt-get install uuid-dev
-        sudo apt-get install libboost-test-dev
 
     - name: Download pre-compiled librairies
       uses: ./.github/workflows/download-extract-precompiled-libraries-tgz

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -39,7 +39,6 @@ jobs:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
       ORTOOLS_DIR: ${{ github.workspace }}/or-tools
       os: windows-2022
-      vcpkgPackages: boost-test
       triplet: x64-windows-release
       # Caching strategy of VCPKG dependencies
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"


### PR DESCRIPTION
vcpkg is used to provide boost & boost-test. Installing it with package managers only creates confusion.