### PR TITLE
refacto: simplify reserves vector allocation

### DIFF
--- a/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
+++ b/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
@@ -549,8 +549,7 @@ void SIM_AllocateAreas(PROBLEME_HEBDO& problem,
         problem.ResultatsHoraires[k].ProductionThermique.resize(NombreDePasDeTemps);
         if (resEnabled)
         {
-            problem.ResultatsHoraires[k].Reserves.emplace();
-            problem.ResultatsHoraires[k].Reserves.value().resize(NombreDePasDeTemps);
+            problem.ResultatsHoraires[k].Reserves.emplace(NombreDePasDeTemps);
             problem.ResultatsHoraires[k].HydroUsage.resize(NombreDePasDeTemps);
         }
 
@@ -597,42 +596,24 @@ void SIM_AllocateAreas(PROBLEME_HEBDO& problem,
               .NombreDeGroupesQuiTombentEnPanneDuPalier.assign(nbPaliers, 0.);
             if (resEnabled)
             {
-                problem.ResultatsHoraires[k]
-                  .ProductionThermique[j]
-                  .ParticipationReservesDuPalier.emplace();
-                problem.ResultatsHoraires[k]
-                  .ProductionThermique[j]
-                  .ParticipationReservesDuPalier.value()
-                  .assign(nbThermalReserveParticipations, 0.);
-                problem.ResultatsHoraires[k]
-                  .ProductionThermique[j]
-                  .ParticipationReservesDuPalierOn.emplace();
-                problem.ResultatsHoraires[k]
-                  .ProductionThermique[j]
-                  .ParticipationReservesDuPalierOn.value()
-                  .assign(nbThermalReserveParticipations, 0.);
-                problem.ResultatsHoraires[k]
-                  .ProductionThermique[j]
-                  .ParticipationReservesDuPalierOff.emplace();
-                problem.ResultatsHoraires[k]
-                  .ProductionThermique[j]
-                  .ParticipationReservesDuPalierOff.value()
-                  .assign(nbThermalReserveParticipations, 0.);
-
-                problem.ResultatsHoraires[k]
-                  .Reserves.value()[j]
-                  .ValeursHorairesInternalUnsatisfied.assign(nbReserves, 0.);
-                problem.ResultatsHoraires[k]
-                  .Reserves.value()[j]
-                  .ValeursHorairesInternalExcessReserve.assign(nbReserves, 0.);
-                problem.ResultatsHoraires[k].Reserves.value()[j].CoutsMarginauxHoraires.assign(
-                  nbReserves,
+                {
+                    auto& thermal = problem.ResultatsHoraires[k].ProductionThermique[j];
+                    thermal.ParticipationReservesDuPalier.emplace(nbThermalReserveParticipations,
+                                                                  0.);
+                    thermal.ParticipationReservesDuPalierOn.emplace(nbThermalReserveParticipations,
+                                                                    0.);
+                    thermal.ParticipationReservesDuPalierOff.emplace(nbThermalReserveParticipations,
+                                                                     0.);
+                }
+                {
+                    auto& res = problem.ResultatsHoraires[k].Reserves.value()[j];
+                    res.ValeursHorairesInternalUnsatisfied.assign(nbReserves, 0.);
+                    res.ValeursHorairesInternalExcessReserve.assign(nbReserves, 0.);
+                    res.CoutsMarginauxHoraires.assign(nbReserves, 0.);
+                }
+                problem.ResultatsHoraires[k].HydroUsage[j].reserveParticipationOfCluster.emplace(
+                  nbHydroReserveParticipations,
                   0.);
-                problem.ResultatsHoraires[k].HydroUsage[j].reserveParticipationOfCluster.emplace();
-                problem.ResultatsHoraires[k]
-                  .HydroUsage[j]
-                  .reserveParticipationOfCluster.value()
-                  .assign(nbHydroReserveParticipations, 0.);
             }
         }
         // Short term storage results

--- a/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
+++ b/src/solver/simulation/sim_alloc_probleme_hebdo.cpp
@@ -173,39 +173,35 @@ void SIM_AllocationProblemePasDeTemps(PROBLEME_HEBDO& problem,
         if (study.parameters.include.reserves)
         {
             variablesMapping.reservesIndices.emplace();
-            variablesMapping.reservesIndices.value().runningThermalClusterParticipation.assign(
-              thermalCount * capacityReservationCount,
-              0);
-            variablesMapping.reservesIndices.value()
-              .offThermalClusterParticipation.assign(thermalCount * capacityReservationCount, 0);
-            variablesMapping.reservesIndices.value()
-              .thermalClusterParticipation.assign(thermalCount * capacityReservationCount, 0);
-            variablesMapping.reservesIndices.value().STStorageClusterParticipation.down.assign(
-              shortTermStorageCount * capacityReservationCount,
-              0);
-            variablesMapping.reservesIndices.value().STStorageClusterParticipation.up.assign(
-              shortTermStorageCount * capacityReservationCount,
-              0);
-            variablesMapping.reservesIndices.value().STStorageReleaseClusterParticipation.assign(
-              shortTermStorageCount * capacityReservationCount,
-              0);
-            variablesMapping.reservesIndices.value().STStorageStoreClusterParticipation.assign(
-              shortTermStorageCount * capacityReservationCount,
-              0);
+            auto& varMapping = variablesMapping.reservesIndices.value();
+            varMapping.runningThermalClusterParticipation.assign(thermalCount
+                                                                   * capacityReservationCount,
+                                                                 0);
+            varMapping.offThermalClusterParticipation.assign(thermalCount
+                                                               * capacityReservationCount,
+                                                             0);
+            varMapping.thermalClusterParticipation.assign(thermalCount * capacityReservationCount,
+                                                          0);
+            varMapping.STStorageClusterParticipation.down.assign(shortTermStorageCount
+                                                                   * capacityReservationCount,
+                                                                 0);
+            varMapping.STStorageClusterParticipation.up.assign(shortTermStorageCount
+                                                                 * capacityReservationCount,
+                                                               0);
+            varMapping.STStorageReleaseClusterParticipation.assign(shortTermStorageCount
+                                                                     * capacityReservationCount,
+                                                                   0);
+            varMapping.STStorageStoreClusterParticipation.assign(shortTermStorageCount
+                                                                   * capacityReservationCount,
+                                                                 0);
 
-            variablesMapping.reservesIndices.value()
-              .HydroParticipation.up.assign(hydroCount * capacityReservationCount, 0);
-            variablesMapping.reservesIndices.value()
-              .HydroParticipation.down.assign(hydroCount * capacityReservationCount, 0);
-            variablesMapping.reservesIndices.value()
-              .HydroReleaseParticipation.assign(hydroCount * capacityReservationCount, 0);
-            variablesMapping.reservesIndices.value()
-              .HydroStoreParticipation.assign(hydroCount * capacityReservationCount, 0);
+            varMapping.HydroParticipation.up.assign(hydroCount * capacityReservationCount, 0);
+            varMapping.HydroParticipation.down.assign(hydroCount * capacityReservationCount, 0);
+            varMapping.HydroReleaseParticipation.assign(hydroCount * capacityReservationCount, 0);
+            varMapping.HydroStoreParticipation.assign(hydroCount * capacityReservationCount, 0);
 
-            variablesMapping.reservesIndices.value()
-              .internalUnsatisfied.assign(capacityReservationCount, 0);
-            variablesMapping.reservesIndices.value().internalExcess.assign(capacityReservationCount,
-                                                                           0);
+            varMapping.internalUnsatisfied.assign(capacityReservationCount, 0);
+            varMapping.internalExcess.assign(capacityReservationCount, 0);
         }
 
         variablesMapping.SIM_ShortTermStorage.OverflowVariable.assign(shortTermStorageCount, 0);
@@ -263,91 +259,48 @@ void SIM_AllocationProblemePasDeTemps(PROBLEME_HEBDO& problem,
         if (study.parameters.include.reserves)
         {
             problem.CorrespondanceCntNativesCntOptim[k].reservesIndices.emplace();
-            problem.CorrespondanceCntNativesCntOptim[k].reservesIndices.value().need.assign(
-              capacityReservationCount,
-              -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .powerOffGroupUnitsInThermalClusterParticipating.assign(thermalCount
+            auto& resCorresp = problem.CorrespondanceCntNativesCntOptim[k].reservesIndices.value();
+            resCorresp.need.assign(capacityReservationCount, -1);
+            resCorresp.powerOffGroupUnitsInThermalClusterParticipating
+              .assign(thermalCount * capacityReservationCount, -1);
+            resCorresp.maxPowerOffUnitsInThermalCluster.assign(thermalCount, -1);
+            resCorresp.thermalClusterPOutBoundMin.assign(thermalCount, -1);
+            resCorresp.thermalClusterPOutBoundMax.assign(thermalCount, -1);
+
+            resCorresp.STStorageClusterMaxReleaseParticipation.assign(shortTermStorageCount
                                                                         * capacityReservationCount,
                                                                       -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .maxPowerOffUnitsInThermalCluster.assign(thermalCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .thermalClusterPOutBoundMin.assign(thermalCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .thermalClusterPOutBoundMax.assign(thermalCount, -1);
+            resCorresp.STStorageClusterMaxStoreParticipation.assign(shortTermStorageCount
+                                                                      * capacityReservationCount,
+                                                                    -1);
 
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageClusterMaxReleaseParticipation.assign(shortTermStorageCount
-                                                                * capacityReservationCount,
-                                                              -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageClusterMaxStoreParticipation.assign(shortTermStorageCount
-                                                              * capacityReservationCount,
+            resCorresp.STStorageClusterReleaseCapacityThresholdsMax.assign(shortTermStorageCount,
+                                                                           -1);
+            resCorresp.STStorageClusterReleaseCapacityThresholdsMin.assign(shortTermStorageCount,
+                                                                           -1);
+            resCorresp.STStorageClusterStoreCapacityThresholds.assign(shortTermStorageCount, -1);
+            resCorresp.STStorageLevelParticipation.down.assign(shortTermStorageCount, -1);
+            resCorresp.STStorageLevelParticipation.up.assign(shortTermStorageCount, -1);
+            resCorresp.STStorageEnergyLevelParticipation.assign(shortTermStorageCount
+                                                                  * capacityReservationCount,
+                                                                -1);
+            resCorresp.STStorageGlobalStockEnergyLevelParticipation.up.assign(shortTermStorageCount,
+                                                                              -1);
+            resCorresp.STStorageGlobalStockEnergyLevelParticipation.down
+              .assign(shortTermStorageCount, -1);
+
+            resCorresp.HydroMaxReleaseParticipation.assign(hydroCount * capacityReservationCount,
+                                                           -1);
+            resCorresp.HydroMaxStoreParticipation.assign(hydroCount * capacityReservationCount, -1);
+            resCorresp.HydroReleaseCapacityThresholdsMax.assign(hydroCount, -1);
+            resCorresp.HydroReleaseCapacityThresholdsMin.assign(hydroCount, -1);
+            resCorresp.HydroStoreCapacityThresholds.assign(hydroCount, -1);
+            resCorresp.HydroLevelParticipation.down.assign(hydroCount, -1);
+            resCorresp.HydroLevelParticipation.up.assign(hydroCount, -1);
+            resCorresp.HydroEnergyLevelParticipation.assign(hydroCount * capacityReservationCount,
                                                             -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageClusterReleaseCapacityThresholdsMax.assign(shortTermStorageCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageClusterReleaseCapacityThresholdsMin.assign(shortTermStorageCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageClusterStoreCapacityThresholds.assign(shortTermStorageCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageLevelParticipation.down.assign(shortTermStorageCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageLevelParticipation.up.assign(shortTermStorageCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageEnergyLevelParticipation.assign(shortTermStorageCount
-                                                          * capacityReservationCount,
-                                                        -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageGlobalStockEnergyLevelParticipation.up.assign(shortTermStorageCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .STStorageGlobalStockEnergyLevelParticipation.down.assign(shortTermStorageCount, -1);
-
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroMaxReleaseParticipation.assign(hydroCount * capacityReservationCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroMaxStoreParticipation.assign(hydroCount * capacityReservationCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroReleaseCapacityThresholdsMax.assign(hydroCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroReleaseCapacityThresholdsMin.assign(hydroCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroStoreCapacityThresholds.assign(hydroCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroLevelParticipation.down.assign(hydroCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroLevelParticipation.up.assign(hydroCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroEnergyLevelParticipation.assign(hydroCount * capacityReservationCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroGlobalEnergyLevelParticipationUp.assign(hydroCount, -1);
-            problem.CorrespondanceCntNativesCntOptim[k]
-              .reservesIndices.value()
-              .HydroGlobalEnergyLevelParticipationDown.assign(hydroCount, -1);
+            resCorresp.HydroGlobalEnergyLevelParticipationUp.assign(hydroCount, -1);
+            resCorresp.HydroGlobalEnergyLevelParticipationDown.assign(hydroCount, -1);
         }
     }
 }
@@ -631,18 +584,13 @@ void SIM_AllocateAreas(PROBLEME_HEBDO& problem,
 
         if (resEnabled)
         {
-            problem.ResultatsHoraires[k].ShortTermStorageReserves.emplace();
-            problem.ResultatsHoraires[k].ShortTermStorageReserves.value().resize(
+            problem.ResultatsHoraires[k].ShortTermStorageReserves.emplace(
               nbSTStorageReserveParticipations);
             for (uint stsRes = 0; stsRes < nbSTStorageReserveParticipations; stsRes++)
             {
                 problem.ResultatsHoraires[k]
                   .ShortTermStorageReserves.value()[stsRes]
-                  .reserveParticipationOfCluster.emplace();
-                problem.ResultatsHoraires[k]
-                  .ShortTermStorageReserves.value()[stsRes]
-                  .reserveParticipationOfCluster.value()
-                  .assign(NombreDePasDeTemps, 0.);
+                  .reserveParticipationOfCluster.emplace(NombreDePasDeTemps, 0.);
             }
         }
     }


### PR DESCRIPTION
## Summary

**File changed:** `src/solver/simulation/sim_alloc_probleme_hebdo.cpp` (−71 lines, ~−40%)

This PR simplifies reserves-related vector allocation in the weekly problem allocator via two changes:

1. **`auto&` references** — Replaces deeply-nested `problem.CorrespondanceCntNativesCntOptim[k].reservesIndices.value()` chains with short local aliases (`varMapping`, `resCorresp`), improving readability across ~50 lines of repetitive member access.

2. **`std::optional::emplace(size, value)`** — Replaces the two-step `emplace()` + `.value().assign(n, v)` / `.resize(n)` pattern with a single in-place construction call. For `std::vector`, `emplace(n, 0)` constructs a vector of size `n` initialized to `0` in one step, eliminating redundant `.value()` calls and reducing boilerplate.

Without `std::optional` this is equivalent to changing
```cpp
std::vector<int> my_vector;
my_vector.assign(N, 10);
```
to
```cpp
std::vector<int> my_vector(N, 10);
```

Applied across `SIM_AllocationProblemePasDeTemps`, `SIM_AllocateAreas`, and related reserve result structures (thermal participation, hydro usage, ST storage reserves). No behavioral changes — purely allocation-level refactoring.