### PR TITLE
Fix: libparquet_writer.so install dir [ANT-4633]

### DIFF
--- a/src/libs/antares/writer/CMakeLists.txt
+++ b/src/libs/antares/writer/CMakeLists.txt
@@ -111,7 +111,7 @@ target_link_libraries(result_writer
 
 install(TARGETS parquet_writer
         RUNTIME DESTINATION bin    # .dll on Windows
-        LIBRARY DESTINATION lib    # .so on Linux
+        LIBRARY DESTINATION bin    # .so on Linux, kept next to executables for runtime loading
         ARCHIVE DESTINATION lib    # .lib import library on Windows
 )
 
@@ -122,4 +122,3 @@ install(DIRECTORY include/antares
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/simulation-table-writers_export.h"
         DESTINATION "include/antares/writer"
 )
-

--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TARGET_LIBS #No alias
         path
         mersenne
         result_writer
+	parquet_writer
         series
         antares-core
         antares-solver-hydro
@@ -125,14 +126,6 @@ set(TARGET_LIBS #No alias
 install(TARGETS ${TARGET_LIBS}
         EXPORT AntaresTargets
         LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
-)
-
-install(TARGETS parquet_writer
-        EXPORT AntaresTargets
-        LIBRARY DESTINATION bin
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin
         INCLUDES DESTINATION include

--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -30,7 +30,6 @@ set(TARGET_LIBS #No alias
         path
         mersenne
         result_writer
-	parquet_writer
         series
         antares-core
         antares-solver-hydro
@@ -126,6 +125,14 @@ set(TARGET_LIBS #No alias
 install(TARGETS ${TARGET_LIBS}
         EXPORT AntaresTargets
         LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
+)
+
+install(TARGETS parquet_writer
+        EXPORT AntaresTargets
+        LIBRARY DESTINATION bin
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin
         INCLUDES DESTINATION include


### PR DESCRIPTION
Fix this runtime error
```
      /deps/antares/bin/antares-modeler: error while loading shared libraries: libparquet_writer.so: cannot open shared object file: No such file or directory
```
since libparquet_writer.so is typically placed under **lib** instead of **bin** (OL8, CentOS7, Ubuntu)