### PR TITLE
Simplify reserves structures

### DIFF
--- a/src/solver/variable/include/antares/solver/variable/economy/reserves/reserveParticipationByHydro.h
+++ b/src/solver/variable/include/antares/solver/variable/economy/reserves/reserveParticipationByHydro.h
@@ -63,7 +63,7 @@ inline void ReserveParticipationByHydro::populateHourlyValues(State& state, unsi
         for (const auto& [reserveName, reserveParticipation]:
              state.reserveData.value()
                .at(state.area->index)
-               .reserveParticipationPerHydroForYear[state.hourInTheYear]["Hydro"])
+               .reserveParticipationPerHydroForYear[state.hourInTheYear])
         {
             pValuesForTheCurrentYear[numSpace]
                                     [state.study.runtime.reserveParticipationIndexMaps.value()

--- a/src/solver/variable/include/antares/solver/variable/state.h
+++ b/src/solver/variable/include/antares/solver/variable/state.h
@@ -200,11 +200,6 @@ public:
             double onUnitsParticipation = 0;
             double offUnitsParticipation = 0;
 
-            void addParticipation(double participation)
-            {
-                totalParticipation += participation;
-            }
-
             void addOffParticipation(double participation)
             {
                 offUnitsParticipation += participation;
@@ -243,8 +238,8 @@ public:
           reserveParticipationPerSTStorageClusterForYear{HOURS_PER_YEAR};
 
         //! Reserve Participation for each Hydro per reserve
-        std::vector<std::map<std::string, std::map<ReserveID, double>>>
-          reserveParticipationPerHydroForYear{HOURS_PER_YEAR};
+        std::vector<std::map<ReserveID, double>> reserveParticipationPerHydroForYear{
+          HOURS_PER_YEAR};
 
         //! Reserve Participation cost for the whole year
         std::vector<double> reserveParticipationCostForYear;
@@ -258,18 +253,15 @@ public:
         //! Reserves participation cost of the Hydro for the whole year
         std::vector<double> HydroReserveParticipationCostForYear;
 
-        ReserveData()
+        ReserveData():
+            reserveParticipationPerThermalClusterForYear(HOURS_PER_YEAR),
+            reserveParticipationPerSTStorageClusterForYear(HOURS_PER_YEAR),
+            reserveParticipationPerHydroForYear(HOURS_PER_YEAR),
+            reserveParticipationCostForYear(HOURS_PER_YEAR, 0),
+            thermalClusterReserveParticipationCostForYear(HOURS_PER_YEAR, 0),
+            STStorageClusterReserveParticipationCostForYear(HOURS_PER_YEAR, 0),
+            HydroReserveParticipationCostForYear(HOURS_PER_YEAR, 0)
         {
-            reserveParticipationCostForYear.resize(HOURS_PER_YEAR, 0);
-            thermalClusterReserveParticipationCostForYear.resize(HOURS_PER_YEAR, 0);
-            STStorageClusterReserveParticipationCostForYear.resize(HOURS_PER_YEAR, 0);
-            HydroReserveParticipationCostForYear.resize(HOURS_PER_YEAR, 0);
-            reserveParticipationPerSTStorageClusterForYear.clear();
-            reserveParticipationPerSTStorageClusterForYear.resize(HOURS_PER_YEAR);
-            reserveParticipationPerHydroForYear.clear();
-            reserveParticipationPerHydroForYear.resize(HOURS_PER_YEAR);
-            reserveParticipationPerThermalClusterForYear.clear();
-            reserveParticipationPerThermalClusterForYear.resize(HOURS_PER_YEAR);
         }
     };
 

--- a/src/solver/variable/include/antares/solver/variable/state.h
+++ b/src/solver/variable/include/antares/solver/variable/state.h
@@ -253,15 +253,12 @@ public:
         //! Reserves participation cost of the Hydro for the whole year
         std::vector<double> HydroReserveParticipationCostForYear;
 
-        ReserveData():
-            reserveParticipationPerThermalClusterForYear(HOURS_PER_YEAR),
-            reserveParticipationPerSTStorageClusterForYear(HOURS_PER_YEAR),
-            reserveParticipationPerHydroForYear(HOURS_PER_YEAR),
-            reserveParticipationCostForYear(HOURS_PER_YEAR, 0),
-            thermalClusterReserveParticipationCostForYear(HOURS_PER_YEAR, 0),
-            STStorageClusterReserveParticipationCostForYear(HOURS_PER_YEAR, 0),
-            HydroReserveParticipationCostForYear(HOURS_PER_YEAR, 0)
+        ReserveData()
         {
+            reserveParticipationCostForYear.assign(HOURS_PER_YEAR, 0);
+            thermalClusterReserveParticipationCostForYear.assign(HOURS_PER_YEAR, 0);
+            STStorageClusterReserveParticipationCostForYear.assign(HOURS_PER_YEAR, 0);
+            HydroReserveParticipationCostForYear.assign(HOURS_PER_YEAR, 0);
         }
     };
 

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -202,8 +202,7 @@ void State::initFromHydro()
             resData.HydroReserveParticipationCostForYear[hourInTheYear]
               += participation * Hydro.reserveParticipationContainer.value().reserveCost(resID);
 
-            resData.reserveParticipationPerHydroForYear[hourInTheYear]["Hydro"][resID]
-              += participation;
+            resData.reserveParticipationPerHydroForYear[hourInTheYear][resID] += participation;
         }
     }
 }


### PR DESCRIPTION
- Remove `ReserveData::DetailledParticipation::addParticipation` (unused)
- `reserveParticipationPerHydroForYear` contains map for which only key "Hydro" is used. Eliminate that map
- Simplify `ReserveData`'s constructor (`clear` not needed at construction)