### PR TITLE
fix: optimize ST output storage

### DIFF
--- a/src/io/outputs/SimulationTable.cpp
+++ b/src/io/outputs/SimulationTable.cpp
@@ -19,9 +19,7 @@ SimulationTable::SimulationTable()
     block_time_index_ = storage_.addOptionalColumn<unsigned int>("block_time_index");
     scenario_index_ = storage_.addIntegralColumn("scenario_index");
     value_ = storage_.addOptionalColumn<double>("value");
-    basis_status_ = storage_
-                      .addOptionalColumn<Antares::Optimisation::LinearProblemApi::MipBasisStatus>(
-                        "basis_status");
+    basis_status_ = storage_.addInternedStringColumn("basis_status");
 }
 
 SimulationTable::SimulationTable(SimulationTable&& other) noexcept = default;
@@ -35,7 +33,7 @@ void SimulationTable::addEntry(const SimulationTableEntry& entry)
     block_time_index_->add(entry.block_time_index);
     scenario_index_->add(entry.scenario_index);
     value_->add(entry.value);
-    basis_status_->add(entry.status);
+    basis_status_->add(StatusToString(entry.status));
 }
 
 const std::vector<std::shared_ptr<IColumn>>& SimulationTable::columns() const

--- a/src/io/outputs/SimulationTable.cpp
+++ b/src/io/outputs/SimulationTable.cpp
@@ -13,8 +13,8 @@ SimulationTable::SimulationTable()
 
 {
     block_ = storage_.addIntegralColumn("block");
-    component_ = storage_.addOptionalColumn<std::string>("component");
-    output_ = storage_.addStringColumn("output");
+    component_ = storage_.addInternedStringColumn("component");
+    output_ = storage_.addInternedStringColumn("output");
     absolute_time_index_ = storage_.addOptionalColumn<unsigned int>("absolute_time_index");
     block_time_index_ = storage_.addOptionalColumn<unsigned int>("block_time_index");
     scenario_index_ = storage_.addIntegralColumn("scenario_index");

--- a/src/io/outputs/include/antares/io/outputs/IColumnAdapterVisitor.h
+++ b/src/io/outputs/include/antares/io/outputs/IColumnAdapterVisitor.h
@@ -19,6 +19,8 @@ namespace Antares::IO::Outputs
 template<typename T>
 class TypedColumn;
 
+class InternedStringColumn;
+
 // Define type aliases
 using StringColumn = TypedColumn<std::string>;
 using IntegralColumn = TypedColumn<unsigned>;
@@ -40,6 +42,7 @@ public:
     virtual std::shared_ptr<IColumnAdapter> visit(const OptionalColumn<std::string>&) = 0;
     virtual std::shared_ptr<IColumnAdapter> visit(const OptionalColumn<double>&) = 0;
     virtual std::shared_ptr<IColumnAdapter> visit(const OptionalColumn<unsigned>&) = 0;
+    virtual std::shared_ptr<IColumnAdapter> visit(const InternedStringColumn&) = 0;
 
     virtual std::shared_ptr<IColumnAdapter>
     visit(const OptionalColumn<Optimisation::LinearProblemApi::MipBasisStatus>&) = 0;

--- a/src/io/outputs/include/antares/io/outputs/IColumnAdapterVisitor.h
+++ b/src/io/outputs/include/antares/io/outputs/IColumnAdapterVisitor.h
@@ -43,8 +43,5 @@ public:
     virtual std::shared_ptr<IColumnAdapter> visit(const OptionalColumn<double>&) = 0;
     virtual std::shared_ptr<IColumnAdapter> visit(const OptionalColumn<unsigned>&) = 0;
     virtual std::shared_ptr<IColumnAdapter> visit(const InternedStringColumn&) = 0;
-
-    virtual std::shared_ptr<IColumnAdapter>
-    visit(const OptionalColumn<Optimisation::LinearProblemApi::MipBasisStatus>&) = 0;
 };
 } // namespace Antares::IO::Outputs

--- a/src/io/outputs/include/antares/io/outputs/SimulationTable.h
+++ b/src/io/outputs/include/antares/io/outputs/SimulationTable.h
@@ -25,8 +25,8 @@ public:
 private:
     ColumnBasedStorage storage_;
     std::shared_ptr<IntegralColumn> block_;
-    std::shared_ptr<OptionalColumn<std::string>> component_;
-    std::shared_ptr<StringColumn> output_;
+    std::shared_ptr<InternedStringColumn> component_;
+    std::shared_ptr<InternedStringColumn> output_;
     std::shared_ptr<OptionalColumn<unsigned int>> absolute_time_index_;
     std::shared_ptr<OptionalColumn<unsigned int>> block_time_index_;
     std::shared_ptr<IntegralColumn> scenario_index_;

--- a/src/io/outputs/include/antares/io/outputs/SimulationTable.h
+++ b/src/io/outputs/include/antares/io/outputs/SimulationTable.h
@@ -31,7 +31,6 @@ private:
     std::shared_ptr<OptionalColumn<unsigned int>> block_time_index_;
     std::shared_ptr<IntegralColumn> scenario_index_;
     std::shared_ptr<OptionalColumn<double>> value_;
-    std::shared_ptr<OptionalColumn<Antares::Optimisation::LinearProblemApi::MipBasisStatus>>
-      basis_status_;
+    std::shared_ptr<InternedStringColumn> basis_status_;
 };
 } // namespace Antares::IO::Outputs

--- a/src/io/outputs/include/antares/io/outputs/columns.h
+++ b/src/io/outputs/include/antares/io/outputs/columns.h
@@ -85,10 +85,6 @@ static std::string FormatValue(const U& v)
     {
         return FromDouble(v);
     }
-    else if constexpr (std::is_same_v<U, Optimisation::LinearProblemApi::MipBasisStatus>)
-    {
-        return StatusToString(v);
-    }
     else if constexpr (is_optional_v<U>)
     {
         return v ? FormatValue(*v) : "None";

--- a/src/io/outputs/include/antares/io/outputs/columns.h
+++ b/src/io/outputs/include/antares/io/outputs/columns.h
@@ -3,8 +3,11 @@
 
 #pragma once
 #include <fmt/format.h>
+#include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "antares/io/outputs/IColumnAdapterVisitor.h"
@@ -142,5 +145,84 @@ public:
 
 private:
     std::vector<T> data_;
+};
+
+// Column of strings with few distinct values (component / output names): each
+// distinct string is stored once in a dictionary and rows only hold a 32-bit
+// index into it, instead of one std::string (and its heap allocation) per row.
+// An absent value (std::nullopt) is encoded as nullIndex.
+class InternedStringColumn final: public IColumn
+{
+public:
+    static constexpr uint32_t nullIndex = std::numeric_limits<uint32_t>::max();
+
+    explicit InternedStringColumn(std::string name):
+        IColumn(name)
+    {
+    }
+
+    void add(const std::string& value)
+    {
+        indices_.push_back(intern(value));
+    }
+
+    void add(const std::optional<std::string>& value)
+    {
+        indices_.push_back(value ? intern(*value) : nullIndex);
+    }
+
+    [[nodiscard]] std::string toString(size_t index) const override
+    {
+        const uint32_t dictionaryIndex = indices_.at(index);
+        return dictionaryIndex == nullIndex ? "None" : dictionary_[dictionaryIndex];
+    }
+
+    [[nodiscard]] size_t size() const override
+    {
+        return indices_.size();
+    }
+
+    void reserve(size_t capacity) override
+    {
+        indices_.reserve(capacity);
+    }
+
+    void clear() override
+    {
+        indices_.clear();
+        dictionary_.clear();
+        lookup_.clear();
+    }
+
+    const std::vector<uint32_t>& indices() const
+    {
+        return indices_;
+    }
+
+    const std::vector<std::string>& dictionary() const
+    {
+        return dictionary_;
+    }
+
+    std::shared_ptr<IColumnAdapter> accept(IColumnAdapterVisitor& visitor) const override
+    {
+        return visitor.visit(*this);
+    }
+
+private:
+    uint32_t intern(const std::string& value)
+    {
+        auto [it, inserted] = lookup_.try_emplace(value,
+                                                  static_cast<uint32_t>(dictionary_.size()));
+        if (inserted)
+        {
+            dictionary_.push_back(value);
+        }
+        return it->second;
+    }
+
+    std::vector<uint32_t> indices_;
+    std::vector<std::string> dictionary_;
+    std::unordered_map<std::string, uint32_t> lookup_;
 };
 } // namespace Antares::IO::Outputs

--- a/src/io/outputs/include/antares/io/outputs/columns.h
+++ b/src/io/outputs/include/antares/io/outputs/columns.h
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #pragma once
-#include <fmt/format.h>
 #include <cstdint>
+#include <fmt/format.h>
 #include <limits>
 #include <optional>
 #include <string>
@@ -212,8 +212,7 @@ public:
 private:
     uint32_t intern(const std::string& value)
     {
-        auto [it, inserted] = lookup_.try_emplace(value,
-                                                  static_cast<uint32_t>(dictionary_.size()));
+        auto [it, inserted] = lookup_.try_emplace(value, static_cast<uint32_t>(dictionary_.size()));
         if (inserted)
         {
             dictionary_.push_back(value);

--- a/src/io/outputs/include/antares/io/outputs/storage.h
+++ b/src/io/outputs/include/antares/io/outputs/storage.h
@@ -19,6 +19,11 @@ public:
         return addColumn<StringColumn>(name);
     }
 
+    std::shared_ptr<InternedStringColumn> addInternedStringColumn(const std::string& name)
+    {
+        return addColumn<InternedStringColumn>(name);
+    }
+
     std::shared_ptr<IntegralColumn> addIntegralColumn(const std::string& name)
     {
         return addColumn<IntegralColumn>(name);

--- a/src/libs/antares/writer/columnToArrowAdapter.cpp
+++ b/src/libs/antares/writer/columnToArrowAdapter.cpp
@@ -119,6 +119,39 @@ std::shared_ptr<arrow::Array> IntColumnAdapter::makeArray() const
 }
 
 // ================================
+// Class InternedStringColumnAdapter
+// ================================
+InternedStringColumnAdapter::InternedStringColumnAdapter(const InternedStringColumn* column):
+    column_(column)
+{
+}
+
+std::shared_ptr<arrow::Field> InternedStringColumnAdapter::makeField() const
+{
+    return arrow::field(column_->name(), arrow::utf8());
+}
+
+std::shared_ptr<arrow::Array> InternedStringColumnAdapter::makeArray() const
+{
+    arrow::StringBuilder builder;
+    const auto& dictionary = column_->dictionary();
+
+    for (const uint32_t index: column_->indices())
+    {
+        if (index == InternedStringColumn::nullIndex)
+        {
+            throwOnStatusKO(builder.AppendNull());
+        }
+        else
+        {
+            throwOnStatusKO(builder.Append(dictionary[index]));
+        }
+    }
+
+    return throwOnResultKO(builder.Finish());
+}
+
+// ================================
 // Class OptStringColumnAdapter
 // ================================
 OptStringColumnAdapter::OptStringColumnAdapter(const OptionalColumn<std::string>* column):
@@ -235,6 +268,11 @@ public:
     std::shared_ptr<IColumnAdapter> visit(const OptionalColumn<std::string>& col) override
     {
         return std::make_shared<OptStringColumnAdapter>(&col);
+    }
+
+    std::shared_ptr<IColumnAdapter> visit(const InternedStringColumn& col) override
+    {
+        return std::make_shared<InternedStringColumnAdapter>(&col);
     }
 
     std::shared_ptr<IColumnAdapter> visit(const OptionalColumn<double>& col) override

--- a/src/libs/antares/writer/columnToArrowAdapter.cpp
+++ b/src/libs/antares/writer/columnToArrowAdapter.cpp
@@ -284,11 +284,6 @@ public:
     {
         return std::make_shared<OptIntColumnAdapter>(&col);
     }
-
-    std::shared_ptr<IColumnAdapter> visit(const OptionalColumn<MipBasisStatus>& col) override
-    {
-        return std::make_shared<OptMipBasisStatusColumnAdapter>(&col);
-    }
 };
 
 std::shared_ptr<IColumnAdapter> makeColumnAdapter(const IColumn& column)

--- a/src/libs/antares/writer/columnToArrowAdapter.h
+++ b/src/libs/antares/writer/columnToArrowAdapter.h
@@ -71,6 +71,20 @@ private:
 };
 
 // ================================
+// Class InternedStringColumnAdapter
+// ================================
+class InternedStringColumnAdapter: public IColumnAdapter
+{
+public:
+    explicit InternedStringColumnAdapter(const IO::Outputs::InternedStringColumn* column);
+    std::shared_ptr<arrow::Field> makeField() const override;
+    std::shared_ptr<arrow::Array> makeArray() const override;
+
+private:
+    const IO::Outputs::InternedStringColumn* column_;
+};
+
+// ================================
 // Class OptStringColumnAdapter
 // ================================
 class OptStringColumnAdapter: public IColumnAdapter

--- a/src/solver/optimisation/LegacyExtraOutputs.cpp
+++ b/src/solver/optimisation/LegacyExtraOutputs.cpp
@@ -86,12 +86,10 @@ public:
         linkNames_.reserve(problemeHebdo.NombreDInterconnexions);
         for (uint32_t interco = 0; interco < problemeHebdo.NombreDInterconnexions; ++interco)
         {
-            const std::string o = problemeHebdo
-                                    .NomsDesPays[problemeHebdo
-                                                   .PaysOrigineDeLInterconnexion[interco]];
-            const std::string d = problemeHebdo
-                                    .NomsDesPays[problemeHebdo
-                                                   .PaysExtremiteDeLInterconnexion[interco]];
+            const std::string o = problemeHebdo.NomsDesPays
+                                    [problemeHebdo.PaysOrigineDeLInterconnexion[interco]];
+            const std::string d = problemeHebdo.NomsDesPays
+                                    [problemeHebdo.PaysExtremiteDeLInterconnexion[interco]];
             const auto& [a1, a2] = (o < d) ? std::tie(o, d) : std::tie(d, o);
             linkNames_.push_back(a1 + "_" + a2 + "_link");
         }

--- a/src/solver/optimisation/LegacyExtraOutputs.cpp
+++ b/src/solver/optimisation/LegacyExtraOutputs.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cmath>
 #include <string>
+#include <vector>
 
 #include "antares/solver/optimisation/opt_structure_probleme_a_resoudre.h"
 #include "antares/solver/optimisation/variables/VariableManagerUtils.h"
@@ -61,6 +62,39 @@ public:
         fillContext_(fillContext),
         block_(currentBlock)
     {
+        // Component names are used for every time step of the week: build them
+        // once instead of re-concatenating them on each hourly call.
+        areaNames_.reserve(problemeHebdo.NombreDePays);
+        hydroStorageNames_.reserve(problemeHebdo.NombreDePays);
+        thermalNames_.reserve(problemeHebdo.NombreDePays);
+        for (uint32_t pays = 0; pays < problemeHebdo.NombreDePays; ++pays)
+        {
+            const std::string area = problemeHebdo.NomsDesPays[pays];
+            areaNames_.push_back(area + "_node");
+            hydroStorageNames_.push_back(area + "_hydro_storage");
+
+            const PALIERS_THERMIQUES& paliers = problemeHebdo.PaliersThermiquesDuPays[pays];
+            auto& clusterNames = thermalNames_.emplace_back();
+            clusterNames.reserve(paliers.NombreDePaliersThermiques);
+            for (int index = 0; index < paliers.NombreDePaliersThermiques; ++index)
+            {
+                clusterNames.push_back(area + "_thermal_"
+                                       + paliers.NomsDesPaliersThermiques[index]);
+            }
+        }
+
+        linkNames_.reserve(problemeHebdo.NombreDInterconnexions);
+        for (uint32_t interco = 0; interco < problemeHebdo.NombreDInterconnexions; ++interco)
+        {
+            const std::string o = problemeHebdo
+                                    .NomsDesPays[problemeHebdo
+                                                   .PaysOrigineDeLInterconnexion[interco]];
+            const std::string d = problemeHebdo
+                                    .NomsDesPays[problemeHebdo
+                                                   .PaysExtremiteDeLInterconnexion[interco]];
+            const auto& [a1, a2] = (o < d) ? std::tie(o, d) : std::tie(d, o);
+            linkNames_.push_back(a1 + "_" + a2 + "_link");
+        }
     }
 
     void areaOutputs(uint32_t pays, int pdt);
@@ -98,6 +132,12 @@ private:
     VariableManagement::VariableManager variableManager_;
     const FillContext& fillContext_;
     unsigned block_;
+
+    // Component names, precomputed once per week (see constructor).
+    std::vector<std::string> areaNames_;
+    std::vector<std::string> hydroStorageNames_;
+    std::vector<std::vector<std::string>> thermalNames_;
+    std::vector<std::string> linkNames_;
 };
 
 void LegacyExtraOutputEmitter::emit(const std::string& output,
@@ -118,7 +158,7 @@ void LegacyExtraOutputEmitter::emit(const std::string& output,
 
 void LegacyExtraOutputEmitter::areaOutputs(uint32_t pays, int pdt)
 {
-    const std::string area = std::string(problemeHebdo_.NomsDesPays[pays]) + "_node";
+    const std::string& area = areaNames_[pays];
 
     const int unsupplied = variableManager_.UnsuppliedEnergy(pays, pdt);
     const int spillage = variableManager_.Spillage(pays, pdt);
@@ -151,8 +191,7 @@ void LegacyExtraOutputEmitter::areaOutputs(uint32_t pays, int pdt)
         return;
     }
     const auto& hydro = problemeHebdo_.CaracteristiquesHydrauliques[pays];
-    const std::string hydroComponent = std::string(problemeHebdo_.NomsDesPays[pays])
-                                       + "_hydro_storage";
+    const std::string& hydroComponent = hydroStorageNames_[pays];
     if (hydro.TailleReservoir > 0.)
     {
         emit("level_percentage", hydroComponent, pdt, x(hydroLevel) / hydro.TailleReservoir * 100.);
@@ -167,10 +206,7 @@ void LegacyExtraOutputEmitter::linkOutputs(uint32_t interco, int pdt)
 {
     const uint32_t origin = problemeHebdo_.PaysOrigineDeLInterconnexion[interco];
     const uint32_t destination = problemeHebdo_.PaysExtremiteDeLInterconnexion[interco];
-    const std::string o = problemeHebdo_.NomsDesPays[origin];
-    const std::string d = problemeHebdo_.NomsDesPays[destination];
-    const auto& [a1, a2] = (o < d) ? std::tie(o, d) : std::tie(d, o);
-    const std::string link = std::string(a1) + "_" + std::string(a2) + "_link";
+    const std::string& link = linkNames_[interco];
 
     const double flow = x(variableManager_.DirectFlow(interco, pdt));
     emit("abs_flow", link, pdt, std::abs(flow));
@@ -213,9 +249,7 @@ void LegacyExtraOutputEmitter::linkOutputs(uint32_t interco, int pdt)
 void LegacyExtraOutputEmitter::thermalOutputs(uint32_t pays, int index, int pdt)
 {
     const PALIERS_THERMIQUES& paliers = problemeHebdo_.PaliersThermiquesDuPays[pays];
-    const std::string& clusterName = paliers.NomsDesPaliersThermiques[index];
-    const std::string cluster = std::string(problemeHebdo_.NomsDesPays[pays]) + "_thermal_"
-                                + clusterName;
+    const std::string& cluster = thermalNames_[pays][static_cast<std::size_t>(index)];
     const int palier = paliers.NumeroDuPalierDansLEnsembleDesPaliersThermiques[index];
 
     const int production = variableManager_.DispatchableProduction(palier, pdt);
@@ -283,7 +317,7 @@ void LegacyExtraOutputEmitter::weeklyHydroOutputs(uint32_t pays) const
     }
     const int pdt = problemeHebdo_.NombreDePasDeTempsPourUneOptimisation - 1;
     emit("hydro_shadow_price",
-         std::string(problemeHebdo_.NomsDesPays[pays]) + "_hydro_storage",
+         hydroStorageNames_[pays],
          pdt,
          dual(problemeHebdo_.NumeroDeContrainteExpressionStockFinal[pays]));
 }


### PR DESCRIPTION
Don't store component name for each cell but use index lookup
[benchmark_report.html](https://github.com/user-attachments/files/30119849/benchmark_report.html)

Study 3 year, 1 weak per year.
antares dev1 (before PR)	--simulation-table	Peak memory **7972**
antares opti-storage	--simulation-table	Peak memory  **6494**	

antares dev1	--simulation-table --parquet	5052
ntares opti-storage	--simulation-table --parquet	3419