### PR TITLE
Fix: merge conflict & build error

### DIFF
--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -133,7 +133,8 @@ public:
     void NODU(unsigned varIndex, const std::string& clusterName) const;
     void NumberStoppingDispatchableUnits(unsigned varIndex, const std::string& clusterName) const;
     void NumberStartingDispatchableUnits(unsigned varIndex, const std::string& clusterName) const;
-    void NumberBreakingDownDispatchableUnits(unsigned varIndex, const std::string& clusterName) const;
+    void NumberBreakingDownDispatchableUnits(unsigned varIndex,
+                                             const std::string& clusterName) const;
     void DirectFlow(unsigned varIndex) const;
     void PositiveDirectFlow(unsigned varIndex) const;
     void PositiveIndirectFlow(unsigned varIndex) const;
@@ -141,8 +142,10 @@ public:
     void ShortTermStorageWithdrawal(unsigned varIndex, const std::string& sts_name) const;
     void ShortTermStorageLevel(unsigned varIndex, const std::string& sts_name) const;
     void ShortTermStorageOverflow(unsigned varIndex, const std::string& sts_name) const;
-    void ShortTermStorageCostVariationInjection(unsigned varIndex, const std::string& sts_name) const;
-    void ShortTermStorageCostVariationWithdrawal(unsigned varIndex, const std::string& sts_name) const;
+    void ShortTermStorageCostVariationInjection(unsigned varIndex,
+                                                const std::string& sts_name) const;
+    void ShortTermStorageCostVariationWithdrawal(unsigned varIndex,
+                                                 const std::string& sts_name) const;
     void HydProd(unsigned varIndex) const;
     void HydProdDown(unsigned varIndex) const;
     void HydProdUp(unsigned varIndex) const;
@@ -156,7 +159,9 @@ public:
     void AreaBalance(unsigned varIndex) const;
 
 private:
-    void SetAreaVariableName(unsigned varIndex, const std::string& variableType, int layerIndex) const;
+    void SetAreaVariableName(unsigned varIndex,
+                             const std::string& variableType,
+                             int layerIndex) const;
     void SetShortTermStorageVariableName(unsigned varIndex,
                                          const std::string& variableType,
                                          const std::string& sts_name) const;
@@ -189,8 +194,10 @@ public:
     void AreaHydroLevel(unsigned constrIndex) const;
     void FinalStockEquivalent(unsigned constrIndex) const;
     void FinalStockExpression(unsigned constrIndex) const;
-    void NbUnitsOutageLessThanNbUnitsStop(unsigned constrIndex, const std::string& clusterName) const;
-    void NbDispUnitsMinBoundSinceMinUpTime(unsigned constrIndex, const std::string& clusterName) const;
+    void NbUnitsOutageLessThanNbUnitsStop(unsigned constrIndex,
+                                          const std::string& clusterName) const;
+    void NbDispUnitsMinBoundSinceMinUpTime(unsigned constrIndex,
+                                           const std::string& clusterName) const;
     void MinDownTime(unsigned constrIndex, const std::string& clusterName) const;
     void PMaxReserve(unsigned constrIndex,
                      const std::string& clusterName,
@@ -222,7 +229,8 @@ public:
                            const std::string& clusterName,
                            const std::string& reserveName) const;
     void STReleaseCapacityThresholdsUp(unsigned constrIndex, const std::string& clusterName) const;
-    void STReleaseCapacityThresholdsDown(unsigned constrIndex, const std::string& clusterName) const;
+    void STReleaseCapacityThresholdsDown(unsigned constrIndex,
+                                         const std::string& clusterName) const;
     void STStoreCapacityThresholdsUp(unsigned constrIndex, const std::string& clusterName) const;
     void STStoreCapacityThresholdsDown(unsigned constrIndex, const std::string& clusterName) const;
     void STStorageLevelReserveParticipation(unsigned constrIndex,
@@ -245,10 +253,13 @@ public:
     void HydroStoreMaxReserve(unsigned constrIndex,
                               const std::string& clusterName,
                               const std::string& reserveName) const;
-    void HydroReleaseCapacityThresholdsUp(unsigned constrIndex, const std::string& clusterName) const;
-    void HydroReleaseCapacityThresholdsDown(unsigned constrIndex, const std::string& clusterName) const;
+    void HydroReleaseCapacityThresholdsUp(unsigned constrIndex,
+                                          const std::string& clusterName) const;
+    void HydroReleaseCapacityThresholdsDown(unsigned constrIndex,
+                                            const std::string& clusterName) const;
     void HydroStoreCapacityThresholdsUp(unsigned constrIndex, const std::string& clusterName) const;
-    void HydroStoreCapacityThresholdsDown(unsigned constrIndex, const std::string& clusterName) const;
+    void HydroStoreCapacityThresholdsDown(unsigned constrIndex,
+                                          const std::string& clusterName) const;
     void HydroLevelReserveParticipation(ReserveType type,
                                         unsigned constrIndex,
                                         const std::string& clusterName) const;

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -335,7 +335,8 @@ void VariableNamer::ParticipationOfOffUnitsToReserve(unsigned varIndex,
                                            reserveName);
 }
 
-void VariableNamer::InternalUnsatisfiedReserve(unsigned varIndex, const std::string& reserveName) const
+void VariableNamer::InternalUnsatisfiedReserve(unsigned varIndex,
+                                               const std::string& reserveName) const
 {
     SetThermalClusterReserveElementName(varIndex, "InternalUnsatisfiedReserve", reserveName);
 }
@@ -571,9 +572,10 @@ void ConstraintNamer::FinalStockExpression(unsigned constrIndex) const
     SetAreaElementNameHour(constrIndex, "FinalStockExpression");
 }
 
-void ConstraintNamer::BindingConstraint(unsigned constrIndex,
-                                        const std::string& name,
-                                        const std::pair<std::string, std::string>& timeGranularity) const
+void ConstraintNamer::BindingConstraint(
+  unsigned constrIndex,
+  const std::string& name,
+  const std::pair<std::string, std::string>& timeGranularity) const
 {
     std::string time = TimeIdentifier(timeGranularity.first);
     std::string new_name = BuildName(name, timeGranularity.second, time);
@@ -651,17 +653,20 @@ void ConstraintNamer::SymmetryReserveParticipation(unsigned constrIndex,
                                             reserveName2);
 }
 
-void ConstraintNamer::POffUnitsUpperBound(unsigned constrIndex, const std::string& clusterName) const
+void ConstraintNamer::POffUnitsUpperBound(unsigned constrIndex,
+                                          const std::string& clusterName) const
 {
     SetThermalClusterElementName(constrIndex, "POffUnitsUpperBound", clusterName);
 }
 
-void ConstraintNamer::POutCapacityThresholdInf(unsigned constrIndex, const std::string& clusterName) const
+void ConstraintNamer::POutCapacityThresholdInf(unsigned constrIndex,
+                                               const std::string& clusterName) const
 {
     SetThermalClusterElementName(constrIndex, "POutCapacityThresholdInf", clusterName);
 }
 
-void ConstraintNamer::POutCapacityThresholdSup(unsigned constrIndex, const std::string& clusterName) const
+void ConstraintNamer::POutCapacityThresholdSup(unsigned constrIndex,
+                                               const std::string& clusterName) const
 {
     SetThermalClusterElementName(constrIndex, "POutCapacityThresholdSup", clusterName);
 }
@@ -852,19 +857,22 @@ void ConstraintNamer::HydroEnergyLevelReserveParticipation(unsigned constrIndex,
                                   reserveName);
 }
 
-void ConstraintNamer::HydroGlobalEnergyLevelReserveParticipationDown(unsigned constrIndex,
-                                                                     const std::string& clusterName) const
+void ConstraintNamer::HydroGlobalEnergyLevelReserveParticipationDown(
+  unsigned constrIndex,
+  const std::string& clusterName) const
 {
     SetHydroElementName(constrIndex, "HydroGlobalEnergyLevelReserveParticipationDown", clusterName);
 }
 
-void ConstraintNamer::HydroGlobalEnergyLevelReserveParticipationUp(unsigned constrIndex,
-                                                                   const std::string& clusterName) const
+void ConstraintNamer::HydroGlobalEnergyLevelReserveParticipationUp(
+  unsigned constrIndex,
+  const std::string& clusterName) const
 {
     SetHydroElementName(constrIndex, "HydroGlobalEnergyLevelReserveParticipationUp", clusterName);
 }
 
-void ConstraintNamer::ReserveSatisfaction(unsigned constrIndex, const std::string& reserveName) const
+void ConstraintNamer::ReserveSatisfaction(unsigned constrIndex,
+                                          const std::string& reserveName) const
 {
     SetThermalClusterReserveElementName(constrIndex, "ReserveSatisfaction", reserveName);
 }

--- a/src/tests/src/solver/optimisation/test_legacy_extra_outputs.cpp
+++ b/src/tests/src/solver/optimisation/test_legacy_extra_outputs.cpp
@@ -192,12 +192,11 @@ struct Fixture
                                double minStablePower = 300.,
                                double minGenPower = 500.)
     {
-        context.thermalMarginByCluster.try_emplace(
-          "area1$$cluster1",
-          unitSize,
-          minStablePower,
-          std::vector<double>{availability},
-          std::vector<double>{minGenPower});
+        context.thermalMarginByCluster.try_emplace("area1$$cluster1",
+                                                   unitSize,
+                                                   minStablePower,
+                                                   std::vector<double>{availability},
+                                                   std::vector<double>{minGenPower});
         return *this;
     }
 
@@ -241,7 +240,7 @@ BOOST_AUTO_TEST_CASE(extra_output_entries_carry_block_time_and_scenario)
 
     const auto row = FindRow(table, "prop_cost", "cluster1");
     BOOST_REQUIRE(row.has_value());
-    BOOST_CHECK_EQUAL(row->block, "1");               // currentBlock (0-indexed, same as mapper path)
+    BOOST_CHECK_EQUAL(row->block, "1"); // currentBlock (0-indexed, same as mapper path)
     BOOST_CHECK_EQUAL(row->absoluteTimeIndex, "168"); // timeIndex (raw, same as mapper path)
     BOOST_CHECK_EQUAL(row->blockTimeIndex, "0");      // first timestep of the block
     BOOST_CHECK_EQUAL(row->scenarioIndex, "2");

--- a/src/tests/src/solver/optimisation/test_legacy_extra_outputs.cpp
+++ b/src/tests/src/solver/optimisation/test_legacy_extra_outputs.cpp
@@ -192,12 +192,12 @@ struct Fixture
                                double minStablePower = 300.,
                                double minGenPower = 500.)
     {
-        LegacyExtraOutputsContext::ThermalMarginData margin;
-        margin.unitSize = unitSize;
-        margin.minStablePower = minStablePower;
-        margin.availability = {availability};
-        margin.minGenPower = {minGenPower};
-        context.thermalMarginByCluster["area1$$cluster1"] = margin;
+        context.thermalMarginByCluster.try_emplace(
+          "area1$$cluster1",
+          unitSize,
+          minStablePower,
+          std::vector<double>{availability},
+          std::vector<double>{minGenPower});
         return *this;
     }
 


### PR DESCRIPTION
 The build fails with:             
```                                                                                                                                                                                            
 error: no matching function for call to 'Antares::Optimization::LegacyExtraOutputsContext::ThermalMarginData::ThermalMarginData()'
 error: use of deleted function 'ThermalMarginData::operator=(ThermalMarginData&&)'                                                                                                         
```                                                                                                                                                                                 

 This is because `ThermalMarginData` has `const` reference members (`availability` and `minGenPower`), which means:                                                                                
 1. It has no default constructor (only a parameterized one)                                                                                                                                               
 2. Move assignment is deleted (due to const members)                                                                                                                                                      

 ## Fix                                                                                                                                                                                                    
Replace the default-construction + assignment pattern with `try_emplace` to construct the `ThermalMarginData` in-place directly into the `unordered_map`.