### PR TITLE
chore: Add changelog for v9.3.10

### DIFF
--- a/docs/developer-guide/CHANGELOG.md
+++ b/docs/developer-guide/CHANGELOG.md
@@ -153,6 +153,12 @@ Fix: several issues on CentOS7 (#3561)
 
 ## Branch 9.3.x
 
+### 9.3.10
+
+#### Bugfixes
+
+* Fix bounds on fictitious load and max unsupplied in adequacy patch [ANT-4906] (#3575)
+
 ### 9.3.9
 
 #### Features


### PR DESCRIPTION
## Description

Add changelog entry for version 9.3.10 (v9.3.9 → v9.3.10).

## Changes

- Added **9.3.10** section to `docs/developer-guide/CHANGELOG.md`

## Related

- Fix bounds on fictitious load and max unsupplied in adequacy patch [ANT-4906] (#3575)