### PR TITLE
Fix : activate parquet for simulation tables in solver

### DIFF
--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -18,6 +18,7 @@
 #include <antares/writer/result_format.h>
 #include "antares/antares/antares.h"
 #include "antares/study/fwd.h"
+#include "antares/writer/table_format.h"
 
 #include "parameters/adq-patch-params.h"
 #include "variable-print-info.h"
@@ -435,7 +436,7 @@ public:
     //@}
 
     // In case we print simulation tables, do we print it in csv or parquet ?
-    bool parquetFmtForSimuTables = false;
+    Writer::TableFormat simuTableFormat = Writer::TableFormat::CSV;
 
     bool hydroDebug;
 

--- a/src/solver/application/application.cpp
+++ b/src/solver/application/application.cpp
@@ -152,7 +152,10 @@ void Application::readDataForTheStudy(Data::StudyLoadOptions& options)
         // no output ?
         study.parameters.noOutput = pSettings.noOutput;
 
-        study.parameters.parquetFmtForSimuTables = pSettings.parquetFmtForSimuTables;
+        if (pSettings.parquetFmtForSimuTables)
+        {
+            study.parameters.simuTableFormat = Writer::TableFormat::Parquet;
+        }
 
         if (pSettings.forceZipOutput)
         {

--- a/src/solver/simulation/adequacy.cpp
+++ b/src/solver/simulation/adequacy.cpp
@@ -342,7 +342,9 @@ bool Adequacy::year(Variable::State& state,
 
     if (simulationTables && !study.folderOutput.empty())
     {
-        LegacySimulationTablesWriter legacyWriter(study.folderOutput, state.year);
+        LegacySimulationTablesWriter legacyWriter(study.folderOutput,
+                                                  state.year,
+                                                  study.parameters.simuTableFormat);
         legacyWriter.write(*simulationTables);
         simulationTables->clear();
     }

--- a/src/solver/simulation/economy.cpp
+++ b/src/solver/simulation/economy.cpp
@@ -204,7 +204,9 @@ bool Economy::year(Variable::State& state,
 
     if (simulationTables && !study.folderOutput.empty())
     {
-        LegacySimulationTablesWriter legacyWriter(study.folderOutput, state.year);
+        LegacySimulationTablesWriter legacyWriter(study.folderOutput,
+                                                  state.year,
+                                                  study.parameters.simuTableFormat);
         legacyWriter.write(*simulationTables);
         simulationTables->clear();
     }


### PR DESCRIPTION
Fixing an overlook : in case of an hybrid study, writing simulation table (only GEMS part at this point) into a given format  (csv or parquet) wasn't properly done : the wiring between the exe **antares-solver**'s option (**--parquet**) and the location of writing in the code was missing. 