### PR TITLE
chore(ci) split short-tests into 3

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -156,12 +156,28 @@ jobs:
         cd _build
         ctest -C Release --output-on-failure -R "^unfeasible$"
 
-    - name: Run short-tests
+    - name: Run short-tests-1
       if: ${{ !cancelled() }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{ env.SIMTEST }}
-        batch-name: short-tests
+        batch-name: short-tests-1
+        os: ${{ env.os }}
+
+    - name: Run short-tests-2
+      if: ${{ !cancelled() }}
+      uses: ./.github/workflows/run-tests
+      with:
+        simtest-tag: ${{ env.SIMTEST }}
+        batch-name: short-tests-2
+        os: ${{ env.os }}
+
+    - name: Run short-tests-3
+      if: ${{ !cancelled() }}
+      uses: ./.github/workflows/run-tests
+      with:
+        simtest-tag: ${{ env.SIMTEST }}
+        batch-name: short-tests-3
         os: ${{ env.os }}
 
     - name: Run tests on adequacy patch (CSR)

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -313,14 +313,29 @@ jobs:
         batch-name: valid-v930
         os: ${{ env.os }}
 
-    - name: Run short-tests
+    - name: Run short-tests-1
       if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{ env.SIMTEST }}
-        batch-name: short-tests
+        batch-name: short-tests-1
         os: ${{ env.os }}
 
+    - name: Run short-tests-2
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+      uses: ./.github/workflows/run-tests
+      with:
+        simtest-tag: ${{ env.SIMTEST }}
+        batch-name: short-tests-2
+        os: ${{ env.os }}
+
+    - name: Run short-tests-3
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+      uses: ./.github/workflows/run-tests
+      with:
+        simtest-tag: ${{ env.SIMTEST }}
+        batch-name: short-tests-3
+        os: ${{ env.os }}
 
     - name: Run mps tests
       if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -288,12 +288,28 @@ jobs:
         batch-name: valid-v930
         os: ${{ env.os }}
 
-    - name: Run short-tests
+    - name: Run short-tests-1
       if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
       uses: ./.github/workflows/run-tests
       with:
         simtest-tag: ${{ env.SIMTEST }}
-        batch-name: short-tests
+        batch-name: short-tests-1
+        os: ${{ env.os }}
+
+    - name: Run short-tests-2
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+      uses: ./.github/workflows/run-tests
+      with:
+        simtest-tag: ${{ env.SIMTEST }}
+        batch-name: short-tests-2
+        os: ${{ env.os }}
+
+    - name: Run short-tests-3
+      if: ${{ env.RUN_SIMPLE_TESTS == 'true' && !cancelled() }}
+      uses: ./.github/workflows/run-tests
+      with:
+        simtest-tag: ${{ env.SIMTEST }}
+        batch-name: short-tests-3
         os: ${{ env.os }}
 
     - name: Run mps tests


### PR DESCRIPTION
TODO before merging this
1. [X] Split short-tests in TNR => https://github.com/AntaresSimulatorTeam/Antares_Simulator_Tests_NR/pull/140
2. [ ] Generate reference results with split short-test. Right now long-tests-{1,2,3} fail probably because of increased RAM usage in ubuntu-22.04