### PR TITLE
Fix: build warnings for output variables

### DIFF
--- a/src/solver/variable/include/antares/solver/variable/commons/miscGenMinusRowPSP.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/miscGenMinusRowPSP.h
@@ -109,7 +109,7 @@ public:
         }
     }
 
-    void initializeFromArea(Data::Study* study, Data::Area* area)
+    void initializeFromArea(Data::Study* /*study*/, Data::Area* area)
     {
         // Copy raw values
         for (unsigned int numSpace = 0; numSpace < pNbYearsParallel; numSpace++)
@@ -147,11 +147,11 @@ public:
     {
     }
 
-    void yearBegin(unsigned int year, unsigned int numSpace)
+    void yearBegin(unsigned int /*year*/, unsigned int /*numSpace*/)
     {
     }
 
-    void yearEnd(unsigned int year, unsigned int numSpace)
+    void yearEnd(unsigned int /*year*/, unsigned int numSpace)
     {
         // Compute all statistics for the current year (daily,weekly,monthly)
         pValuesForTheCurrentYear[numSpace].computeStatisticsForTheCurrentYear();
@@ -163,11 +163,11 @@ public:
         AncestorType::pResults.merge(year, pValuesForTheCurrentYear[numSpace]);
     }
 
-    void hourBegin(unsigned int hourInTheYear)
+    void hourBegin(unsigned int /*hourInTheYear*/)
     {
     }
 
-    void hourForEachArea(State& state, unsigned int numSpace)
+    void hourForEachArea(State& /*state*/, unsigned int /*numSpace*/)
     {
     }
 

--- a/src/solver/variable/include/antares/solver/variable/commons/psp.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/psp.h
@@ -109,7 +109,7 @@ public:
         }
     }
 
-    void initializeFromArea(Data::Study* study, Data::Area* area)
+    void initializeFromArea(Data::Study* /*study*/, Data::Area* area)
     {
         // Copy raw values
         for (unsigned int numSpace = 0; numSpace < pNbYearsParallel; numSpace++)
@@ -134,11 +134,11 @@ public:
     {
     }
 
-    void yearBegin(unsigned int year, unsigned int numSpace)
+    void yearBegin(unsigned int /*year*/, unsigned int /*numSpace*/)
     {
     }
 
-    void yearEnd(unsigned int year, unsigned int numSpace)
+    void yearEnd(unsigned int /*year*/, unsigned int numSpace)
     {
         // Compute all statistics for the current year (daily,weekly,monthly)
         pValuesForTheCurrentYear[numSpace].computeStatisticsForTheCurrentYear();
@@ -150,11 +150,11 @@ public:
         AncestorType::pResults.merge(year, pValuesForTheCurrentYear[numSpace]);
     }
 
-    void hourBegin(unsigned int hourInTheYear)
+    void hourBegin(unsigned int /*hourInTheYear*/)
     {
     }
 
-    void hourForEachArea(State& state, unsigned int numSpace)
+    void hourForEachArea(State& /*state*/, unsigned int /*numSpace*/)
     {
     }
 

--- a/src/solver/variable/include/antares/solver/variable/commons/rowBalance.h
+++ b/src/solver/variable/include/antares/solver/variable/commons/rowBalance.h
@@ -145,23 +145,23 @@ public:
     {
     }
 
-    void yearBegin(unsigned int year, unsigned int numSpace)
+    void yearBegin(unsigned int /*year*/, unsigned int /*numSpace*/)
     {
     }
 
-    void yearEnd(unsigned int year, unsigned int numSpace)
+    void yearEnd(unsigned int /*year*/, unsigned int /*numSpace*/)
     {
     }
 
-    void computeSummary(unsigned int year, unsigned int numSpace)
+    void computeSummary(unsigned int /*year*/, unsigned int /*numSpace*/)
     {
     }
 
-    void hourBegin(unsigned int hourInTheYear)
+    void hourBegin(unsigned int /*hourInTheYear*/)
     {
     }
 
-    void hourForEachArea(State& state, unsigned int numSpace)
+    void hourForEachArea(State& /*state*/, unsigned int /*numSpace*/)
     {
     }
 

--- a/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/bindingConstraints/bindingConstraintsMarginalCost.h
@@ -140,13 +140,13 @@ public:
         return nbCount_ * ResultsType::count;
     }
 
-    void yearBegin(unsigned int year, unsigned int numSpace)
+    void yearBegin(unsigned int /*year*/, unsigned int numSpace)
     {
         // Reset the values for the current year
         pValuesForTheCurrentYear[numSpace].reset();
     }
 
-    void yearEnd(unsigned int year, unsigned int numSpace)
+    void yearEnd(unsigned int /*year*/, unsigned int numSpace)
     {
         if (isInitialized())
         {
@@ -226,15 +226,15 @@ public:
         }
     }
 
-    void hourBegin(unsigned int hourInTheYear)
+    void hourBegin(unsigned int /*hourInTheYear*/)
     {
     }
 
-    void hourForEachArea(State& state, unsigned int numSpace)
+    void hourForEachArea(State& /*state*/, unsigned int /*numSpace*/)
     {
     }
 
-    void weekForEachArea(State& state, unsigned int numSpace)
+    void weekForEachArea(State& /*state*/, unsigned int /*numSpace*/)
     {
     }
 
@@ -244,7 +244,7 @@ public:
     {
     }
 
-    void buildDigest(SurveyResults& results, int digestLevel, int dataLevel) const
+    void buildDigest(SurveyResults& /*results*/, int /*digestLevel*/, int /*dataLevel*/) const
     {
     }
 
@@ -260,7 +260,7 @@ public:
     {
     }
 
-    void beforeYearByYearExport(uint year, uint numSpace)
+    void beforeYearByYearExport(uint /*year*/, uint /*numSpace*/)
     {
     }
 

--- a/src/solver/variable/include/antares/solver/variable/economy/links/congestionProbability.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/links/congestionProbability.h
@@ -154,7 +154,7 @@ public:
     {
     }
 
-    void yearBegin(uint year, unsigned int numSpace)
+    void yearBegin(uint /*year*/, unsigned int numSpace)
     {
         // Reset
         pValuesForTheCurrentYear[numSpace][0].reset();
@@ -164,7 +164,7 @@ public:
         pValuesForYearLocalReport[numSpace][1].reset();
     }
 
-    void yearEnd(uint year, uint numSpace)
+    void yearEnd(uint /*year*/, uint numSpace)
     {
         for (uint i = 0; i != VCardType::columnCount; ++i)
         {
@@ -183,11 +183,11 @@ public:
         }
     }
 
-    void hourBegin(uint hourInTheYear)
+    void hourBegin(uint /*hourInTheYear*/)
     {
     }
 
-    void hourForEachArea(State& state, unsigned int numSpace)
+    void hourForEachArea(State& /*state*/, unsigned int /*numSpace*/)
     {
     }
 

--- a/src/solver/variable/include/antares/solver/variable/storage/average.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/average.h
@@ -51,8 +51,8 @@ public:
 
     template<class S, class VCardT>
     void buildSurveyReport(SurveyResults& report,
-                           const S& results,
-                           int dataLevel,
+                           const S& /*results*/,
+                           int /*dataLevel*/,
                            int fileLevel,
                            int precision) const
     {

--- a/src/solver/variable/include/antares/solver/variable/storage/minmax.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/minmax.h
@@ -26,8 +26,8 @@ public:
 
     template<class S, class VCardT>
     void buildSurveyReport(SurveyResults& report,
-                           const S& results,
-                           int dataLevel,
+                           const S& /*results*/,
+                           int /*dataLevel*/,
                            int fileLevel,
                            int precision) const
     {

--- a/src/solver/variable/include/antares/solver/variable/storage/stdDeviation.h
+++ b/src/solver/variable/include/antares/solver/variable/storage/stdDeviation.h
@@ -70,7 +70,7 @@ public:
     template<class S, class VCardT>
     void buildSurveyReport(SurveyResults& report,
                            const S& results,
-                           int dataLevel,
+                           int /*dataLevel*/,
                            int fileLevel,
                            int precision) const
     {


### PR DESCRIPTION
Mostly unused parameters

| File | Parameters fixed |
|------|-----------------|
| `miscGenMinusRowPSP.h` | `study`, `year`, `numSpace` (x2), `hourInTheYear`, `state`, `numSpace` |
| `psp.h` | `study`, `year`, `numSpace` (x2), `hourInTheYear`, `state`, `numSpace` |
| `rowBalance.h` | `year`, `numSpace` (x2), `year`, `numSpace` (x2), `hourInTheYear`, `state`, `numSpace` |
| `bindingConstraintsMarginalCost.h` | `year`, `numSpace`, `year`, `numSpace` (x2), `hourInTheYear`, `state`, `numSpace` (x2), `results`, `digestLevel`, `dataLevel`, `year`, `numSpace` |
| `congestionProbability.h` | `year`, `numSpace` (x2), `year`, `numSpace` (x2), `hourInTheYear`, `state`, `numSpace` |
| `average.h` | `results`, `dataLevel` |
| `stdDeviation.h` | `dataLevel` |
| `minmax.h` | `results`, `dataLevel` |