### PR TITLE
fix(sanitizer): name FillContext local in EvalVisitor tests (stack-use-after-scope)

### DIFF
--- a/src/tests/src/expressions/test_PrintAndEvalVisitors.cpp
+++ b/src/tests/src/expressions/test_PrintAndEvalVisitors.cpp
@@ -849,8 +849,13 @@ EvaluationResult CreateAndEvaluateTimeNode(Node* p)
     MockLinearProblem linearProblem = MockLinearProblem(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
+    const Antares::Optimisation::LinearProblemApi::FillContext fillContext{first,
+                                                                           last /*three hours*/,
+                                                                           first,
+                                                                           last,
+                                                                           0};
     EvalVisitor visitor(optimContainer,
-                        {first, last /*three hours*/, first, last, 0},
+                        fillContext,
                         components.back(),
                         &dummy_data,
                         scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
@@ -902,8 +907,13 @@ EvaluationResult CreateAndEvaluateTimeSumNode(Node* from, Node* to)
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
 
+    const Antares::Optimisation::LinearProblemApi::FillContext fillContext{first,
+                                                                           last /*three hours*/,
+                                                                           first,
+                                                                           last,
+                                                                           0};
     EvalVisitor visitor(optimContainer,
-                        {first, last /*three hours*/, first, last, 0},
+                        fillContext,
                         components.back(),
                         &dummy_data,
                         scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
@@ -970,8 +980,13 @@ EvaluationResult CreateAndEvaluateAllTimeSumNode()
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
 
+    const Antares::Optimisation::LinearProblemApi::FillContext fillContext{first,
+                                                                           last /*three hours*/,
+                                                                           first,
+                                                                           last,
+                                                                           0};
     EvalVisitor visitor(optimContainer,
-                        {first, last /*three hours*/, first, last, 0},
+                        fillContext,
                         components.back(),
                         &dummy_data,
                         scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
@@ -1010,8 +1025,13 @@ BOOST_FIXTURE_TEST_CASE(evaluate_time_dependent_multiplication, MyDummyFixture)
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
 
+    const Antares::Optimisation::LinearProblemApi::FillContext fillContext{hour_0,
+                                                                           hour_1 /*two hours*/,
+                                                                           hour_0,
+                                                                           hour_1,
+                                                                           0};
     EvalVisitor visitor(optimContainer,
-                        {hour_0, hour_1 /*two hours*/, hour_0, hour_1, 0},
+                        fillContext,
                         components.back(),
                         &dummy_data,
                         scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
@@ -1076,8 +1096,13 @@ void evaluate_time_dependent_operation()
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
 
+    const Antares::Optimisation::LinearProblemApi::FillContext fillContext{hour_0,
+                                                                           hour_1 /*three hours*/,
+                                                                           hour_0,
+                                                                           hour_1,
+                                                                           0};
     EvalVisitor visitor(optimContainer,
-                        {hour_0, hour_1 /*three hours*/, hour_0, hour_1, 0},
+                        fillContext,
                         components.back(),
                         &dummy_data,
                         scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
@@ -1114,8 +1139,10 @@ void evaluate_time_dependent_operation_on_TimeShiftNode(Node* timeShift)
     MockLinearProblem linearProblem = MockLinearProblem(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
+    const Antares::Optimisation::LinearProblemApi::FillContext
+      fillContext{hours.at(0), hours.at(1) /*two hours*/, hours.at(0), hours.at(1), 0};
     EvalVisitor visitor(optimContainer,
-                        {hours.at(0), hours.at(1) /*two hours*/, hours.at(0), hours.at(1), 0},
+                        fillContext,
                         components.back(),
                         &dummy_data,
                         scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));
@@ -1160,8 +1187,10 @@ void evaluate_time_dependent_operation_on_TimeIndexNode(Node* timeIndex)
     MockLinearProblem linearProblem = MockLinearProblem(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
+    const Antares::Optimisation::LinearProblemApi::FillContext
+      fillContext{hours.at(0), hours.at(1) /*two hours*/, hours.at(0), hours.at(1), 0};
     EvalVisitor visitor(optimContainer,
-                        {hours.at(0), hours.at(1) /*two hours*/, hours.at(0), hours.at(1), 0},
+                        fillContext,
                         components.back(),
                         &dummy_data,
                         scenarioGroupRepo.scenario(components.back().getScenarioGroupId()));


### PR DESCRIPTION
Second batch of **real bugs** from the ASan/UBSan test phase (#3730).

## Issue
ASan reported `stack-use-after-scope` in `FillContext::getYear()` during `_PrintAndEvalNodes_/evaluate_shifted_param`:

```
#0 FillContext::getYear()  ILinearProblemData.h:67
#1 EvalVisitor::visit(ParameterNode const*)  EvalVisitor.cpp:114
...
#8 evaluate_shifted_param::test_method()  test_PrintAndEvalVisitors.cpp:864
```

`EvalVisitor` stores its `FillContext` **by reference** — and that's intentional: production `ComponentFiller` constructs a single visitor and mutates the context across timesteps, relying on the visitor seeing the updates (so switching to by-value is not an option). The bug is in the tests: several passed a **brace-temporary** `FillContext` straight to the constructor. The temporary is destroyed at the end of the constructor expression, so the later `visitor.dispatch()` read a destroyed stack object.

## Fix
Bind the `FillContext` to a named local that outlives the visitor at each affected site (7 sites), matching the pattern already used by production and by the other tests. Only the `evaluate_shifted_param` path tripped ASan (the binary aborts on first error), but all sites shared the same latent dangling-reference pattern, so all are fixed to avoid follow-up failures.

## Note
"Fix real bugs first" track; sanitizers stay blocking. Remaining: the `date.cpp` out-of-bounds month index needs deeper calendar-build tracing (flagging separately), and the OR-Tools `MPObjective` SEGV cluster looks test-harness-related.

https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiHqH6wJd7QKqdawpKWXdo)_