### PR TITLE
fix(cmake): install libparquet_writer.so to bin instead of lib

### DIFF
--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -30,7 +30,6 @@ set(TARGET_LIBS #No alias
         path
         mersenne
         result_writer
-	parquet_writer
         series
         antares-core
         antares-solver-hydro
@@ -127,6 +126,18 @@ set(TARGET_LIBS #No alias
 install(TARGETS ${TARGET_LIBS}
         EXPORT AntaresTargets
         LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
+)
+
+# parquet_writer: install to bin (not lib) for runtime loading by executables.
+# It is NOT in TARGET_LIBS to avoid installing its .so to lib/.
+# It IS added to the export set here so that result_writer (which depends on it)
+# can correctly resolve the dependency in the generated CMake config.
+install(TARGETS parquet_writer
+        EXPORT AntaresTargets
+        LIBRARY DESTINATION bin
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin
         INCLUDES DESTINATION include


### PR DESCRIPTION
## Problem

`libparquet_writer.so` was being installed to `lib/` instead of `bin/`. This caused runtime loading issues since the shared library needs to be next to the executables.

The root cause was a conflict between two install rules:
1. `src/libs/antares/writer/CMakeLists.txt` had a dedicated install with `LIBRARY DESTINATION bin` ✅
2. `src/packaging/CMakeLists.txt` listed `parquet_writer` in `TARGET_LIBS`, which installed everything to `lib/` ❌

## Fix

In `src/packaging/CMakeLists.txt`:
- Remove `parquet_writer` from the `TARGET_LIBS` list (so it doesn't get installed to `lib/` by the bulk install)
- Add a dedicated `install(TARGETS parquet_writer EXPORT AntaresTargets ...)` with `LIBRARY DESTINATION bin` — this keeps it in the export set (so `result_writer` and `write-modeler-files` can resolve the dependency) but installs the `.so` to `bin/`

## Verification

- `cmake --install .` now places `libparquet_writer.so` only in `bin/` (not `lib/`)
- `cpack -G TGZ` produces a package with `bin/libparquet_writer.so` only
- CMake configuration and build complete without errors