### PR TITLE
fix: address guilpier-code PR #3627 review comments

### DIFF
--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_fonctions.h
@@ -101,7 +101,7 @@ void OPT_AjusterLeNombreMinDeGroupesDemarresCoutsDeDemarrage(PROBLEME_HEBDO*);
 double OPT_SommeDesPminThermiques(const PROBLEME_HEBDO*, int, uint);
 Optimisation::LinearProblemApi::FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo,
                                                              int NumIntervalle);
-void fillLinearProblem(Optimisation::LinearProblemApi::FillContext& fillCtx,
+void fillLinearProblem(const Optimisation::LinearProblemApi::FillContext& fillCtx,
                        PROBLEME_HEBDO* problemeHebdo,
                        Optimisation::OptimEntityContainer& optimEntityContainer,
                        bool namedProblems,

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -3,6 +3,7 @@
 
 #include <mutex>
 
+#include <antares/antares/constants.h>
 #include <antares/antares/fatal-error.h>
 #include <antares/logs/logs.h>
 #include <antares/solver/utils/ortools_utils.h>
@@ -79,7 +80,7 @@ FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo, int NumInterva
 {
     unsigned globalFirst, globalLast;
     unsigned localFirst = 0, localLast;
-    auto nTsInDay = static_cast<unsigned>(problemeHebdo->NombreDePasDeTempsDUneJournee);
+    auto nTsInDay = HOURS_PER_DAY;
     if (problemeHebdo->OptimisationAuPasHebdomadaire)
     {
         globalFirst = static_cast<unsigned>(problemeHebdo->HeureDansLAnnee);
@@ -100,8 +101,7 @@ FillContext buildFillContext(const PROBLEME_HEBDO* problemeHebdo, int NumInterva
             problemeHebdo->year}; // TODO: handle scenarios/year
 }
 
-// Returns a shared_ptr to the solver
-void fillLinearProblem(FillContext& fillCtx,
+void fillLinearProblem(const FillContext& fillCtx,
                        PROBLEME_HEBDO* problemeHebdo,
                        OptimEntityContainer& optimEntityContainer,
                        bool namedProblems,

--- a/src/tests/cucumber/features/steps/common_steps/modeler_output_handler.py
+++ b/src/tests/cucumber/features/steps/common_steps/modeler_output_handler.py
@@ -51,7 +51,7 @@ class modeler_output_handler:
             paths = [simulation_table_location]
         frames = [pd.read_csv(p, header=0, sep=",", low_memory=False) for p in paths]
         df = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
-        # We need an int or a range for scenario the modeler step 
+        # We need an int or a range for scenario the modeler step
         df['scenario_index'] = df['scenario_index'].replace("None", 0)
         df['scenario_index'] = df['scenario_index'].replace(np.nan, 0)
         df.replace("None", np.nan, inplace=True)
@@ -59,6 +59,34 @@ class modeler_output_handler:
         for col in cols:
             df[col] = df[col].astype(float)
         return df
+
+    @staticmethod
+    def __build_lookup_error_msg(component, output, block, timestep, scenario, df, simulation_table):
+        """Build a detailed error message for simulation table lookup failures."""
+        all_components = simulation_table["component"].dropna().unique().tolist()
+        all_outputs = simulation_table["output"].dropna().unique().tolist()
+        available_components = sorted([str(c) for c in all_components])
+        available_outputs = sorted([str(o) for o in all_outputs])
+
+        df_for_comp = simulation_table[(simulation_table["component"] == component)]
+        available_for_comp = sorted(df_for_comp["absolute_time_index"].unique().tolist()) if not df_for_comp.empty else "none"
+
+        df_comp_out = simulation_table[(simulation_table["component"] == component)
+                                       & (simulation_table["output"] == output)]
+        available_timesteps = sorted(df_comp_out["absolute_time_index"].unique().tolist()) if not df_comp_out.empty else "n/a (no component/output match)"
+
+        return (
+            f"Simulation table lookup failed for:\n"
+            f"  component: '{component}'\n"
+            f"  output: '{output}'\n"
+            f"  block: '{block}'\n"
+            f"  timestep: '{timestep}'\n"
+            f"  scenario: '{scenario}'\n"
+            f"Found {len(df)} row(s) (expected 1).\n"
+            f"Available components: {available_components}\n"
+            f"Available outputs: {available_outputs}\n"
+            f"Available timesteps for component '{component}': {available_for_comp}\n"
+            f"Available absolute_time_index values: {available_timesteps}")
 
     def get_simulation_table_entry(self, component: str, output: str, block: int, timestep: int, scenario: int):
         df = self.simulation_table[(self.simulation_table["component"] == component)
@@ -74,27 +102,7 @@ class modeler_output_handler:
         else:
             df = df[df["scenario_index"] == scenario]
         if len(df) != 1:
-            all_components = self.simulation_table["component"].dropna().unique().tolist()
-            all_outputs = self.simulation_table["output"].dropna().unique().tolist()
-            available_components = sorted([str(c) for c in all_components])
-            available_outputs = sorted([str(o) for o in all_outputs])
-            available_timesteps = sorted(df["absolute_time_index"].unique().tolist()) if not df.empty else "n/a (no component/output match)"
-            
-            df_for_comp = self.simulation_table[(self.simulation_table["component"] == component)]
-            available_for_comp = sorted(df_for_comp["absolute_time_index"].unique().tolist()) if not df_for_comp.empty else "none"
-            
-            raise LookupError(
-                f"Simulation table lookup failed for:\n"
-                f"  component: '{component}'\n"
-                f"  output: '{output}'\n"
-                f"  block: '{block}'\n"
-                f"  timestep: '{timestep}'\n"
-                f"  scenario: '{scenario}'\n"
-                f"Found {len(df)} row(s) (expected 1).\n"
-                f"Available components: {available_components}\n"
-                f"Available outputs: {available_outputs}\n"
-                f"Available timesteps for component '{component}': {available_for_comp}\n"
-                f"Available absolute_time_index values: {available_timesteps}")
+            raise LookupError(self.__build_lookup_error_msg(component, output, block, timestep, scenario, df, self.simulation_table))
         return df["value"].iloc[0]
 
     def get_objective_value(self):


### PR DESCRIPTION
This PR addresses the review comments from **guilpier-code** on PR #3627 (merged as commit 128d4369e).

## Changes

### 1. `opt_appel_solveur_lineaire.cpp` — Explicit header include
- Added `#include <antares/antares/constants.h>` to explicitly declare `HOURS_PER_DAY` and `Antares::Constants::nbHoursInAWeek`
- Fixes the transitive include dependency flagged in review

### 2. `opt_appel_solveur_lineaire.cpp` — Use `HOURS_PER_DAY` constant
- Replaced `problemeHebdo->NombreDePasDeTempsDUneJournee` with `HOURS_PER_DAY`
- `NombreDePasDeTempsDUneJournee` is always 24 and should be a constant
- `HOURS_PER_DAY` already exists in `constants.h` and is used elsewhere in this file

### 3. `opt_appel_solveur_lineaire.cpp` — Remove misleading comment
- Removed the comment `// Returns a shared_ptr to the solver` which is incorrect (the function returns void)

### 4. `opt_appel_solveur_lineaire.cpp` — `const` correctness
- Changed `fillLinearProblem(FillContext& fillCtx, ...` to `fillLinearProblem(const FillContext& fillCtx, ...`
- `fillCtx` is not modified within the function

### 5. `modeler_output_handler.py` — Extract error message builder
- Extracted the verbose error message building logic into a new `__build_lookup_error_msg()` static method
- Reduces lines in the already fat `get_simulation_table_entry()` function
- Also fixed `available_timesteps` computation to use component+output filtered dataframe (more accurate diagnostics)
- Removed trailing whitespace on blank lines

## Related
Addresses review comments from **guilpier-code** on [PR #3627](https://github.com/AntaresSimulatorTeam/Antares_Simulator/pull/3627)