### PR TITLE
replace raw Area* with unique_ptr in AreaList

### DIFF
--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -447,7 +447,7 @@ YearlyData SingleProblemGetter::computeHydroLevels(unsigned year,
             continue;
         }
         auto inflows = area->hydro.series->storage.getColumn(year);
-        auto& level = hydroLevels[area];
+        auto& level = hydroLevels[area.get()];
 
         // Initialize first week level
         uint firstDay = calendar.weeks[0].daysYear.first;

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -151,14 +151,6 @@ AreaList::AreaList(Study& study):
 {
 }
 
-AreaList::~AreaList()
-{
-    for (auto* area: areas | std::views::values)
-    {
-        delete area;
-    }
-}
-
 bool AreaList::empty() const
 {
     return areas.empty();
@@ -188,7 +180,7 @@ void AreaList::rebuildIndexes()
     auto end = areas.end();
     for (auto i = areas.begin(); i != end; ++i, ++indx)
     {
-        Area* area = i->second;
+        Area* area = i->second.get();
         byIndex[indx] = area;
         area->index = indx;
     }
@@ -204,7 +196,7 @@ Area* AreaList::add(Area* a)
         [[maybe_unused]] unsigned count = (uint)areas.size(); // used for assert
 
         // Adding the area in the list
-        areas[a->id] = a;
+        areas[a->id] = std::unique_ptr<Area>(a);
         rebuildIndexes();
 
         assert(areas.size() == (count + 1) and "Invalid count of areas in the map");
@@ -778,27 +770,27 @@ bool AreaList::loadFromFolder(const StudyLoadOptions& options)
 Area* AreaList::find(const AreaName& id)
 {
     auto i = this->areas.find(id);
-    return (i != this->areas.end()) ? i->second : nullptr;
+    return (i != this->areas.end()) ? i->second.get() : nullptr;
 }
 
 const Area* AreaList::find(const AreaName& id) const
 {
     auto i = this->areas.find(id);
-    return (i != this->areas.end()) ? i->second : nullptr;
+    return (i != this->areas.end()) ? i->second.get() : nullptr;
 }
 
 Area* AreaList::findFromName(const AreaName& name)
 {
     AreaName id = transformNameIntoID(name);
     auto i = this->areas.find(id);
-    return (i != this->areas.end()) ? i->second : nullptr;
+    return (i != this->areas.end()) ? i->second.get() : nullptr;
 }
 
 const Area* AreaList::findFromName(const AreaName& name) const
 {
     AreaName id = transformNameIntoID(name);
     auto i = this->areas.find(id);
-    return (i != this->areas.end()) ? i->second : nullptr;
+    return (i != this->areas.end()) ? i->second.get() : nullptr;
 }
 
 Area* AreaListLFind(AreaList* l, const char lname[])
@@ -806,7 +798,7 @@ Area* AreaListLFind(AreaList* l, const char lname[])
     if (l && !l->areas.empty() && lname)
     {
         auto i = l->areas.find(AreaName(lname));
-        return (i != l->areas.end()) ? i->second : nullptr;
+        return (i != l->areas.end()) ? i->second.get() : nullptr;
     }
     return nullptr;
 }
@@ -818,9 +810,9 @@ Area* AreaListFindPtr(AreaList* l, const Area* ptr)
         auto end = l->areas.end();
         for (auto i = l->areas.begin(); i != end; ++i)
         {
-            if (ptr == i->second)
+            if (ptr == i->second.get())
             {
-                return i->second;
+                return i->second.get();
             }
         }
     }

--- a/src/libs/antares/study/area/sets.cpp
+++ b/src/libs/antares/study/area/sets.cpp
@@ -396,7 +396,7 @@ bool SetHandlerAreas::applyFilter(Sets::SetAreasType& set, const std::string& va
     {
         for (const auto& [areaName, area]: areas_)
         {
-            set.insert(area);
+            set.insert(area.get());
         }
         return true;
     }

--- a/src/libs/antares/study/cleaner/cleaner-v20.cpp
+++ b/src/libs/antares/study/cleaner/cleaner-v20.cpp
@@ -307,7 +307,7 @@ bool listOfFilesAnDirectoriesToKeep(StudyCleaningInfos* infos)
         for (auto i = arealist->areas.begin(); i != end; ++i)
         {
             // Ref to the area
-            auto* area = i->second;
+            auto* area = i->second.get();
 
             {
                 // Do not display useless messages

--- a/src/libs/antares/study/include/antares/study/area/area.h
+++ b/src/libs/antares/study/include/antares/study/area/area.h
@@ -272,16 +272,18 @@ private:
 class AreaList final: public Yuni::NonCopyable<AreaList>
 {
 public:
+    using OwningAreaMap = std::map<AreaName, std::unique_ptr<Area>>;
+
     //! An iterator
-    using iterator = Area::Map::iterator;
+    using iterator = OwningAreaMap::iterator;
     //! A const iterator
-    using const_iterator = Area::Map::const_iterator;
+    using const_iterator = OwningAreaMap::const_iterator;
     //! An iterator
-    using reverse_iterator = Area::Map::reverse_iterator;
+    using reverse_iterator = OwningAreaMap::reverse_iterator;
     //! A const iterator
-    using const_reverse_iterator = Area::Map::const_reverse_iterator;
+    using const_reverse_iterator = OwningAreaMap::const_reverse_iterator;
     //! Key-value type
-    using value_type = Area::Map::value_type;
+    using value_type = OwningAreaMap::value_type;
 
     //! \name Constructor & Destructor
     //@{
@@ -289,14 +291,6 @@ public:
     ** \brief Default constructor
     */
     explicit AreaList(Study& study);
-
-    /*!
-     ** \brief Destructor
-     **
-     ** Frees all Area instances owned by this list.
-     */
-    ~AreaList();
-    //@}
 
     //! \name Iterating through all areas
     //@{
@@ -475,7 +469,7 @@ public:
     //! All areas by their index
     std::vector<Area*> byIndex;
     //! All areas in the list
-    Area::Map areas;
+    OwningAreaMap areas;
 
     //! Name set (must be updated by updateNameSet)
     // used by the copy/paste

--- a/src/libs/antares/study/parameters/adq-patch-params.cpp
+++ b/src/libs/antares/study/parameters/adq-patch-params.cpp
@@ -199,7 +199,7 @@ void AdqPatchParams::checkAdqPatchContainsAdqPatchArea(const Antares::Data::Area
 {
     const bool containsAdqArea = std::any_of(areas.cbegin(),
                                              areas.cend(),
-                                             [](const std::pair<AreaName, Area*>& area) {
+                                             [](const auto& area) {
                                                  return area.second->adequacyPatchMode
                                                         == physicalAreaInsideAdqPatch;
                                              });

--- a/src/tests/src/solver/variable/test_dynamic.cpp
+++ b/src/tests/src/solver/variable/test_dynamic.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(SetDataSingleYearAddResultsToSet_WithMockData)
     std::set<Area*, CompareAreaName> areaSet;
     for (auto& [_, area]: study->areas)
     {
-        areaSet.insert(area);
+        areaSet.insert(area.get());
     }
 
     SetDataSingleYear setData(areaSet);

--- a/src/tests/src/solver/variable/test_residual_load.cpp
+++ b/src/tests/src/solver/variable/test_residual_load.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(hourly_values_are_copied_from_state)
     // Attach area
     auto itArea = study->areas.begin();
     BOOST_REQUIRE(itArea != study->areas.end());
-    state.area = itArea->second;
+    state.area = itArea->second.get();
     // Create real weekly problem structure with one country
     PROBLEME_HEBDO weeklyProblem;
     weeklyProblem.NombreDePays = 1;


### PR DESCRIPTION
AreaList was storing Area instances as raw pointers in a std::map,
requiring a manual destructor to free memory. This was flagged by
SonarQube as a misuse of dynamic memory.

Replace the raw pointer map with a std::unique_ptr-based map to make
ownership explicit and automatic. The destructor is removed as it is
no longer needed.

All call sites updated to use .get() where a non-owning raw pointer
is required (observers, find functions, index rebuilding, etc.).