### PR TITLE
fix(warnings): dangling pointers and pessimizing move in modeler mocks

### DIFF
--- a/src/tests/src/modeler/UtilMocks.h
+++ b/src/tests/src/modeler/UtilMocks.h
@@ -254,8 +254,9 @@ public:
     Antares::Optimisation::LinearProblemApi::IMipConstraint* getConstraint(
       std::size_t) const override
     {
-        adHocConstraints_.push_back(RandomConstraint());
-        return adHocConstraints_.back().get();
+        static MockMipConstraint mock(
+          Antares::Optimisation::LinearProblemApi::MipBasisStatus::AT_LOWER_BOUND);
+        return &mock;
     }
 
     [[nodiscard]]
@@ -268,8 +269,11 @@ public:
     [[nodiscard]] Antares::Optimisation::LinearProblemApi::IMipVariable* lookupVariable(
       const std::string&) const override
     {
-        adHocVariables_.push_back(RandomVariable());
-        return adHocVariables_.back().get();
+        static MockMipVariable mock(
+          12.25,
+          Antares::Optimisation::LinearProblemApi::MipBasisStatus::AT_LOWER_BOUND,
+          false);
+        return &mock;
     }
 
     [[nodiscard]] int variableCount() const override
@@ -327,13 +331,6 @@ protected:
       constraints_;
     int variableCount_ = 0;
     int constraintCount_ = 0;
-    // Storage backing the pointers handed out by the const getConstraint()/
-    // lookupVariable() accessors, so they outlive the call (was returning the
-    // address of a destroyed temporary: -Wreturn-stack-address).
-    mutable std::vector<std::unique_ptr<Antares::Optimisation::LinearProblemApi::IMipConstraint>>
-      adHocConstraints_;
-    mutable std::vector<std::unique_ptr<Antares::Optimisation::LinearProblemApi::IMipVariable>>
-      adHocVariables_;
 };
 
 // Mock component and model classes for testing template functions

--- a/src/tests/src/modeler/UtilMocks.h
+++ b/src/tests/src/modeler/UtilMocks.h
@@ -254,7 +254,8 @@ public:
     Antares::Optimisation::LinearProblemApi::IMipConstraint* getConstraint(
       std::size_t) const override
     {
-        return RandomConstraint().get();
+        adHocConstraints_.push_back(RandomConstraint());
+        return adHocConstraints_.back().get();
     }
 
     [[nodiscard]]
@@ -267,7 +268,8 @@ public:
     [[nodiscard]] Antares::Optimisation::LinearProblemApi::IMipVariable* lookupVariable(
       const std::string&) const override
     {
-        return RandomVariable().get();
+        adHocVariables_.push_back(RandomVariable());
+        return adHocVariables_.back().get();
     }
 
     [[nodiscard]] int variableCount() const override
@@ -325,6 +327,13 @@ protected:
       constraints_;
     int variableCount_ = 0;
     int constraintCount_ = 0;
+    // Storage backing the pointers handed out by the const getConstraint()/
+    // lookupVariable() accessors, so they outlive the call (was returning the
+    // address of a destroyed temporary: -Wreturn-stack-address).
+    mutable std::vector<std::unique_ptr<Antares::Optimisation::LinearProblemApi::IMipConstraint>>
+      adHocConstraints_;
+    mutable std::vector<std::unique_ptr<Antares::Optimisation::LinearProblemApi::IMipVariable>>
+      adHocVariables_;
 };
 
 // Mock component and model classes for testing template functions
@@ -459,7 +468,7 @@ struct MyDummyFixture: Antares::Expressions::Registry<Antares::Expressions::Node
     Antares::Optimisation::LinearProblemDataImpl::LinearProblemData data;
     Antares::ModelerStudy::SystemModel::Model model = createModelWithoutParameters();
     std::vector<Antares::ModelerStudy::SystemModel::Component> components = {
-      std::move(createComponent(model))};
+      createComponent(model)};
     Antares::Optimisation::ScenarioGroupRepository scenarioGroupRepository = makeScenarioGroupRepo(
       components.front());
 


### PR DESCRIPTION
Part of the Clang `-Werror` clean-up (batch 3/4: test-mock correctness).

## Changes in `src/tests/src/modeler/UtilMocks.h`
- **Dangling pointers (`-Wreturn-stack-address`)**: `MockLinearProblem::getConstraint()` and `lookupVariable()` returned `RandomConstraint()/RandomVariable().get()` — the raw pointer of a `unique_ptr` **temporary** destroyed at the end of the full expression. The returned pointer was immediately dangling. Now the created objects are stored in `mutable` member vectors and the still-valid `.back().get()` is returned, mirroring the store-then-return pattern already used by the other accessors.
- **Pessimizing move (`-Wpessimizing-move`)**: dropped `std::move()` around the `createComponent()` prvalue in `MyDummyFixture`; it prevented copy elision.

These are genuine lifetime bugs in the mocks (not just warning noise), so this is the highest-value batch.

## Context
Surfaced by the new Ubuntu + up-to-date-Clang CI job that builds with `-Werror`.

https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo)_