### PR TITLE
Use const ref for scenario in EvalVisitor

### DIFF
--- a/src/expressions/include/antares/expressions/visitors/EvalVisitor.h
+++ b/src/expressions/include/antares/expressions/visitors/EvalVisitor.h
@@ -314,7 +314,7 @@ public:
                          const Optimisation::LinearProblemApi::FillContext& fillContext,
                          const ModelerStudy::SystemModel::Component& component,
                          const Optimisation::LinearProblemApi::ILinearProblemData* data,
-                         const Optimisation::LinearProblemApi::IScenario* scenario);
+                         const Optimisation::LinearProblemApi::IScenario& scenario);
 
     std::string name() const override;
 
@@ -322,7 +322,7 @@ private:
     const Optimisation::OptimEntityContainer& optimContainer_;
     const ModelerStudy::SystemModel::Component& component_;
     const Optimisation::LinearProblemApi::ILinearProblemData* data_;
-    const Optimisation::LinearProblemApi::IScenario* scenario_;
+    const Optimisation::LinearProblemApi::IScenario& scenario_;
     const Optimisation::EvaluationContext evalContext_;
     const Optimisation::LinearProblemApi::FillContext& fillContext_;
 

--- a/src/expressions/visitors/EvalVisitor.cpp
+++ b/src/expressions/visitors/EvalVisitor.cpp
@@ -22,7 +22,7 @@ EvalVisitor::EvalVisitor(const OptimEntityContainer& optimContainer,
                          const LinearProblemApi::FillContext& fillContext,
                          const ModelerStudy::SystemModel::Component& component,
                          const LinearProblemApi::ILinearProblemData* data,
-                         const LinearProblemApi::IScenario* scenario):
+                         const LinearProblemApi::IScenario& scenario):
     // TODO put component or its id inside context, it is already component-bound.
     // Plus it is mandatory to visit Variables & PortFieldSums
     // Else, create a PostOptimEvalVisitor that inherits from EvalVisitor & has a different ctor
@@ -30,7 +30,7 @@ EvalVisitor::EvalVisitor(const OptimEntityContainer& optimContainer,
     component_(component),
     data_(data),
     scenario_(scenario),
-    evalContext_(&component, data, scenario),
+    evalContext_(&component, data, &scenario),
     fillContext_(fillContext)
 {
 }

--- a/src/io/outputs/SimulationTableGenerator.cpp
+++ b/src/io/outputs/SimulationTableGenerator.cpp
@@ -167,7 +167,7 @@ void addConstraintEntries(SimulationTable& simulationTable,
                           const ModelerStudy::SystemModel::Component& component,
                           const OptimEntityContainer& optimEntityContainer,
                           const LinearProblemApi::ILinearProblemData* data,
-                          const LinearProblemApi::IScenario* scenario,
+                          const LinearProblemApi::IScenario& scenario,
                           unsigned currentBlock,
                           const TimeConversionMode& timeConversionMode,
                           unsigned year,
@@ -430,7 +430,7 @@ void FillSimulationTable(SimulationTable& simulationTable,
         const auto& scenario = modelerData.scenarioGroupRepository.scenario(
           component.getScenarioGroupId());
 
-        Visitors::EvalVisitor evalVisitor(optimContainer, fillContext, component, data, &scenario);
+        Visitors::EvalVisitor evalVisitor(optimContainer, fillContext, component, data, scenario);
         Visitors::VariabilityVisitor variabilityVisitor(optimContainer, component, data, &scenario);
 
         addVariableEntries(simulationTable,
@@ -448,7 +448,7 @@ void FillSimulationTable(SimulationTable& simulationTable,
                              component,
                              optimContainer,
                              data,
-                             &scenario,
+                             scenario,
                              currentBlock,
                              timeConversionMode,
                              year,

--- a/src/solver/optim-model-filler/ComponentFiller.cpp
+++ b/src/solver/optim-model-filler/ComponentFiller.cpp
@@ -30,7 +30,7 @@ unsigned countActiveConstraintTimesteps(
     }
 
     const auto& scenario = scenarioGroupRepo.scenario(component.getScenarioGroupId());
-    Visitors::EvalVisitor evalVisitor(optimEntityContainer, ctx, component, data, &scenario);
+    Visitors::EvalVisitor evalVisitor(optimEntityContainer, ctx, component, data, scenario);
     unsigned activeConstraintCount = 0;
     for (const auto timeStep: Antares::Optimisation::IntegerInterval{ctx.getLocalFirstTimeStep(),
                                                                      ctx.getLocalLastTimeStep()})
@@ -271,11 +271,12 @@ void ComponentFiller::addVariables(const LinearProblemApi::FillContext& ctx)
         return;
     }
 
+    const auto& scenario = scenarioGroupRepo_.scenario(component_.getScenarioGroupId());
     Visitors::EvalVisitor evaluator(optimEntityContainer_,
                                     ctx,
                                     component_,
                                     data_,
-                                    &scenarioGroupRepo_.scenario(component_.getScenarioGroupId()));
+                                    scenario);
     auto valueOrDefault = [&evaluator](const auto& node, double defaultValue)
     {
         if (node.Empty())
@@ -352,12 +353,12 @@ void ComponentFiller::addTimeDependentConstraints(const LinearConstraint& linear
     // If DROP mode is enabled, construct a single EvalVisitor and iterate timesteps once.
     if (isDrop)
     {
+        const auto& scenario = scenarioGroupRepo_.scenario(component_.getScenarioGroupId());
         Expressions::Visitors::EvalVisitor evalVisitor(optimEntityContainer_,
                                                        ctx,
                                                        component_,
                                                        data_,
-                                                       &scenarioGroupRepo_.scenario(
-                                                         component_.getScenarioGroupId()));
+                                                       scenario);
 
         for (const auto t: dims.getTimesteps())
         {

--- a/src/solver/optim-model-filler/ComponentFiller.cpp
+++ b/src/solver/optim-model-filler/ComponentFiller.cpp
@@ -272,11 +272,7 @@ void ComponentFiller::addVariables(const LinearProblemApi::FillContext& ctx)
     }
 
     const auto& scenario = scenarioGroupRepo_.scenario(component_.getScenarioGroupId());
-    Visitors::EvalVisitor evaluator(optimEntityContainer_,
-                                    ctx,
-                                    component_,
-                                    data_,
-                                    scenario);
+    Visitors::EvalVisitor evaluator(optimEntityContainer_, ctx, component_, data_, scenario);
     auto valueOrDefault = [&evaluator](const auto& node, double defaultValue)
     {
         if (node.Empty())

--- a/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
+++ b/src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp
@@ -37,10 +37,10 @@ ReadLinearExpressionVisitor::ReadLinearExpressionVisitor(
     optimEntityContainer_(optimEntityContainer),
     component_(component),
     scenarioGroupRepo_(scenarioGroupRepo),
-    scenario_(&scenarioGroupRepo.scenario(component.getScenarioGroupId())),
-    evalContext_(&component, data, scenario_),
-    fillContext_(fillContext),
+    scenario_(scenarioGroupRepo.scenario(component.getScenarioGroupId())),
     evalVisitor_(optimEntityContainer, fillContext, component, data, scenario_),
+    evalContext_(&component, data, &scenario_),
+    fillContext_(fillContext),
     data_(data),
     nbtimeSteps_(fillContext.getLocalNumberOfTimeSteps())
 {

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ReadLinearExpressionVisitor.h
@@ -104,10 +104,10 @@ private:
     const Antares::Optimisation::OptimEntityContainer& optimEntityContainer_;
     const Antares::ModelerStudy::SystemModel::Component& component_;
     const Optimisation::ScenarioGroupRepository& scenarioGroupRepo_;
-    const Optimisation::LinearProblemApi::IScenario* scenario_;
+    const Optimisation::LinearProblemApi::IScenario& scenario_;
+    Antares::Expressions::Visitors::EvalVisitor evalVisitor_;
     const Antares::Optimisation::EvaluationContext evalContext_;
     const Antares::Optimisation::LinearProblemApi::FillContext& fillContext_;
-    Antares::Expressions::Visitors::EvalVisitor evalVisitor_;
     const Optimisation::LinearProblemApi::ILinearProblemData* data_;
 
     const unsigned nbtimeSteps_;

--- a/src/tests/src/expressions/test_PrintAndEvalVisitors.cpp
+++ b/src/tests/src/expressions/test_PrintAndEvalVisitors.cpp
@@ -587,7 +587,7 @@ BOOST_FIXTURE_TEST_CASE(comparisonEqualNode_complex, MyDummyFixture)
                         ctx,
                         *compo,
                         &data,
-                        &scenarioGroupRepository.scenario(compo->getScenarioGroupId()));
+                        scenarioGroupRepository.scenario(compo->getScenarioGroupId()));
 
     const double num = 221.3;
     Node* equalLiteralParam = create<EqualNode>(create<LiteralNode>(num), &root);
@@ -661,7 +661,7 @@ BOOST_FIXTURE_TEST_CASE(evaluate_param, MyDummyFixture)
                         ctx,
                         *compo,
                         &data,
-                        &scenarioGroupRepository.scenario(compo->getScenarioGroupId()));
+                        scenarioGroupRepository.scenario(compo->getScenarioGroupId()));
 
     const double eval = visitor.dispatch(&root).valueAsDouble();
 
@@ -682,7 +682,7 @@ BOOST_FIXTURE_TEST_CASE(evaluate_param_scenario_only, MyDummyFixture)
                         ctx,
                         *compo,
                         &data,
-                        &scenarioGroupRepository.scenario(compo->getScenarioGroupId()));
+                        scenarioGroupRepository.scenario(compo->getScenarioGroupId()));
 
     const double eval = visitor.dispatch(&root).valueAsDouble();
 
@@ -801,7 +801,7 @@ struct TimeDependentParameterFixture
                                                     ctx,
                                                     components.front(),
                                                     &dummy_data,
-                                                    &scenarioGroupRepo.scenario(
+                                                    scenarioGroupRepo.scenario(
                                                       components.front().getScenarioGroupId()));
     }
 };
@@ -853,7 +853,7 @@ EvaluationResult CreateAndEvaluateTimeNode(Node* p)
                         {first, last /*three hours*/, first, last, 0},
                         components.back(),
                         &dummy_data,
-                        &scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
+                        scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
 
     return visitor.dispatch(&root);
 }
@@ -906,7 +906,7 @@ EvaluationResult CreateAndEvaluateTimeSumNode(Node* from, Node* to)
                         {first, last /*three hours*/, first, last, 0},
                         components.back(),
                         &dummy_data,
-                        &scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
+                        scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
 
     return visitor.dispatch(&root);
 }
@@ -951,7 +951,7 @@ EvaluationResult CreateAndEvaluateAllTimeSumNode()
                         {first, last /*three hours*/, first, last, 0},
                         components.back(),
                         &dummy_data,
-                        &scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
+                        scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
     return visitor.dispatch(&root);
 }
 
@@ -991,7 +991,7 @@ BOOST_FIXTURE_TEST_CASE(evaluate_time_dependent_multiplication, MyDummyFixture)
                         {hour_0, hour_1 /*two hours*/, hour_0, hour_1, 0},
                         components.back(),
                         &dummy_data,
-                        &scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
+                        scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
     const auto eval = visitor.dispatch(&root).valuesAsVector();
 
     BOOST_CHECK_EQUAL(eval[0], hour_0 * literal.value());
@@ -1057,7 +1057,7 @@ void evaluate_time_dependent_operation()
                         {hour_0, hour_1 /*three hours*/, hour_0, hour_1, 0},
                         components.back(),
                         &dummy_data,
-                        &scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
+                        scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
     const auto eval = visitor.dispatch(&root).valuesAsVector();
 
     BOOST_CHECK_EQUAL(eval[0], evalExpected<BinaryNode>(literal.value(), hour_0));
@@ -1095,7 +1095,7 @@ void evaluate_time_dependent_operation_on_TimeShiftNode(Node* timeShift)
                         {hours.at(0), hours.at(1) /*two hours*/, hours.at(0), hours.at(1), 0},
                         components.back(),
                         &dummy_data,
-                        &scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
+                        scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
     const auto eval = visitor.dispatch(&root).valuesAsVector();
 
     std::vector<double> result_before_timeShift = {evalExpected<BinaryNode>(literal.value(),
@@ -1141,7 +1141,7 @@ void evaluate_time_dependent_operation_on_TimeIndexNode(Node* timeIndex)
                         {hours.at(0), hours.at(1) /*two hours*/, hours.at(0), hours.at(1), 0},
                         components.back(),
                         &dummy_data,
-                        &scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
+                        scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
 
     const auto eval = visitor.dispatch(&root).valueAsDouble();
 
@@ -1668,7 +1668,7 @@ BOOST_FIXTURE_TEST_CASE(testVariableNodeEvaluation, MyDummyFixture)
                         fillContext,
                         components.back(),
                         &testData,
-                        &scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
+                        scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
     double eval = visitor.dispatch(root).valueAsDouble();
     BOOST_CHECK_EQUAL(eval, 12.5);
 

--- a/src/tests/src/expressions/test_evaluate-function-operators.cpp
+++ b/src/tests/src/expressions/test_evaluate-function-operators.cpp
@@ -98,12 +98,12 @@ CreateEvalVisitor::CreateEvalVisitor():
     optimEntityContainer_->addFromSystemComponents(components_);
 
     // And finally, creation of the evaluation visitor (purpose of this fixture)
+    const auto& scenario = scenarioGroupRepo_.scenario(component_.getScenarioGroupId());
     evalVisitor = std::make_unique<EvalVisitor>(*optimEntityContainer_,
                                                 fillCtx_,
                                                 component_,
                                                 &data_,
-                                                &scenarioGroupRepo_.scenario(
-                                                  component_.getScenarioGroupId()));
+                                                scenario);
 }
 
 // =================================================

--- a/src/tests/src/expressions/test_evaluate-sum-operators.cpp
+++ b/src/tests/src/expressions/test_evaluate-sum-operators.cpp
@@ -108,12 +108,12 @@ build_eval_visitor_fixture::build_eval_visitor_fixture():
     optimEntityContainer_->addFromSystemComponents(components_);
 
     // And finally, creation of the evaluation visitor (purpose of this fixture)
+    const auto& scenario = scenarioGroupRepo_.scenario(component_.getScenarioGroupId());
     evalVisitor = std::make_unique<EvalVisitor>(*optimEntityContainer_,
                                                 fillCtx_,
                                                 component_,
                                                 &data_,
-                                                &scenarioGroupRepo_.scenario(
-                                                  component_.getScenarioGroupId()));
+                                                scenario);
 }
 
 // =================================================

--- a/src/tests/src/modeler/UtilMocks.h
+++ b/src/tests/src/modeler/UtilMocks.h
@@ -476,13 +476,13 @@ struct MyDummyFixture: Antares::Expressions::Registry<Antares::Expressions::Node
         optimEntityContainer.addFromSystemComponents(components);
         for (const auto& compo: components)
         {
+            const auto& scenario = scenarioGroupRepository.scenario(compo.getScenarioGroupId());
             defaultComponentEvalVisitor = std::make_unique<
               Antares::Expressions::Visitors::EvalVisitor>(optimEntityContainer,
                                                            ctx,
                                                            compo,
                                                            &data,
-                                                           &scenarioGroupRepository.scenario(
-                                                             compo.getScenarioGroupId()));
+                                                           scenario);
         }
     }
 


### PR DESCRIPTION
Changed `EvalVisitor`'s last parameter from `const LinearProblemApi::IScenario* scenario` (pointer) to `const LinearProblemApi::IScenario& scenario` (reference), and the member `scenario_` from `const LinearProblemApi::IScenario*` to `const LinearProblemApi::IScenario&`.

### Files modified:

1. **`src/expressions/include/antares/expressions/visitors/EvalVisitor.h`** — Constructor parameter and member variable changed from pointer to reference.
2. **`src/expressions/visitors/EvalVisitor.cpp`** — Constructor parameter changed to reference; `evalContext_` initialization updated to pass `&scenario` (address of the reference) since `EvaluationContext` still takes a pointer.
3. **`src/io/outputs/SimulationTableGenerator.cpp`** — Updated `addConstraintEntries` function signature to take `IScenario&` instead of `IScenario*`, and updated both call sites to pass the reference directly (removing `&`).
4. **`src/solver/optim-model-filler/ComponentFiller.cpp`** — Fixed 3 call sites: removed `&` from existing reference scenarios, and stored temporaries in local `const auto&` variables before passing to `EvalVisitor`.
5. **`src/solver/optim-model-filler/ReadLinearExpressionVisitor.h`** — Changed `scenario_` member from pointer to reference; reordered members so `evalVisitor_` (which depends on `scenario_`) is initialized before `evalContext_`.
6. **`src/solver/optim-model-filler/ReadLinearExpressionVisitor.cpp`** — Updated constructor to bind `scenario_` to a local reference and pass it to `evalVisitor_` and `evalContext_`.
7. **`src/tests/src/modeler/UtilMocks.h`** — Stored scenario in local `const auto&` before passing to `EvalVisitor`.
8. **`src/tests/src/expressions/test_evaluate-sum-operators.cpp`** — Same fix: local `const auto&` before passing.
9. **`src/tests/src/expressions/test_evaluate-function-operators.cpp`** — Same fix.
10. **`src/tests/src/expressions/test_PrintAndEvalVisitors.cpp`** — Removed `&` from all `scenarioGroupRepo.scenario(...)` and `scenarioGroupRepository.scenario(...)` call sites.