### PR TITLE
fix(warnings): delete WeeklyOptimization move assignment

### DIFF
--- a/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/weekly_optimization.h
@@ -24,7 +24,7 @@ public:
     WeeklyOptimization(const WeeklyOptimization&) = delete;
     WeeklyOptimization& operator=(const WeeklyOptimization&) = delete;
     WeeklyOptimization(WeeklyOptimization&&) = default;
-    WeeklyOptimization& operator=(WeeklyOptimization&&) = default;
+    WeeklyOptimization& operator=(WeeklyOptimization&&) = delete;
     void solve();
     IO::Outputs::OptimisationsSimulationTable* simulationTables();
 


### PR DESCRIPTION
Part of the Clang `-Werror` clean-up (batch 2/4: move semantics).

## Change
`WeeklyOptimization` has a `const` pointer member (`problemeHebdo_`) and reference members, so its move assignment operator is **implicitly deleted**. Declaring it `= default` triggers `-Wdefaulted-function-deleted`.

Declared it `= delete` instead — consistent with the already-deleted copy assignment, and accurately reflecting that the type is non-assignable. No behavior change (the operator was already unusable).

## Context
Surfaced by the new Ubuntu + up-to-date-Clang CI job that builds with `-Werror`.

https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo)_