### PR TITLE
fix: adapt tests for basis_status string column change

### DIFF
--- a/src/io/outputs/SimulationTable.cpp
+++ b/src/io/outputs/SimulationTable.cpp
@@ -33,9 +33,8 @@ void SimulationTable::addEntry(const SimulationTableEntry& entry)
     block_time_index_->add(entry.block_time_index);
     scenario_index_->add(entry.scenario_index);
     value_->add(entry.value);
-    basis_status_->add(entry.status.has_value()
-                        ? std::make_optional(StatusToString(entry.status))
-                        : std::nullopt);
+    basis_status_->add(entry.status.has_value() ? std::make_optional(StatusToString(entry.status))
+                                                : std::nullopt);
 }
 
 const std::vector<std::shared_ptr<IColumn>>& SimulationTable::columns() const

--- a/src/io/outputs/SimulationTable.cpp
+++ b/src/io/outputs/SimulationTable.cpp
@@ -33,7 +33,9 @@ void SimulationTable::addEntry(const SimulationTableEntry& entry)
     block_time_index_->add(entry.block_time_index);
     scenario_index_->add(entry.scenario_index);
     value_->add(entry.value);
-    basis_status_->add(StatusToString(entry.status));
+    basis_status_->add(entry.status.has_value()
+                        ? std::make_optional(StatusToString(entry.status))
+                        : std::nullopt);
 }
 
 const std::vector<std::shared_ptr<IColumn>>& SimulationTable::columns() const

--- a/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp
+++ b/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp
@@ -16,6 +16,8 @@
 
 #include "antares/io/outputs/SimulationTable.h"
 
+#include "antares/optimisation/linear-problem-api/hasStatus.h"
+
 #include "private/parquet_table_writer.h"
 
 namespace fs = std::filesystem;
@@ -136,8 +138,8 @@ BOOST_FIXTURE_TEST_CASE(write_SimuTable_then_read_it_back___reading_fits, LocalF
     BOOST_CHECK_EQUAL(value->Value(0), entry.value.value());
 
     // entry : status
-    auto status = getColumn<arrow::Int32Array>(read_table, 7);
-    BOOST_CHECK_EQUAL(status->Value(0), static_cast<unsigned>(entry.status.value()));
+    auto status = getColumn<arrow::StringArray>(read_table, 7);
+    BOOST_CHECK_EQUAL(status->Value(0), StatusToString(entry.status));
 }
 
 BOOST_FIXTURE_TEST_CASE(write_table_with_many_empty_entries_then_read_it_back___read_fits,
@@ -196,7 +198,7 @@ BOOST_FIXTURE_TEST_CASE(write_table_with_many_empty_entries_then_read_it_back___
     BOOST_CHECK(!value->IsValid(0));
 
     // entry : status
-    auto status = getColumn<arrow::Int32Array>(read_table, 7);
+    auto status = getColumn<arrow::StringArray>(read_table, 7);
     BOOST_CHECK(!status->IsValid(0));
 }
 
@@ -267,8 +269,8 @@ BOOST_FIXTURE_TEST_CASE(write_3_lines_table_then_read_it_back___read_fits, Local
     BOOST_CHECK_EQUAL(col_6->Value(2), line_2.value.value());
 
     // column 7 (status):
-    auto col_7 = getColumn<arrow::Int32Array>(read_table, 7);
-    BOOST_CHECK_EQUAL(col_7->Value(0), (unsigned)line_0.status.value());
-    BOOST_CHECK_EQUAL(col_7->Value(1), (unsigned)line_1.status.value());
+    auto col_7 = getColumn<arrow::StringArray>(read_table, 7);
+    BOOST_CHECK_EQUAL(col_7->Value(0), StatusToString(line_0.status));
+    BOOST_CHECK_EQUAL(col_7->Value(1), StatusToString(line_1.status));
     BOOST_CHECK(!col_7->IsValid(2));
 }

--- a/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp
+++ b/src/tests/src/io/outputs/test-parquet-simulation-table-writer.cpp
@@ -15,7 +15,6 @@
 #include <parquet/exception.h>
 
 #include "antares/io/outputs/SimulationTable.h"
-
 #include "antares/optimisation/linear-problem-api/hasStatus.h"
 
 #include "private/parquet_table_writer.h"


### PR DESCRIPTION
## Bug description
Commit 78264d880a changed `basis_status_` from `OptionalColumn<MipBasisStatus>` to `InternedStringColumn`, but the `add()` call always passed a non-null string `StatusToString(entry.status)` returns "None" for `nullopt` instead of a real null.

Tests read column 7 as `Int32Array` and compare numeric enum values, which no longer matches the string-based column.

## Fix

- **SimulationTable.cpp**: Pass `std::optional<std::string>` to `add()` so a `nullopt` status is stored as a true null (via `nullIndex`).
- **Tests**: Read column 7 as `StringArray` and compare with `StatusToString()` results instead of numeric values."