### PR TITLE
fix(test): Increase timeout of case 035 - 30s -> 45s

### DIFF
--- a/src/tests/cucumber/features/solver-features/medium_tests.feature
+++ b/src/tests/cucumber/features/solver-features/medium_tests.feature
@@ -5,7 +5,7 @@ Feature: medium tests
     Given the solver study path is "Antares_Simulator_Tests_NR/medium-tests/035 Mixed Expansion - Smart grid model 2"
     When I run antares simulator
     Then the simulation succeeds
-    And the simulation takes less than 30 seconds
+    And the simulation takes less than 45 seconds
     And the expected value of the annual system cost is 3.725e+10
     And the minimum annual system cost is 3.642e+10
     And the maximum annual system cost is 4.011e+10


### PR DESCRIPTION
Examples
>       ASSERT FAILED: Simulation time 33.772 exceeds 30.0 seconds

https://github.com/AntaresSimulatorTeam/Antares_Simulator/actions/runs/27622982137/job/81676751421

>       ASSERT FAILED: Simulation time 36.139 exceeds 30.0 seconds

https://github.com/AntaresSimulatorTeam/Antares_Simulator/actions/runs/27673013962/job/81841586342