### PR TITLE
fix: resolve sign-compare warnings in test-cluster-series.cpp

### DIFF
--- a/src/tests/src/libs/antares/study/parts/cluster/test-cluster-series.cpp
+++ b/src/tests/src/libs/antares/study/parts/cluster/test-cluster-series.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(disabled_thermal_cluster_skips_series_loading)
     fs::create_directories(working_tmp_dir / area->id / cluster->id());
 
     std::ofstream seriesFile(working_tmp_dir / area->id / cluster->id() / "series.txt");
-    for (int i = 0; i < HOURS_PER_YEAR; ++i)
+    for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         seriesFile << "100\n";
     }
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(enabled_thermal_cluster_loads_series)
     fs::create_directories(working_tmp_dir / area->id / cluster->id());
 
     std::ofstream seriesFile(working_tmp_dir / area->id / cluster->id() / "series.txt");
-    for (int i = 0; i < HOURS_PER_YEAR; ++i)
+    for (unsigned int i = 0; i < HOURS_PER_YEAR; ++i)
     {
         seriesFile << "100\n";
     }


### PR DESCRIPTION
 Change loop variable from `int` to `unsigned int` to match `HOURS_PER_YEAR` type, eliminating -Wsign-compare warnings.