### PR TITLE
fix: digest dynamic variables [ANT-4826]

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - develop
     - dependabot/**
+    - fix/*
   schedule:
   - cron: '21 2 * * *'
   workflow_call:

--- a/src/libs/antares/study/include/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/include/antares/study/variable-print-info.h
@@ -29,7 +29,7 @@ public:
     bool isPrinted() const;
     void reverse();
 
-    uint getMaxColumnsCount();
+    uint getMaxColumnsCount() const;
     void setMaxColumns(uint maxColumnsNumber);
 
     bool isPrintedOnDataLevel(uint dataLevel) const
@@ -92,6 +92,7 @@ public:
     void setPrintStatus(unsigned int index, bool printStatus);
 
     void setMaxColumns(std::string varname, uint maxColumnsNumber);
+    uint getMaxColumns(const std::string& varname) const;
     std::string name_of(unsigned int index) const;
 
     void prepareForSimulation(bool isThematicTrimmingEnabled,

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -38,7 +38,7 @@ void VariablePrintInfo::reverse()
     to_be_printed_ = !to_be_printed_;
 }
 
-uint VariablePrintInfo::getMaxColumnsCount()
+uint VariablePrintInfo::getMaxColumnsCount() const
 {
     return maxNumberColumns_;
 }
@@ -117,6 +117,15 @@ void AllVariablesPrintInfo::setPrintStatus(unsigned int index, bool printStatus)
 void AllVariablesPrintInfo::setMaxColumns(std::string varname, uint maxColumnsNumber)
 {
     allVarsPrintInfo.at(to_uppercase(varname)).setMaxColumns(maxColumnsNumber);
+}
+
+uint AllVariablesPrintInfo::getMaxColumns(const std::string& varname) const
+{
+    std::string upper = varname;
+    auto it = allVarsPrintInfo.find(to_uppercase(upper));
+    if (it != allVarsPrintInfo.end())
+        return it->second.getMaxColumnsCount();
+    return 0;
 }
 
 [[deprecated("Only needed by the GUI, to be removed")]]

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -124,7 +124,9 @@ uint AllVariablesPrintInfo::getMaxColumns(const std::string& varname) const
     std::string upper = varname;
     auto it = allVarsPrintInfo.find(to_uppercase(upper));
     if (it != allVarsPrintInfo.end())
+    {
         return it->second.getMaxColumnsCount();
+    }
     return 0;
 }
 

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -285,8 +285,8 @@ public:
             // Advance columnIndex for columns this area doesn't have so that subsequent
             // variables align correctly across all areas (different areas may have different
             // numbers of STS groups).
-            const uint maxCols = results.data.study.parameters.variablesPrintInfo
-                                     .getMaxColumns(VCardType::Caption());
+            const uint maxCols = results.data.study.parameters.variablesPrintInfo.getMaxColumns(
+              VCardType::Caption());
             const uint actualCols = nbColumns_ * static_cast<uint>(ResultsType::count);
             if (maxCols > actualCols)
             {

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -281,6 +281,17 @@ public:
                                                                                digestLevel,
                                                                                dataLevel);
             }
+
+            // Advance columnIndex for columns this area doesn't have so that subsequent
+            // variables align correctly across all areas (different areas may have different
+            // numbers of STS groups).
+            const uint maxCols = results.data.study.parameters.variablesPrintInfo
+                                     .getMaxColumns(VCardType::Caption());
+            const uint actualCols = nbColumns_ * static_cast<uint>(ResultsType::count);
+            if (maxCols > actualCols)
+            {
+                results.data.columnIndex += maxCols - actualCols;
+            }
         }
         // Ask to build the digest to the next variable
         NextType::buildDigest(results, digestLevel, dataLevel);

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -229,6 +229,17 @@ public:
                                                                                digestLevel,
                                                                                dataLevel);
             }
+
+            // Advance columnIndex for columns this area doesn't have so that subsequent
+            // variables align correctly across all areas (different areas may have different
+            // numbers of dispatchable groups).
+            const uint maxCols = results.data.study.parameters.variablesPrintInfo
+                                     .getMaxColumns(VCardType::Caption());
+            const uint actualCols = nbColumns_ * static_cast<uint>(ResultsType::count);
+            if (maxCols > actualCols)
+            {
+                results.data.columnIndex += maxCols - actualCols;
+            }
         }
         // Ask to build the digest to the next variable
         NextType::buildDigest(results, digestLevel, dataLevel);

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -233,8 +233,8 @@ public:
             // Advance columnIndex for columns this area doesn't have so that subsequent
             // variables align correctly across all areas (different areas may have different
             // numbers of dispatchable groups).
-            const uint maxCols = results.data.study.parameters.variablesPrintInfo
-                                     .getMaxColumns(VCardType::Caption());
+            const uint maxCols = results.data.study.parameters.variablesPrintInfo.getMaxColumns(
+              VCardType::Caption());
             const uint actualCols = nbColumns_ * static_cast<uint>(ResultsType::count);
             if (maxCols > actualCols)
             {

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -231,6 +231,17 @@ public:
                                                                                digestLevel,
                                                                                dataLevel);
             }
+
+            // Advance columnIndex for columns this area doesn't have so that subsequent
+            // variables align correctly across all areas (different areas may have different
+            // numbers of renewable groups).
+            const uint maxCols = results.data.study.parameters.variablesPrintInfo
+                                     .getMaxColumns(VCardType::Caption());
+            const uint actualCols = nbColumns_ * static_cast<uint>(ResultsType::count);
+            if (maxCols > actualCols)
+            {
+                results.data.columnIndex += maxCols - actualCols;
+            }
         }
         // Ask to build the digest to next variable
         NextType::buildDigest(results, digestLevel, dataLevel);

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -235,8 +235,8 @@ public:
             // Advance columnIndex for columns this area doesn't have so that subsequent
             // variables align correctly across all areas (different areas may have different
             // numbers of renewable groups).
-            const uint maxCols = results.data.study.parameters.variablesPrintInfo
-                                     .getMaxColumns(VCardType::Caption());
+            const uint maxCols = results.data.study.parameters.variablesPrintInfo.getMaxColumns(
+              VCardType::Caption());
             const uint actualCols = nbColumns_ * static_cast<uint>(ResultsType::count);
             if (maxCols > actualCols)
             {

--- a/src/solver/variable/include/antares/solver/variable/info.h
+++ b/src/solver/variable/include/antares/solver/variable/info.h
@@ -391,6 +391,17 @@ struct VariableAccessor<ResultsT, Category::dynamicColumns>
                     results.variableCaption = st_storage_part.storagesByIndex[i].properties.name;
                     container[i].template buildDigest<VCardT>(results, digestLevel, dataLevel);
                 }
+
+                // Advance columnIndex for clusters this area doesn't have so that subsequent
+                // variables align correctly across all areas (different areas may have different
+                // numbers of ST storage clusters).
+                const uint maxCols = results.data.study.parameters.variablesPrintInfo
+                                         .getMaxColumns(VCardT::Caption());
+                const uint actualCols = container.size() * static_cast<uint>(CleanType::count);
+                if (maxCols > actualCols)
+                {
+                    results.data.columnIndex += maxCols - actualCols;
+                }
             }
         }
     }

--- a/src/solver/variable/include/antares/solver/variable/info.h
+++ b/src/solver/variable/include/antares/solver/variable/info.h
@@ -395,8 +395,8 @@ struct VariableAccessor<ResultsT, Category::dynamicColumns>
                 // Advance columnIndex for clusters this area doesn't have so that subsequent
                 // variables align correctly across all areas (different areas may have different
                 // numbers of ST storage clusters).
-                const uint maxCols = results.data.study.parameters.variablesPrintInfo
-                                         .getMaxColumns(VCardT::Caption());
+                const uint maxCols = results.data.study.parameters.variablesPrintInfo.getMaxColumns(
+                  VCardT::Caption());
                 const uint actualCols = container.size() * static_cast<uint>(CleanType::count);
                 if (maxCols > actualCols)
                 {


### PR DESCRIPTION
Digest is wrong when dynamique groups exist. Issue is that when a dynamique group exist, column are reseted once we encounter a classique variable after having processed dyn groups

This pull request introduces improvements to the handling of variable column alignment in simulation results, ensuring that output columns are consistently aligned across different areas, even when the number of groups or clusters differs. It also adds new API methods for accessing per-variable maximum column counts and makes some minor workflow improvements.

Key changes include:

**API and Interface Enhancements:**
* Added a new method `getMaxColumns(const std::string& varname) const` to `AllVariablesPrintInfo`, allowing retrieval of the maximum column count for a specific variable. The corresponding implementation was added to both the header and source files. [[1]](diffhunk://#diff-376a08eaef97f41b42acce1d62b9dd60de77d052dda77bce4478ac3b766d2435R95) [[2]](diffhunk://#diff-100a86bd4c989e602f1771504eb19d9ae17b8c8345c16a916fb7df87931decb3R122-R132)
* Made the `getMaxColumnsCount()` method in `VariablePrintInfo` a `const` method for better const-correctness. [[1]](diffhunk://#diff-376a08eaef97f41b42acce1d62b9dd60de77d052dda77bce4478ac3b766d2435L32-R32) [[2]](diffhunk://#diff-100a86bd4c989e602f1771504eb19d9ae17b8c8345c16a916fb7df87931decb3L41-R41)

**Column Alignment Logic:**
* Updated the digest/build logic in `STSbyGroup`, `DispatchableGeneration`, `RenewableGeneration`, and dynamic columns in `VariableAccessor` to advance the `columnIndex` when an area has fewer groups/clusters than the maximum. This ensures that subsequent variables remain aligned across all areas, regardless of differing numbers of groups/clusters. [[1]](diffhunk://#diff-8e274fedab28bdd8ea65ff7ca0d4d000693fd5c96626985dab7a4c86b6154fdcR284-R294) [[2]](diffhunk://#diff-7152fafb6b2b1b872c9e4415e5f187ada6e5cd80a4f36dd346f5a014100967e2R232-R242) [[3]](diffhunk://#diff-f220d07b36668e13628106788d95aefb34ef2317f91778cfa3fdaa7d869765c6R234-R244) [[4]](diffhunk://#diff-430b0103c3a2d74c557626244e636d0712a5ac11edb6d3e35a69d21667783309R394-R404)

**CI Workflow:**
* Modified the CentOS 7 GitHub Actions workflow to also trigger on branches matching the `fix/*` pattern, in addition to the existing branch filters.