### PR TITLE
fix(warnings): misc cleanups (unused, tautological compare, typeid, nodiscard)

### DIFF
--- a/src/libs/antares/correlation/correlation.cpp
+++ b/src/libs/antares/correlation/correlation.cpp
@@ -157,36 +157,6 @@ static inline void ReadCorrelationCoefficients(Correlation& correlation,
     }
 }
 
-static inline void ExportCorrelationCoefficients(Study& study,
-                                                 const Matrix<>& m,
-                                                 std::ostream& file,
-                                                 const std::string& name)
-{
-    if (m.empty() or m.width != m.height)
-    {
-        return;
-    }
-
-    file << '[' << name << "]\n";
-
-    // For each column
-    for (uint x = 0; x != m.width; ++x)
-    {
-        const AreaName& from = study.areas.byIndex[x]->id;
-
-        auto& col = m.entry[x];
-        for (uint y = 0; y < x; ++y)
-        {
-            if (!Utils::isZero(col[y]))
-            {
-                file << from << '%' << study.areas.byIndex[y]->id << " = " << col[y] << '\n';
-            }
-        }
-    }
-
-    file << '\n';
-}
-
 int InterAreaCorrelationLoadFromIniFile(Matrix<>* m, AreaList* l, IniFile* ini, int warnings)
 {
     // Asserts

--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -1124,7 +1124,7 @@ const AreaLink* AreaList::findLinkFromINIKey(const AnyString& key) const
         return nullptr;
     }
     auto offset = key.find('%');
-    if (offset == AreaName::npos || (0 == offset) || (offset == key.size() - 1))
+    if (offset == AnyString::npos || (0 == offset) || (offset == key.size() - 1))
     {
         return nullptr;
     }
@@ -1141,7 +1141,7 @@ ThermalCluster* AreaList::findClusterFromINIKey(const AnyString& key)
         return nullptr;
     }
     auto offset = key.find('.');
-    if (offset == AreaName::npos || (0 == offset) || (offset == key.size() - 1))
+    if (offset == AnyString::npos || (0 == offset) || (offset == key.size() - 1))
     {
         return nullptr;
     }

--- a/src/solver/infeasible-problem-analysis/report.cpp
+++ b/src/solver/infeasible-problem-analysis/report.cpp
@@ -27,13 +27,19 @@ bool lessTypeName(const std::shared_ptr<WatchedConstraint> a,
                   const std::shared_ptr<WatchedConstraint> b)
 {
     // TODO Compiler-dependent behavior
-    return typeid(*a).before(typeid(*b));
+    // Dereference before applying typeid so its operand is a side-effect-free
+    // glvalue (the dynamic type is still resolved): -Wpotentially-evaluated-expression.
+    const WatchedConstraint& ra = *a;
+    const WatchedConstraint& rb = *b;
+    return typeid(ra).before(typeid(rb));
 }
 
 bool sameType(const std::shared_ptr<WatchedConstraint> a,
               const std::shared_ptr<WatchedConstraint> b)
 {
-    return typeid(*a) == typeid(*b);
+    const WatchedConstraint& ra = *a;
+    const WatchedConstraint& rb = *b;
+    return typeid(ra) == typeid(rb);
 }
 
 bool greaterValue(const std::shared_ptr<WatchedConstraint> a, std::shared_ptr<WatchedConstraint> b)

--- a/src/tests/src/io/outputs/testSimulationTable.cpp
+++ b/src/tests/src/io/outputs/testSimulationTable.cpp
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(ConcurrentAccess_MultipleThreads)
     for (int t = 0; t < numThreads; ++t)
     {
         threads.emplace_back(
-          [&table, &tableMutex, t, entriesPerThread]()
+          [&table, &tableMutex, t]()
           {
               for (int i = 0; i < entriesPerThread; ++i)
               {

--- a/src/tests/src/optimisation/linear-problem-api/test_structured_linear_problem.cpp
+++ b/src/tests/src/optimisation/linear-problem-api/test_structured_linear_problem.cpp
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(dual_not_available)
     (void)lp.addNumVariable(0.0, 10.0, "x");
     auto* c = lp.addConstraint(1.0, 10.0, "c");
 
-    BOOST_CHECK_THROW(c->dual(), RuntimeError);
+    BOOST_CHECK_THROW((void)c->dual(), RuntimeError);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Part of the Clang `-Werror` clean-up (batch 4/4: miscellaneous cleanups).

## Changes
- **`list.cpp` — latent bug (`-Wtautological-constant-out-of-range-compare`)**: `findLinkFromINIKey`/`findClusterFromINIKey` compared the result of `key.find(...)` (type `AnyString::Size`, 32-bit) against `AreaName::npos` (64-bit `SIZE_MAX`). The comparison was **always false**, so the "separator not found" guard never fired. Now compares against `AnyString::npos`, matching the `find()` return type.
- **`correlation.cpp` (`-Wunused-function`)**: removed the dead `static inline ExportCorrelationCoefficients` (no callers anywhere in the tree).
- **`report.cpp` (`-Wpotentially-evaluated-expression`)**: bind the dereferenced `shared_ptr` to a reference before `typeid`, so the operand is a side-effect-free glvalue. Dynamic type resolution is unchanged.
- **`testSimulationTable.cpp` (`-Wunused-lambda-capture`)**: dropped the needless capture of the compile-time constant `entriesPerThread`.
- **`test_structured_linear_problem.cpp` (`-Wunused-result`)**: cast the `[[nodiscard]]` `dual()` result to `void` inside `BOOST_CHECK_THROW`.

## Context
Surfaced by the new Ubuntu + up-to-date-Clang CI job that builds with `-Werror`.

https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo)_