### PR TITLE
fix(warnings): drop unused parameter name in SGDIntLoadFamily_General

### DIFF
--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -359,7 +359,7 @@ bool Parameters::isTSGeneratedByPrepro(const TimeSeriesType ts) const
 static bool SGDIntLoadFamily_General(Parameters& d,
                                      const String& key,
                                      const String& value,
-                                     const String& rawvalue)
+                                     const String&)
 {
     if (key == "active-rules-scenario")
     {


### PR DESCRIPTION
Next `-Werror` warning surfaced on the Clang job of #3730 (run 27957656964):

```
src/libs/antares/study/parameters.cpp:362:52: fatal error:
  unused parameter 'rawvalue' [-Wunused-parameter]
```

## Fix
`SGDIntLoadFamily_General` is one of a family of section handlers dispatched through a function-pointer table (`sectionAssociatedToKeyFamily`), so all of them share the same 4-argument signature `(Parameters&, const String& key, const String& value, const String&)`. The fourth argument (the raw value) is unused in `_General`.

Every other handler in the family that doesn't need the raw value already leaves that parameter **unnamed**; `_General` was the lone exception that named it `rawvalue`. Dropped the name to match the established convention and clear `-Wunused-parameter`. No behaviour change.

## Note
This appeared because `libs/antares` compiles before `solver`, so it halts the `-Werror` build before reaching the `report.cpp` deprecation handled in #3740. Both need to land for the Clang job to go fully green; re-run it afterward to confirm or surface the next one.

https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo)_