### PR TITLE
Remove one of Study::IsRootStudy static methods

### DIFF
--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -149,6 +149,12 @@ public:
     SimulationMode mode{SimulationMode::Economy};
     //@}
 
+    //! \name Horizon
+    //@{
+    //! Horizon year, not used by the solver
+    Yuni::String horizon;
+    //@}
+
     //! \name Calendar
     //@{
     //! Number of years to study
@@ -272,7 +278,6 @@ public:
     ** generaldata.ini. The default value is `false`.
     */
     bool readonly;
-
     //! Write the simulation synthesis into the output
     bool synthesis;
 

--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -149,12 +149,6 @@ public:
     SimulationMode mode{SimulationMode::Economy};
     //@}
 
-    //! \name Horizon
-    //@{
-    //! Horizon year, not used by the solver
-    Yuni::String horizon;
-    //@}
-
     //! \name Calendar
     //@{
     //! Number of years to study
@@ -278,11 +272,6 @@ public:
     ** generaldata.ini. The default value is `false`.
     */
     bool readonly;
-
-    /*!
-    ** \brief Activation of the reserves
-    */
-    bool reservesEnabled = false;
 
     //! Write the simulation synthesis into the output
     bool synthesis;

--- a/src/libs/antares/study/include/antares/study/study.h
+++ b/src/libs/antares/study/include/antares/study/study.h
@@ -64,15 +64,6 @@ public:
     */
     static bool IsRootStudy(const AnyString& folder);
 
-    /*!
-    ** \brief Get if a folder if a study
-    **
-    ** \param folder A study folder
-    ** \param buffer A buffer to reuse for temporary operations
-    ** \return True if the folder is a study, false otherwise
-    */
-    static bool IsRootStudy(const AnyString& folder, YString& buffer);
-
     //! \name Constructor & Destructor
     //@{
     /*!

--- a/src/libs/antares/study/study.extra.cpp
+++ b/src/libs/antares/study/study.extra.cpp
@@ -33,16 +33,10 @@ void Study::scenarioRulesLoadIfNotAvailable()
 // TODO remove after vacuum
 bool Study::IsRootStudy(const AnyString& folder)
 {
-    String buffer;
-    buffer.reserve(folder.size() + 16);
-    return IsRootStudy(folder, buffer);
-}
-
-bool Study::IsRootStudy(const AnyString& folder, String& buffer)
-{
-    buffer.clear() << folder << IO::Separator << "study.antares";
+    String buffer(folder.size() + 16);
+    buffer << folder << IO::Separator << "study.antares";
     StudyHeader header;
-    return (header.loadFromFile(buffer.c_str(), false));
+    return header.loadFromFile(buffer.c_str(), false);
 }
 
 } // namespace Antares::Data

--- a/src/libs/antares/study/study.extra.cpp
+++ b/src/libs/antares/study/study.extra.cpp
@@ -33,8 +33,9 @@ void Study::scenarioRulesLoadIfNotAvailable()
 // TODO remove after vacuum
 bool Study::IsRootStudy(const AnyString& folder)
 {
-    String buffer(folder.size() + 16);
-    buffer << folder << IO::Separator << "study.antares";
+    String buffer;
+    buffer.reserve(folder.size() + 16);
+    buffer.clear() << folder << IO::Separator << "study.antares";
     StudyHeader header;
     return header.loadFromFile(buffer.c_str(), false);
 }


### PR DESCRIPTION
The change simplifies the `IsRootStudy` method by inlining the buffer creation logic.

*   **Before**: The single-argument `IsRootStudy` called a separate two-argument overload, which handled string construction.
*   **After**: The string construction is done directly within the single-argument method using a locally scoped `String` buffer.
*   **Result**: The separate two-argument overload was removed, reducing code complexity without altering behavior.