### PR TITLE
[feature/reserves_scalian_lot_2_new] Mis à jour des tests et homogénéisation du nommage de contraintes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,5 @@
 	url = https://github.com/microsoft/vcpkg.git
 [submodule "Antares_Simulator_Tests_NR"]
 	path = resources/Antares_Simulator_Tests_NR
-	url = https://github.com/AntaresSimulatorTeam/Antares_Simulator_Tests_NR.git
+	url = https://github.com/sylvmara/Antares_Simulator_Tests_NR.git
+	branch = feature/reserves_scalian_lot_2_new

--- a/src/solver/optimisation/CMakeLists.txt
+++ b/src/solver/optimisation/CMakeLists.txt
@@ -145,8 +145,8 @@ set(RTESOLVER_OPT
         constraints/MinDownTime.cpp
 		include/antares/solver/optimisation/constraints/PMaxReserve.h
 		constraints/PMaxReserve.cpp
-		include/antares/solver/optimisation/constraints/OffUnitsThermalParticipatingToReserves.h
-		constraints/OffUnitsThermalParticipatingToReserves.cpp
+		include/antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.h
+		constraints/ParticipationOfOffUnitsToReserve.cpp
 		include/antares/solver/optimisation/constraints/POutCapacityThresholds.h
 		constraints/POutCapacityThresholds.cpp
 		include/antares/solver/optimisation/constraints/POutBounds.h
@@ -155,8 +155,8 @@ set(RTESOLVER_OPT
 		constraints/ThermalReserveParticipation.cpp
 		include/antares/solver/optimisation/constraints/SymmetryReserveParticipation.h
 		constraints/SymmetryReserveParticipation.cpp
-		include/antares/solver/optimisation/constraints/POffUnits.h
-		constraints/POffUnits.cpp
+		include/antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserves.h
+		constraints/ParticipationOfOffUnitsToReserves.cpp
 		include/antares/solver/optimisation/constraints/ReserveSatisfaction.h
 		constraints/ReserveSatisfaction.cpp
 		include/antares/solver/optimisation/constraints/STReleaseMaxReserve.h

--- a/src/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.cpp
+++ b/src/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.cpp
@@ -1,18 +1,20 @@
 // Copyright 2007-2026, RTE (https://www.rte-france.com)
 // SPDX-License-Identifier: MPL-2.0
 
-#include "antares/solver/optimisation/constraints/OffUnitsThermalParticipatingToReserves.h"
+#include "antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.h"
 
-void OffUnitsThermalParticipatingToReserves::add(int pays, int reserve, int cluster, int pdt)
+void ParticipationOfOffUnitsToReserve::add(int pays, int reserve, int cluster, int pdt)
 {
     if (!data.Simulation)
     {
         // 16 ter
         // The max power of off units participating to Reserves is bounded by the number of units
-        // and max power of each unit : P^off +(Pmax^off . M)  <= (Pmax^off . M^on) with P^off:
-        // total participation of turned off units to res Pmax^off : max participation for each off
-        // unit M : Number of units in the cluster M^on : Number of running units in the cluster
-        //
+        // and max power of each unit : 
+        // P^off +(Pmax^off . M)  <= (Pmax^off . M^on)
+        // with P^off: total participation of turned off units to res
+        // Pmax^off : max participation for each off unit 
+        // M : Number of units in the cluster 
+        // M^on : Number of running units in the cluster
 
         CAPACITY_RESERVATION& capacityReservation = data.areaReserves[pays]
                                                       .areaCapacityReservations[reserve];

--- a/src/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.cpp
+++ b/src/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.cpp
@@ -9,11 +9,11 @@ void ParticipationOfOffUnitsToReserve::add(int pays, int reserve, int cluster, i
     {
         // 16 ter
         // The max power of off units participating to Reserves is bounded by the number of units
-        // and max power of each unit : 
+        // and max power of each unit :
         // P^off +(Pmax^off . M)  <= (Pmax^off . M^on)
         // with P^off: total participation of turned off units to res
-        // Pmax^off : max participation for each off unit 
-        // M : Number of units in the cluster 
+        // Pmax^off : max participation for each off unit
+        // M : Number of units in the cluster
         // M^on : Number of running units in the cluster
 
         CAPACITY_RESERVATION& capacityReservation = data.areaReserves[pays]

--- a/src/solver/optimisation/constraints/ParticipationOfOffUnitsToReserves.cpp
+++ b/src/solver/optimisation/constraints/ParticipationOfOffUnitsToReserves.cpp
@@ -1,9 +1,9 @@
 // Copyright 2007-2026, RTE (https://www.rte-france.com)
 // SPDX-License-Identifier: MPL-2.0
 
-#include "antares/solver/optimisation/constraints/POffUnits.h"
+#include "antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserves.h"
 
-void POffUnits::add(int pays, int cluster, int pdt)
+void ParticipationOfOffUnitsToReserves::add(int pays, int cluster, int pdt)
 {
     if (!data.Simulation)
     {
@@ -11,9 +11,9 @@ void POffUnits::add(int pays, int cluster, int pdt)
         // Sum of participations to reserves is inferior to unit max power times number of off units
         // Sum P^off  ≤ Umax (M - M^on)
         // P^off : total participation of turned off units to res
-        // Umax : Max power of an unit
+        // Umax : Max power of an off unit
         // M : max number of running units in cluster
-        // M : actual number of running units in cluster
+        // M^on : actual number of running units in cluster
 
         int globalClusterIdx = data.thermalClusters[pays]
                                  .NumeroDuPalierDansLEnsembleDesPaliersThermiques[cluster];
@@ -48,8 +48,9 @@ void POffUnits::add(int pays, int cluster, int pdt)
             const int hourInTheYear = builder.data.weekInTheYear * 168 + pdt;
             namer.UpdateTimeStep(hourInTheYear);
             namer.UpdateArea(builder.data.NomsDesPays[pays]);
-            namer.POffUnitsUpperBound(builder.data.nombreDeContraintes,
-                                      data.thermalClusters[pays].NomsDesPaliersThermiques[cluster]);
+            namer.ParticipationOfOffUnitsToReserves(
+              builder.data.nombreDeContraintes,
+              data.thermalClusters[pays].NomsDesPaliersThermiques[cluster]);
             builder.build();
         }
     }

--- a/src/solver/optimisation/constraints/ReserveParticipationGroup.cpp
+++ b/src/solver/optimisation/constraints/ReserveParticipationGroup.cpp
@@ -12,11 +12,11 @@
 #include "antares/solver/optimisation/constraints/HydroReserveParticipation.h"
 #include "antares/solver/optimisation/constraints/HydroStoreCapacityThresholds.h"
 #include "antares/solver/optimisation/constraints/HydroStoreMaxReserve.h"
-#include "antares/solver/optimisation/constraints/OffUnitsThermalParticipatingToReserves.h"
 #include "antares/solver/optimisation/constraints/PMaxReserve.h"
-#include "antares/solver/optimisation/constraints/POffUnits.h"
 #include "antares/solver/optimisation/constraints/POutBounds.h"
 #include "antares/solver/optimisation/constraints/POutCapacityThresholds.h"
+#include "antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.h"
+#include "antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserves.h"
 #include "antares/solver/optimisation/constraints/ReserveSatisfaction.h"
 #include "antares/solver/optimisation/constraints/STReleaseCapacityThresholds.h"
 #include "antares/solver/optimisation/constraints/STReleaseMaxReserve.h"
@@ -55,9 +55,8 @@ void ReserveParticipationGroup::BuildConstraints()
     {
         auto data = GetReserveDataFromProblemHebdo();
         PMaxReserve pMaxReserve(builder_, data);
-        OffUnitsThermalParticipatingToReserves offUnitsThermalParticipatingToReserves(builder_,
-                                                                                      data);
-        POffUnits pOffUnits(builder_, data);
+        ParticipationOfOffUnitsToReserve participationOfOffUnitsToReserve(builder_, data);
+        ParticipationOfOffUnitsToReserves pOffUnits(builder_, data);
         ThermalReserveParticipation thermalReserveParticipation(builder_, data);
         ReserveSatisfaction reserveSatisfaction(builder_, data);
         STReleaseMaxReserve STReleaseMaxReserve(builder_, data);
@@ -106,10 +105,7 @@ void ReserveParticipationGroup::BuildConstraints()
                                 && clusterReserveParticipation.maxPowerOff > 0)
                             {
                                 // 16 ter
-                                offUnitsThermalParticipatingToReserves.add(pays,
-                                                                           reserve,
-                                                                           clusterId,
-                                                                           pdt);
+                                participationOfOffUnitsToReserve.add(pays, reserve, clusterId, pdt);
                             }
 
                             // 17 quinquies & sexies

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserve.h
@@ -5,12 +5,12 @@
 #include "ConstraintBuilder.h"
 
 /*!
- * represent 'POffUnits' Constraint type
+ * represent 'ParticipationOfOffUnitsToReserve' Constraint type
  */
-class POffUnits: private ConstraintFactory
+class ParticipationOfOffUnitsToReserve: private ConstraintFactory
 {
 public:
-    POffUnits(ConstraintBuilder& builder, ReserveData& data):
+    ParticipationOfOffUnitsToReserve(ConstraintBuilder& builder, ReserveData& data):
         ConstraintFactory(builder),
         data(data)
     {
@@ -19,10 +19,11 @@ public:
     /*!
      * @brief Add variables to the constraint and update constraints Matrix
      * @param pays : area
-     * @param cluster : global index of the cluster
+     * @param reserve : capacity reservation
+     * @param cluster : local index of the cluster
      * @param pdt : timestep
      */
-    void add(int pays, int cluster, int pdt);
+    void add(int pays, int reserve, int cluster, int pdt);
 
 private:
     ReserveData& data;

--- a/src/solver/optimisation/include/antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserves.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/constraints/ParticipationOfOffUnitsToReserves.h
@@ -5,12 +5,12 @@
 #include "ConstraintBuilder.h"
 
 /*!
- * represent 'OffUnitsThermalParticipatingToReserves' Constraint type
+ * represent 'ParticipationOfOffUnitsToReserves' Constraint type
  */
-class OffUnitsThermalParticipatingToReserves: private ConstraintFactory
+class ParticipationOfOffUnitsToReserves: private ConstraintFactory
 {
 public:
-    OffUnitsThermalParticipatingToReserves(ConstraintBuilder& builder, ReserveData& data):
+    ParticipationOfOffUnitsToReserves(ConstraintBuilder& builder, ReserveData& data):
         ConstraintFactory(builder),
         data(data)
     {
@@ -19,11 +19,10 @@ public:
     /*!
      * @brief Add variables to the constraint and update constraints Matrix
      * @param pays : area
-     * @param reserve : capacity reservation
-     * @param cluster : local index of the cluster
+     * @param cluster : global index of the cluster
      * @param pdt : timestep
      */
-    void add(int pays, int reserve, int cluster, int pdt);
+    void add(int pays, int cluster, int pdt);
 
 private:
     ReserveData& data;

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -198,7 +198,7 @@ public:
                                       const std::string& clusterName,
                                       const std::string& reserveName1,
                                       const std::string& reserveName2);
-    void POffUnitsUpperBound(unsigned constrIndex, const std::string& clusterName);
+    void ParticipationOfOffUnitsToReserves(unsigned constrIndex, const std::string& clusterName);
     void POutCapacityThresholdInf(unsigned constrIndex, const std::string& clusterName);
     void POutCapacityThresholdSup(unsigned constrIndex, const std::string& clusterName);
     void POutBoundMin(unsigned constrIndex, const std::string& clusterName);

--- a/src/solver/optimisation/opt_construction_variables_reserves.cpp
+++ b/src/solver/optimisation/opt_construction_variables_reserves.cpp
@@ -102,19 +102,6 @@ void OPT_ConstruireLaListeDesVariablesOptimiseesDuProblemeLineaireReserves(
                                                                    clusterName,
                                                                    reserveName);
                     NombreDeVariables++;
-
-                    variableManager.OffThermalClusterReserveParticipation(
-                      clusterReserveParticipation.globalIndexClusterParticipation,
-                      pdt)
-                      = NombreDeVariables;
-                    ProblemeAResoudre->TypeDeVariable[NombreDeVariables]
-                      = VARIABLE_BORNEE_DES_DEUX_COTES;
-                    ProblemeAResoudre->VariablesEntieres[NombreDeVariables]
-                      = problemeHebdo->OptimisationAvecVariablesEntieres;
-                    variableNamer.ParticipationOfOffUnitsToReserve(NombreDeVariables,
-                                                                   clusterName,
-                                                                   reserveName);
-                    NombreDeVariables++;
                 }
 
                 // For all units in cluster

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -654,9 +654,10 @@ void ConstraintNamer::SymmetryReserveParticipation(unsigned constrIndex,
                                             reserveName2);
 }
 
-void ConstraintNamer::POffUnitsUpperBound(unsigned constrIndex, const std::string& clusterName)
+void ConstraintNamer::ParticipationOfOffUnitsToReserves(unsigned constrIndex,
+                                                        const std::string& clusterName)
 {
-    SetThermalClusterElementName(constrIndex, "POffUnitsUpperBound", clusterName);
+    SetThermalClusterElementName(constrIndex, "ParticipationOfOffUnitsToReserves", clusterName);
 }
 
 void ConstraintNamer::POutCapacityThresholdInf(unsigned constrIndex, const std::string& clusterName)

--- a/src/tests/cucumber/features/solver-features/reserves_tests.feature
+++ b/src/tests/cucumber/features/solver-features/reserves_tests.feature
@@ -81,7 +81,7 @@ Feature: reserves tests
 
 @fast @short
 # Lot 2 : Intégration de la participation du thermique éteint et des stockage CT et LT
-# TODO : Ask test description to Thibault Toujouse
+# Description : L'objectif de ce test est de permettre la participation d'un cluster lorsqu'il est allumé ou éteint. l'optimisation doit donner la répartition allumé/éteint optimale pour minimiser le coût total.
   Scenario: lot_2_cluster_off_1_area
     Given the solver study path is "Antares_Simulator_Tests_NR/reserves-tests/lot_2_cluster_off_1_area"
     When I run antares simulator
@@ -92,11 +92,11 @@ Feature: reserves tests
     And in area "AREA", during year 1, for cluster "cluster1" and reserve "Res_2", participation of off units to the reserve is always equal to 50 MWh
     And in area "AREA", during year 1, for reserve "Res_2", reserve unsupplied power is always equal to 10 MWh
     And in area "AREA", during year 1, for reserve "Res_1", reserve unsupplied power is always equal to 5 MWh
-    And in area "AREA", overall cost on "1 JAN 06:00" of year 1 is of 6500 Euro 
-
+    And in area "AREA", overall cost on "1 JAN 06:00" of year 1 is of 6500 Euro
+ 
 @fast @short
-# Lot 2 : Intégration de la participation du thermique éteint et des stockage CT et LT
-# TODO : Ask test description to Thibault Toujouse
+# Lot 2 : Intégration de la participation du thermique éteint sur 2 zones
+# Description : L'objectif de ce test est de permettre la participation d'un cluster lorsqu'il est allumé ou éteint. l'optimisation doit donner la répartition allumé/éteint optimale pour minimiser le coût total. On considère plusieurs zones afin de vérifier les résultats dans ce contexte.
   Scenario: lot_2_cluster_off_2_areas
     Given the solver study path is "Antares_Simulator_Tests_NR/reserves-tests/lot_2_cluster_off_2_areas"
     When I run antares simulator

--- a/src/tests/cucumber/features/solver-features/reserves_tests.feature
+++ b/src/tests/cucumber/features/solver-features/reserves_tests.feature
@@ -81,35 +81,38 @@ Feature: reserves tests
 
 @fast @short
 # Lot 2 : Intégration de la participation du thermique éteint et des stockage CT et LT
-# Un cluster qui participe avec à une réserve à la hausse avec des unités off
-  Scenario: lot_2_off_cluster_participation
-    Given the solver study path is "Antares_Simulator_Tests_NR/reserves-tests/lot_2_off_cluster_participation"
+# TODO : Ask test description to Thibault Toujouse
+  Scenario: lot_2_cluster_off_1_area
+    Given the solver study path is "Antares_Simulator_Tests_NR/reserves-tests/lot_2_cluster_off_1_area"
     When I run antares simulator
     Then the simulation succeeds
     And the simulation takes less than 20 seconds
-    And in area "AREA", during year 1, for cluster "thermal1" and reserve "Res_1", total reserve participation power is 0 MWh
-    And in area "AREA", during year 1, for cluster "thermal1" and reserve "Res_1", participation of off units to the reserve is always equal to 40 MWh
-    # OV. Cost = 20 *50+1*40+500*50+3000*10 euros (Prod cluster + Surcoûts réserves + défaillance EOD + défaillance réserves)
-    And in area "AREA", overall cost on "1 JAN 06:00" of year 1 is of 56040 Euro 
-    And the annual system cost is 9.408e+06
+    And in area "AREA", during year 1, for cluster "cluster1" and reserve "Res_1", reserve participation power is always equal to 10 MWh
+    And in area "AREA", during year 1, for cluster "cluster1" and reserve "Res_1", participation of off units to the reserve is always equal to 10 MWh
+    And in area "AREA", during year 1, for cluster "cluster1" and reserve "Res_2", participation of off units to the reserve is always equal to 50 MWh
+    And in area "AREA", during year 1, for reserve "Res_2", reserve unsupplied power is always equal to 10 MWh
+    And in area "AREA", during year 1, for reserve "Res_1", reserve unsupplied power is always equal to 5 MWh
+    And in area "AREA", overall cost on "1 JAN 06:00" of year 1 is of 6500 Euro 
 
 @fast @short
-# Lot 2
-# Un cluster qui participe avec à deux réserves à la hausse avec des unités off, on vérifié qu'il priviligie la plus rentable
-  Scenario: lot_2_off_cluster_participation_multiple_res
-    Given the solver study path is "Antares_Simulator_Tests_NR/reserves-tests/lot_2_off_cluster_participation_multiple_res"
+# Lot 2 : Intégration de la participation du thermique éteint et des stockage CT et LT
+# TODO : Ask test description to Thibault Toujouse
+  Scenario: lot_2_cluster_off_2_areas
+    Given the solver study path is "Antares_Simulator_Tests_NR/reserves-tests/lot_2_cluster_off_2_areas"
     When I run antares simulator
     Then the simulation succeeds
     And the simulation takes less than 20 seconds
-    And in area "AREA", during year 1, for cluster "thermal1" and reserve "Res_1", total reserve participation power is 0 MWh
-    And in area "AREA", during year 1, for cluster "thermal1" and reserve "Res_2", total reserve participation power is 0 MWh
-    And in area "AREA", during year 1, for cluster "thermal1" and reserve "Res_1", participation of off units to the reserve is always equal to 30 MWh
-    And in area "AREA", during year 1, for cluster "thermal1" and reserve "Res_2", participation of off units to the reserve is always equal to 20 MWh
-    And in area "AREA", during year 1, for reserve "Res_1", reserve unsupplied power is always equal to 10 MWh
-    And in area "AREA", during year 1, for reserve "Res_2", reserve unsupplied power is always equal to 0 MWh
-    And in area "AREA", overall cost on "1 JAN 06:00" of year 1 is of 80050 Euro 
-    And in area "AREA", unsupplied energy on "2 JAN 09:00" of year 1 is of 100 MW
-    And the annual system cost is 1.344e+07
+    And in area "AREA", during year 1, for cluster "cluster1" and reserve "Res_1", reserve participation power is always equal to 10 MWh
+    And in area "AREA", during year 1, for cluster "cluster1" and reserve "Res_1", participation of off units to the reserve is always equal to 10 MWh
+    And in area "AREA", during year 1, for cluster "cluster1" and reserve "Res_2", participation of off units to the reserve is always equal to 50 MWh
+    And in area "AREA", during year 1, for reserve "Res_2", reserve unsupplied power is always equal to 10 MWh
+    And in area "AREA", during year 1, for reserve "Res_1", reserve unsupplied power is always equal to 5 MWh
+    And in area "AREA1", during year 1, for cluster "cluster1" and reserve "Res_1", reserve participation power is always equal to 10 MWh
+    And in area "AREA1", during year 1, for cluster "cluster1" and reserve "Res_1", participation of off units to the reserve is always equal to 10 MWh
+    And in area "AREA1", during year 1, for cluster "cluster1" and reserve "Res_2", participation of off units to the reserve is always equal to 50 MWh
+    And in area "AREA1", during year 1, for reserve "Res_2", reserve unsupplied power is always equal to 10 MWh
+    And in area "AREA1", during year 1, for reserve "Res_1", reserve unsupplied power is always equal to 5 MWh
+    And in area "AREA1", during year 1, for reserve "Res_3", reserve unsupplied power is always equal to 25 MWh
 
 #
 # Pour les tests du lot 3 : se référer au document "Schema_de_tests_des_réserves_3_nov_2024.pptx"


### PR DESCRIPTION
L'objectif  est de généraliser la participation des clusters thermique éteints aux réserves.

Actuellement, il est possible de définir une capacité de participation max des unités éteintes d’un cluster thermique. Un cluster peut également avoir des capacités max de participation des unités éteintes différenciés pour différentes réserves. Cependant dans le cas où un même cluster éteint peut participer à différentes réserves, les équations intégrées dans le simulator perdent leur sens métier.

L’objectif est ainsi de rendre générique la participation du thermique éteint à plusieurs réserves pour un même cluster.

Impacts sur le problème d’optimisation :
<img width="643" height="229" alt="image" src="https://github.com/user-attachments/assets/3679ed58-955b-4e02-98c8-dd150aa8ef3e" />

**Il semblerait que les équations étaient déjà à jour dans la version actuelle. Cette PR permet de mettre au clair et d'homogénéiser les équations de participation aux réserves et de mettre à jour les tests**

Linked to PR https://github.com/AntaresSimulatorTeam/Antares_Simulator_Tests_NR/pull/136