### PR TITLE
Relax expressions in port definition : fixes after tests [ANT-4646]

### DIFF
--- a/src/io/inputs/forbidden-nodes/ForbiddenNodes.cpp
+++ b/src/io/inputs/forbidden-nodes/ForbiddenNodes.cpp
@@ -17,27 +17,37 @@ bool ForbiddenNodes::isForbiddenByParent(const std::type_index& parentTypeId,
 
 using namespace Antares::Expressions::Nodes;
 
-void ForbidInFunctionNodes(ForbiddenNodes& f)
+void forbidVariablesInFunctionNodes(ForbiddenNodes& f)
+{
+    f.parentForbidsChild<FunctionNodeType::max, VariableNode>();
+    f.parentForbidsChild<FunctionNodeType::min, VariableNode>();
+    f.parentForbidsChild<FunctionNodeType::floor, VariableNode>();
+    f.parentForbidsChild<FunctionNodeType::ceil, VariableNode>();
+}
+
+void forbidPortFieldsInFunctionNodes(ForbiddenNodes& f)
 {
     // max(...) : fordidding children
-    f.parentForbidsChild<FunctionNodeType::max, VariableNode>();
     f.parentForbidsChild<FunctionNodeType::max, PortFieldNode>();
     f.parentForbidsChild<FunctionNodeType::max, PortFieldSumNode>();
 
     // min(...) : fordidding children
-    f.parentForbidsChild<FunctionNodeType::min, VariableNode>();
     f.parentForbidsChild<FunctionNodeType::min, PortFieldNode>();
     f.parentForbidsChild<FunctionNodeType::min, PortFieldSumNode>();
 
     // floor(node) : fordidding children
-    f.parentForbidsChild<FunctionNodeType::floor, VariableNode>();
     f.parentForbidsChild<FunctionNodeType::floor, PortFieldNode>();
     f.parentForbidsChild<FunctionNodeType::floor, PortFieldSumNode>();
 
     // ceil(node) : fordidding children
-    f.parentForbidsChild<FunctionNodeType::ceil, VariableNode>();
     f.parentForbidsChild<FunctionNodeType::ceil, PortFieldNode>();
     f.parentForbidsChild<FunctionNodeType::ceil, PortFieldSumNode>();
+}
+
+void ForbidInFunctionNodes(ForbiddenNodes& f)
+{
+    forbidVariablesInFunctionNodes(f);
+    forbidPortFieldsInFunctionNodes(f);
 }
 
 void ForbidConstraintSignNodes(ForbiddenNodes& f)
@@ -75,7 +85,7 @@ ForbiddenNodes ForbidNodesInVariableBounds()
 ForbiddenNodes ForbidNodesInPortFieldDef()
 {
     ForbiddenNodes f;
-    ForbidInFunctionNodes(f);
+    forbidPortFieldsInFunctionNodes(f);
     ForbidConstraintSignNodes(f);
     f.forbidGlobally<PortFieldSumNode>();
     return f;

--- a/src/io/inputs/forbidden-nodes/ForbiddenNodesVisitor.cpp
+++ b/src/io/inputs/forbidden-nodes/ForbiddenNodesVisitor.cpp
@@ -111,13 +111,12 @@ void ForbiddenNodesVisitor::visit(const ParameterNode*)
 
 void ForbiddenNodesVisitor::visit(const PortFieldNode* portFieldNode)
 {
-    // gp : could be dead code, considering visit(const PortFieldSumNode* portFieldSumNode)
     checkIsForbidden(portFieldNode, typeIndexOf<PortFieldNode>());
 }
 
-void ForbiddenNodesVisitor::visit(const PortFieldSumNode*)
+void ForbiddenNodesVisitor::visit(const PortFieldSumNode* portFieldSumNode)
 {
-    // keep empty
+    checkIsForbidden(portFieldSumNode, typeIndexOf<PortFieldSumNode>());
 }
 
 void ForbiddenNodesInComponentVisitor::visit(const PortFieldSumNode* portFieldSumNode)

--- a/src/tests/src/io/yml-importers/testModelConverter.cpp
+++ b/src/tests/src/io/yml-importers/testModelConverter.cpp
@@ -382,19 +382,52 @@ BOOST_FIXTURE_TEST_CASE(model_port_field_definitions_properly_translated, Fixtur
 
 BOOST_FIXTURE_TEST_CASE(port_fields_definitions_forbid_usage_of_sum_connections, Fixture)
 {
-    library.port_types = {};
-    YmlModel::Model model1{.id = "model1",
-                           .description = "description",
-                           .parameters = {},
-                           .variables = {},
-                           .ports = {},
-                           .port_field_definitions = {{"port", "field", "sum_connections(port.field)"}},
-                           .constraints = {},
-                           .binding_constraints = {},
-                           .objectives = {},
-                           .extra_outputs = {}};
-    library.models = {model1};
-    BOOST_CHECK_THROW(ModelConverter::convert(library), std::runtime_error);
+    YmlModel::PortType portType{"my-port-type", "description", {"field"}, "", {}};
+    library.port_types = {portType};
+
+    YmlModel::Model model{
+      .id = "my-model",
+      .description = "description",
+      .parameters = {},
+      .variables = {},
+      .ports = {{"port", "my-port-type"}},
+      .port_field_definitions = {{"port", "field", "sum_connections(port.field)"}},
+      .constraints = {},
+      .binding_constraints = {},
+      .objectives = {},
+      .extra_outputs = {}};
+    library.models = {model};
+
+    std::string err_msg = "'PortFieldSumNode' is not allowed in expression "
+                          "'sum_connections(port.field)'";
+    BOOST_CHECK_EXCEPTION(ModelConverter::convert(library),
+                          std::invalid_argument,
+                          checkMessage(err_msg));
+}
+
+BOOST_FIXTURE_TEST_CASE(in_port_fields_definitions__min_operator_accepts_a_variable, Fixture)
+{
+    YmlModel::PortType portType{"my-port-type", "description", {"field"}, "", {}};
+    library.port_types = {portType};
+
+    std::string location = "master-and-subproblems";
+
+    Variable spillage = {"spillage", "0", "100", ValueType::CONTINUOUS, true, true, location};
+    Variable ens = {"ens", "0", "100", ValueType::CONTINUOUS, true, true, location};
+
+    YmlModel::Model model{.id = "my-model",
+                          .description = "description",
+                          .parameters = {},
+                          .variables = {spillage, ens},
+                          .ports = {{"port", "my-port-type"}},
+                          .port_field_definitions = {{"port", "field", "min(spillage, ens)"}},
+                          .constraints = {},
+                          .binding_constraints = {},
+                          .objectives = {},
+                          .extra_outputs = {}};
+    library.models = {model};
+
+    BOOST_CHECK_NO_THROW(ModelConverter::convert(library), std::invalid_argument);
 }
 
 bool portNotFoundForDef(const ModelConverter::PortNotFoundForDefinition& ex)

--- a/src/tests/src/io/yml-importers/testModelConverter.cpp
+++ b/src/tests/src/io/yml-importers/testModelConverter.cpp
@@ -380,6 +380,23 @@ BOOST_FIXTURE_TEST_CASE(model_port_field_definitions_properly_translated, Fixtur
     BOOST_CHECK_EQUAL(pfd1.Definition().Value(), "param1");
 }
 
+BOOST_FIXTURE_TEST_CASE(port_fields_definitions_forbid_usage_of_sum_connections, Fixture)
+{
+    library.port_types = {};
+    YmlModel::Model model1{.id = "model1",
+                           .description = "description",
+                           .parameters = {},
+                           .variables = {},
+                           .ports = {},
+                           .port_field_definitions = {{"port", "field", "sum_connections(port.field)"}},
+                           .constraints = {},
+                           .binding_constraints = {},
+                           .objectives = {},
+                           .extra_outputs = {}};
+    library.models = {model1};
+    BOOST_CHECK_THROW(ModelConverter::convert(library), std::runtime_error);
+}
+
 bool portNotFoundForDef(const ModelConverter::PortNotFoundForDefinition& ex)
 {
     BOOST_CHECK_EQUAL(ex.what(), "In port-field-definitions, port not found: port2");

--- a/src/tests/src/io/yml-importers/testModelConverter.cpp
+++ b/src/tests/src/io/yml-importers/testModelConverter.cpp
@@ -427,7 +427,7 @@ BOOST_FIXTURE_TEST_CASE(in_port_fields_definitions__min_operator_accepts_a_varia
                           .extra_outputs = {}};
     library.models = {model};
 
-    BOOST_CHECK_NO_THROW(ModelConverter::convert(library), std::invalid_argument);
+    BOOST_CHECK_NO_THROW(ModelConverter::convert(library));
 }
 
 bool portNotFoundForDef(const ModelConverter::PortNotFoundForDefinition& ex)


### PR DESCRIPTION
This PR is about [ticket ANT-4646](https://gopro-tickets.rte-france.com/browse/ANT-4646).

A first PR ([PR 3483](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/3483)) was merged into **develop**.

After tests by @Juliette-Gerbaux, some fixes were recommended : 
- relax port field definitions expressions, so that non linear operators **min**, **max**, **ceil**, **floor**  can accept variable nodes (**VariableNode**).
- restore prohibition of operator **sum_connections** (node **PortFieldSumNode**) in port field definitions