### PR TITLE
Fix: build warnings

### DIFF
--- a/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp
+++ b/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp
@@ -33,9 +33,12 @@ std::shared_ptr<arrow::Table> readParquet(const fs::path& file_path)
     std::unique_ptr<parquet::arrow::FileReader> reader;
     PARQUET_ASSIGN_OR_THROW(reader, parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
 
-    std::shared_ptr<arrow::Table> table;
-    PARQUET_THROW_NOT_OK(reader->ReadTable(&table));
-    return table;
+    auto table_or = reader->ReadTable();
+    if (!table_or.ok())
+    {
+        throw std::runtime_error(table_or.status().ToString());
+    }
+    return *table_or;
 }
 
 template<typename T>

--- a/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
+++ b/src/tests/src/io/yml-importers/testConvertorVisitor.cpp
@@ -392,8 +392,8 @@ struct SupplyModelForDualOperator
                           .variables = {},
                           .ports = {},
                           .port_field_definitions = {},
-                          .constraints = {{"constraintA", "", "test.yaml"}},
-                          .binding_constraints = {{"constraintB", "", "test.yaml"}},
+                          .constraints = {{"constraintA", "", "test.yaml", ""}},
+                          .binding_constraints = {{"constraintB", "", "test.yaml", ""}},
                           .objectives = {{"objective-id", "", "test.yaml"}},
                           .extra_outputs = {}};
 };

--- a/src/tests/src/io/yml-importers/testModelConverter.cpp
+++ b/src/tests/src/io/yml-importers/testModelConverter.cpp
@@ -265,9 +265,9 @@ BOOST_FIXTURE_TEST_CASE(model_constraints_properly_translated, Fixture)
       .variables = {},
       .ports = {},
       .port_field_definitions = {},
-      .constraints = {{"constraint1", "expression1", "subproblems"},
-                      {"constraint2", "expression2", "master-and-subproblems"}},
-      .binding_constraints = {{"constraint3", "expression3", "master"}},
+      .constraints = {{"constraint1", "expression1", "subproblems", ""},
+                      {"constraint2", "expression2", "master-and-subproblems", ""}},
+      .binding_constraints = {{"constraint3", "expression3", "master", ""}},
       .objectives = {},
       .extra_outputs = {}};
     library.models = {model1};

--- a/src/tests/src/io/yml-importers/testSystemConverter.cpp
+++ b/src/tests/src/io/yml-importers/testSystemConverter.cpp
@@ -26,7 +26,7 @@ struct LibraryObjects
                            .variables = {},
                            .ports = {},
                            .port_field_definitions = {},
-                           .constraints = {{"constraint1", "cost", "subproblems"}},
+                           .constraints = {{"constraint1", "cost", "subproblems", ""}},
                            .binding_constraints = {},
                            .objectives = {},
                            .extra_outputs = {}};


### PR DESCRIPTION
## Fixes
 1. testModelConverter.cpp (line 267-270): Added "" (empty string) as the 4th field to each Constraint aggregate initializer in constraints and binding_constraints vectors, matching the                   
 `out_of_bounds_processing_mode` member.                                                                                                                                                                      
 2. testSystemConverter.cpp (line 29): Added "" as the 4th field to the `Constraint` initializer in the constraints vector.                                                                                   
 3. testConvertorVisitor.cpp (line 395-396): Added "" as the 4th field to each `Constraint` initializer in constraints and binding_constraints vectors.                                                       
 4. test-parquet-simulation-table-writer.cpp (line 36-41): Replaced the deprecated `reader->ReadTable(&table)` call with the modern `reader->ReadTable()` no-argument version that returns                      
 `arrow::Result<std::shared_ptr<arrow::Table>>`, handling the result via `auto table_or` and dereferencing with `*table_or`.                                                                                      

## Warnings
```
/home/omnesflo/Antares_Simulator/src/tests/src/io/yml-importers/testModelConverter.cpp: In member function ‘void model_constraints_properly_translated::test_method()’:                                    
 /home/omnesflo/Antares_Simulator/src/tests/src/io/yml-importers/testModelConverter.cpp:272:26: warning: missing initializer for member                                                                     
 ‘Antares::IO::Inputs::YmlModel::Constraint::out_of_bounds_processing_mode’ [-Wmissing-field-initializers]                                                                                                  
   272 |       .extra_outputs = {}};                                                                                                                                                                        
       |                          ^                                                                                                                                                                         
 /home/omnesflo/Antares_Simulator/src/tests/src/io/yml-importers/testModelConverter.cpp:272:26: warning: missing initializer for member                                                                     
 ‘Antares::IO::Inputs::YmlModel::Constraint::out_of_bounds_processing_mode’ [-Wmissing-field-initializers]                                                                                                  
 /home/omnesflo/Antares_Simulator/src/tests/src/io/yml-importers/testModelConverter.cpp:272:26: warning: missing initializer for member                                                                     
 ‘Antares::IO::Inputs::YmlModel::Constraint::out_of_bounds_processing_mode’ [-Wmissing-field-initializers]                                                                                                  
 [760/798] Building CXX object tests/src/io/yml-importers/CMakeFiles/TestYmlModel.dir/testSystemConverter.cpp.o                                                                                             
 /home/omnesflo/Antares_Simulator/src/tests/src/io/yml-importers/testSystemConverter.cpp:32:47: warning: missing initializer for member                                                                     
 ‘Antares::IO::Inputs::YmlModel::Constraint::out_of_bounds_processing_mode’ [-Wmissing-field-initializers]                                                                                                  
    32 |                            .extra_outputs = {}};                                                                                                                                                   
       |                                               ^                                                                                                                                                    
 [762/798] Building CXX object tests/src/io/yml-importers/CMakeFiles/TestYmlModel.dir/testConvertorVisitor.cpp.o                                                                                            
 /home/omnesflo/Antares_Simulator/src/tests/src/io/yml-importers/testConvertorVisitor.cpp:398:46: warning: missing initializer for member                                                                   
 ‘Antares::IO::Inputs::YmlModel::Constraint::out_of_bounds_processing_mode’ [-Wmissing-field-initializers]                                                                                                  
   398 |                           .extra_outputs = {}};                                                                                                                                                    
       |                                              ^                                                                                                                                                     
 /home/omnesflo/Antares_Simulator/src/tests/src/io/yml-importers/testConvertorVisitor.cpp:398:46: warning: missing initializer for member                                                                   
 ‘Antares::IO::Inputs::YmlModel::Constraint::out_of_bounds_processing_mode’ [-Wmissing-field-initializers]                                                                                                  
 [773/798] Building CXX object tests/src/io/outputs/CMakeFiles/test-parquet-simulation-table-writer.dir/test-parquet-simulation-table-writer.cpp.o                                                          
 In file included from /home/omnesflo/Antares_Simulator/build-22/vcpkg_installed/x64-linux/include/parquet/encryption/encryption.h:28,                                                                      
                  from /home/omnesflo/Antares_Simulator/build-22/vcpkg_installed/x64-linux/include/parquet/properties.h:30,                                                                                 
                  from /home/omnesflo/Antares_Simulator/build-22/vcpkg_installed/x64-linux/include/parquet/metadata.h:31,                                                                                   
                  from /home/omnesflo/Antares_Simulator/build-22/vcpkg_installed/x64-linux/include/parquet/file_reader.h:27,                                                                                
                  from /home/omnesflo/Antares_Simulator/build-22/vcpkg_installed/x64-linux/include/parquet/arrow/reader.h:26,                                                                               
                  from /home/omnesflo/Antares_Simulator/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp:13:                                                                               
 /home/omnesflo/Antares_Simulator/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp: In function ‘std::shared_ptrarrow::Table readParquet(const std::filesystem::__cxx11::path&)’:          
 /home/omnesflo/Antares_Simulator/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp:37:43: warning: ‘arrow::Status parquet::arrow::FileReader::ReadTable(std::shared_ptrarrow::Table)’ is   
 deprecated: Deprecated in 24.0.0. Use arrow::Result version instead. [-Wdeprecated-declarations]                                                                                                           
    37 |     PARQUET_THROW_NOT_OK(reader->ReadTable(&table));                                                                                                                                               
       |                          ~~~~~~~~~~~~~~~~~^~~~~~~~                                                                                                                                                 
 In file included from /home/omnesflo/Antares_Simulator/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp:13:                                                                               
 /home/omnesflo/Antares_Simulator/build-22/vcpkg_installed/x64-linux/include/parquet/arrow/reader.h:242:19: note: declared here                                                                             
   242 |   ::arrow::Status ReadTable(std::shared_ptr<::arrow::Table> out);   
```