### PR TITLE
Avoid column lookup for simulation tables

### DIFF
--- a/src/io/outputs/SimulationTable.cpp
+++ b/src/io/outputs/SimulationTable.cpp
@@ -12,35 +12,33 @@ namespace Antares::IO::Outputs
 SimulationTable::SimulationTable()
 
 {
-    storage_.addIntegralColumn("block");
-    storage_.addOptionalColumn<std::string>("component");
-    storage_.addStringColumn("output");
-    storage_.addOptionalColumn<unsigned int>("absolute_time_index");
-    storage_.addOptionalColumn<unsigned int>("block_time_index");
-    storage_.addIntegralColumn("scenario_index");
-    storage_.addOptionalColumn<double>("value");
-    storage_.addOptionalColumn<Antares::Optimisation::LinearProblemApi::MipBasisStatus>(
-      "basis_status");
+    block_ = storage_.addIntegralColumn("block");
+    component_ = storage_.addOptionalColumn<std::string>("component");
+    output_ = storage_.addStringColumn("output");
+    absolute_time_index_ = storage_.addOptionalColumn<unsigned int>("absolute_time_index");
+    block_time_index_ = storage_.addOptionalColumn<unsigned int>("block_time_index");
+    scenario_index_ = storage_.addIntegralColumn("scenario_index");
+    value_ = storage_.addOptionalColumn<double>("value");
+    basis_status_ = storage_
+                      .addOptionalColumn<Antares::Optimisation::LinearProblemApi::MipBasisStatus>(
+                        "basis_status");
 }
 
-SimulationTable::SimulationTable(SimulationTable&& other) noexcept:
-    storage_(std::move(other.storage_))
-{
-}
+SimulationTable::SimulationTable(SimulationTable&& other) noexcept = default;
 
 void SimulationTable::addEntry(const SimulationTableEntry& entry)
 {
-    storage_.addValue("block", entry.block);
-    storage_.addValue("component", entry.component);
-    storage_.addValue("output", entry.output);
-    storage_.addValue("absolute_time_index", entry.absolute_time_index);
-    storage_.addValue("block_time_index", entry.block_time_index);
-    storage_.addValue("scenario_index", entry.scenario_index);
-    storage_.addValue("value", entry.value);
-    storage_.addValue("basis_status", entry.status);
+    block_->add(entry.block);
+    component_->add(entry.component);
+    output_->add(entry.output);
+    absolute_time_index_->add(entry.absolute_time_index);
+    block_time_index_->add(entry.block_time_index);
+    scenario_index_->add(entry.scenario_index);
+    value_->add(entry.value);
+    basis_status_->add(entry.status);
 }
 
-const std::vector<std::unique_ptr<IColumn>>& SimulationTable::columns() const
+const std::vector<std::shared_ptr<IColumn>>& SimulationTable::columns() const
 {
     return storage_.columns();
 }

--- a/src/io/outputs/include/antares/io/outputs/SimulationTable.h
+++ b/src/io/outputs/include/antares/io/outputs/SimulationTable.h
@@ -17,12 +17,21 @@ public:
     SimulationTable();
     SimulationTable(SimulationTable&& other) noexcept;
     void addEntry(const SimulationTableEntry& entry);
-    const std::vector<std::unique_ptr<IColumn>>& columns() const;
+    const std::vector<std::shared_ptr<IColumn>>& columns() const;
     size_t rowCount() const;
     void clear();
     std::vector<std::vector<std::string>> storageIntoRows() const;
 
 private:
     ColumnBasedStorage storage_;
+    std::shared_ptr<IntegralColumn> block_;
+    std::shared_ptr<OptionalColumn<std::string>> component_;
+    std::shared_ptr<StringColumn> output_;
+    std::shared_ptr<OptionalColumn<unsigned int>> absolute_time_index_;
+    std::shared_ptr<OptionalColumn<unsigned int>> block_time_index_;
+    std::shared_ptr<IntegralColumn> scenario_index_;
+    std::shared_ptr<OptionalColumn<double>> value_;
+    std::shared_ptr<OptionalColumn<Antares::Optimisation::LinearProblemApi::MipBasisStatus>>
+      basis_status_;
 };
 } // namespace Antares::IO::Outputs

--- a/src/io/outputs/include/antares/io/outputs/storage.h
+++ b/src/io/outputs/include/antares/io/outputs/storage.h
@@ -11,51 +11,25 @@ namespace Antares::IO::Outputs
 class ColumnBasedStorage
 {
 public:
-    void addStringColumn(const std::string& name)
+    std::shared_ptr<StringColumn> addStringColumn(const std::string& name)
     {
-        addColumn<StringColumn>(name);
+        return addColumn<StringColumn>(name);
     }
 
-    void addIntegralColumn(const std::string& name)
+    std::shared_ptr<IntegralColumn> addIntegralColumn(const std::string& name)
     {
-        addColumn<IntegralColumn>(name);
+        return addColumn<IntegralColumn>(name);
     }
 
-    void addDoubleColumn(const std::string& name)
+    std::shared_ptr<DoubleColumn> addDoubleColumn(const std::string& name)
     {
-        addColumn<DoubleColumn>(name);
-    }
-
-    template<typename T>
-    void addOptionalColumn(const std::string& name)
-    {
-        addColumn<OptionalColumn<T>>(name);
+        return addColumn<DoubleColumn>(name);
     }
 
     template<typename T>
-    void addValue(const std::string& column_name, const T& value)
+    std::shared_ptr<OptionalColumn<T>> addOptionalColumn(const std::string& name)
     {
-        if constexpr (std::is_same_v<T, std::string>)
-        {
-            getColumn<StringColumn>(column_name).add(value);
-        }
-        else if constexpr (std::is_integral_v<T>)
-        {
-            getColumn<IntegralColumn>(column_name).add(value);
-        }
-        else if constexpr (std::is_floating_point_v<T>)
-        {
-            getColumn<DoubleColumn>(column_name).add(static_cast<double>(value));
-        }
-        else if constexpr (is_optional_v<T>)
-        {
-            using Inner = T::value_type;
-            getColumn<OptionalColumn<Inner>>(column_name).add(value);
-        }
-        else
-        {
-            throw std::runtime_error("Unsupported type"); // TODO
-        }
+        return addColumn<OptionalColumn<T>>(name);
     }
 
     [[nodiscard]] size_t rowCount() const
@@ -63,18 +37,7 @@ public:
         return columns_.empty() ? 0 : (*columns_.begin())->size();
     }
 
-    [[nodiscard]] const IColumn& getColumn(const std::string& name) const
-    {
-        const auto it = std::ranges::find_if(columns_,
-                                             [&name](const auto& c) { return c->name() == name; });
-        if (it == columns_.end())
-        {
-            throw std::runtime_error("Column not found: " + name);
-        }
-        return **it;
-    }
-
-    [[nodiscard]] const std::vector<std::unique_ptr<IColumn>>& columns() const
+    [[nodiscard]] const std::vector<std::shared_ptr<IColumn>>& columns() const
     {
         return columns_;
     }
@@ -89,7 +52,7 @@ public:
 
 private:
     template<typename ColumnType>
-    void addColumn(const std::string& name)
+    std::shared_ptr<ColumnType> addColumn(const std::string& name)
     {
         auto it = std::ranges::find_if(columns_,
                                        [&name](const auto& c) { return c->name() == name; });
@@ -97,34 +60,10 @@ private:
         {
             throw std::runtime_error("Column already exists: " + name);
         }
-        auto col = std::make_unique<ColumnType>(name);
-        columns_.push_back(std::move(col));
+        columns_.push_back(std::make_shared<ColumnType>(name));
+        return std::static_pointer_cast<ColumnType>(columns_.back());
     }
 
-    // Access column by name
-    template<typename ColumnType>
-    ColumnType& getColumn(const std::string& name)
-    {
-        const auto it = std::ranges::find_if(columns_,
-                                             [&name](const auto& c) { return c->name() == name; });
-        if (it == columns_.end())
-        {
-            throw std::runtime_error("Column not found: " + name);
-        }
-        return dynamic_cast<ColumnType&>(**it);
-    }
-
-    // Access column by index
-    template<typename ColumnType>
-    ColumnType& getColumn(const size_t index)
-    {
-        if (index >= columns_.size())
-        {
-            throw std::out_of_range("Column index out of range");
-        }
-        return dynamic_cast<ColumnType&>(*columns_[index]);
-    }
-
-    std::vector<std::unique_ptr<IColumn>> columns_;
+    std::vector<std::shared_ptr<IColumn>> columns_;
 };
 } // namespace Antares::IO::Outputs

--- a/src/io/outputs/include/antares/io/outputs/storage.h
+++ b/src/io/outputs/include/antares/io/outputs/storage.h
@@ -63,6 +63,7 @@ private:
         auto col = std::make_shared<ColumnType>(name);
         columns_.push_back(col);
         return col;
+    }
 
     std::vector<std::shared_ptr<IColumn>> columns_;
 };

--- a/src/io/outputs/include/antares/io/outputs/storage.h
+++ b/src/io/outputs/include/antares/io/outputs/storage.h
@@ -60,9 +60,9 @@ private:
         {
             throw std::runtime_error("Column already exists: " + name);
         }
-        columns_.push_back(std::make_shared<ColumnType>(name));
-        return std::static_pointer_cast<ColumnType>(columns_.back());
-    }
+        auto col = std::make_shared<ColumnType>(name);
+        columns_.push_back(col);
+        return col;
 
     std::vector<std::shared_ptr<IColumn>> columns_;
 };

--- a/src/libs/antares/writer/columnToArrowAdapter.cpp
+++ b/src/libs/antares/writer/columnToArrowAdapter.cpp
@@ -253,24 +253,18 @@ public:
     }
 };
 
-std::shared_ptr<IColumnAdapter> makeColumnAdapter(const std::unique_ptr<IColumn>& column)
+std::shared_ptr<IColumnAdapter> makeColumnAdapter(const IColumn& column)
 {
-    if (!column)
-    {
-        throw InvalidArgumentError("makeColumnAdapter: null column");
-    }
-
     ColumnAdapterFactory factory;
 
     try
     {
-        return column->accept(factory);
+        return column.accept(factory);
     }
     catch (const std::bad_cast& e)
     {
         // This shouldn't happen if all column types are properly registered
-        std::string err_msg = "makeColumnAdapter: column type unknown: " + column->name()
-                              + " (dynamic type: " + std::string(typeid(*column).name()) + ")";
+        std::string err_msg = "makeColumnAdapter: column type unknown: " + column.name();
         throw InvalidArgumentError(err_msg);
     }
 }

--- a/src/libs/antares/writer/columnToArrowAdapter.h
+++ b/src/libs/antares/writer/columnToArrowAdapter.h
@@ -130,7 +130,6 @@ private:
 // ===========================
 // Column adapter factory
 // ===========================
-std::shared_ptr<IColumnAdapter> makeColumnAdapter(
-  const std::unique_ptr<IO::Outputs::IColumn>& column);
+std::shared_ptr<IColumnAdapter> makeColumnAdapter(const IO::Outputs::IColumn& column);
 
 } // namespace Antares::Writer

--- a/src/libs/antares/writer/parquet_table_writer.cpp
+++ b/src/libs/antares/writer/parquet_table_writer.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<arrow::Table> makeArrowTable(const Antares::IO::Outputs::Simulat
     std::vector<std::shared_ptr<arrow::Array>> arrow_columns;
     for (const auto& column: columns)
     {
-        auto columnAdapter = makeColumnAdapter(column);
+        auto columnAdapter = makeColumnAdapter(*column);
         fields.push_back(columnAdapter->makeField());
         arrow_columns.push_back(columnAdapter->makeArray());
     }


### PR DESCRIPTION
# The good
- Simplify the code by removing multiple `getColumn()` methods
- Avoid 1 linear search for every entry add
# The bad
- Hard-coded columns