### PR TITLE
chore(deps): Up build.os@readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.11"
+    python: "3.13"
 
 python:
   install:


### PR DESCRIPTION
Ubuntu 20.04 will be deprecated by readthedocs on June, 1st as a result of this version no longer receiving updates.

See https://docs.readthedocs.com/platform/stable/config-file/v2.html#build-os