### PR TITLE
fix(hydro): add loading for inter-monthly breakdown properties [ANT-4985]

### DIFF
--- a/src/libs/antares/study/parts/hydro/container.cpp
+++ b/src/libs/antares/study/parts/hydro/container.cpp
@@ -136,6 +136,15 @@ bool PartHydro::LoadIniFile(Study& study, const std::filesystem::path& folder)
               && ret;
     }
 
+    if (IniFile::Section* section = ini.find("inter-monthly-breakdown"))
+    {
+        ret = loadProperties(study,
+                             section->firstProperty,
+                             path,
+                             &PartHydro::intermonthlyBreakdown)
+              && ret;
+    }
+
     if (IniFile::Section* section = ini.find("reservoir"))
     {
         ret = loadProperties(study, section->firstProperty, path, &PartHydro::reservoirManagement)


### PR DESCRIPTION
* Implemented loading of properties from the "inter-monthly-breakdown" section in the configuration file.
* Ensured integration with existing property loading mechanisms.