### PR TITLE
bugfix[ANT-5179] : RESERVE PARTICIPATION COST is computed as zero, should not be

### DIFF
--- a/src/solver/variable/include/antares/solver/variable/state.hxx
+++ b/src/solver/variable/include/antares/solver/variable/state.hxx
@@ -20,6 +20,11 @@ inline void State::startANewYear()
            0,
            sizeof(thermalClusterDispatchedUnitsCountForYear));
 
+    if (study.parameters.include.reserves)
+    {
+        study.areas.each([this](const auto& area) { reserveData->at(area.index) = ReserveData(); });
+    }
+
     // Re-initializing annual costs (to be printed in output into separate files)
     annualSystemCost = 0.;
     optimalSolutionCost1 = 0.;
@@ -33,10 +38,6 @@ inline void State::yearEndResetThermal()
 {
     memset(thermalClusterProductionForYear, 0, sizeof(thermalClusterProductionForYear));
     memset(thermalClusterOperatingCostForYear, 0, sizeof(thermalClusterOperatingCostForYear));
-    if (study.parameters.include.reserves)
-    {
-        reserveData.emplace(study.areas.size());
-    }
     memset(thermalClusterNonProportionalCostForYear,
            0,
            sizeof(thermalClusterNonProportionalCostForYear));

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -165,8 +165,9 @@ void State::initFromShortTermStorageClusterIndex(const uint clusterAreaWideIndex
                                                 .STStorageClusters.left.at(
                                                   std::make_pair(resID, STStorageCluster->id))]
                                      .reserveParticipationOfCluster.value()[hourInTheWeek];
-            const double participationCost
-              = participation * STStorageCluster->reserveParticipationContainer->reserveCost(resID);
+            const double participationCost = participation
+                                             * STStorageCluster->reserveParticipationContainer
+                                                 ->reserveCost(resID);
 
             resData.STStorageClusterReserveParticipationCostForYear[hourInTheYear]
               += participationCost;
@@ -201,8 +202,9 @@ void State::initFromHydro()
                                      .reserveParticipationOfCluster
                                      .value()[study.reserveMaps->participationIndexMaps.at(area->id)
                                                 .Hydro.left.at(resID)];
-            const double participationCost
-              = participation * Hydro.reserveParticipationContainer->reserveCost(resID);
+            const double participationCost = participation
+                                             * Hydro.reserveParticipationContainer->reserveCost(
+                                               resID);
 
             resData.HydroReserveParticipationCostForYear[hourInTheYear] += participationCost;
             resData.reserveParticipationCostForYear[hourInTheYear] += participationCost;
@@ -310,11 +312,12 @@ void State::initFromThermalClusterIndexProduction(const uint clusterEnabledIndex
                                             .ParticipationReservesDuPalierOff
                                             .value()[reserveParticipationIdx];
 
-                const double participationCost
-                  = participationOn
-                      * thermalCluster->reserveParticipationContainer->reserveCost(reserveID)
-                    + participationOff
-                        * thermalCluster->reserveParticipationContainer->reserveCostOff(reserveID);
+                const double participationCost = participationOn
+                                                   * thermalCluster->reserveParticipationContainer
+                                                       ->reserveCost(reserveID)
+                                                 + participationOff
+                                                     * thermalCluster->reserveParticipationContainer
+                                                         ->reserveCostOff(reserveID);
 
                 thermal[area->index].thermalClustersOperatingCost[clusterEnabledIndex]
                   += participationCost;

--- a/src/solver/variable/state.cpp
+++ b/src/solver/variable/state.cpp
@@ -165,9 +165,12 @@ void State::initFromShortTermStorageClusterIndex(const uint clusterAreaWideIndex
                                                 .STStorageClusters.left.at(
                                                   std::make_pair(resID, STStorageCluster->id))]
                                      .reserveParticipationOfCluster.value()[hourInTheWeek];
+            const double participationCost
+              = participation * STStorageCluster->reserveParticipationContainer->reserveCost(resID);
+
             resData.STStorageClusterReserveParticipationCostForYear[hourInTheYear]
-              += participation
-                 * STStorageCluster->reserveParticipationContainer.value().reserveCost(resID);
+              += participationCost;
+            resData.reserveParticipationCostForYear[hourInTheYear] += participationCost;
 
             resData.reserveParticipationPerGroupForYear[hourInTheYear]
               .shortTermStorageGroupsReserveParticipation[STStorageCluster->getGroup()][resID]
@@ -198,8 +201,11 @@ void State::initFromHydro()
                                      .reserveParticipationOfCluster
                                      .value()[study.reserveMaps->participationIndexMaps.at(area->id)
                                                 .Hydro.left.at(resID)];
-            resData.HydroReserveParticipationCostForYear[hourInTheYear]
-              += participation * Hydro.reserveParticipationContainer.value().reserveCost(resID);
+            const double participationCost
+              = participation * Hydro.reserveParticipationContainer->reserveCost(resID);
+
+            resData.HydroReserveParticipationCostForYear[hourInTheYear] += participationCost;
+            resData.reserveParticipationCostForYear[hourInTheYear] += participationCost;
 
             resData.reserveParticipationPerHydroForYear[hourInTheYear]["Hydro"][resID]
               += participation;
@@ -304,21 +310,18 @@ void State::initFromThermalClusterIndexProduction(const uint clusterEnabledIndex
                                             .ParticipationReservesDuPalierOff
                                             .value()[reserveParticipationIdx];
 
+                const double participationCost
+                  = participationOn
+                      * thermalCluster->reserveParticipationContainer->reserveCost(reserveID)
+                    + participationOff
+                        * thermalCluster->reserveParticipationContainer->reserveCostOff(reserveID);
+
                 thermal[area->index].thermalClustersOperatingCost[clusterEnabledIndex]
-                  += participationOn
-                       * thermalCluster->reserveParticipationContainer.value().reserveCost(
-                         reserveID)
-                     + participationOff
-                         * thermalCluster->reserveParticipationContainer.value().reserveCostOff(
-                           reserveID);
+                  += participationCost;
 
                 resData.thermalClusterReserveParticipationCostForYear[hourInTheYear]
-                  += participationOn
-                       * thermalCluster->reserveParticipationContainer.value().reserveCost(
-                         reserveID)
-                     + participationOff
-                         * thermalCluster->reserveParticipationContainer.value().reserveCostOff(
-                           reserveID);
+                  += participationCost;
+                resData.reserveParticipationCostForYear[hourInTheYear] += participationCost;
 
                 resData.reserveParticipationPerGroupForYear[hourInTheYear]
                   .thermalGroupsReserveParticipation[thermalCluster->getGroup()][reserveID]
@@ -498,9 +501,9 @@ void State::calculateReserveParticipationCosts()
         for (uint h = startHourForCurrentYear; h < endHourForCurrentYear; ++h)
         {
             resData.reserveParticipationCostForYear[h]
-              += resData.thermalClusterReserveParticipationCostForYear[h]
-                 + resData.STStorageClusterReserveParticipationCostForYear[h]
-                 + resData.HydroReserveParticipationCostForYear[h];
+              = resData.thermalClusterReserveParticipationCostForYear[h]
+                + resData.STStorageClusterReserveParticipationCostForYear[h]
+                + resData.HydroReserveParticipationCostForYear[h];
         }
     }
 }

--- a/src/tests/cucumber/features/solver-features/reserves_tests.feature
+++ b/src/tests/cucumber/features/solver-features/reserves_tests.feature
@@ -642,7 +642,8 @@ Scenario: ST_3UP_unavailable_reserves_test3
 	  And in area "AREA", during year 1, for cluster "Hydro" and reserve "Res_2", total reserve participation power is 1680 MWh
     And in area "AREA", during year 1, for cluster "Hydro" and reserve "Res_1", on "1 JAN 06:00", reserve participation power is 6 MWh
 	  And in area "AREA", during year 1, for cluster "Hydro" and reserve "Res_2", on "1 JAN 06:00", reserve participation power is 10 MWh
-    And the annual system cost is 2.1504e+06
+    And in area "AREA", during year 1, total reserve participation cost is 436.8 Euro
+    And the annual system cost is 2.1508368e+06
 	
 
 @short
@@ -655,7 +656,7 @@ Scenario: ST_3UP_unavailable_reserves_test3
     And the simulation takes less than 20 seconds
     And in area "AREA", during year 1, for cluster "Hydro" and reserve "Res_1", total reserve participation power is inferior to 1000 MWh
 	  And in area "AREA", during year 1, for cluster "Hydro" and reserve "Res_2", total reserve participation power is 1680 MWh
-    And the annual system cost is 2.15533e+06
+    And the annual system cost is 2.15577e+06
 
 
 @short
@@ -668,7 +669,7 @@ Scenario: ST_3UP_unavailable_reserves_test3
     And the simulation takes less than 20 seconds
     And in area "AREA", during year 1, for cluster "Hydro" and reserve "Res_1", total reserve participation power is 1008 MWh
 	  And in area "AREA", during year 1, for cluster "Hydro" and reserve "Res_2", total reserve participation power is inferior to 1680 MWh
-    And the annual system cost is 2.15718e+06
+    And the annual system cost is 2.15761e+06
 
 @medium
 # Lot 3_1 : intégration des contraintes de symétries

--- a/src/tests/cucumber/features/steps/common_steps/solver_steps.py
+++ b/src/tests/cucumber/features/steps/common_steps/solver_steps.py
@@ -442,6 +442,12 @@ def check_res_participation_for_specific_year_and_cluster_yearly(context, area, 
 def check_res_participation_for_specific_year_and_cluster_yearly_inferior(context, area, year, res, cluster, res_part):
     assert (context.soh.get_reserve_total_participation_for_year_and_cluster(area, year, res,cluster) < res_part)
 
+
+@then('in area "{area}", during year {year:d}, total reserve participation cost is {expected_cost:g} Euro')
+def check_reserve_participation_cost(context, area, year, expected_cost):
+    actual_cost = context.soh.get_reserve_participation_cost(area, year)
+    assert_double_close(expected_cost, actual_cost, 1e-6, "Reserve participation cost")
+
 @step('the message "{log}" is reported in the logs')
 def ckeck_log_exists(context, log):
     for log_line in context.logs_err.splitlines():


### PR DESCRIPTION
### Root cause

`RESERVE PARTICIPATION COST` was being aggregated **too late**.

What happens in the current code path:

- hourly reserve participation costs for
  - thermal,
  - short-term storage,
  - hydro
  are computed during hourly state initialization in `src/solver/variable/state.cpp`
- but the aggregate field used by the output variable:
  - `reserveParticipationCostForYear`
  was only filled later in `State::calculateReserveParticipationCosts()`
- that aggregation happens at **year-end**, while output variables like:
  - `RESERVE PARTICIPATION COST`
  - `OP. COST`
  - `OV. COST`
  consume the hourly aggregate earlier

So the output column stayed at `0`, even though participation powers were non-zero.

There was also a second issue making this worse:
- `yearEndResetThermal()` was recreating `reserveData`, which is area-wide reserve state and should not be reset there.

### Fix applied

I updated:

- `src/solver/variable/state.cpp`
- `src/solver/variable/include/antares/solver/variable/state.hxx`

Changes:
- reserve participation costs are now added **online, hour by hour**, as soon as thermal / ST storage / hydro participation is read
- yearly reserve data is reset at **start of year**, not during thermal year-end processing
- `calculateReserveParticipationCosts()` now recomputes with assignment instead of accumulating again