### PR TITLE
docs: add accurate-shave-peaks-include-sts parameter documentation

### DIFF
--- a/docs/user-guide/solver/04-parameters.md
+++ b/docs/user-guide/solver/04-parameters.md
@@ -680,7 +680,7 @@ These parameters are listed under the `[other preferences]` section in the `.ini
 - **Expected value:** `true` or `false`
 - **Required:** no
 - **Default value:** `false`
-- **Usage:** when the shedding policy is set to `accurate shave peaks`, this parameter controls whether short-term storage (STS) is included in the remix algorithm. If set to `yes`, STS is considered alongside conventional hydro storage when solving the power-shaving problem. This can improve the accuracy of the simulation for studies that include short-term storage facilities.
+- **Usage:** when the shedding policy is set to `accurate shave peaks`, this parameter controls whether short-term storage (STS) is included in the remix algorithm. If set to `true`, STS is considered alongside conventional hydro storage when solving the power-shaving problem. This can improve the accuracy of the simulation for studies that include short-term storage facilities.
 
 ---
 #### unit-commitment-mode

--- a/docs/user-guide/solver/04-parameters.md
+++ b/docs/user-guide/solver/04-parameters.md
@@ -676,6 +676,13 @@ These parameters are listed under the `[other preferences]` section in the `.ini
     - `minimize duration`:
 
 ---
+#### accurate-shave-peaks-include-short-term-storage
+- **Expected value:** `true` or `false`
+- **Required:** no
+- **Default value:** `false`
+- **Usage:** when the shedding policy is set to `accurate shave peaks`, this parameter controls whether short-term storage (STS) is included in the remix algorithm. If set to `yes`, STS is considered alongside conventional hydro storage when solving the power-shaving problem. This can improve the accuracy of the simulation for studies that include short-term storage facilities.
+
+---
 #### unit-commitment-mode
 [//]: # (TODO: complete the usage paragraph by adding details & links to relevant UC doc)
 - **Expected value:** one of the following (case-insensitive):


### PR DESCRIPTION
## Description

Add documentation for the `accurate-shave-peaks-include-sts` parameter in the solver parameters reference.

## Changes

- Document the new `accurate-shave-peaks-include-sts` parameter in `docs/user-guide/solver/04-parameters.md`
- This parameter controls whether short-term storage (STS) is included in the remix algorithm when using the `accurate shave peaks` shedding policy

## Parameter Details

- **Name:** `accurate-shave-peaks-include-sts`
- **Section:** `[other preferences]`
- **Expected value:** `true` or `false`
- **Default value:** `false`
- **Usage:** When the shedding policy is set to `accurate shave peaks`, this parameter controls whether short-term storage (STS) is included in the remix algorithm. If set to `yes`, STS is considered alongside conventional hydro storage when solving the power-shaving problem.