### PR TITLE
Avoid info() log spam in binding constraint loading

### DIFF
--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -44,10 +44,9 @@ std::vector<std::shared_ptr<BindingConstraint>> BindingConstraintLoader::load(En
     if (!bc->pEnabled)
     {
         /// This BC won't be used, return it without loading time series
-        logs.info() << "DEBUG: BC " << bc->name() << " is disabled, skipping time series";
+        logs.debug() << "BC " << bc->name() << " is disabled, skipping time series loading";
         return {bc};
     }
-    logs.info() << "DEBUG: BC " << bc->name() << " is enabled, loading time series";
     return loadByOperator(env, bc);
 }
 


### PR DESCRIPTION
- We don't need `info()` logs, just `debug()`
- If a constraint is **enabled**, there is already a log 
```
[2026-05-05 08:52:26][solver][debug]   :: loading `/home/omnesflo/opencode/Antares_Simulator/src/tests/resources/Antares_Simulator_Tests_NR/valid-bind/BIND-03-gen/input/bindingconstraints/uto_0004.txt`
```
so we don't need to add one.

See [logging functions](https://antares-simulator.readthedocs.io/en/latest/developer-guide/6-Contributing/#logging-functions)