### PR TITLE
fix: use fmt for double conversion. Improve performances

### DIFF
--- a/src/io/outputs/CMakeLists.txt
+++ b/src/io/outputs/CMakeLists.txt
@@ -21,9 +21,11 @@ target_include_directories(simulation-table
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
+find_package(fmt REQUIRED)
 target_link_libraries(simulation-table
         PUBLIC
-        Antares::linear-problem-api)
+        Antares::linear-problem-api
+        fmt::fmt)
 
 
 # =======================================

--- a/src/io/outputs/include/antares/io/outputs/columns.h
+++ b/src/io/outputs/include/antares/io/outputs/columns.h
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #pragma once
-#include <iomanip>
+#include <fmt/format.h>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -69,9 +68,7 @@ inline constexpr bool is_optional_v = is_optional<T>::value;
 
 [[maybe_unused]] static std::string FromDouble(const double value)
 {
-    std::ostringstream oss;
-    oss << std::setprecision(15) << value;
-    return oss.str();
+    return fmt::format("{:.15g}", value);
 }
 
 template<typename U>


### PR DESCRIPTION
When using csv simulation table, a large amount of time is pass inside operator <<(double) for double to string conversion.
We opt to use fmt for faster conversion.