### PR TITLE
fix(sanitizer): initialize Parameters members read uninitialized (UBSan)

### DIFF
--- a/src/libs/antares/study/include/antares/study/parameters.h
+++ b/src/libs/antares/study/include/antares/study/parameters.h
@@ -176,9 +176,9 @@ public:
     //! Export results each year
     bool yearByYear;
     //! Derated
-    bool derated;
+    bool derated = false;
     //! Custom scenario
-    bool useCustomScenario;
+    bool useCustomScenario = false;
     //! Custom playlist (each year will be manually selected by the user)
     bool userPlaylist;
     //! Flag to perform the calculations or not from the solver
@@ -411,7 +411,7 @@ public:
     //! Transmission capacities
     GlobalTransmissionCapacities transmissionCapacities;
     //! Simplex optimization range (day/week)
-    SimplexOptimization simplexOptimizationRange;
+    SimplexOptimization simplexOptimizationRange = sorWeek;
     //@}
 
     AdequacyPatch::AdqPatchParams adqPatchParams;


### PR DESCRIPTION
First batch of fixes for the **real bugs** surfaced by the ASan/UBSan test phase of the new Clang workflow (#3730).

## Issue
UBSan reported invalid `bool`/enum loads when `Antares::Data::Parameters` fields are read before a full `Parameters::reset()`:

```
ecoInput.cpp:43                    load of value 190, not valid for 'bool'   (parameters.derated)
cluster.cpp:98                     load of value 190, not valid for 'bool'   (parameters.derated)
HydroInputsChecker.cpp:39          load of value 190, not valid for 'bool'   (parameters.useCustomScenario)
BindingConstraintsRepository.cpp:180  invalid value for 'SimplexOptimization' (parameters.simplexOptimizationRange)
```

These members have no in-class initializer and rely solely on `Parameters::reset()`; tests that build a `Parameters`/`Study` without a full reset read uninitialized memory (undefined behavior).

## Fix
Give the three flagged members in-class default initializers matching exactly the values `Parameters::reset()` assigns (`false`, `false`, `sorWeek`). Reading them before a reset is now well-defined; normal operation is unchanged.

## Note
Part of the "fix real bugs first" track; the sanitizer step stays blocking. Other findings (an out-of-bounds month index in `date.cpp`, a `FillContext` stack-use-after-scope, and the OR-Tools `MPObjective` SEGV cluster) are being handled separately.

https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo)_