### PR TITLE
ci: reduce behave verbosity in CI logs

### DIFF
--- a/.github/workflows/cucumber-tests/action.yml
+++ b/.github/workflows/cucumber-tests/action.yml
@@ -20,4 +20,4 @@ runs:
       shell: bash
       run: |
         cd src/tests/cucumber
-        behave --tags ${{ inputs.tags }} ${{ inputs.feature }}
+        behave --format progress3 --no-timings --no-multiline --quiet --tags ${{ inputs.tags }} ${{ inputs.feature }}


### PR DESCRIPTION
## What

Reduce verbosity of `behave` cucumber tests in CI to make logs more readable.

## Changes

Updated `.github/workflows/cucumber-tests/action.yml` to add flags to the `behave` command:

| Flag | Effect |
|---|---|
| `--format progress3` | Compact dot progress per scenario, with full failure details for failing scenarios |
| `--no-timings` | Remove per-step timing |
| `--no-multiline` | Hide multiline strings/tables under steps |
| `--quiet` | Hide step source locations and snippets |

## Why

The default `pretty` formatter prints every step with source location, timing, and multiline content — making CI logs extremely verbose and hard to scan. `progress3` keeps output compact for passing scenarios while still showing full failure context (step name, location, error message) for any failing scenario.

## Before
```
  @fast @short
  Scenario: actual_num_units_on is emitted in accurate unit-commitment mode                                              # features/solver-features/legacy_simulation_table.feature:153
    Given the solver study path is "Antares_Simulator_Tests_NR/short-tests/008 Thermal fleet - Accurate unit commitment" # None
    When I run antares simulator                                                                                         # None
    Then the simulation succeeds                                                                                         # None
    And the modeler outputs contain the following entries                                                                # None
      | block | component | output               | timestep | scenario | value |
      | 0     | base      | actual_num_units_on  | 33       | 0        | 4     |
      | 0     | semi base | actual_num_units_on  | 33       | 0        | 5     |
      | 0     | peak      | actual_num_units_on  | 33       | 0        | 8     |
      | 0     | area      | is_loss_of_load      | 33       | 0        | 1     |
      | 0     | base      | co2_emissions        | 33       | 0        | 4320  |
      | 0     | semi base | co2_emissions        | 33       | 0        | 900   |
      | 0     | peak      | co2_emissions        | 33       | 0        | 560   |
      | 0     | base      | cluster_availability | 33       | 0        | 3600  |
      | 0     | semi base | cluster_availability | 33       | 0        | 1500  |
      | 0     | peak      | cluster_availability | 33       | 0        | 800   |
      | 0     | base      | up_margin            | 33       | 0        | 0     |
      | 0     | semi base | up_margin            | 33       | 0        | 0     |
      | 0     | peak      | up_margin            | 33       | 0        | 0     |
      | 0     | base      | min_gen_power        | 33       | 0        | 0     |
      | 0     | base      | down_margin          | 33       | 0        | 3600  |
    And the modeler outputs contain the following entries with relative tolerance 1e-4                                   # None
      | block | component | output         | timestep | scenario | value   |
      | 0     | base      | prop_cost      | 33       | 0        | 126000  |
      | 0     | semi base | prop_cost      | 33       | 0        | 75000   |
      | 0     | peak      | prop_cost      | 33       | 0        | 64000   |
      | 0     | base      | non_prop_cost  | 33       | 0        | 6800    |
      | 0     | area      | imbalance_cost | 33       | 0        | 1040000 |

Feature: medium tests # features/solver-features/medium_tests.feature:1

  @long @incomplete
  Scenario: 035 Mixed Expansion - Smart grid model 2                                                                  # features/solver-features/medium_tests.feature:4
    Given the solver study path is "Antares_Simulator_Tests_NR/medium-tests/035 Mixed Expansion - Smart grid model 2" # features/steps/common_steps/solver_steps.py:36
    When I run antares simulator                                                                                      # features/steps/common_steps/solver_steps.py:88
    Then the simulation succeeds                                                                                      # features/steps/common_steps/solver_steps.py:94
    And the simulation takes less than 45 seconds                                                                     # features/steps/common_steps/solver_steps.py:159
      ASSERT FAILED: Simulation time 67.5 exceeds 45.0 seconds
```
## After
```
  001 One node - passive  .....
  002 Thermal fleet - Base  .......
  003 Thermal fleet - Must-run  ........
  004 Thermal fleet - Partial must-run  ........
  005 Thermal fleet - Minimum stable power and min up down times  ........
  006 Thermal fleet - Extra costs  .........
  007 Thermal fleet - Fast unit commitment  ...........
  008 Thermal fleet - Accurate unit commitment  ...........
  009 TS generation - Thermal power  .........
  010 TS generation - Wind speed  ......
  011 TS generation - Wind power - small scale  ......
  012 TS Generation - Wind power - large scale  ......
  013 TS Generation - Solar power  ........
  014 TS generation - Load  ........
  015 TS generation - Hydro power  ..........
  016 Probabilistic vs deterministic - 1  ...F
--------------------------------------------------------------------------------
FAILURE in step 'the simulation takes less than 5 seconds' (features/solver-features/short_tests.feature:222):
ASSERT FAILED: Simulation time 5.619 exceeds 5.0 seconds
--------------------------------------------------------------------------------
  __CAPTURED_SCENARIO_OUTPUT__________________________
  CAPTURED STDOUT: scenario
  Running command: ['D:/a/Antares_Simulator/Antares_Simulator/_build/src/solver/Release/antares-solver.exe', '-i', 'D:\\a\\Antares_Simulator\\Antares_Simulator\\resources\\Antares_Simulator_Tests_NR\\short-tests\\016 Probabilistic vs deterministic - 1', '--linear-solver=sirius', '--quadratic-solver=sirius']
  __CAPTURED_SCENARIO_OUTPUT_END______________________
  018 Probabilistic vs deterministic - 3  ...F
```