### PR TITLE
ci: Use fixed submodule for Antares_Simulator_Tests_NR instead of branch main

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -120,7 +120,7 @@ jobs:
 
     - name: Init submodule
       run: |
-        git submodule update --init --depth 1 --remote src/tests/resources/Antares_Simulator_Tests_NR
+        git submodule update --init --depth 1 src/tests/resources/Antares_Simulator_Tests_NR
 
     - name: Configure
       run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: Init submodule Antares_Simulator_Tests_NR
       run: |
-        git submodule update --init --remote --recursive src/tests/resources/Antares_Simulator_Tests_NR
+        git submodule update --init --recursive src/tests/resources/Antares_Simulator_Tests_NR
 
     - name: Run named mps tests
       if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: Init submodule Antares_Simulator_Tests_NR
       run: |
-        git submodule update --init --recursive src/tests/resources/Antares_Simulator_Tests_NR
+        git submodule update --init --depth 1 --recursive src/tests/resources/Antares_Simulator_Tests_NR
 
     - name: Run named mps tests
       if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -185,7 +185,7 @@ jobs:
 
     - name: Init submodule Antares_Simulator_Tests_NR
       run: |
-        git submodule update --init --remote src/tests/resources/Antares_Simulator_Tests_NR
+        git submodule update --init --depth 1 src/tests/resources/Antares_Simulator_Tests_NR
 
     - name: Run named mps tests
       if: ${{ env.RUN_SIMPLE_TESTS == 'true' && ! cancelled() }}


### PR DESCRIPTION
## Before
Using flag `--remote` forces pulling the main branch of submodule Antares_Simulator_Tests_NR, which is not fixed.

## After
Without this flag, we pull the fixed commit id as defined in the Antares_Simulator repository.

## Benefits
- Each feature branch in Antares_Simulator can use it's own version of Antares_Simulator_Tests_NR.
- There is no side-effect on Antares_Simulator branches when pushing to Antares_Simulator_Tests_NR's main branch