### PR TITLE
refactor(yuni): replace Yuni::NonCopyable with deleted copy members

### DIFF
--- a/src/libs/antares/study/include/antares/study/area/area.h
+++ b/src/libs/antares/study/include/antares/study/area/area.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 #include <yuni/core/string.h>
 
 #include <antares/array/matrix.h>
@@ -31,9 +30,12 @@ struct CompareAreaName;
 /*!
 ** \brief Definition for a single area
 */
-class Area final: private Yuni::NonCopyable<Area>
+class Area final
 {
 public:
+    Area(const Area&) = delete;
+    Area& operator=(const Area&) = delete;
+
     using NameSet = std::set<AreaName>;
     using Map = std::map<AreaName, Area*>;
     using Vector = std::vector<Area*>;
@@ -275,9 +277,12 @@ private:
 ** printf("Area name : `%s`\n", (*(l->byIndex[2])).name);
 ** \endcode
 */
-class AreaList final: public Yuni::NonCopyable<AreaList>
+class AreaList final
 {
 public:
+    AreaList(const AreaList&) = delete;
+    AreaList& operator=(const AreaList&) = delete;
+
     using OwningAreaMap = std::map<AreaName, std::unique_ptr<Area>>;
 
     //! An iterator

--- a/src/libs/antares/study/include/antares/study/area/links.h
+++ b/src/libs/antares/study/include/antares/study/area/links.h
@@ -7,7 +7,6 @@
 #include <set>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 #include <yuni/core/string.h>
 
 #include <antares/array/matrix.h>
@@ -37,9 +36,12 @@ struct CompareLinkName;
 **
 ** \ingroup area
 */
-class AreaLink final: public Yuni::NonCopyable<AreaLink>
+class AreaLink final
 {
 public:
+    AreaLink(const AreaLink&) = delete;
+    AreaLink& operator=(const AreaLink&) = delete;
+
     //! Vector of links
     using Vector = std::vector<AreaLink*>;
     //! Set of links

--- a/src/libs/antares/study/include/antares/study/area/scratchpad.h
+++ b/src/libs/antares/study/include/antares/study/area/scratchpad.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 #include <yuni/core/string.h>
 
 #include <antares/array/matrix.h>

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 #include <yuni/core/string.h>
 
 #include <antares/array/matrix.h>
@@ -28,11 +27,14 @@ namespace Antares::Data
 // Forward declaration
 struct CompareBindingConstraintName;
 
-class BindingConstraint final: public Yuni::NonCopyable<BindingConstraint>
+class BindingConstraint final
 {
     friend class BindingConstraintLoader;
 
 public:
+    BindingConstraint(const BindingConstraint&) = delete;
+    BindingConstraint& operator=(const BindingConstraint&) = delete;
+
     enum Type
     {
         //! Unknown status

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
@@ -32,6 +32,7 @@ class BindingConstraint final
     friend class BindingConstraintLoader;
 
 public:
+    BindingConstraint() = default;
     BindingConstraint(const BindingConstraint&) = delete;
     BindingConstraint& operator=(const BindingConstraint&) = delete;
 

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintsRepository.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraintsRepository.h
@@ -14,9 +14,12 @@
 
 namespace Antares::Data
 {
-class BindingConstraintsRepository final: public Yuni::NonCopyable<BindingConstraintsRepository>
+class BindingConstraintsRepository final
 {
 public:
+    BindingConstraintsRepository(const BindingConstraintsRepository&) = delete;
+    BindingConstraintsRepository& operator=(const BindingConstraintsRepository&) = delete;
+
     //! Vector of binding constraints
     using Vector = std::vector<std::shared_ptr<BindingConstraint>>;
 

--- a/src/libs/antares/study/include/antares/study/parts/common/cluster.h
+++ b/src/libs/antares/study/include/antares/study/parts/common/cluster.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 
 #include <antares/array/matrix.h>
 #include <antares/series/series.h>

--- a/src/libs/antares/study/include/antares/study/parts/load/container.h
+++ b/src/libs/antares/study/include/antares/study/parts/load/container.h
@@ -4,8 +4,6 @@
 #ifndef __ANTARES_LIBS_STUDY_PARTS_LOAD_CONTAINER_H__
 #define __ANTARES_LIBS_STUDY_PARTS_LOAD_CONTAINER_H__
 
-#include <yuni/core/noncopyable.h>
-
 #include <antares/series/series.h>
 
 namespace Antares::Data::Load
@@ -13,9 +11,12 @@ namespace Antares::Data::Load
 
 class Prepro;
 
-class Container final: private Yuni::NonCopyable<Container>
+class Container final
 {
 public:
+    Container(const Container&) = delete;
+    Container& operator=(const Container&) = delete;
+
     //! \name Constructor & Destructor
     //@{
     /*!

--- a/src/libs/antares/study/include/antares/study/parts/renewable/cluster.h
+++ b/src/libs/antares/study/include/antares/study/parts/renewable/cluster.h
@@ -5,7 +5,6 @@
 #define __ANTARES_LIBS_STUDY_PARTS_RENEWABLE_CLUSTER_H__
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 
 #include <antares/array/matrix.h>
 

--- a/src/libs/antares/study/include/antares/study/parts/thermal/cluster.h
+++ b/src/libs/antares/study/include/antares/study/parts/thermal/cluster.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 
 #include <antares/solver/ts-generator/law.h>
 

--- a/src/libs/antares/study/include/antares/study/scenario-builder/rules.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/rules.h
@@ -31,9 +31,12 @@ namespace Antares::Data::ScenarioBuilder
 /*!
 ** \brief Rules for TS numbers, for all years and a single timeseries
 */
-class Rules final: private Yuni::NonCopyable<Rules>
+class Rules final
 {
 public:
+    Rules(const Rules&) = delete;
+    Rules& operator=(const Rules&) = delete;
+
     //! Smart pointer
     using Ptr = std::shared_ptr<Rules>;
     //! Map

--- a/src/libs/antares/study/include/antares/study/scenario-builder/scBuilderDataInterface.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/scBuilderDataInterface.h
@@ -5,7 +5,6 @@
 #define __LIBS_STUDY_SCENARIO_BUILDER_DATA_INTERFACE_H__
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 
 #include "antares/study/study.h"
 

--- a/src/libs/antares/study/include/antares/study/scenario-builder/sets.h
+++ b/src/libs/antares/study/include/antares/study/scenario-builder/sets.h
@@ -13,9 +13,12 @@ namespace Antares::Data::ScenarioBuilder
 /*!
 ** \brief Sets for TS numbers, for all years and a single timeseries
 */
-class Sets final: private Yuni::NonCopyable<Sets>
+class Sets final
 {
 public:
+    Sets(const Sets&) = delete;
+    Sets& operator=(const Sets&) = delete;
+
     //! Iterator
     using iterator = Rules::Map::iterator;
     //! Const iterator

--- a/src/libs/antares/study/include/antares/study/study.h
+++ b/src/libs/antares/study/include/antares/study/study.h
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 
 #include <antares/benchmarking/DurationCollector.h>
 #include <antares/correlation/correlation.h>
@@ -30,9 +29,12 @@ namespace Antares::Data
 ** \brief Antares Study
 */
 
-class Study: public Yuni::NonCopyable<Study>
+class Study
 {
 public:
+    Study(const Study&) = delete;
+    Study& operator=(const Study&) = delete;
+
     using Ptr = std::shared_ptr<Study>;
     //! Set of studies
     using Set = std::set<Ptr>;

--- a/src/libs/antares/study/include/antares/study/xcast/xcast.h
+++ b/src/libs/antares/study/include/antares/study/xcast/xcast.h
@@ -7,16 +7,18 @@
 #include <vector>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 
 #include <antares/array/matrix.h>
 #include <antares/study/fwd.h>
 
 namespace Antares::Data
 {
-class XCast final: private Yuni::NonCopyable<XCast>
+class XCast final
 {
 public:
+    XCast(const XCast&) = delete;
+    XCast& operator=(const XCast&) = delete;
+
     /*!
     ** \brief All coefficients
     */

--- a/src/libs/fswalker/fswalker.cpp
+++ b/src/libs/fswalker/fswalker.cpp
@@ -8,7 +8,6 @@
 #include <mutex>
 #include <stack>
 
-#include <yuni/core/noncopyable.h>
 #include <yuni/core/system/cpu.h>
 #include <yuni/core/system/suspend.h>
 #include <yuni/io/directory/info.h>
@@ -82,9 +81,12 @@ protected:
     void waitForAllJobs() const;
 
 private:
-    class DirectoryContext final: private Yuni::NonCopyable<DirectoryContext>
+    class DirectoryContext final
     {
     public:
+        DirectoryContext(const DirectoryContext&) = delete;
+        DirectoryContext& operator=(const DirectoryContext&) = delete;
+
         using Stack = std::stack<DirectoryContext*>;
 
         explicit DirectoryContext(const String& path):

--- a/src/libs/fswalker/fswalker.h
+++ b/src/libs/fswalker/fswalker.h
@@ -8,7 +8,6 @@
 
 #include <yuni/yuni.h>
 #include <yuni/core/bind.h>
-#include <yuni/core/noncopyable.h>
 #include <yuni/core/string.h>
 #include <yuni/thread/thread.h>
 
@@ -107,9 +106,12 @@ public:
 /*!
 ** This class is thread-safe.
 */
-class Walker final: public Yuni::NonCopyable<Walker>
+class Walker final
 {
 public:
+    Walker(const Walker&) = delete;
+    Walker& operator=(const Walker&) = delete;
+
     Walker();
     explicit Walker(const AnyString& logprefix);
     ~Walker();

--- a/src/libs/fswalker/registry.inc.hxx
+++ b/src/libs/fswalker/registry.inc.hxx
@@ -7,13 +7,15 @@
 #include <vector>
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 
 namespace FSWalker
 {
-class EventsRegistry: private Yuni::NonCopyable<EventsRegistry>
+class EventsRegistry
 {
 public:
+    EventsRegistry(const EventsRegistry&) = delete;
+    EventsRegistry& operator=(const EventsRegistry&) = delete;
+
     using OnDirectoryEventList = std::vector<OnDirectoryEvent>;
     using OnFileEventList = std::vector<OnFileEvent>;
     using IndexList = std::vector<uint>;

--- a/src/solver/ts-generator/include/antares/solver/ts-generator/xcast/xcast.h
+++ b/src/solver/ts-generator/include/antares/solver/ts-generator/xcast/xcast.h
@@ -5,7 +5,6 @@
 #define __ANTARES_SOLVER_TS_GENERATOR_XCAST_XCAST_H__
 
 #include <yuni/yuni.h>
-#include <yuni/core/noncopyable.h>
 
 #include <antares/mersenne-twister/mersenne-twister.h>
 #include <antares/study/fwd.h>
@@ -21,9 +20,12 @@ namespace Antares::TSGenerator::XCast
 **
 ** \see predicate.hxx for specializations
 */
-class XCast final: private Yuni::NonCopyable<XCast>
+class XCast final
 {
 public:
+    XCast(const XCast&) = delete;
+    XCast& operator=(const XCast&) = delete;
+
     /*!
     ** \brief Compute
     */

--- a/src/tools/vacuum/antares-study.cpp
+++ b/src/tools/vacuum/antares-study.cpp
@@ -21,9 +21,12 @@ enum
     traces = 0
 };
 
-class UserData: private Yuni::NonCopyable<UserData>
+class UserData
 {
 public:
+    UserData(const UserData&) = delete;
+    UserData& operator=(const UserData&) = delete;
+
     UserData():
         bytesDeleted(0),
         filesDeleted(0),

--- a/src/tools/vacuum/modified-inode.cpp
+++ b/src/tools/vacuum/modified-inode.cpp
@@ -5,7 +5,6 @@
 
 #include <unordered_set>
 
-#include <yuni/core/noncopyable.h>
 #include <yuni/datetime/timestamp.h>
 #include <yuni/io/file.h>
 
@@ -24,9 +23,12 @@ enum
     maxLogEntriesRetention = 1000,
 };
 
-class UserData: private Yuni::NonCopyable<UserData>
+class UserData
 {
 public:
+    UserData(const UserData&) = delete;
+    UserData& operator=(const UserData&) = delete;
+
     UserData():
         bytesDeleted(0),
         filesDeleted(0),


### PR DESCRIPTION
## What

Replace the `Yuni::NonCopyable<T>` CRTP base class with explicitly deleted copy operations on each class:

```cpp
Foo(const Foo&) = delete;
Foo& operator=(const Foo&) = delete;
```

This matches the idiom already used elsewhere in the codebase (`Antares::Concurrency::FutureSet`, the concurrency tests) and removes another `<yuni/...>` dependency.

**16 classes** converted across `study`, `fswalker`, `ts-generator`, and the `vacuum` tool (e.g. `Area`, `AreaList`, `AreaLink`, `Study`, `BindingConstraint(sRepository)`, `Rules`, `Sets`, `XCast`, `Walker`, …). The now-unused `#include <yuni/core/noncopyable.h>` is dropped from every file that had it — including 5 files that included it without using it.

## Why it's behaviour-preserving

`Yuni::NonCopyable<T>` deletes the copy constructor and copy assignment, and — by declaring no move members — also makes derived types non-movable. Deleting the copy operations directly on the class yields the **same** result: the class is non-copyable and (because a user-declared copy ctor suppresses implicit move) non-movable. So every affected type keeps exactly the same value semantics; any code that compiled before still compiles.

`noncopyable.h` only pulls in `preprocessor/capabilities.h` (feature macros, no types), so removing the include has no transitive effect — verified none of the touched files reference those macros.

## Formatting

Ran the repo's clang-format (18.1.3, `src/format-code.sh` style) on the changed files; they pass the `--dry-run --Werror` check that CI enforces.

Part of the incremental removal of the bundled libYuni dependency (follows #3769, #3770, #3774).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6D8kGQNL4xBgwTFgW1WGi)_