### PR TITLE
Remove unused Study members

### DIFF
--- a/src/libs/antares/study/include/antares/study/study.h
+++ b/src/libs/antares/study/include/antares/study/study.h
@@ -43,19 +43,6 @@ public:
     //! Multiple sets of areas
     using SetsOfAreas = Antares::Data::Sets;
 
-    //! Extension filename
-    using FileExtension = std::string;
-
-    /*!
-    ** \brief Extract the title of a study
-    **
-    ** \param folder A study folder
-    ** \param[out] out      The variable where the title will be written
-    ** \param      warnings False to prevent warnings/errors when loading
-    ** \return True if the operation succeeded, false otherwise
-    */
-    static bool TitleFromStudyFolder(const AnyString& folder, YString& out, bool warnings = false);
-
     /*!
     ** \brief Get if a folder if a study
     **
@@ -333,14 +320,6 @@ public:
     ** These informations are only needed when a study is processed.
     */
     StudyRuntimeInfos runtime;
-
-    /*!
-    ** \brief The file extension for file within the input ('txt' or 'csv')
-    **
-    ** Since the v3.1, the file extensions in the input have been renamed into .txt,
-    ** (instead of .csv)
-    */
-    FileExtension inputExtension = "txt";
 
     /*!
     ** \name Cache

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -255,8 +255,6 @@ void Parameters::reset()
 {
     // Mode
     mode = SimulationMode::Economy;
-    // Calendar
-    horizon.clear();
 
     // Reset output variables print info tool
     variablesPrintInfo.clear();
@@ -299,8 +297,6 @@ void Parameters::reset()
 
     // timeseries numbers
     storeTimeseriesNumbers = false;
-    // readonly
-    readonly = false;
     synthesis = true;
 
     // Hydro heuristic policy
@@ -400,13 +396,6 @@ static bool SGDIntLoadFamily_General(Parameters& d,
         return ConvertCStrToListTimeSeries(value, d.timeSeriesToGenerate);
     }
 
-    if (key == "horizon")
-    {
-        d.horizon = rawvalue;
-        d.horizon.trim(" \t\n\r");
-        return true;
-    }
-
     // Same time-series
     if (key == "intra-modal")
     {
@@ -473,11 +462,6 @@ static bool SGDIntLoadFamily_General(Parameters& d,
         // This data is among solver data, but is useless while running a simulation
         // Only by TS generator. We skip it here (otherwise, we get a reading error).
         return true;
-    }
-    // readonly
-    if (key == "readonly")
-    {
-        return value.to<bool>(d.readonly);
     }
 
     if (key == "simulation.start")
@@ -571,7 +555,7 @@ static bool SGDIntLoadFamily_Optimization(Parameters& d,
     }
     if (key == "include-loopflowfee") // backward compatibility
     {
-        return true; // value.to<bool>(d.include.loopFlowFee);
+        return true;
     }
     if (key == "include-tc-minstablepower")
     {
@@ -1123,6 +1107,18 @@ static bool SGDIntLoadFamily_Legacy(Parameters& d,
         return true;
     }
 
+    // was never used, metadata
+    if (key == "horizon")
+    {
+        return true;
+    }
+
+    // ignored since the GUI is gone
+    if (key == "readonly")
+    {
+        return true;
+    }
+
     return false;
 }
 
@@ -1374,9 +1370,6 @@ void Parameters::setYearWeight(uint year, float weight)
 
 void Parameters::prepareForSimulation(const StudyLoadOptions& options)
 {
-    // We don't care of the variable `horizon` since it is not used by the solver
-    horizon.clear();
-
     // Simplex optimization range
     switch (simplexOptimizationRange)
     {

--- a/src/libs/antares/study/study.cpp
+++ b/src/libs/antares/study/study.cpp
@@ -77,7 +77,6 @@ void Study::clear()
     folderInput.clear();
     folderOutput.clear();
     folderSettings.clear();
-    inputExtension.clear();
 }
 
 void Study::reduceMemoryUsage()

--- a/src/tests/src/libs/antares/study/parameters/parameters-tests.cpp
+++ b/src/tests/src/libs/antares/study/parameters/parameters-tests.cpp
@@ -18,7 +18,6 @@ IniFile validINI()
     std::stringstream s;
     s << R"([general]
             mode = Economy
-            horizon = 2000
             nbyears = 5
             simulation.start = 1
             simulation.end = 365
@@ -40,7 +39,6 @@ IniFile validINI()
             nbtimeseriessolar = 1
             intra-modal =
             inter-modal =
-            readonly = false
 
             [input]
             import =


### PR DESCRIPTION
This PR removes unused configuration parameters and their associated logic from the `Study` class

*   **Removed `horizon`**: Removed from `Parameters` struct, its loading logic in `SGDIntLoadFamily_General`, and its reset/clear operations. It is now treated as a legacy/ignored key in `SGDIntLoadFamily_Legacy` with a comment stating it was "never used."
*   **Removed `readonly`**: Removed from `Parameters` struct, its loading logic, and its reset operation. Treated as an ignored legacy key since the GUI is gone.
*   **Removed `inputExtension`**: Removed the `FileExtension` type alias, the `inputExtension` member variable, and its clear operation.
*   **Removed `TitleFromStudyFolder`**: Declared but unused
*   **Test Updates**: Removed `horizon` and `readonly` keys from the test INI file to reflect their removal from the expected configuration.