### PR TITLE
Fix: remove dynamique variables from digest

### DIFF
--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -7,7 +7,6 @@ on:
     branches:
     - develop
     - dependabot/**
-    - fix/*
   schedule:
   - cron: '21 2 * * *'
   workflow_call:

--- a/.github/workflows/centos7.yml
+++ b/.github/workflows/centos7.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - develop
     - dependabot/**
+    - fix/*
   schedule:
   - cron: '21 2 * * *'
   workflow_call:

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -269,20 +269,7 @@ public:
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
-        if (AncestorType::isPrinted[0])
-        {
-            results.isCurrentVarNA = AncestorType::isNonApplicable;
-
-            for (unsigned int column = 0; column < nbColumns_; column++)
-            {
-                results.variableCaption = caption(column);
-                results.variableUnit = unit(column);
-                AncestorType::pResults[column].template buildDigest<VCardType>(results,
-                                                                               digestLevel,
-                                                                               dataLevel);
-            }
-        }
-        // Ask to build the digest to the next variable
+        // Dynamic-columns variables are intentionally excluded from digest generation.
         NextType::buildDigest(results, digestLevel, dataLevel);
     }
 

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -217,20 +217,7 @@ public:
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
-        if (AncestorType::isPrinted[0])
-        {
-            results.isCurrentVarNA = AncestorType::isNonApplicable;
-
-            for (unsigned int column = 0; column < nbColumns_; column++)
-            {
-                results.variableCaption = groupNames_[column];
-                results.variableUnit = VCardType::Unit();
-                AncestorType::pResults[column].template buildDigest<VCardType>(results,
-                                                                               digestLevel,
-                                                                               dataLevel);
-            }
-        }
-        // Ask to build the digest to the next variable
+        // Dynamic-columns variables are intentionally excluded from digest generation.
         NextType::buildDigest(results, digestLevel, dataLevel);
     }
 

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -219,20 +219,7 @@ public:
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
-        if (AncestorType::isPrinted[0])
-        {
-            results.isCurrentVarNA = AncestorType::isNonApplicable;
-
-            for (unsigned int column = 0; column < nbColumns_; column++)
-            {
-                results.variableCaption = groupNames_[column];
-                results.variableUnit = VCardType::Unit();
-                AncestorType::pResults[column].template buildDigest<VCardType>(results,
-                                                                               digestLevel,
-                                                                               dataLevel);
-            }
-        }
-        // Ask to build the digest to next variable
+        // Dynamic-columns variables are intentionally excluded from digest generation.
         NextType::buildDigest(results, digestLevel, dataLevel);
     }
 

--- a/src/solver/variable/include/antares/solver/variable/variable.h
+++ b/src/solver/variable/include/antares/solver/variable/variable.h
@@ -245,6 +245,7 @@ public:
                                  uint numSpace) const;
 
     void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const;
+    bool hasColumn() const;
 
     /*!
     ** \brief Event triggered before exporting a year-by-year survey report

--- a/src/solver/variable/include/antares/solver/variable/variable.hxx
+++ b/src/solver/variable/include/antares/solver/variable/variable.hxx
@@ -315,7 +315,7 @@ inline void IVariable<ChildT, NextT, VCardT>::buildDigest(SurveyResults& results
                                                           int dataLevel) const
 {
     // Generate the Digest for the local results (areas part)
-    if (VCardType::columnCount != 0
+    if (VCardType::columnCount > 0
         && (VCardType::categoryDataLevel & Category::DataLevel::setOfAreas
             || VCardType::categoryDataLevel & Category::DataLevel::area
             || VCardType::categoryDataLevel & Category::DataLevel::link))

--- a/src/solver/variable/include/antares/solver/variable/variable.hxx
+++ b/src/solver/variable/include/antares/solver/variable/variable.hxx
@@ -312,7 +312,7 @@ inline void IVariable<ChildT, NextT, VCardT>::buildAnnualSurveyReport(SurveyResu
 template<class ChildT, class NextT, class VCardT>
 inline bool IVariable<ChildT, NextT, VCardT>::hasColumn() const
 {
-    //Leverage the fact that dynamicType has columnCount = -1
+    // Leverage the fact that dynamicType has columnCount = -1
     if (VCardType::columnCount > 0)
     {
         return true;

--- a/src/solver/variable/include/antares/solver/variable/variable.hxx
+++ b/src/solver/variable/include/antares/solver/variable/variable.hxx
@@ -313,11 +313,7 @@ template<class ChildT, class NextT, class VCardT>
 inline bool IVariable<ChildT, NextT, VCardT>::hasColumn() const
 {
     // Leverage the fact that dynamicType has columnCount = -1
-    if (VCardType::columnCount > 0)
-    {
-        return true;
-    }
-    return false;
+    return VCardType::columnCount > 0;
 }
 
 template<class ChildT, class NextT, class VCardT>

--- a/src/solver/variable/include/antares/solver/variable/variable.hxx
+++ b/src/solver/variable/include/antares/solver/variable/variable.hxx
@@ -310,12 +310,23 @@ inline void IVariable<ChildT, NextT, VCardT>::buildAnnualSurveyReport(SurveyResu
 }
 
 template<class ChildT, class NextT, class VCardT>
+inline bool IVariable<ChildT, NextT, VCardT>::hasColumn() const
+{
+    //Leverage the fact that dynamicType has columnCount = -1
+    if (VCardType::columnCount > 0)
+    {
+        return true;
+    }
+    return false;
+}
+
+template<class ChildT, class NextT, class VCardT>
 inline void IVariable<ChildT, NextT, VCardT>::buildDigest(SurveyResults& results,
                                                           int digestLevel,
                                                           int dataLevel) const
 {
     // Generate the Digest for the local results (areas part)
-    if (VCardType::columnCount > 0
+    if (hasColumn()
         && (VCardType::categoryDataLevel & Category::DataLevel::setOfAreas
             || VCardType::categoryDataLevel & Category::DataLevel::area
             || VCardType::categoryDataLevel & Category::DataLevel::link))


### PR DESCRIPTION
When there are dynamique variable activated, digest is wrong. Some columns have the wrong values.
We remove dynamique variables from digest and fix values for other columns.
Dynamique variables will be reintegrated properly in digest later