### PR TITLE
Fix reserves participation never computed [ANT-5179]

### DIFF
--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -278,12 +278,6 @@ public:
     ** generaldata.ini. The default value is `false`.
     */
     bool readonly;
-
-    /*!
-    ** \brief Activation of the reserves
-    */
-    bool reservesEnabled = false;
-
     //! Write the simulation synthesis into the output
     bool synthesis;
 

--- a/src/solver/variable/include/antares/solver/variable/area.hxx
+++ b/src/solver/variable/include/antares/solver/variable/area.hxx
@@ -393,7 +393,7 @@ void Areas<VariableList>::buildThermalClusterYearEndResults(State& state, uint y
           } // for each thermal cluster
 
           // Calculation of reserve participation costs
-          if (state.study.parameters.reservesEnabled)
+          if (state.study.parameters.include.reserves)
           {
               state.calculateReserveParticipationCosts();
           }


### PR DESCRIPTION
Fix reserves participation never computed. This commit removes the deprecated `reservesEnabled` boolean parameter from `parameters.h` and updates the solver logic in `area.hxx` to use the new `include.reserves` flag for calculating reserve participation costs.

**Note** `reservesEnabled` was initialized to `false` and never set.