### PR TITLE
Remove member function Study::areaAdd [ANT-4815]

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -268,10 +268,8 @@ bool AreaList::loadListFromFile(const fs::path& filename)
     AreaName name;
     // Each lines in the file
     std::string buffer;
-    uint line = 0;
     while (std::getline(file, buffer))
     {
-        ++line;
         // The area name
         name = buffer;
         boost::trim(name);

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -231,6 +231,12 @@ Area* AreaListAddFromNames(AreaList& list, const AnyString& name, const AnyStrin
         }
         return nullptr;
     }
+
+    if (CheckForbiddenCharacterInAreaName(name))
+    {
+        logs.error() << "Invalid area name: `" << name << "` contains forbidden character `*`";
+        return nullptr;
+    }
     // Look up
     if (!AreaListLFind(&list, lname.c_str()))
     {
@@ -276,12 +282,6 @@ bool AreaList::loadListFromFile(const fs::path& filename)
         if (name.empty())
         {
             continue;
-        }
-
-        if (CheckForbiddenCharacterInAreaName(name))
-        {
-            logs.error() << "Invalid area name: `" << name << "` contains forbidden character `*`";
-            return false;
         }
 
         // Add the area in the list

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -225,6 +225,10 @@ Area* AreaListAddFromNames(AreaList& list, const AnyString& name, const AnyStrin
 {
     if (!name || !lname)
     {
+        if (name.empty())
+        {
+            logs.warning() << "ignoring invalid area name: `" << name;
+        }
         return nullptr;
     }
     // Look up
@@ -262,7 +266,6 @@ bool AreaList::loadListFromFile(const fs::path& filename)
 
     // Initialization of the strings
     AreaName name;
-    AreaName lname;
     // Each lines in the file
     std::string buffer;
     uint line = 0;
@@ -277,21 +280,8 @@ bool AreaList::loadListFromFile(const fs::path& filename)
             continue;
         }
 
-        lname.clear();
-        lname = transformNameIntoID(name);
-        if (lname.empty())
-        {
-            logs.warning() << "ignoring invalid area name: `" << name << "`, " << filename
-                           << ": line " << line;
-            continue;
-        }
-        if (CheckForbiddenCharacterInAreaName(name))
-        {
-            logs.error() << "character '*' is forbidden in area name: `" << name << "`";
-            continue;
-        }
         // Add the area in the list
-        AreaListAddFromNames(*this, name, lname);
+        addAreaToListOfAreas(*this, name);
     }
 
     switch (areas.size())

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -280,6 +280,12 @@ bool AreaList::loadListFromFile(const fs::path& filename)
             continue;
         }
 
+        if (CheckForbiddenCharacterInAreaName(name))
+        {
+            logs.error() << "Invalid area name: `" << name << "` contains forbidden character `*`";
+            return false;
+        }
+
         // Add the area in the list
         addAreaToListOfAreas(*this, name);
     }

--- a/src/libs/antares/study/include/antares/study/study.h
+++ b/src/libs/antares/study/include/antares/study/study.h
@@ -127,11 +127,6 @@ public:
     */
     bool modifyAreaNameIfAlreadyTaken(AreaName& out, const AreaName& basename);
 
-    /*!
-    ** \brief Add an area and make all required initialization
-    */
-    Area* areaAdd(const AreaName& name);
-
     //! \name Time-series
     //@{
     /*!

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -356,51 +356,6 @@ void Study::saveAboutTheStudy(Solver::IResultWriter& resultWriter)
     }
 }
 
-Area* Study::areaAdd(const AreaName& name)
-{
-    if (name.empty())
-    {
-        return nullptr;
-    }
-    if (CheckForbiddenCharacterInAreaName(name))
-    {
-        logs.error() << "character '*' is forbidden in area name: `" << name << "`";
-        return nullptr;
-    }
-
-    // Result
-    Area* area = nullptr;
-    logs.info() << "adding new area " << name;
-
-    // The new scope is mandatory to rebuild the correlation matrices
-    // and the scenario builder data
-    {
-        // Adding an area
-        AreaName newName;
-        if (not modifyAreaNameIfAlreadyTaken(newName, name) or newName.empty())
-        {
-            logs.error() << "Impossible to find a name for a new area";
-            return nullptr;
-        }
-
-        // Adding an area
-        area = addAreaToListOfAreas(areas, newName);
-        if (not area)
-        {
-            return nullptr;
-        }
-
-        // Rebuild indexes for all areas
-        areas.rebuildIndexes();
-
-        // Default values for the area
-        area->createMissingData();
-        area->resetToDefaultValues();
-    }
-
-    return area;
-}
-
 template<>
 inline void Study::destroyTSGeneratorData<TimeSeriesType::timeSeriesLoad>()
 

--- a/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
@@ -70,9 +70,9 @@ BOOST_AUTO_TEST_CASE(load_basic_attributes)
 BOOST_AUTO_TEST_CASE(BC_load_RHS)
 {
     auto study = std::make_shared<Study>();
-    study->areaAdd("area1");
-    study->areaAdd("area2");
-    study->areaAdd("area3");
+    addAreaToListOfAreas(study->areas, "area1");
+    addAreaToListOfAreas(study->areas, "area2");
+    addAreaToListOfAreas(study->areas, "area3");
 
     StudyLoadOptions options;
     BindingConstraintsRepository bindingConstraints;
@@ -117,9 +117,9 @@ BOOST_AUTO_TEST_CASE(BC_load_RHS)
 BOOST_AUTO_TEST_CASE(BC_load_range_type)
 {
     auto study = std::make_shared<Study>();
-    study->areaAdd("area1");
-    study->areaAdd("area2");
-    study->areaAdd("area3");
+    addAreaToListOfAreas(study->areas, "area1");
+    addAreaToListOfAreas(study->areas, "area2");
+    addAreaToListOfAreas(study->areas, "area3");
 
     StudyLoadOptions options;
     BindingConstraintsRepository bindingConstraints;
@@ -184,9 +184,9 @@ BOOST_AUTO_TEST_CASE(BC_load_range_type)
 BOOST_AUTO_TEST_CASE(BC_load_legacy)
 {
     auto study = std::make_shared<Study>();
-    study->areaAdd("area1");
-    study->areaAdd("area2");
-    study->areaAdd("area3");
+    addAreaToListOfAreas(study->areas, "area1");
+    addAreaToListOfAreas(study->areas, "area2");
+    addAreaToListOfAreas(study->areas, "area3");
 
     StudyLoadOptions options;
     BindingConstraintsRepository bindingConstraints;
@@ -231,9 +231,9 @@ BOOST_AUTO_TEST_CASE(BC_load_legacy)
 BOOST_AUTO_TEST_CASE(BC_load_legacy_range)
 {
     auto study = std::make_shared<Study>();
-    study->areaAdd("area1");
-    study->areaAdd("area2");
-    study->areaAdd("area3");
+    addAreaToListOfAreas(study->areas, "area1");
+    addAreaToListOfAreas(study->areas, "area2");
+    addAreaToListOfAreas(study->areas, "area3");
 
     StudyLoadOptions options;
     BindingConstraintsRepository bindingConstraints;
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(BC_load_legacy_range)
 BOOST_AUTO_TEST_CASE(BindingConstraint_clusterCount)
 {
     auto study = std::make_unique<Study>();
-    auto area = study->areaAdd("area1");
+    auto area = addAreaToListOfAreas(study->areas, "area1");
     BindingConstraint bc;
     // Add a thermal cluster to area1 and bc
     // return the number of clusters of bc

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
@@ -35,6 +35,11 @@ struct Fixture
 
         // Add areas to studies
         area_1 = addAreaToListOfAreas(study->areas, "Area1");
+        if (area_1)
+        {
+            area_1->createMissingData();
+            area_1->resetToDefaultValues();
+        }
         study->areas.rebuildIndexes();
 
         // Create necessary folders and files for these two areas

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydro-series.cpp
@@ -34,7 +34,7 @@ struct Fixture
         study = std::make_shared<Study>();
 
         // Add areas to studies
-        area_1 = study->areaAdd("Area1");
+        area_1 = addAreaToListOfAreas(study->areas, "Area1");
         study->areas.rebuildIndexes();
 
         // Create necessary folders and files for these two areas

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
@@ -67,6 +67,11 @@ struct Fixture
 
         // Add areas
         area_1 = addAreaToListOfAreas(study->areas, "Area1");
+        if (area_1)
+        {
+            area_1->createMissingData();
+            area_1->resetToDefaultValues();
+        }
         study->areas.rebuildIndexes();
         dailyMaxPumpAndGen.reset(4U, DAYS_PER_YEAR);
         reader = std::make_shared<HydroMaxTimeSeriesReader>(area_1->hydro,

--- a/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
+++ b/src/tests/src/libs/antares/study/parts/hydro/test-hydroreader-class.cpp
@@ -66,7 +66,7 @@ struct Fixture
         study = std::make_shared<Study>();
 
         // Add areas
-        area_1 = study->areaAdd("Area1");
+        area_1 = addAreaToListOfAreas(study->areas, "Area1");
         study->areas.rebuildIndexes();
         dailyMaxPumpAndGen.reset(4U, DAYS_PER_YEAR);
         reader = std::make_shared<HydroMaxTimeSeriesReader>(area_1->hydro,

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
@@ -60,6 +60,14 @@ struct Fixture
         area_1 = addAreaToListOfAreas(study->areas, "Area 1");
         area_2 = addAreaToListOfAreas(study->areas, "Area 2");
         area_3 = addAreaToListOfAreas(study->areas, "Area 3");
+        for (auto* area: {area_1, area_2, area_3})
+        {
+            if (area)
+            {
+                area->createMissingData();
+                area->resetToDefaultValues();
+            }
+        }
         study->areas.rebuildIndexes();
 
         // Load : set the nb of ready made TS

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-file-read-line.cpp
@@ -57,9 +57,9 @@ struct Fixture
                                                     // time-series
 
         // Add areas
-        area_1 = study->areaAdd("Area 1");
-        area_2 = study->areaAdd("Area 2");
-        area_3 = study->areaAdd("Area 3");
+        area_1 = addAreaToListOfAreas(study->areas, "Area 1");
+        area_2 = addAreaToListOfAreas(study->areas, "Area 2");
+        area_3 = addAreaToListOfAreas(study->areas, "Area 3");
         study->areas.rebuildIndexes();
 
         // Load : set the nb of ready made TS

--- a/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
+++ b/src/tests/src/libs/antares/study/scenario-builder/test-sc-builder-get-set.cpp
@@ -43,7 +43,7 @@ class IntegerIndex
 public:
     IntegerIndex():
         study(std::make_unique<Study>()),
-        area(study->areaAdd("area 1"))
+        area(addAreaToListOfAreas(study->areas, "area 1"))
     {
     }
 
@@ -84,8 +84,8 @@ public:
 
     explicit StructureIndex():
         study(std::make_unique<Study>()),
-        area1(study->areaAdd("area 1")),
-        area2(study->areaAdd("area 2")),
+        area1(addAreaToListOfAreas(study->areas, "area 1")),
+        area2(addAreaToListOfAreas(study->areas, "area 2")),
         link(AreaAddLinkBetweenAreas(area1, area2, false)),
         thcluster(std::make_shared<ThermalCluster>(area1)),
         rencluster(std::make_shared<RenewableCluster>(area1)),

--- a/src/tests/src/libs/antares/study/test_duplicates.cpp
+++ b/src/tests/src/libs/antares/study/test_duplicates.cpp
@@ -24,8 +24,8 @@ BOOST_AUTO_TEST_SUITE(study_duplicates)
 struct DuplicateFixture: public Antares::UnitTests::CaptureAntaresLogs
 {
     std::unique_ptr<Study> study = std::make_unique<Study>();
-    Data::Area* areaA = study->areaAdd("A");
-    Data::Area* areaB = study->areaAdd("B");
+    Data::Area* areaA = addAreaToListOfAreas(study->areas, "A");
+    Data::Area* areaB = addAreaToListOfAreas(study->areas, "B");
 
     void addBindingConstraint(const std::string& name)
     {

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -360,4 +360,11 @@ BOOST_FIXTURE_TEST_CASE(cpu_count, OneAreaStudy)
     BOOST_CHECK_EQUAL(study->getNumberOfCoresPerMode(10, 120), 1);
 }
 
+BOOST_AUTO_TEST_CASE(add_area_with_empty_name_returns_nullptr)
+{
+    auto study = std::make_unique<Study>();
+    const auto area = addAreaToListOfAreas(study->areas, "");
+    BOOST_CHECK(area == nullptr);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // version

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -17,7 +17,7 @@ struct OneAreaStudy
     OneAreaStudy()
     {
         study = std::make_unique<Study>();
-        areaA = study->areaAdd("A");
+        areaA = addAreaToListOfAreas(study->areas, "A");
         study->parameters.simulationDays.first = 0;
         study->parameters.simulationDays.end = 7;
     }
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(areas_operations)
 BOOST_AUTO_TEST_CASE(area_add)
 {
     auto study = std::make_unique<Study>();
-    const auto areaA = study->areaAdd("A");
+    const auto areaA = addAreaToListOfAreas(study->areas, "A");
     BOOST_CHECK(areaA != nullptr);
     BOOST_CHECK_EQUAL(areaA->name, "A");
     BOOST_CHECK_EQUAL(areaA->id, "a");
@@ -267,7 +267,7 @@ struct RenewableClusterStudy: public OneAreaStudy
 {
     RenewableClusterStudy()
     {
-        areaA = study->areaAdd("A");
+        areaA = addAreaToListOfAreas(study->areas, "A");
         auto newCluster = std::make_shared<RenewableCluster>(areaA);
         newCluster->setName("WindCluster");
         areaA->renewable.list.addToCompleteList(newCluster);
@@ -336,8 +336,8 @@ BOOST_FIXTURE_TEST_CASE(check_filename_limit, OneAreaStudy)
 #ifdef YUNI_OS_WINDOWS
     std::string area1name(128, 'a');
     std::string area2name(128, 'b');
-    auto areaB = study->areaAdd(area1name);
-    auto areaC = study->areaAdd(area2name);
+    auto areaB = addAreaToListOfAreas(study->areas, area1name);
+    auto areaC = addAreaToListOfAreas(study->areas, area2name);
     AreaAddLinkBetweenAreas(areaB, areaC);
     BOOST_CHECK(!study->checkForFilenameLimits());
 #endif

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -367,4 +367,12 @@ BOOST_AUTO_TEST_CASE(add_area_with_empty_name_returns_nullptr)
     BOOST_CHECK(area == nullptr);
 }
 
+BOOST_AUTO_TEST_CASE(add_area_with_forbidden_character_returns_nullptr)
+{
+    auto study = std::make_unique<Study>();
+    const auto area = addAreaToListOfAreas(study->areas, "area*name");
+    BOOST_CHECK(area == nullptr);
+    BOOST_CHECK_EQUAL(study->areas.size(), 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // version

--- a/src/tests/src/libs/antares/study/test_study.cpp
+++ b/src/tests/src/libs/antares/study/test_study.cpp
@@ -18,6 +18,11 @@ struct OneAreaStudy
     {
         study = std::make_unique<Study>();
         areaA = addAreaToListOfAreas(study->areas, "A");
+        if (areaA)
+        {
+            areaA->createMissingData();
+            areaA->resetToDefaultValues();
+        }
         study->parameters.simulationDays.first = 0;
         study->parameters.simulationDays.end = 7;
     }
@@ -267,7 +272,6 @@ struct RenewableClusterStudy: public OneAreaStudy
 {
     RenewableClusterStudy()
     {
-        areaA = addAreaToListOfAreas(study->areas, "A");
         auto newCluster = std::make_shared<RenewableCluster>(areaA);
         newCluster->setName("WindCluster");
         areaA->renewable.list.addToCompleteList(newCluster);

--- a/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
+++ b/src/tests/src/libs/antares/study/thermal-price-definition/thermal-price-definition.cpp
@@ -96,7 +96,7 @@ struct FixtureFull: private ThermalIniFile
 
     FixtureFull()
     {
-        area = study->areaAdd("area");
+        area = addAreaToListOfAreas(study->areas, "area");
         study->parameters.include.thermal.minUPTime = true;
         study->parameters.include.thermal.minStablePower = true;
         study->parameters.include.reserve.spinning = true;

--- a/src/tests/src/solver/simulation/test-hydro-final-reservoir-level-functions.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-final-reservoir-level-functions.cpp
@@ -32,6 +32,15 @@ struct Fixture
         area_1 = addAreaToListOfAreas(study->areas, "Area1");
         area_2 = addAreaToListOfAreas(study->areas, "Area2");
 
+        for (auto* area: {area_1, area_2})
+        {
+            if (area)
+            {
+                area->createMissingData();
+                area->resetToDefaultValues();
+            }
+        }
+
         area_1->hydro.reservoirManagement = true;
         area_2->hydro.reservoirManagement = true;
 

--- a/src/tests/src/solver/simulation/test-hydro-final-reservoir-level-functions.cpp
+++ b/src/tests/src/solver/simulation/test-hydro-final-reservoir-level-functions.cpp
@@ -29,8 +29,8 @@ struct Fixture
         study->parameters.firstMonthInYear = january;
         uint nbYears = study->parameters.nbYears = 2;
 
-        area_1 = study->areaAdd("Area1");
-        area_2 = study->areaAdd("Area2");
+        area_1 = addAreaToListOfAreas(study->areas, "Area1");
+        area_2 = addAreaToListOfAreas(study->areas, "Area2");
 
         area_1->hydro.reservoirManagement = true;
         area_2->hydro.reservoirManagement = true;

--- a/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
+++ b/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(sts_area_cluster_inflows_timeseries_numbers_store_values)
     study->parameters.storeTimeseriesNumbers = true;
 
     // Create an area
-    auto area = study->areaAdd("fr");
+    auto area = addAreaToListOfAreas(study->areas, "fr");
     auto& clusters = area->shortTermStorage.storagesByIndex;
 
     // Add one STS cluster
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(sts_area_cluster_additional_constraints_timeseries_numbers_
     study->parameters.storeTimeseriesNumbers = true;
 
     // Create an area
-    auto area = study->areaAdd("fr");
+    auto area = addAreaToListOfAreas(study->areas, "fr");
     auto& clusters = area->shortTermStorage.storagesByIndex;
 
     // Add one STS cluster

--- a/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
+++ b/src/tests/src/solver/simulation/test-store-timeseries-number.cpp
@@ -133,6 +133,11 @@ BOOST_AUTO_TEST_CASE(sts_area_cluster_inflows_timeseries_numbers_store_values)
 
     // Create an area
     auto area = addAreaToListOfAreas(study->areas, "fr");
+    if (area)
+    {
+        area->createMissingData();
+        area->resetToDefaultValues();
+    }
     auto& clusters = area->shortTermStorage.storagesByIndex;
 
     // Add one STS cluster
@@ -181,6 +186,11 @@ BOOST_AUTO_TEST_CASE(sts_area_cluster_additional_constraints_timeseries_numbers_
 
     // Create an area
     auto area = addAreaToListOfAreas(study->areas, "fr");
+    if (area)
+    {
+        area->createMissingData();
+        area->resetToDefaultValues();
+    }
     auto& clusters = area->shortTermStorage.storagesByIndex;
 
     // Add one STS cluster

--- a/src/tests/src/solver/simulation/tests-ts-numbers.cpp
+++ b/src/tests/src/solver/simulation/tests-ts-numbers.cpp
@@ -35,7 +35,7 @@ void initializeStudy(Study::Ptr study, unsigned int nbYears = 1)
 // ========================
 Area* addAreaToStudy(Study::Ptr study, const std::string& areaName)
 {
-    Area* area = study->areaAdd(areaName);
+    Area* area = addAreaToListOfAreas(study->areas, areaName);
     BOOST_CHECK(area);
 
     return area;

--- a/src/tests/src/solver/simulation/tests-ts-numbers.cpp
+++ b/src/tests/src/solver/simulation/tests-ts-numbers.cpp
@@ -36,6 +36,11 @@ void initializeStudy(Study::Ptr study, unsigned int nbYears = 1)
 Area* addAreaToStudy(Study::Ptr study, const std::string& areaName)
 {
     Area* area = addAreaToListOfAreas(study->areas, areaName);
+    if (area)
+    {
+        area->createMissingData();
+        area->resetToDefaultValues();
+    }
     BOOST_CHECK(area);
 
     return area;

--- a/src/tests/src/solver/variable/test_dynamic.cpp
+++ b/src/tests/src/solver/variable/test_dynamic.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<Study> createMockStudy()
     auto study = std::make_unique<Study>();
 
     // Create Area1 with thermal groups A and B
-    Area* area1 = study->areaAdd("Area1");
+    Area* area1 = addAreaToListOfAreas(study->areas, "Area1");
     area1->index = 0;
 
     auto thermalA1 = addClusterToArea(area1, "Thermal_A1");
@@ -31,7 +31,7 @@ std::unique_ptr<Study> createMockStudy()
     thermalB1->index = 1;
 
     // Create Area2 with thermal groups B and C
-    Area* area2 = study->areaAdd("Area2");
+    Area* area2 = addAreaToListOfAreas(study->areas, "Area2");
     area2->index = 1;
 
     auto thermalB2 = addClusterToArea(area2, "Thermal_B2");


### PR DESCRIPTION
- Remove the function
- Transform loadListFromFile to allow a call to addAreaToListOfAreas
- move the case lname empty to AreaListAddFromNames (because duplicate code)
- remove CheckForbiddenCharacterInAreaName, useless (due to previous call of transformNameIntoID)
- Replace calls to areaAdd in tests by calls to addAreaToListOfAreas

Possible follow ticket :  Area::createMissingData and Area::resetToDefaultValues are unused. Can they be removed safely ?