### PR TITLE
feat(column-descriptors): add buildColumnDescriptors for Study

### DIFF
--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -136,12 +136,23 @@ public:
         pNbYearsParallel = study->maxNbYearsInParallel;
         pValuesForTheCurrentYear.resize(pNbYearsParallel);
 
-        // Building the vector of group names the clusters belong to.
-        groupNames_ = sortedUniqueGroups(area->shortTermStorage.storagesByIndex);
+        // Study-wide column set: every area produces identically-positioned columns,
+        // so the shared captions array stays consistent with each area's rows.
+        descriptors_ = buildColumnDescriptors(*study, area);
+
+        std::set<std::string> names;
+        study->areas.each(
+          [&names](Data::Area& currentArea)
+          {
+              for (const auto& sts: currentArea.shortTermStorage.storagesByIndex)
+              {
+                  names.insert(sts.properties.groupName);
+              }
+          });
+        groupNames_ = {names.begin(), names.end()};
         groupToNumbers_ = Utils::giveNumbersToStrings(groupNames_);
 
-        descriptors_ = buildColumnDescriptors(area);
-        nbColumns_ = groupNames_.size() * NB_COLS_PER_GROUP;
+        nbColumns_ = descriptors_.size();
 
         if (nbColumns_)
         {
@@ -312,7 +323,24 @@ public:
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
-        // Dynamic-columns variables are intentionally excluded from digest generation.
+        // Column layout is study-wide (see initializeFromArea), so every area writes the
+        // same captions in the same indices — safe to contribute to the digest now.
+        if (AncestorType::isPrinted[0]
+            && (VCardType::categoryDataLevel & Category::DataLevel::area
+                || VCardType::categoryDataLevel & Category::DataLevel::setOfAreas))
+        {
+            results.isPrinted = AncestorType::isPrinted;
+            results.isCurrentVarNA = AncestorType::isNonApplicable;
+
+            for (size_t c = 0; c < nbColumns_; ++c)
+            {
+                results.variableCaption = descriptors_[c].caption;
+                results.variableUnit = descriptors_[c].unit;
+                AncestorType::pResults[c].template buildDigest<VCardType>(results,
+                                                                          digestLevel,
+                                                                          dataLevel);
+            }
+        }
         NextType::buildDigest(results, digestLevel, dataLevel);
     }
 

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -326,8 +326,8 @@ public:
         // Column layout is study-wide (see initializeFromArea), so every area writes the
         // same captions in the same indices — safe to contribute to the digest now.
         if (AncestorType::isPrinted[0]
-            && (VCardType::categoryDataLevel & Category::DataLevel::area
-                || VCardType::categoryDataLevel & Category::DataLevel::setOfAreas))
+            && (VCardType::categoryDataLevel
+                & (Category::DataLevel::area | Category::DataLevel::setOfAreas)))
         {
             results.isPrinted = AncestorType::isPrinted;
             results.isCurrentVarNA = AncestorType::isNonApplicable;

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -140,6 +140,7 @@ public:
         groupNames_ = sortedUniqueGroups(area->shortTermStorage.storagesByIndex);
         groupToNumbers_ = Utils::giveNumbersToStrings(groupNames_);
 
+        descriptors_ = buildColumnDescriptors(area);
         nbColumns_ = groupNames_.size() * NB_COLS_PER_GROUP;
 
         if (nbColumns_)
@@ -259,6 +260,24 @@ public:
         return descriptors;
     }
 
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Area* area)
+    {
+        std::set<std::string> uniqueGroups;
+        for (const auto& sts: area->shortTermStorage.storagesByIndex)
+        {
+            uniqueGroups.insert(sts.properties.groupName);
+        }
+
+        std::vector<ColumnDescriptor> descriptors;
+        for (const auto& groupName: uniqueGroups)
+        {
+            descriptors.push_back({groupName + "_INJECTION", "MW"});
+            descriptors.push_back({groupName + "_WITHDRAWAL", "MW"});
+            descriptors.push_back({groupName + "_LEVEL", "MWh"});
+        }
+        return descriptors;
+    }
+
     void hourForEachArea(State& state, unsigned int numSpace)
     {
         using namespace Antares::Data::ShortTermStorage;
@@ -343,8 +362,8 @@ public:
 
         for (unsigned int column = 0; column < nbColumns_; column++)
         {
-            results.variableCaption = caption(column);
-            results.variableUnit = unit(column);
+            results.variableCaption = descriptors_[column].caption;
+            results.variableUnit = descriptors_[column].unit;
             pValuesForTheCurrentYear[numSpace][column]
               .template buildAnnualSurveyReport<VCardType>(results, fileLevel, precision);
         }
@@ -390,6 +409,7 @@ private:
     size_t nbColumns_ = 0;
     std::vector<std::string> groupNames_; // Names of group containing the clusters of the area
     std::map<std::string, unsigned int> groupToNumbers_; // Gives to each group (of area) a number
+    std::vector<ColumnDescriptor> descriptors_;
     const int NB_COLS_PER_GROUP = 3; // Injection + withdrawal + levels = 3 variables
     unsigned int pNbYearsParallel;
 

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -235,6 +235,29 @@ public:
         NextType::hourBegin(hourInTheYear);
     }
 
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Study& study,
+                                                                Data::Area* /*area*/)
+    {
+        std::set<std::string> uniqueGroups;
+        study.areas.each(
+          [&uniqueGroups](Data::Area& currentArea)
+          {
+              for (const auto& sts: currentArea.shortTermStorage.storagesByIndex)
+              {
+                  uniqueGroups.insert(sts.properties.groupName);
+              }
+          });
+
+        std::vector<ColumnDescriptor> descriptors;
+        for (const auto& groupName: uniqueGroups)
+        {
+            descriptors.push_back({groupName + "_INJECTION", "MW"});
+            descriptors.push_back({groupName + "_WITHDRAWAL", "MW"});
+            descriptors.push_back({groupName + "_LEVEL", "MWh"});
+        }
+        return descriptors;
+    }
+
     void hourForEachArea(State& state, unsigned int numSpace)
     {
         using namespace Antares::Data::ShortTermStorage;

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <antares/utils/utils.h>
+#include "antares/solver/variable/economy/dynamic_multi_column_base.h"
 #include "antares/solver/variable/variable.h"
 
 namespace

--- a/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/STSbyGroup.h
@@ -248,12 +248,12 @@ public:
         NextType::hourBegin(hourInTheYear);
     }
 
-    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Study& study,
-                                                                Data::Area* /*area*/)
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(const Data::Study& study,
+                                                                const Data::Area* /*area*/)
     {
         std::set<std::string> uniqueGroups;
         study.areas.each(
-          [&uniqueGroups](Data::Area& currentArea)
+          [&uniqueGroups](const Data::Area& currentArea)
           {
               for (const auto& sts: currentArea.shortTermStorage.storagesByIndex)
               {

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -122,6 +122,7 @@ public:
         groupNames_ = {names.begin(), names.end()};
         groupToNumbers_ = Utils::giveNumbersToStrings(groupNames_);
 
+        descriptors_ = buildColumnDescriptors(area);
         nbColumns_ = groupNames_.size();
 
         if (nbColumns_)
@@ -221,6 +222,22 @@ public:
         return descriptors;
     }
 
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Area* area)
+    {
+        std::set<std::string> uniqueGroups;
+        for (auto& cluster: area->thermal.list.each_enabled())
+        {
+            uniqueGroups.insert(cluster->getGroup());
+        }
+
+        std::vector<ColumnDescriptor> descriptors;
+        for (const auto& group: uniqueGroups)
+        {
+            descriptors.push_back({group, "MWh"});
+        }
+        return descriptors;
+    }
+
     void hourForEachArea(State& state, unsigned int numSpace)
     {
         auto area = state.area;
@@ -265,8 +282,8 @@ public:
 
         for (unsigned int column = 0; column < nbColumns_; column++)
         {
-            results.variableCaption = groupNames_[column];
-            results.variableUnit = VCardType::Unit();
+            results.variableCaption = descriptors_[column].caption;
+            results.variableUnit = descriptors_[column].unit;
             pValuesForTheCurrentYear[numSpace][column]
               .template buildAnnualSurveyReport<VCardType>(results, fileLevel, precision);
         }
@@ -290,8 +307,8 @@ public:
 
                 for (unsigned int column = 0; column < nbColumns_; column++)
                 {
-                    results.variableCaption = groupNames_[column];
-                    results.variableUnit = VCardType::Unit();
+                    results.variableCaption = descriptors_[column].caption;
+                    results.variableUnit = descriptors_[column].unit;
                     AncestorType::pResults[column]
                       .template buildSurveyReport<ResultsType, VCardType>(
                         results,
@@ -311,6 +328,7 @@ private:
     typename VCardType::IntermediateValuesType pValuesForTheCurrentYear;
     std::vector<std::string> groupNames_; // Names of group containing the clusters of the area
     std::map<std::string, unsigned int> groupToNumbers_; // Gives to each group (of area) a number
+    std::vector<ColumnDescriptor> descriptors_;
     size_t nbColumns_ = 0;
     unsigned int pNbYearsParallel;
 

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -113,17 +113,23 @@ public:
         pNbYearsParallel = study->maxNbYearsInParallel;
         pValuesForTheCurrentYear.resize(pNbYearsParallel);
 
-        // Building the vector of group names the clusters belong to.
+        // Study-wide column set: every area produces identically-positioned columns,
+        // so the shared captions array stays consistent with each area's rows.
+        descriptors_ = buildColumnDescriptors(*study, area);
+
         std::set<std::string> names;
-        for (const auto& cluster: area->thermal.list.each_enabled())
-        {
-            names.insert(cluster->getGroup());
-        }
+        study->areas.each(
+          [&names](Data::Area& currentArea)
+          {
+              for (auto& cluster: currentArea.thermal.list.each_enabled())
+              {
+                  names.insert(cluster->getGroup());
+              }
+          });
         groupNames_ = {names.begin(), names.end()};
         groupToNumbers_ = Utils::giveNumbersToStrings(groupNames_);
 
-        descriptors_ = buildColumnDescriptors(area);
-        nbColumns_ = groupNames_.size();
+        nbColumns_ = descriptors_.size();
 
         if (nbColumns_)
         {
@@ -256,7 +262,24 @@ public:
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
-        // Dynamic-columns variables are intentionally excluded from digest generation.
+        // Column layout is study-wide (see initializeFromArea), so every area writes the
+        // same captions in the same indices — safe to contribute to the digest now.
+        if (AncestorType::isPrinted[0]
+            && (VCardType::categoryDataLevel & Category::DataLevel::area
+                || VCardType::categoryDataLevel & Category::DataLevel::setOfAreas))
+        {
+            results.isPrinted = AncestorType::isPrinted;
+            results.isCurrentVarNA = AncestorType::isNonApplicable;
+
+            for (size_t c = 0; c < nbColumns_; ++c)
+            {
+                results.variableCaption = descriptors_[c].caption;
+                results.variableUnit = descriptors_[c].unit;
+                AncestorType::pResults[c].template buildDigest<VCardType>(results,
+                                                                          digestLevel,
+                                                                          dataLevel);
+            }
+        }
         NextType::buildDigest(results, digestLevel, dataLevel);
     }
 

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -207,12 +207,12 @@ public:
         NextType::hourBegin(hourInTheYear);
     }
 
-    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Study& study,
-                                                                Data::Area* /*area*/)
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(const Data::Study& study,
+                                                                const Data::Area* /*area*/)
     {
         std::set<std::string> uniqueGroups;
         study.areas.each(
-          [&uniqueGroups](Data::Area& currentArea)
+          [&uniqueGroups](const Data::Area& currentArea)
           {
               for (auto& cluster: currentArea.thermal.list.each_enabled())
               {

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -265,8 +265,8 @@ public:
         // Column layout is study-wide (see initializeFromArea), so every area writes the
         // same captions in the same indices — safe to contribute to the digest now.
         if (AncestorType::isPrinted[0]
-            && (VCardType::categoryDataLevel & Category::DataLevel::area
-                || VCardType::categoryDataLevel & Category::DataLevel::setOfAreas))
+            && (VCardType::categoryDataLevel
+                & (Category::DataLevel::area | Category::DataLevel::setOfAreas)))
         {
             results.isPrinted = AncestorType::isPrinted;
             results.isCurrentVarNA = AncestorType::isNonApplicable;

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <antares/utils/utils.h>
+#include "antares/solver/variable/economy/dynamic_multi_column_base.h"
 #include "antares/solver/variable/variable.h"
 
 namespace Antares::Solver::Variable::Economy

--- a/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dispatchableGeneration.h
@@ -199,6 +199,27 @@ public:
         NextType::hourBegin(hourInTheYear);
     }
 
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Study& study,
+                                                                Data::Area* /*area*/)
+    {
+        std::set<std::string> uniqueGroups;
+        study.areas.each(
+          [&uniqueGroups](Data::Area& currentArea)
+          {
+              for (auto& cluster: currentArea.thermal.list.each_enabled())
+              {
+                  uniqueGroups.insert(cluster->getGroup());
+              }
+          });
+
+        std::vector<ColumnDescriptor> descriptors;
+        for (const auto& group: uniqueGroups)
+        {
+            descriptors.push_back({group, "MWh"});
+        }
+        return descriptors;
+    }
+
     void hourForEachArea(State& state, unsigned int numSpace)
     {
         auto area = state.area;

--- a/src/solver/variable/include/antares/solver/variable/economy/dynamic_multi_column_base.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/dynamic_multi_column_base.h
@@ -1,0 +1,15 @@
+// Copyright 2007-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+#include <string>
+
+namespace Antares::Solver::Variable::Economy
+{
+struct ColumnDescriptor
+{
+    std::string caption;
+    std::string unit;
+};
+} // namespace Antares::Solver::Variable::Economy

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -116,6 +116,22 @@ public:
         return descriptors;
     }
 
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Area* area)
+    {
+        std::set<std::string> uniqueGroups;
+        for (auto& cluster: area->renewable.list.each_enabled())
+        {
+            uniqueGroups.insert(cluster->getGroup());
+        }
+
+        std::vector<ColumnDescriptor> descriptors;
+        for (const auto& group: uniqueGroups)
+        {
+            descriptors.push_back({group, "MWh"});
+        }
+        return descriptors;
+    }
+
     template<int CDataLevel, int CFile>
     struct Statistics
     {
@@ -143,6 +159,7 @@ public:
         groupNames_ = {names.begin(), names.end()};
         groupToNumbers_ = Utils::giveNumbersToStrings(groupNames_);
 
+        descriptors_ = buildColumnDescriptors(area);
         nbColumns_ = groupNames_.size();
 
         if (nbColumns_)
@@ -267,8 +284,8 @@ public:
 
         for (unsigned int column = 0; column < nbColumns_; column++)
         {
-            results.variableCaption = groupNames_[column];
-            results.variableUnit = VCardType::Unit();
+            results.variableCaption = descriptors_[column].caption;
+            results.variableUnit = descriptors_[column].unit;
             pValuesForTheCurrentYear[numSpace][column]
               .template buildAnnualSurveyReport<VCardType>(results, fileLevel, precision);
         }
@@ -292,8 +309,8 @@ public:
 
                 for (unsigned int column = 0; column < nbColumns_; column++)
                 {
-                    results.variableCaption = groupNames_[column];
-                    results.variableUnit = VCardType::Unit();
+                    results.variableCaption = descriptors_[column].caption;
+                    results.variableUnit = descriptors_[column].unit;
                     AncestorType::pResults[column]
                       .template buildSurveyReport<ResultsType, VCardType>(
                         results,
@@ -313,6 +330,7 @@ private:
     typename VCardType::IntermediateValuesType pValuesForTheCurrentYear;
     std::vector<std::string> groupNames_; // Names of group containing the clusters of the area
     std::map<std::string, unsigned int> groupToNumbers_; // Gives to each group (of area) a number
+    std::vector<ColumnDescriptor> descriptors_;
     size_t nbColumns_ = 0;
     unsigned int pNbYearsParallel;
 

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -95,12 +95,12 @@ public:
         count = 1 + NextT::count,
     };
 
-    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Study& study,
-                                                                Data::Area* /*area*/)
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(const Data::Study& study,
+                                                                const Data::Area* /*area*/)
     {
         std::set<std::string> uniqueGroups;
         study.areas.each(
-          [&uniqueGroups](Data::Area& currentArea)
+          [&uniqueGroups](const Data::Area& currentArea)
           {
               for (auto& cluster: currentArea.renewable.list.each_enabled())
               {
@@ -116,7 +116,7 @@ public:
         return descriptors;
     }
 
-    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Area* area)
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(const Data::Area* area)
     {
         std::set<std::string> uniqueGroups;
         for (auto& cluster: area->renewable.list.each_enabled())

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -267,8 +267,8 @@ public:
         // Column layout is study-wide (see initializeFromArea), so every area writes the
         // same captions in the same indices — safe to contribute to the digest now.
         if (AncestorType::isPrinted[0]
-            && (VCardType::categoryDataLevel & Category::DataLevel::area
-                || VCardType::categoryDataLevel & Category::DataLevel::setOfAreas))
+            && (VCardType::categoryDataLevel
+                & (Category::DataLevel::area | Category::DataLevel::setOfAreas)))
         {
             results.isPrinted = AncestorType::isPrinted;
             results.isCurrentVarNA = AncestorType::isNonApplicable;

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -150,17 +150,23 @@ public:
         pNbYearsParallel = study->maxNbYearsInParallel;
         pValuesForTheCurrentYear.resize(pNbYearsParallel);
 
-        // Building the vector of group names the clusters belong to.
+        // Study-wide column set: every area produces identically-positioned columns,
+        // so the shared captions array stays consistent with each area's rows.
+        descriptors_ = buildColumnDescriptors(*study, area);
+
         std::set<std::string> names;
-        for (const auto& cluster: area->renewable.list.each_enabled())
-        {
-            names.insert(cluster->getGroup());
-        }
+        study->areas.each(
+          [&names](Data::Area& currentArea)
+          {
+              for (auto& cluster: currentArea.renewable.list.each_enabled())
+              {
+                  names.insert(cluster->getGroup());
+              }
+          });
         groupNames_ = {names.begin(), names.end()};
         groupToNumbers_ = Utils::giveNumbersToStrings(groupNames_);
 
-        descriptors_ = buildColumnDescriptors(area);
-        nbColumns_ = groupNames_.size();
+        nbColumns_ = descriptors_.size();
 
         if (nbColumns_)
         {
@@ -258,7 +264,24 @@ public:
 
     inline void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
     {
-        // Dynamic-columns variables are intentionally excluded from digest generation.
+        // Column layout is study-wide (see initializeFromArea), so every area writes the
+        // same captions in the same indices — safe to contribute to the digest now.
+        if (AncestorType::isPrinted[0]
+            && (VCardType::categoryDataLevel & Category::DataLevel::area
+                || VCardType::categoryDataLevel & Category::DataLevel::setOfAreas))
+        {
+            results.isPrinted = AncestorType::isPrinted;
+            results.isCurrentVarNA = AncestorType::isNonApplicable;
+
+            for (size_t c = 0; c < nbColumns_; ++c)
+            {
+                results.variableCaption = descriptors_[c].caption;
+                results.variableUnit = descriptors_[c].unit;
+                AncestorType::pResults[c].template buildDigest<VCardType>(results,
+                                                                          digestLevel,
+                                                                          dataLevel);
+            }
+        }
         NextType::buildDigest(results, digestLevel, dataLevel);
     }
 

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -94,6 +94,27 @@ public:
         count = 1 + NextT::count,
     };
 
+    static std::vector<ColumnDescriptor> buildColumnDescriptors(Data::Study& study,
+                                                                Data::Area* /*area*/)
+    {
+        std::set<std::string> uniqueGroups;
+        study.areas.each(
+          [&uniqueGroups](Data::Area& currentArea)
+          {
+              for (auto& cluster: currentArea.renewable.list.each_enabled())
+              {
+                  uniqueGroups.insert(cluster->getGroup());
+              }
+          });
+
+        std::vector<ColumnDescriptor> descriptors;
+        for (const auto& group: uniqueGroups)
+        {
+            descriptors.push_back({group, "MWh"});
+        }
+        return descriptors;
+    }
+
     template<int CDataLevel, int CFile>
     struct Statistics
     {

--- a/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/renewableGeneration.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <antares/utils/utils.h>
+#include "antares/solver/variable/economy/dynamic_multi_column_base.h"
 #include "antares/solver/variable/variable.h"
 
 namespace Antares::Solver::Variable::Economy


### PR DESCRIPTION
This pull request refactors the way group-based multi-column variables are handled in the solver, specifically for short-term storage, dispatchable generation, and renewable generation. The main improvement is the introduction of a unified `ColumnDescriptor` structure, which ensures that all areas in a study use a consistent, study-wide column layout for these variables. This change simplifies column management, improves consistency in reporting, and enables digest generation for these dynamic-column variables.

**Core infrastructure changes:**

* Introduced a new `ColumnDescriptor` struct in `dynamic_multi_column_base.h` to encapsulate column captions and units, providing a unified way to describe variable columns.

**Refactoring of variable classes for study-wide columns:**

* Updated `STSbyGroup`, `DispatchableGeneration`, and `RenewableGeneration` classes to:
  - Build study-wide column descriptors using the new `ColumnDescriptor` struct, ensuring that all areas use the same column order and captions.
  - Replace previous per-area group name logic with descriptor-based logic for column management.
  - Store descriptors in a new `descriptors_` member and use it throughout for captions and units. 

**Digest and reporting improvements:**

* Enabled digest generation for these dynamic-column variables by iterating over the unified descriptors, ensuring consistent reporting across all areas. 
* Updated all reporting code paths to use `descriptors_` for variable captions and units, replacing previous group name and unit logic.

**Codebase consistency:**

* Added the new base header `dynamic_multi_column_base.h` to all relevant variable files to support the new column descriptor logic.
These changes make the handling of group-based, multi-column variables more robust, maintainable, and consistent across the codebase.