### PR TITLE
ANT-4899 - Not loading binding constraints when enabled is set to false in INI file

### DIFF
--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -43,9 +43,11 @@ std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintLoader::load(En
 
     if (!bc->pEnabled)
     {
-        return {};
+        /// This BC won't be used, return it without loading time series
+        logs.info() << "DEBUG: BC " << bc->name() << " is disabled, skipping time series";
+        return {bc};
     }
-
+    logs.info() << "DEBUG: BC " << bc->name() << " is enabled, loading time series";
     return loadByOperator(env, bc);
 }
 
@@ -190,7 +192,7 @@ bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(
     return false;
 }
 
-void BindingConstraintLoader::populateConstraint(EnvForLoading& env,
+void BindingConstraintLoader::populateConstraint(const EnvForLoading& env,
                                                  std::shared_ptr<BindingConstraint>& bc)
 {
     // Foreach property in the section...
@@ -251,7 +253,7 @@ void BindingConstraintLoader::populateConstraint(EnvForLoading& env,
     }
 }
 
-void BindingConstraintLoader::parseWeightAndOffset(EnvForLoading& env,
+void BindingConstraintLoader::parseWeightAndOffset(const EnvForLoading& env,
                                                    const IniFile::Property* p,
                                                    std::shared_ptr<BindingConstraint>& bc)
 {
@@ -323,7 +325,7 @@ void BindingConstraintLoader::parseWeightAndOffset(EnvForLoading& env,
     }
 }
 
-bool BindingConstraintLoader::validate(EnvForLoading& env,
+bool BindingConstraintLoader::validate(const EnvForLoading& env,
                                        const std::shared_ptr<BindingConstraint>& bc)
 {
     if (bc->pName.empty())
@@ -371,17 +373,18 @@ std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintLoader::loadByO
     }
     case BindingConstraint::opBoth:
     {
-        auto greater_bc = std::make_shared<BindingConstraint>();
-        greater_bc->copyFrom(bc.get());
-        greater_bc->name(bc->name() + "_sup");
-        greater_bc->pID = bc->pID;
-        greater_bc->operatorType(BindingConstraint::opGreater);
-        bc->name(bc->name() + "_inf");
+        auto greaterBc = std::make_shared<BindingConstraint>();
+        const auto originalName = bc->name();
+        greaterBc->copyFrom(bc.get());
+        greaterBc->name(originalName + "_sup");
+        greaterBc->pID = bc->pID;
+        greaterBc->operatorType(BindingConstraint::opGreater);
+        bc->name(originalName + "_inf");
         bc->operatorType(BindingConstraint::opLess);
 
-        if (loadTimeSeries(env, bc.get()) && loadTimeSeries(env, greater_bc.get()))
+        if (loadTimeSeries(env, bc.get()) && loadTimeSeries(env, greaterBc.get()))
         {
-            return {bc, greater_bc};
+            return {bc, greaterBc};
         }
         break;
     }

--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -27,152 +27,11 @@ std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintLoader::load(En
     auto bc = std::make_shared<BindingConstraint>();
     bc->clear();
 
-    // Foreach property in the section...
-    for (const IniFile::Property* p = env.section->firstProperty; p; p = p->next)
-    {
-        if (p->key.empty())
-        {
-            continue;
-        }
-
-        if (p->key == "name")
-        {
-            bc->pName = p->value;
-            continue;
-        }
-        if (p->key == "id")
-        {
-            bc->pID = p->value;
-            boost::to_lower(bc->pID);
-            continue;
-        }
-        if (p->key == "enabled")
-        {
-            bc->pEnabled = p->value.to<bool>();
-            continue;
-        }
-        if (p->key == "type")
-        {
-            bc->pType = BindingConstraint::StringToType(p->value);
-            continue;
-        }
-        if (p->key == "operator")
-        {
-            bc->pOperator = BindingConstraint::StringToOperator(p->value);
-            continue;
-        }
-        if (p->key == "filter-year-by-year")
-        {
-            bc->pFilterYearByYear = stringIntoDatePrecision(p->value);
-            continue;
-        }
-        if (p->key == "filter-synthesis")
-        {
-            bc->pFilterSynthesis = stringIntoDatePrecision(p->value);
-            continue;
-        }
-        if (p->key == "comments")
-        {
-            bc->pComments = p->value;
-            continue;
-        }
-        if (p->key == "group")
-        {
-            bc->group_ = p->value.c_str();
-            continue;
-        }
-
-        // initialize the values
-        double w = .0;
-        int o = 0;
-
-        // Separate the value
-        if (auto setKey = p->key.find('%'); setKey != 0 && setKey != String::npos) // It is a link
-        {
-            if (bool ret = SeparateValue(env, p, w, o); !ret)
-            {
-                continue;
-            }
-
-            const AreaLink* lnk = env.areaList.findLinkFromINIKey(p->key);
-            if (!lnk)
-            {
-                logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
-                             << "`: link not found";
-                continue;
-            }
-            if (!Utils::isZero(w))
-            {
-                bc->weight(lnk, w);
-            }
-
-            if (!Utils::isZero(o))
-            {
-                bc->offset(lnk, o);
-            }
-
-            continue;
-        }
-        else // It must be a cluster
-        {
-            // Separate the key
-            setKey = p->key.find('.');
-            if (0 == setKey || setKey == String::npos)
-            {
-                logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
-                             << "`: invalid key";
-                continue;
-            }
-
-            if (bool ret = SeparateValue(env, p, w, o); !ret)
-            {
-                continue;
-            }
-
-            const ThermalCluster* clstr = env.areaList.findClusterFromINIKey(p->key);
-            if (!clstr)
-            {
-                logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
-                             << "`: cluster not found";
-                continue;
-            }
-            if (!Utils::isZero(w))
-            {
-                bc->weight(clstr, w);
-            }
-
-            if (!Utils::isZero(o))
-            {
-                bc->offset(clstr, o);
-            }
-
-            continue;
-        }
-    }
+    populateConstraint(env, bc);
 
     // Checking for validity
-    if (bc->pName.empty())
+    if (!validate(env, bc))
     {
-        logs.error() << env.iniFilename << ": in [" << env.section->name
-                     << "]: Invalid binding constraint name";
-        return {};
-    }
-    if (bc->pID.empty())
-    {
-        logs.error() << env.iniFilename << ": in [" << env.section->name
-                     << "]: Invalid binding constraint id";
-        return {};
-    }
-    if (bc->pType == bc->typeUnknown)
-    {
-        logs.error() << env.iniFilename << ": in [" << env.section->name
-                     << "]: Invalid type [hourly,daily,weekly]";
-        return {};
-    }
-    if (bc->pOperator == BindingConstraint::opUnknown)
-    {
-        logs.error() << env.iniFilename << ": in [" << env.section->name
-                     << "]: Invalid operator [less,greater,equal,both]";
         return {};
     }
 
@@ -182,41 +41,12 @@ std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintLoader::load(En
         bc->pEnabled = false;
     }
 
-    switch (bc->operatorType())
+    if (!bc->pEnabled)
     {
-    case BindingConstraint::opLess:
-    case BindingConstraint::opEquality:
-    case BindingConstraint::opGreater:
-    {
-        if (loadTimeSeries(env, bc.get()))
-        {
-            return {bc};
-        }
-        break;
-    }
-    case BindingConstraint::opBoth:
-    {
-        auto greater_bc = std::make_shared<BindingConstraint>();
-        greater_bc->copyFrom(bc.get());
-        greater_bc->name(bc->name() + "_sup");
-        greater_bc->pID = bc->pID;
-        greater_bc->operatorType(BindingConstraint::opGreater);
-        bc->name(bc->name() + "_inf");
-        bc->operatorType(BindingConstraint::opLess);
-
-        if (loadTimeSeries(env, bc.get()) && loadTimeSeries(env, greater_bc.get()))
-        {
-            return {bc, greater_bc};
-        }
-        break;
-    }
-    default:
-    {
-        logs.error() << "Wrong binding constraint operator type for constraint " << bc->name();
         return {};
     }
-    }
-    return {};
+
+    return loadByOperator(env, bc);
 }
 
 bool BindingConstraintLoader::SeparateValue(const EnvForLoading& env,
@@ -359,4 +189,209 @@ bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(
 
     return false;
 }
+
+void BindingConstraintLoader::populateConstraint(EnvForLoading& env,
+                                                 std::shared_ptr<BindingConstraint>& bc)
+{
+    // Foreach property in the section...
+    for (const IniFile::Property* p = env.section->firstProperty; p; p = p->next)
+    {
+        if (p->key.empty())
+        {
+            continue;
+        }
+
+        if (p->key == "name")
+        {
+            bc->pName = p->value;
+            continue;
+        }
+        if (p->key == "id")
+        {
+            bc->pID = p->value;
+            boost::to_lower(bc->pID);
+            continue;
+        }
+        if (p->key == "enabled")
+        {
+            bc->pEnabled = p->value.to<bool>();
+            continue;
+        }
+        if (p->key == "type")
+        {
+            bc->pType = BindingConstraint::StringToType(p->value);
+            continue;
+        }
+        if (p->key == "operator")
+        {
+            bc->pOperator = BindingConstraint::StringToOperator(p->value);
+            continue;
+        }
+        if (p->key == "filter-year-by-year")
+        {
+            bc->pFilterYearByYear = stringIntoDatePrecision(p->value);
+            continue;
+        }
+        if (p->key == "filter-synthesis")
+        {
+            bc->pFilterSynthesis = stringIntoDatePrecision(p->value);
+            continue;
+        }
+        if (p->key == "comments")
+        {
+            bc->pComments = p->value;
+            continue;
+        }
+        if (p->key == "group")
+        {
+            bc->group_ = p->value.c_str();
+            continue;
+        }
+        parseWeightAndOffset(env, p, bc);
+    }
+}
+
+void BindingConstraintLoader::parseWeightAndOffset(EnvForLoading& env,
+                                                   const IniFile::Property* p,
+                                                   std::shared_ptr<BindingConstraint>& bc)
+{
+    // initialize the values
+    double w = .0;
+    int o = 0;
+
+    // Separate the value
+    if (auto setKey = p->key.find('%'); setKey != 0 && setKey != String::npos) // It is a link
+    {
+        if (bool ret = SeparateValue(env, p, w, o); !ret)
+        {
+            return;
+        }
+
+        const AreaLink* lnk = env.areaList.findLinkFromINIKey(p->key);
+        if (!lnk)
+        {
+            logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
+                         << "`: link not found";
+            return;
+        }
+        if (!Utils::isZero(w))
+        {
+            bc->weight(lnk, w);
+        }
+
+        if (!Utils::isZero(o))
+        {
+            bc->offset(lnk, o);
+        }
+
+        return;
+    }
+    else // It must be a cluster
+    {
+        // Separate the key
+        setKey = p->key.find('.');
+        if (0 == setKey || setKey == String::npos)
+        {
+            logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
+                         << "`: invalid key";
+            return;
+        }
+
+        if (bool ret = SeparateValue(env, p, w, o); !ret)
+        {
+            return;
+        }
+
+        const ThermalCluster* clstr = env.areaList.findClusterFromINIKey(p->key);
+        if (!clstr)
+        {
+            logs.error() << env.iniFilename << ": in [" << env.section->name << "]: `" << p->key
+                         << "`: cluster not found";
+            return;
+        }
+        if (!Utils::isZero(w))
+        {
+            bc->weight(clstr, w);
+        }
+
+        if (!Utils::isZero(o))
+        {
+            bc->offset(clstr, o);
+        }
+
+        return;
+    }
+}
+
+bool BindingConstraintLoader::validate(EnvForLoading& env,
+                                       const std::shared_ptr<BindingConstraint>& bc)
+{
+    if (bc->pName.empty())
+    {
+        logs.error() << env.iniFilename << ": in [" << env.section->name
+                     << "]: Invalid binding constraint name";
+        return false;
+    }
+    if (bc->pID.empty())
+    {
+        logs.error() << env.iniFilename << ": in [" << env.section->name
+                     << "]: Invalid binding constraint id";
+        return false;
+    }
+    if (bc->pType == bc->typeUnknown)
+    {
+        logs.error() << env.iniFilename << ": in [" << env.section->name
+                     << "]: Invalid type [hourly,daily,weekly]";
+        return false;
+    }
+    if (bc->pOperator == BindingConstraint::opUnknown)
+    {
+        logs.error() << env.iniFilename << ": in [" << env.section->name
+                     << "]: Invalid operator [less,greater,equal,both]";
+        return false;
+    }
+    return true;
+}
+
+std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintLoader::loadByOperator(
+  EnvForLoading& env,
+  std::shared_ptr<BindingConstraint>& bc)
+{
+    switch (bc->operatorType())
+    {
+    case BindingConstraint::opLess:
+    case BindingConstraint::opEquality:
+    case BindingConstraint::opGreater:
+    {
+        if (loadTimeSeries(env, bc.get()))
+        {
+            return {bc};
+        }
+        break;
+    }
+    case BindingConstraint::opBoth:
+    {
+        auto greater_bc = std::make_shared<BindingConstraint>();
+        greater_bc->copyFrom(bc.get());
+        greater_bc->name(bc->name() + "_sup");
+        greater_bc->pID = bc->pID;
+        greater_bc->operatorType(BindingConstraint::opGreater);
+        bc->name(bc->name() + "_inf");
+        bc->operatorType(BindingConstraint::opLess);
+
+        if (loadTimeSeries(env, bc.get()) && loadTimeSeries(env, greater_bc.get()))
+        {
+            return {bc, greater_bc};
+        }
+        break;
+    }
+    default:
+    {
+        logs.error() << "Wrong binding constraint operator type for constraint " << bc->name();
+        return {};
+    }
+    }
+    return {};
+}
+
 } // namespace Antares::Data

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintLoader.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintLoader.h
@@ -36,6 +36,18 @@ private:
     bool loadTimeSeries(EnvForLoading& env,
                         BindingConstraint::Operator operatorType,
                         BindingConstraint* bindingConstraint) const;
+
+    void populateConstraint(EnvForLoading& env, std::shared_ptr<BindingConstraint>& bc);
+
+    void parseWeightAndOffset(EnvForLoading& env,
+                            const IniFile::Property* p,
+                            std::shared_ptr<BindingConstraint>& bc);
+
+                            bool validate(EnvForLoading& env, const std::shared_ptr<BindingConstraint>& bc);
+
+     std::vector<std::shared_ptr<BindingConstraint>> loadByOperator(
+        EnvForLoading& env,
+        std::shared_ptr<BindingConstraint>& bc);
 };
 
 } // namespace Antares::Data

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintLoader.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintLoader.h
@@ -40,14 +40,14 @@ private:
     void populateConstraint(EnvForLoading& env, std::shared_ptr<BindingConstraint>& bc);
 
     void parseWeightAndOffset(EnvForLoading& env,
-                            const IniFile::Property* p,
-                            std::shared_ptr<BindingConstraint>& bc);
+                              const IniFile::Property* p,
+                              std::shared_ptr<BindingConstraint>& bc);
 
-                            bool validate(EnvForLoading& env, const std::shared_ptr<BindingConstraint>& bc);
+    bool validate(EnvForLoading& env, const std::shared_ptr<BindingConstraint>& bc);
 
-     std::vector<std::shared_ptr<BindingConstraint>> loadByOperator(
-        EnvForLoading& env,
-        std::shared_ptr<BindingConstraint>& bc);
+    std::vector<std::shared_ptr<BindingConstraint>> loadByOperator(
+      EnvForLoading& env,
+      std::shared_ptr<BindingConstraint>& bc);
 };
 
 } // namespace Antares::Data

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintLoader.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintLoader.h
@@ -37,13 +37,13 @@ private:
                         BindingConstraint::Operator operatorType,
                         BindingConstraint* bindingConstraint) const;
 
-    void populateConstraint(EnvForLoading& env, std::shared_ptr<BindingConstraint>& bc);
+    void populateConstraint(const EnvForLoading& env, std::shared_ptr<BindingConstraint>& bc);
 
-    void parseWeightAndOffset(EnvForLoading& env,
+    void parseWeightAndOffset(const EnvForLoading& env,
                               const IniFile::Property* p,
                               std::shared_ptr<BindingConstraint>& bc);
 
-    bool validate(EnvForLoading& env, const std::shared_ptr<BindingConstraint>& bc);
+    bool validate(const EnvForLoading& env, const std::shared_ptr<BindingConstraint>& bc);
 
     std::vector<std::shared_ptr<BindingConstraint>> loadByOperator(
       EnvForLoading& env,

--- a/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
@@ -307,6 +307,88 @@ BOOST_AUTO_TEST_CASE(BC_load_legacy_range)
     BOOST_CHECK_CLOSE((*bc_gt)->RHSTimeSeries()[0][8783], 0.4, 0.0001);
 }
 
+BOOST_AUTO_TEST_CASE(BC_disabled_returns_constraint_without_timeseries)
+{
+    auto study = std::make_shared<Study>();
+    auto area1 = addAreaToListOfAreas(study->areas, "area1");
+    auto area2 = addAreaToListOfAreas(study->areas, "area2");
+    AreaAddLinkBetweenAreas(area1, area2);
+
+    StudyLoadOptions options;
+    BindingConstraintsRepository bindingConstraints;
+
+    auto working_tmp_dir = CREATE_TMP_DIR_BASED_ON_TEST_NAME();
+
+    std::ofstream constraints(working_tmp_dir / "bindingconstraints.ini");
+    constraints << "[1]\n"
+                << "name = dummy_name\n"
+                << "id = dummy_id\n"
+                << "enabled = false\n"
+                << "type = hourly\n"
+                << "operator = equal\n"
+                << "group = dummy_group\n"
+                << "area1%area2 = 1.000000\n";
+    constraints.close();
+    std::ofstream rhs(working_tmp_dir / "dummy_id_eq.txt");
+    for (int i = 0; i < 8784; ++i)
+    {
+        rhs << "0.2\t0.4\t0.6\n";
+    }
+    rhs.close();
+
+    study->header.version = StudyVersion(8, 7);
+    const bool loading_ok = bindingConstraints.loadFromFolder(*study,
+                                                              options,
+                                                              working_tmp_dir.string());
+
+    BOOST_CHECK_EQUAL(loading_ok, true);
+
+    auto constraint = *bindingConstraints.begin();
+    BOOST_CHECK_EQUAL(constraint->enabled(), false);
+    BOOST_CHECK_EQUAL(constraint->RHSTimeSeries().width, 0);
+    BOOST_CHECK_EQUAL(constraint->RHSTimeSeries().height, 0);
+}
+
+BOOST_AUTO_TEST_CASE(BC_disabled_both_operator_returns_single_constraint)
+{
+    auto study = std::make_shared<Study>();
+    auto area1 = addAreaToListOfAreas(study->areas, "area1");
+    auto area2 = addAreaToListOfAreas(study->areas, "area2");
+    AreaAddLinkBetweenAreas(area1, area2);
+
+    StudyLoadOptions options;
+    BindingConstraintsRepository bindingConstraints;
+
+    auto working_tmp_dir = CREATE_TMP_DIR_BASED_ON_TEST_NAME();
+
+    std::ofstream constraints(working_tmp_dir / "bindingconstraints.ini");
+    constraints << "[1]\n"
+                << "name = dummy_name\n"
+                << "id = dummy_id\n"
+                << "enabled = false\n"
+                << "type = hourly\n"
+                << "operator = both\n"
+                << "group = dummy_group\n"
+                << "area1%area2 = 1.000000\n";
+    constraints.close();
+    std::ofstream lt(working_tmp_dir / "dummy_id_lt.txt");
+    lt.close();
+    std::ofstream gt(working_tmp_dir / "dummy_id_gt.txt");
+    gt.close();
+
+    study->header.version = StudyVersion(8, 7);
+    const bool loading_ok = bindingConstraints.loadFromFolder(*study,
+                                                              options,
+                                                              working_tmp_dir.string());
+
+    BOOST_CHECK_EQUAL(loading_ok, true);
+    // With enabled=false, the constraint is returned without splitting into lt/gt
+    BOOST_CHECK_EQUAL(bindingConstraints.size(), 1);
+
+    auto constraint = *bindingConstraints.begin();
+    BOOST_CHECK_EQUAL(constraint->enabled(), false);
+}
+
 BOOST_AUTO_TEST_CASE(BindingConstraint_clusterCount)
 {
     auto study = std::make_unique<Study>();

--- a/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(load_basic_attributes)
     constraints << "[1]\n"
                 << "name = dummy_name\n"
                 << "id = dummy_id\n"
-                << "enabled = false\n"
+                << "enabled = true\n"
                 << "type = hourly\n"
                 << "operator = equal\n"
                 << "filter-year-by-year = annual\n"
@@ -70,9 +70,14 @@ BOOST_AUTO_TEST_CASE(load_basic_attributes)
 BOOST_AUTO_TEST_CASE(BC_load_RHS)
 {
     auto study = std::make_shared<Study>();
-    addAreaToListOfAreas(study->areas, "area1");
-    addAreaToListOfAreas(study->areas, "area2");
-    addAreaToListOfAreas(study->areas, "area3");
+
+    auto area1 = addAreaToListOfAreas(study->areas, "area1");
+    auto area2 = addAreaToListOfAreas(study->areas, "area2");
+    auto area3 = addAreaToListOfAreas(study->areas, "area3");
+
+    AreaAddLinkBetweenAreas(area1, area2);
+    AreaAddLinkBetweenAreas(area2, area3);
+    AreaAddLinkBetweenAreas(area3, area1);
 
     StudyLoadOptions options;
     BindingConstraintsRepository bindingConstraints;
@@ -83,7 +88,7 @@ BOOST_AUTO_TEST_CASE(BC_load_RHS)
     constraints << "[1]\n"
                 << "name = dummy_name\n"
                 << "id = dummy_id\n"
-                << "enabled = false\n"
+                << "enabled = true\n"
                 << "type = hourly\n"
                 << "operator = equal\n"
                 << "filter-year-by-year = annual\n"
@@ -117,9 +122,13 @@ BOOST_AUTO_TEST_CASE(BC_load_RHS)
 BOOST_AUTO_TEST_CASE(BC_load_range_type)
 {
     auto study = std::make_shared<Study>();
-    addAreaToListOfAreas(study->areas, "area1");
-    addAreaToListOfAreas(study->areas, "area2");
-    addAreaToListOfAreas(study->areas, "area3");
+    auto area1 = addAreaToListOfAreas(study->areas, "area1");
+    auto area2 = addAreaToListOfAreas(study->areas, "area2");
+    auto area3 = addAreaToListOfAreas(study->areas, "area3");
+
+    AreaAddLinkBetweenAreas(area1, area2);
+    AreaAddLinkBetweenAreas(area2, area3);
+    AreaAddLinkBetweenAreas(area3, area1);
 
     StudyLoadOptions options;
     BindingConstraintsRepository bindingConstraints;
@@ -130,7 +139,7 @@ BOOST_AUTO_TEST_CASE(BC_load_range_type)
     constraints << "[1]\n"
                 << "name = dummy_name\n"
                 << "id = dummy_id\n"
-                << "enabled = false\n"
+                << "enabled = true\n"
                 << "type = hourly\n"
                 << "operator = both\n"
                 << "filter-year-by-year = annual\n"
@@ -184,10 +193,13 @@ BOOST_AUTO_TEST_CASE(BC_load_range_type)
 BOOST_AUTO_TEST_CASE(BC_load_legacy)
 {
     auto study = std::make_shared<Study>();
-    addAreaToListOfAreas(study->areas, "area1");
-    addAreaToListOfAreas(study->areas, "area2");
-    addAreaToListOfAreas(study->areas, "area3");
+    auto area1 = addAreaToListOfAreas(study->areas, "area1");
+    auto area2 = addAreaToListOfAreas(study->areas, "area2");
+    auto area3 = addAreaToListOfAreas(study->areas, "area3");
 
+    AreaAddLinkBetweenAreas(area1, area2);
+    AreaAddLinkBetweenAreas(area2, area3);
+    AreaAddLinkBetweenAreas(area3, area1);
     StudyLoadOptions options;
     BindingConstraintsRepository bindingConstraints;
 
@@ -197,7 +209,7 @@ BOOST_AUTO_TEST_CASE(BC_load_legacy)
     constraints << "[1]\n"
                 << "name = dummy_name\n"
                 << "id = dummy_id\n"
-                << "enabled = false\n"
+                << "enabled = true\n"
                 << "type = hourly\n"
                 << "operator = less\n"
                 << "filter-year-by-year = annual\n"
@@ -207,6 +219,7 @@ BOOST_AUTO_TEST_CASE(BC_load_legacy)
                 << "area2%area3 = -1.000000\n"
                 << "area3%area1 = 2.000000\n";
     constraints.close();
+
     std::ofstream lt(working_tmp_dir / "dummy_id.txt");
     for (int i = 0; i < 8784; ++i)
     {
@@ -231,9 +244,13 @@ BOOST_AUTO_TEST_CASE(BC_load_legacy)
 BOOST_AUTO_TEST_CASE(BC_load_legacy_range)
 {
     auto study = std::make_shared<Study>();
-    addAreaToListOfAreas(study->areas, "area1");
-    addAreaToListOfAreas(study->areas, "area2");
-    addAreaToListOfAreas(study->areas, "area3");
+    auto area1 = addAreaToListOfAreas(study->areas, "area1");
+    auto area2 = addAreaToListOfAreas(study->areas, "area2");
+    auto area3 = addAreaToListOfAreas(study->areas, "area3");
+
+    AreaAddLinkBetweenAreas(area1, area2);
+    AreaAddLinkBetweenAreas(area2, area3);
+    AreaAddLinkBetweenAreas(area3, area1);
 
     StudyLoadOptions options;
     BindingConstraintsRepository bindingConstraints;
@@ -244,7 +261,7 @@ BOOST_AUTO_TEST_CASE(BC_load_legacy_range)
     constraints << "[1]\n"
                 << "name = dummy_name\n"
                 << "id = dummy_id\n"
-                << "enabled = false\n"
+                << "enabled = true\n"
                 << "type = hourly\n"
                 << "operator = both\n"
                 << "filter-year-by-year = annual\n"

--- a/src/tests/src/solver/simulation/test-time_series.cpp
+++ b/src/tests/src/solver/simulation/test-time_series.cpp
@@ -184,6 +184,31 @@ BOOST_FIXTURE_TEST_CASE(load_binding_constraints_timeseries_upper_bound, Fixture
                expected_upper_bound_series);
 }
 
+BOOST_FIXTURE_TEST_CASE(BC_disabled_skips_timeseries_loading, Fixture)
+{
+    {
+        std::ofstream constraints(working_tmp_dir / "bindingconstraints"
+                                  / "bindingconstraints.ini");
+        constraints << "[1]\n"
+                    << "name = dummy_name\n"
+                    << "id = dummy_name\n"
+                    << "enabled = false\n"
+                    << "type = hourly\n"
+                    << "operator = equal\n"
+                    << "group = dummy_group\n"
+                    << "area1%area2 = 1.000000\n";
+        constraints.close();
+    }
+    bool loading_ok = study->internalLoadBindingConstraints(options);
+    BOOST_CHECK_EQUAL(loading_ok, true);
+    BOOST_CHECK_EQUAL(study->bindingConstraints.size(), 1);
+
+    auto bc = study->bindingConstraints.find("dummy_name");
+    BOOST_CHECK_EQUAL(bc->enabled(), false);
+    BOOST_CHECK_EQUAL(bc->RHSTimeSeries().width, 0);
+    BOOST_CHECK_EQUAL(bc->RHSTimeSeries().height, 0);
+}
+
 BOOST_FIXTURE_TEST_CASE(
   verify_all_constraints_in_a_group_have_the_same_number_of_time_series_error_case,
   Fixture)

--- a/src/tests/src/solver/simulation/test-time_series.cpp
+++ b/src/tests/src/solver/simulation/test-time_series.cpp
@@ -64,6 +64,11 @@ struct Fixture
         study->folderInput = working_tmp_dir.string();
         fs::create_directories(working_tmp_dir / "bindingconstraints");
 
+        // Setup areas and links
+        auto area1 = addAreaToListOfAreas(study->areas, "area1");
+        auto area2 = addAreaToListOfAreas(study->areas, "area2");
+        AreaAddLinkBetweenAreas(area1, area2);
+
         addConstraint("dummy_name", "dummy_group");
         initializeStudy(*study);
 
@@ -104,13 +109,14 @@ struct Fixture
         constraints << "[" << constraintNumber++ << "]\n"
                     << "name = " << name << "\n"
                     << "id = " << name << "\n"
-                    << "enabled = false\n"
+                    << "enabled = true\n"
                     << "type = hourly\n"
                     << "operator = equal\n"
                     << "filter-year-by-year = annual\n"
                     << "filter-synthesis = hourly\n"
                     << "comments = dummy_comment\n"
-                    << "group = " << group << "\n";
+                    << "group = " << group << "\n"
+                    << "area1%area2 = 1.000000\n";
         constraints.close();
         std::ofstream rhs(working_tmp_dir / "bindingconstraints" / (name + "_eq.txt"));
         rhs.close();
@@ -144,10 +150,11 @@ BOOST_FIXTURE_TEST_CASE(load_binding_constraints_timeseries_lower_bound, Fixture
         constraints << "[1]\n"
                     << "name = dummy_name\n"
                     << "id = dummy_name\n"
-                    << "enabled = false\n"
+                    << "enabled = true\n"
                     << "type = hourly\n"
                     << "operator = less\n"
-                    << "group = dummy_group\n";
+                    << "group = dummy_group\n"
+                    << "area1%area2 = 1.000000\n";
         constraints.close();
     }
     bool loading_ok = study->internalLoadBindingConstraints(options);
@@ -164,10 +171,11 @@ BOOST_FIXTURE_TEST_CASE(load_binding_constraints_timeseries_upper_bound, Fixture
         constraints << "[1]\n"
                     << "name = dummy_name\n"
                     << "id = dummy_name\n"
-                    << "enabled = false\n"
+                    << "enabled = true\n"
                     << "type = hourly\n"
                     << "operator = greater\n"
-                    << "group = dummy_group\n";
+                    << "group = dummy_group\n"
+                    << "area1%area2 = 1.000000\n";
         constraints.close();
     }
     bool loading_ok = study->internalLoadBindingConstraints(options);


### PR DESCRIPTION
### Refactor BindingConstraintLoader::load and add early return when disabled
**Context**

The initial goal was to add an early return when enabled is set to false in the INI file, so that we skip time series loading entirely for disabled constraints. Since the load function was doing too many things in a single method, I took the opportunity to refactor it into smaller, focused functions.
Changes

_populateConstraint_ — Parses all key-value pairs from the INI section and fills the corresponding fields of the BindingConstraint.
_parseWeightAndOffset_ — Resolves link or cluster references and assigns their weight and offset to the constraint.
_validate_ — Checks that all required fields (name, id, type, operator) are set and valid.
_loadByOperator_ — Loads time series and builds the final constraint(s) depending on the operator type (single or both).
Early return — If pEnabled is false (either from the INI file or because no weights were found), load now returns an empty vector before reaching the time series loading step.