### PR TITLE
move NullResultWriter from i_write.h to null_result_writer.h

### DIFF
--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <antares/optimisation/linear-problem-api/StructuredLinearProblem.h>
+#include <antares/writer/null_result_writer.h>
 #include "antares/application/ScenarioBuilderOwner.h"
 #include "antares/benchmarking/DurationCollector.h"
 #include "antares/file-tree-study-loader/FileTreeStudyLoader.h"

--- a/src/libs/antares/writer/CMakeLists.txt
+++ b/src/libs/antares/writer/CMakeLists.txt
@@ -39,8 +39,10 @@ add_library(result_writer
         ensure_queue_started.cpp
         immediate_file_writer.cpp
         in_memory_writer.cpp
+        null_result_writer.cpp
         include/antares/writer/i_table_writer.h
         include/antares/writer/in_memory_writer.h # Public (for tests)
+        include/antares/writer/null_result_writer.h
         include/antares/writer/result_format.h
         include/antares/writer/table_format.h
         include/antares/writer/table_writer_factory.h

--- a/src/libs/antares/writer/immediate_file_writer.cpp
+++ b/src/libs/antares/writer/immediate_file_writer.cpp
@@ -85,25 +85,4 @@ void ImmediateFileResultWriter::finalize(bool /*verbose*/)
 {
     // Do nothing
 }
-
-void NullResultWriter::addEntryFromBuffer(const fs::path&, std::string&)
-{
-}
-
-void NullResultWriter::addEntryFromFile(const fs::path&, const fs::path&)
-{
-}
-
-void NullResultWriter::flush()
-{
-}
-
-bool NullResultWriter::needsTheJobQueue() const
-{
-    return false;
-}
-
-void NullResultWriter::finalize(bool)
-{
-}
 } // namespace Antares::Solver

--- a/src/libs/antares/writer/include/antares/writer/i_writer.h
+++ b/src/libs/antares/writer/include/antares/writer/i_writer.h
@@ -16,6 +16,8 @@ class IResultWriter
 public:
     using Ptr = std::shared_ptr<IResultWriter>;
 
+    virtual ~IResultWriter() = default;
+
     virtual void addEntryFromBuffer(const std::filesystem::path& entryPath,
                                     std::string& entryContent)
       = 0;

--- a/src/libs/antares/writer/include/antares/writer/i_writer.h
+++ b/src/libs/antares/writer/include/antares/writer/i_writer.h
@@ -31,14 +31,4 @@ public:
     virtual bool needsTheJobQueue() const = 0;
     virtual void finalize(bool verbose) = 0;
 };
-
-class NullResultWriter: public Solver::IResultWriter
-{
-    void addEntryFromBuffer(const std::filesystem::path&, std::string&) override;
-    void addEntryFromFile(const std::filesystem::path&, const std::filesystem::path&) override;
-    void flush() override;
-    bool needsTheJobQueue() const override;
-    void finalize(bool) override;
-};
-
 } // namespace Antares::Solver

--- a/src/libs/antares/writer/include/antares/writer/null_result_writer.h
+++ b/src/libs/antares/writer/include/antares/writer/null_result_writer.h
@@ -10,6 +10,7 @@ namespace Antares::Solver
 
 class NullResultWriter: public IResultWriter
 {
+    ~NullResultWriter() override = default;
     void addEntryFromBuffer(const std::filesystem::path&, std::string&) override;
     void addEntryFromFile(const std::filesystem::path&, const std::filesystem::path&) override;
     void flush() override;

--- a/src/libs/antares/writer/include/antares/writer/null_result_writer.h
+++ b/src/libs/antares/writer/include/antares/writer/null_result_writer.h
@@ -1,0 +1,20 @@
+// Copyright 2007-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include "antares/writer/i_writer.h"
+
+namespace Antares::Solver
+{
+
+class NullResultWriter: public IResultWriter
+{
+    void addEntryFromBuffer(const std::filesystem::path&, std::string&) override;
+    void addEntryFromFile(const std::filesystem::path&, const std::filesystem::path&) override;
+    void flush() override;
+    bool needsTheJobQueue() const override;
+    void finalize(bool) override;
+};
+
+} // namespace Antares::Solver

--- a/src/libs/antares/writer/include/antares/writer/null_result_writer.h
+++ b/src/libs/antares/writer/include/antares/writer/null_result_writer.h
@@ -10,6 +10,7 @@ namespace Antares::Solver
 
 class NullResultWriter: public IResultWriter
 {
+public:
     ~NullResultWriter() override = default;
     void addEntryFromBuffer(const std::filesystem::path&, std::string&) override;
     void addEntryFromFile(const std::filesystem::path&, const std::filesystem::path&) override;

--- a/src/libs/antares/writer/null_result_writer.cpp
+++ b/src/libs/antares/writer/null_result_writer.cpp
@@ -1,0 +1,32 @@
+// Copyright 2007-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+
+#include <antares/writer/null_result_writer.h>
+
+namespace fs = std::filesystem;
+
+namespace Antares::Solver
+{
+
+void NullResultWriter::addEntryFromBuffer(const fs::path&, std::string&)
+{
+}
+
+void NullResultWriter::addEntryFromFile(const fs::path&, const fs::path&)
+{
+}
+
+void NullResultWriter::flush()
+{
+}
+
+bool NullResultWriter::needsTheJobQueue() const
+{
+    return false;
+}
+
+void NullResultWriter::finalize(bool)
+{
+}
+
+} // namespace Antares::Solver

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -5,6 +5,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <limits>
 
+#include <antares/writer/null_result_writer.h>
 #include "antares/io/outputs/SimulationTableCsv.h"
 #include "antares/solver/simulation/ISimulationObserver.h"
 #include "antares/solver/simulation/economy.h"

--- a/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
+++ b/src/tests/src/solver/infeasible-problem-analysis/test-unfeasible-problem-analyzer.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <antares/writer/null_result_writer.h>
 #include "antares/io/outputs/SimulationTableCsv.h"
 #include "antares/solver/infeasible-problem-analysis/constraint-slack-analysis.h"
 #include "antares/solver/infeasible-problem-analysis/report.h"


### PR DESCRIPTION
### Move NullResultWriter to its own source/header files
**Description**
NullResultWriter was previously declared in i_writer.h and implemented in immediate_file_writer.cpp. <
This PR moves it into dedicated files for better separation of concerns:

New: _include/antares/writer/null_result_writer.h_
New: _null_result_writer.cpp_
Modified: i_writer.h — removed NullResultWriter declaration
Modified: _immediate_file_writer.cpp_ — removed NullResultWriter implementation
Modified: CMakeLists.txt — added _null_result_writer.cpp_ to the build
Modified: includes in tests and _singleProblemGetterImpl.cpp_

**Impact**
No functional change. Pure refactoring.