### PR TITLE
[ANT-5250] Remove `overrideComponent`, clean up

### DIFF
--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -35,11 +35,16 @@ protected:
     }
 
     void SetLinkElementName(unsigned varIndex, const std::string& variableType) const;
-    void SetAreaElementNameHour(unsigned varIndex, const std::string& variableType) const;
-    void SetAreaElementNameWeek(unsigned varIndex, const std::string& variableType) const;
+    void SetAreaElementNameHour(unsigned varIndex,
+                                const std::string& variableType,
+                                std::string component = {}) const;
+    void SetAreaElementNameWeek(unsigned varIndex,
+                                const std::string& variableType,
+                                std::string component = {}) const;
     void SetAreaElementName(unsigned varIndex,
                             const std::string& variableType,
-                            const std::string& timeGranularity) const;
+                            const std::string& timeGranularity,
+                            std::string component = {}) const;
     void SetThermalClusterElementName(unsigned varIndex,
                                       const std::string& variableType,
                                       const std::string& clusterName) const;
@@ -73,14 +78,6 @@ protected:
     std::string linkLocation() const;
     std::string areaLocation() const;
     std::vector<std::string>& names() const;
-
-    void overrideComponent(unsigned index, const std::string& component) const
-    {
-        if (legacyInfo_ && (*legacyInfo_)[index])
-        {
-            (*legacyInfo_)[index]->component = component;
-        }
-    }
 
 protected:
     const std::string& getArea() const
@@ -170,7 +167,8 @@ public:
 private:
     void SetAreaVariableName(unsigned varIndex,
                              const std::string& variableType,
-                             int layerIndex) const;
+                             int layerIndex,
+                             std::string component = {}) const;
     void SetShortTermStorageVariableName(unsigned varIndex,
                                          const std::string& variableType,
                                          const std::string& sts_name) const;

--- a/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/opt_rename_problem.h
@@ -74,32 +74,18 @@ protected:
     std::string areaLocation() const;
     std::vector<std::string>& names() const;
 
-    const std::string& getArea() const
-    {
-        return area_.value();
-    }
-
-    const std::string& getOrigin() const
-    {
-        return origin_;
-    }
-
-    const std::string& getDestination() const
-    {
-        return destination_;
-    }
-
-    auto& getLegacyInfo()
-    {
-        return legacyInfo_;
-    }
-
-    void overrideComponent(unsigned index, const std::string& component)
+    void overrideComponent(unsigned index, const std::string& component) const
     {
         if (legacyInfo_ && (*legacyInfo_)[index])
         {
             (*legacyInfo_)[index]->component = component;
         }
+    }
+
+protected:
+    const std::string& getArea() const
+    {
+        return area_.value();
     }
 
 private:
@@ -169,17 +155,17 @@ public:
                                                 const std::string& sts_name) const;
     void ShortTermStorageCostVariationWithdrawal(unsigned varIndex,
                                                  const std::string& sts_name) const;
-    void HydProd(unsigned varIndex);
-    void HydProdDown(unsigned varIndex);
-    void HydProdUp(unsigned varIndex);
-    void Pumping(unsigned varIndex);
-    void HydroLevel(unsigned varIndex);
-    void Overflow(unsigned varIndex);
-    void FinalStorage(unsigned varIndex);
-    void LayerStorage(unsigned varIndex, int layerIndex);
-    void UnsuppliedEnergy(unsigned varIndex);
-    void Spillage(unsigned varIndex);
-    void AreaBalance(unsigned varIndex);
+    void HydProd(unsigned varIndex) const;
+    void HydProdDown(unsigned varIndex) const;
+    void HydProdUp(unsigned varIndex) const;
+    void Pumping(unsigned varIndex) const;
+    void HydroLevel(unsigned varIndex) const;
+    void Overflow(unsigned varIndex) const;
+    void FinalStorage(unsigned varIndex) const;
+    void LayerStorage(unsigned varIndex, int layerIndex) const;
+    void UnsuppliedEnergy(unsigned varIndex) const;
+    void Spillage(unsigned varIndex) const;
+    void AreaBalance(unsigned varIndex) const;
 
 private:
     void SetAreaVariableName(unsigned varIndex,
@@ -196,7 +182,7 @@ public:
     using Namer::Namer;
 
     void FlowDissociation(unsigned constrIndex) const;
-    void AreaBalance(unsigned constrIndex);
+    void AreaBalance(unsigned constrIndex) const;
     void FictiveLoads(unsigned constrIndex) const;
     void MaxUnsuppliedEnergy(unsigned constrIndex) const;
     void HydroPower(unsigned constrIndex) const;
@@ -208,7 +194,7 @@ public:
     void MaxPumping(unsigned constrIndex) const;
     void AreaHydroLevel(unsigned constrIndex) const;
     void FinalStockEquivalent(unsigned constrIndex) const;
-    void FinalStockExpression(unsigned constrIndex);
+    void FinalStockExpression(unsigned constrIndex) const;
     void NbUnitsOutageLessThanNbUnitsStop(unsigned constrIndex,
                                           const std::string& clusterName) const;
     void NbDispUnitsMinBoundSinceMinUpTime(unsigned constrIndex,

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -98,36 +98,50 @@ void Namer::SetLinkElementName(unsigned elementIndex, const std::string& element
     RecordLegacyVariableInfo(elementIndex, elementType, a1 + "_" + a2 + "_link");
 }
 
-void Namer::SetAreaElementNameHour(unsigned elementIndex, const std::string& elementType) const
+void Namer::SetAreaElementNameHour(unsigned elementIndex,
+                                   const std::string& elementType,
+                                   std::string component) const
 {
-    SetAreaElementName(elementIndex, elementType, HOUR);
+    SetAreaElementName(elementIndex, elementType, HOUR, std::move(component));
 }
 
-void Namer::SetAreaElementNameWeek(unsigned elementIndex, const std::string& elementType) const
+void Namer::SetAreaElementNameWeek(unsigned elementIndex,
+                                   const std::string& elementType,
+                                   std::string component) const
 {
-    SetAreaElementName(elementIndex, elementType, WEEK);
+    SetAreaElementName(elementIndex, elementType, WEEK, std::move(component));
 }
 
 void Namer::SetAreaElementName(unsigned elementIndex,
                                const std::string& elementType,
-                               const std::string& timeGranularity) const
+                               const std::string& timeGranularity,
+                               std::string component) const
 {
     std::string location = LocationIdentifier(area_.value(), AREA);
     std::string time = TimeIdentifier(timeGranularity);
     std::string name = BuildName(elementType, location, time);
     names_[elementIndex] = name;
-    RecordLegacyVariableInfo(elementIndex, elementType, area_.value() + "_node");
+    if (component.empty())
+    {
+        component = area_.value();
+    }
+    RecordLegacyVariableInfo(elementIndex, elementType, std::move(component));
 }
 
 void VariableNamer::SetAreaVariableName(unsigned varIndex,
                                         const std::string& variableType,
-                                        int layerIndex) const
+                                        int layerIndex,
+                                        std::string component) const
 {
     std::string location = areaLocation() + SEP + "Layer<" + std::to_string(layerIndex) + ">";
     std::string time = TimeIdentifier(HOUR);
     std::string name = BuildName(variableType, location, time);
     names()[varIndex] = name;
-    RecordLegacyVariableInfo(varIndex, variableType, std::to_string(layerIndex));
+    if (component.empty())
+    {
+        component = getArea();
+    }
+    RecordLegacyVariableInfo(varIndex, variableType, std::move(component));
 }
 
 void Namer::SetThermalClusterElementName(unsigned varIndex,
@@ -436,68 +450,57 @@ void VariableNamer::ShortTermStorageCostVariationWithdrawal(unsigned varIndex,
 
 void VariableNamer::HydProd(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "HydProd");
-    overrideComponent(varIndex, getArea() + "_hydro_storage");
+    SetAreaElementNameHour(varIndex, "HydProd", getArea() + "_hydro_storage");
 }
 
 void VariableNamer::HydProdDown(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "HydProdDown");
-    overrideComponent(varIndex, getArea() + "_hydro_storage");
+    SetAreaElementNameHour(varIndex, "HydProdDown", getArea() + "_hydro_storage");
 }
 
 void VariableNamer::HydProdUp(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "HydProdUp");
-    overrideComponent(varIndex, getArea() + "_hydro_storage");
+    SetAreaElementNameHour(varIndex, "HydProdUp", getArea() + "_hydro_storage");
 }
 
 void VariableNamer::Pumping(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "Pumping");
-    overrideComponent(varIndex, getArea() + "_hydro_storage");
+    SetAreaElementNameHour(varIndex, "Pumping", getArea() + "_hydro_storage");
 }
 
 void VariableNamer::HydroLevel(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "HydroLevel");
-    overrideComponent(varIndex, getArea() + "_hydro_storage");
+    SetAreaElementNameHour(varIndex, "HydroLevel", getArea() + "_hydro_storage");
 }
 
 void VariableNamer::Overflow(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "Overflow");
-    overrideComponent(varIndex, getArea() + "_hydro_storage");
+    SetAreaElementNameHour(varIndex, "Overflow", getArea() + "_hydro_storage");
 }
 
 void VariableNamer::LayerStorage(unsigned varIndex, int layerIndex) const
 {
-    SetAreaVariableName(varIndex, "LayerStorage", layerIndex);
-    overrideComponent(varIndex, getArea() + "_hydro_storage");
+    SetAreaVariableName(varIndex, "LayerStorage", layerIndex, getArea() + "_hydro_storage");
 }
 
 void VariableNamer::FinalStorage(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "FinalStorage");
-    overrideComponent(varIndex, getArea() + "_hydro_storage");
+    SetAreaElementNameHour(varIndex, "FinalStorage", getArea() + "_hydro_storage");
 }
 
 void VariableNamer::UnsuppliedEnergy(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "UnsuppliedEnergy");
-    overrideComponent(varIndex, getArea() + "_node");
+    SetAreaElementNameHour(varIndex, "UnsuppliedEnergy", getArea() + "_node");
 }
 
 void VariableNamer::Spillage(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "Spillage");
-    overrideComponent(varIndex, getArea() + "_node");
+    SetAreaElementNameHour(varIndex, "Spillage", getArea() + "_node");
 }
 
 void VariableNamer::AreaBalance(unsigned varIndex) const
 {
-    SetAreaElementNameHour(varIndex, "AreaBalance");
-    overrideComponent(varIndex, getArea() + "_node");
+    SetAreaElementNameHour(varIndex, "AreaBalance", getArea() + "_node");
 }
 
 void ConstraintNamer::FlowDissociation(unsigned constrIndex) const
@@ -517,8 +520,7 @@ void ConstraintNamer::CsrAreaBalance(unsigned constrIndex) const
 
 void ConstraintNamer::AreaBalance(unsigned constrIndex) const
 {
-    SetAreaElementNameHour(constrIndex, "AreaBalance");
-    overrideComponent(constrIndex, getArea() + "_node");
+    SetAreaElementNameHour(constrIndex, "AreaBalance", getArea() + "_node");
 }
 
 void ConstraintNamer::FictiveLoads(unsigned constrIndex) const
@@ -588,8 +590,7 @@ void ConstraintNamer::FinalStockEquivalent(unsigned constrIndex) const
 
 void ConstraintNamer::FinalStockExpression(unsigned constrIndex) const
 {
-    SetAreaElementNameHour(constrIndex, "FinalStockExpression");
-    overrideComponent(constrIndex, getArea() + "_hydro_storage");
+    SetAreaElementNameHour(constrIndex, "FinalStockExpression", getArea() + "_hydro_storage");
 }
 
 void ConstraintNamer::BindingConstraint(

--- a/src/solver/optimisation/opt_rename_problem.cpp
+++ b/src/solver/optimisation/opt_rename_problem.cpp
@@ -434,67 +434,67 @@ void VariableNamer::ShortTermStorageCostVariationWithdrawal(unsigned varIndex,
     SetShortTermStorageVariableName(varIndex, "CostVariationWithdrawal", sts_name);
 }
 
-void VariableNamer::HydProd(unsigned varIndex)
+void VariableNamer::HydProd(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "HydProd");
     overrideComponent(varIndex, getArea() + "_hydro_storage");
 }
 
-void VariableNamer::HydProdDown(unsigned varIndex)
+void VariableNamer::HydProdDown(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "HydProdDown");
     overrideComponent(varIndex, getArea() + "_hydro_storage");
 }
 
-void VariableNamer::HydProdUp(unsigned varIndex)
+void VariableNamer::HydProdUp(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "HydProdUp");
     overrideComponent(varIndex, getArea() + "_hydro_storage");
 }
 
-void VariableNamer::Pumping(unsigned varIndex)
+void VariableNamer::Pumping(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "Pumping");
     overrideComponent(varIndex, getArea() + "_hydro_storage");
 }
 
-void VariableNamer::HydroLevel(unsigned varIndex)
+void VariableNamer::HydroLevel(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "HydroLevel");
     overrideComponent(varIndex, getArea() + "_hydro_storage");
 }
 
-void VariableNamer::Overflow(unsigned varIndex)
+void VariableNamer::Overflow(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "Overflow");
     overrideComponent(varIndex, getArea() + "_hydro_storage");
 }
 
-void VariableNamer::LayerStorage(unsigned varIndex, int layerIndex)
+void VariableNamer::LayerStorage(unsigned varIndex, int layerIndex) const
 {
     SetAreaVariableName(varIndex, "LayerStorage", layerIndex);
     overrideComponent(varIndex, getArea() + "_hydro_storage");
 }
 
-void VariableNamer::FinalStorage(unsigned varIndex)
+void VariableNamer::FinalStorage(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "FinalStorage");
     overrideComponent(varIndex, getArea() + "_hydro_storage");
 }
 
-void VariableNamer::UnsuppliedEnergy(unsigned varIndex)
+void VariableNamer::UnsuppliedEnergy(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "UnsuppliedEnergy");
     overrideComponent(varIndex, getArea() + "_node");
 }
 
-void VariableNamer::Spillage(unsigned varIndex)
+void VariableNamer::Spillage(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "Spillage");
     overrideComponent(varIndex, getArea() + "_node");
 }
 
-void VariableNamer::AreaBalance(unsigned varIndex)
+void VariableNamer::AreaBalance(unsigned varIndex) const
 {
     SetAreaElementNameHour(varIndex, "AreaBalance");
     overrideComponent(varIndex, getArea() + "_node");
@@ -515,7 +515,7 @@ void ConstraintNamer::CsrAreaBalance(unsigned constrIndex) const
     SetAreaElementNameHour(constrIndex, "CsrAreaBalance");
 }
 
-void ConstraintNamer::AreaBalance(unsigned constrIndex)
+void ConstraintNamer::AreaBalance(unsigned constrIndex) const
 {
     SetAreaElementNameHour(constrIndex, "AreaBalance");
     overrideComponent(constrIndex, getArea() + "_node");
@@ -586,7 +586,7 @@ void ConstraintNamer::FinalStockEquivalent(unsigned constrIndex) const
     SetAreaElementNameHour(constrIndex, "FinalStockEquivalent");
 }
 
-void ConstraintNamer::FinalStockExpression(unsigned constrIndex)
+void ConstraintNamer::FinalStockExpression(unsigned constrIndex) const
 {
     SetAreaElementNameHour(constrIndex, "FinalStockExpression");
     overrideComponent(constrIndex, getArea() + "_hydro_storage");


### PR DESCRIPTION
### Old approach (two-step):
1. Call `SetAreaElementNameHour(varIndex, "HydProd")` → calls `SetAreaElementName` → calls `RecordLegacyVariableInfo(varIndex, "HydProd", area_ + "_node")` — sets component to `"_node"`
2. Call `overrideComponent(varIndex, area_ + "_hydro_storage")` — **overwrites** the component to `"_hydro_storage"`

**Net result:** component = `area_ + "_hydro_storage"`

### New approach (one-step):
1. Call `SetAreaElementNameHour(varIndex, "HydProd", area_ + "_hydro_storage")` → calls `SetAreaElementName` with `component` already set → `component` is non-empty → `RecordLegacyVariableInfo(varIndex, "HydProd", area_ + "_hydro_storage")`

**Net result:** component = `area_ + "_hydro_storage"` ✅

### Default case (no override):
- **Old:** `SetAreaElementNameHour(varIndex, "AreaBalance")` → `RecordLegacyVariableInfo(varIndex, "AreaBalance", area_ + "_node")` — always `"_node"`
- **New:** `SetAreaElementNameHour(varIndex, "AreaBalance", area_ + "_node")` → same result ✅

### `SetAreaVariableName` (e.g., `LayerStorage`):
- **Old:** `SetAreaVariableName(varIndex, "LayerStorage", layerIndex)` → `RecordLegacyVariableInfo(varIndex, "LayerStorage", std::to_string(layerIndex))` — component = layer index string
- Then `overrideComponent(varIndex, area_ + "_hydro_storage")` — overwrites to `"_hydro_storage"`
- **New:** `SetAreaVariableName(varIndex, "LayerStorage", layerIndex, area_ + "_hydro_storage")` → same final result ✅

### `SetAreaElementName` default fallback:
The new code defaults `component` to `area_.value()` (without suffix) when empty. But **all call sites pass an explicit component**, so this default is never actually used in the current codebase. This is a minor behavioral difference — if a future caller passes an empty string, the component would be `area_` instead of `area_ + "_node"`. However, since every call site provides a non-empty component, the observable behavior is identical.

### Summary

| Aspect | Old | New | Equivalent? |
|--------|-----|-----|-------------|
| `overrideComponent` calls | 12 locations, each overwriting `_node` or layer index | Passed inline as 3rd arg | ✅ Yes |
| Default component behavior | Always `area_ + "_node"` | `area_` (when empty) | ⚠️ Different, but unreachable |
| `overrideComponent` helper removed | Yes (cleaner) | N/A | ✅ Good cleanup |
| `std::move` usage | N/A | Used for `component` | ✅ Efficient |

**Verdict:** The diff is functionally equivalent. The refactoring consolidates the two-step pattern (set default, then override) into a single-step pattern (pass the desired value directly), which is cleaner and eliminates the need for the `overrideComponent` helper.