### PR TITLE
Add delete in AreaList desctuctor to free memory

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -153,6 +153,14 @@ AreaList::AreaList(Study& study):
 {
 }
 
+AreaList::~AreaList()
+{
+    for (auto& area: areas | std::views::values)
+    {
+        delete area;
+    }
+}
+
 bool AreaList::empty() const
 {
     return areas.empty();

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -155,7 +155,7 @@ AreaList::AreaList(Study& study):
 
 AreaList::~AreaList()
 {
-    for (auto& area: areas | std::views::values)
+    for (auto* area: areas | std::views::values)
     {
         delete area;
     }

--- a/src/libs/antares/study/include/antares/study/area/area.h
+++ b/src/libs/antares/study/include/antares/study/area/area.h
@@ -295,7 +295,13 @@ public:
     ** \brief Default constructor
     */
     explicit AreaList(Study& study);
-    ~AreaList() = default;
+
+    /*!
+     ** \brief Destructor
+     **
+     ** Frees all Area instances owned by this list.
+     */
+    ~AreaList();
     //@}
 
     //! \name Iterating through all areas


### PR DESCRIPTION
# Fix: memory leak in `AreaList` — `Area*` pointers never freed
 
## Context
 
While auditing the lifecycle of `Area` objects, we identified that dynamically allocated
instances were never freed, causing a systematic memory leak on every study load.
 
## Root cause
 
`Area` objects are created with `new` in `AreaListAddFromNames` (`list.cpp`):
 
```cpp
Area* area = new Area(name, lname);
list.add(area);
```
 
`AreaList::add()` stores the raw pointer in a `std::map<AreaName, Area*>`:
 
```cpp
areas[a->id] = a;  // Area::Map = std::map<AreaName, Area*>
```
 
However, the destructor of `AreaList` is declared `= default` in `area.h`:
 
```cpp
~AreaList() = default;
```
 
When `AreaList` is destroyed, the map is cleaned up correctly — but the `Area*` pointers it
holds are **never** `delete`d. Every `Area` allocated during a study load leaks until the
process exits.
 
## Fix
 
Replace `= default` with an explicit destructor that iterates over the map and frees each
pointer:
 
```cpp
~AreaList()
{
    for (auto& [name, area] : areas)
    {
        delete area;
    }
}
```
 
## Why this approach over `unique_ptr`
 
The idiomatic modern C++ alternative would have been to migrate `Area::Map` to
`std::map<AreaName, std::unique_ptr<Area>>`, making ownership explicit and automatic.
This was ruled out for this PR for two reasons:
 
- **Scope**: `Area::Map` is used in many places across the codebase .
The migration would produce a much larger diff with a non-trivial risk of regression.
- **Separation of concerns**: fixing the leak without refactoring ownership keeps this PR
  focused and easy to review in isolation. The migration to `unique_ptr` can be addressed
  in a dedicated follow-up PR.
 
The explicit destructor is a targeted, readable fix with no impact on the rest of the codebase.