### PR TITLE
Fix `::memset` build warning

### DIFF
--- a/src/libs/antares/date/date.cpp
+++ b/src/libs/antares/date/date.cpp
@@ -370,12 +370,6 @@ void Calendar::reset()
                  << ", january 1rst : " << DayOfTheWeekToString(settings_.weekday1rstJanuary)
                  << ", first weekday : " << DayOfTheWeekToString(settings_.weekFirstDay);
 #endif
-    (void)::memset(hours, '\0', sizeof(hours));
-    (void)::memset(days, '\0', sizeof(days));
-    (void)::memset(weeks, '\0', sizeof(weeks));
-    (void)::memset(months, '\0', sizeof(months));
-    (void)::memset(&mapping, '\0', sizeof(mapping));
-
     for (auto& monthText: text.months)
     {
         monthText.name.clear();

--- a/src/libs/antares/date/include/antares/date/date.h
+++ b/src/libs/antares/date/include/antares/date/date.h
@@ -193,7 +193,7 @@ public:
         bool firstHourInDay;
         //! First hour in the current month
         bool firstHourInMonth;
-    } hours[maxHoursInYear];
+    } hours[maxHoursInYear] = {};
 
     //! Informations about days in the year according the current
     // calendar settings
@@ -209,7 +209,7 @@ public:
         uint dayMonth;
         //! Week
         uint week;
-    } days[maxDaysInYear];
+    } days[maxDaysInYear] = {};
 
     /*!
     ** \brief Informations about weeks according the current calendar settings
@@ -229,7 +229,7 @@ public:
         // of simulation is. If the 1st january is the same than the first weekday,
         // the week number for this day will be 1, 53 otherwise.
         uint userweek;
-    } weeks[maxWeeksInYear];
+    } weeks[maxWeeksInYear] = {};
 
     /*!
     ** \brief Informations about months according the current calendar settings
@@ -251,7 +251,7 @@ public:
         DayOfTheWeek firstWeekday;
         //! Real month index
         MonthName realmonth;
-    } months[12 + 1]; // september..august for example
+    } months[12 + 1] = {}; // september..august for example
 
     /*!
     ** \brief Mappings between any expected calendar and our own calendar
@@ -259,7 +259,7 @@ public:
     struct
     {
         //! Mapping for months index
-        uint months[12 /*january..december*/];
+        uint months[12 /*january..december*/] = {};
     } mapping;
 
     //! The calendar settings


### PR DESCRIPTION
### Fix `::memset` build warning

This commit removes explicit `memset` calls in `Calendar::reset()` that trigger build warnings. Instead, the underlying arrays (`hours`, `days`, `weeks`, `months`) and the `mapping` struct are now zero-initialized at declaration using `{}`.

This approach is cleaner, avoids compiler warnings regarding `memset` usage, and ensures proper initialization without manual memory management in the reset function.

**Changes:**
- Removed `(void)::memset(...)` calls from `src/libs/antares/date/date.cpp`.
- Added `{}` initializer to array declarations in `src/libs/antares/date/include/antares/date/date.h`.