### PR TITLE
fix(warnings): virtual/override hygiene

### DIFF
--- a/src/libs/antares/study/include/antares/study/parts/thermal/cluster_list.h
+++ b/src/libs/antares/study/include/antares/study/parts/thermal/cluster_list.h
@@ -35,7 +35,7 @@ public:
     /*!
     ** \brief Destructor
     */
-    virtual ~ThermalClusterList();
+    ~ThermalClusterList();
     //@}
 
     //! \name Spinning

--- a/src/tests/src/expressions/test_PrintAndEvalVisitors.cpp
+++ b/src/tests/src/expressions/test_PrintAndEvalVisitors.cpp
@@ -36,11 +36,11 @@ BOOST_AUTO_TEST_CASE(test_getSystemParameterValueAsDouble)
             return 123.45; // Mock return value for testing
         }
 
-        [[nodiscard]] virtual std::span<const double> getData(
+        [[nodiscard]] std::span<const double> getData(
           [[maybe_unused]] const std::string& dataSetId,
           [[maybe_unused]] unsigned timeSeriesNumber,
           [[maybe_unused]] unsigned firstHour,
-          [[maybe_unused]] unsigned lastHour) const
+          [[maybe_unused]] unsigned lastHour) const override
         {
             static std::vector<double> data = {123.45};
             return data;


### PR DESCRIPTION
Part of the Clang `-Werror` clean-up (batch 1/4: virtual/override hygiene).

## Changes
- **`cluster_list.h`**: `ThermalClusterList` is declared `final`, so the `virtual` specifier on its destructor is unnecessary (`-Wunnecessary-virtual-specifier`). This single header is included very widely — removing the specifier eliminates **322** of the build's warning occurrences.
- **`test_PrintAndEvalVisitors.cpp`**: the `std::span` overload of the mock `getData()` overrides a base virtual but was marked `virtual` instead of `override` (`-Winconsistent-missing-override`). Marked `override`.

## Context
Surfaced by the new Ubuntu + up-to-date-Clang CI job that builds with `-Werror`. No behavior change.

https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo)_