### PR TITLE
[ANT-5179] Update annual costs in reserve cucumber tests

### DIFF
--- a/src/tests/cucumber/features/solver-features/reserves_tests.feature
+++ b/src/tests/cucumber/features/solver-features/reserves_tests.feature
@@ -31,7 +31,7 @@ Feature: reserves tests
     And in area "AREA", during year 1, for cluster "thermal_all_cheap" and reserve "Res_1", reserve participation power is always equal to 20 MWh
     And in area "AREA", during year 1, for cluster "thermal_expensive_prod" and reserve "Res_1", reserve participation power is always equal to 20 MWh
     And in area "AREA", during year 1, for cluster "thermal_expensive_res_part" and reserve "Res_1", reserve participation power is always equal to 0 MWh
-    And the annual system cost is 7.04928e+07
+    And the annual system cost is 7.04995e+07
 
 @short
 # Lot 1 : Intégration de la participation du thermique allumé à des réserves à la baisse
@@ -50,7 +50,7 @@ Feature: reserves tests
     And in area "AREA", during year 1, for cluster "thermal_all_cheap" and reserve "Res_1", reserve participation power is always equal to 20 MWh
     And in area "AREA", during year 1, for cluster "thermal_expensive_prod" and reserve "Res_1", reserve participation power is always equal to 0 MWh
     And in area "AREA", during year 1, for cluster "thermal_expensive_res_part" and reserve "Res_1", reserve participation power is always equal to 0 MWh
-    And the annual system cost is 7.0896e+07
+    And the annual system cost is 7.08994e+07
 
 @short
 # Lot 1 : Intégration de la participation du thermique allumé à des réserves à la hausse et baisse
@@ -77,7 +77,7 @@ Feature: reserves tests
     And in area "AREA", during year 1, for cluster "thermal_expensive_res_part" and reserve "Res_down", reserve participation power is always equal to 0 MWh
 	  And in area "AREA", during year 1, for group "COAL" and reserve "Res_down", reserve participation power is always equal to 0 MWh
 
-    And the annual system cost is 7.35168e+07
+    And the annual system cost is 7.35269e+07
 
 @short
 # Lot 2 : Intégration de la participation du thermique éteint et des stockage CT et LT
@@ -91,7 +91,7 @@ Feature: reserves tests
     And in area "AREA", during year 1, for cluster "thermal1" and reserve "Res_1", participation of off units to the reserve is always equal to 40 MWh
     # OV. Cost = 20 *50+1*40+500*50+3000*10 euros (Prod cluster + Surcoûts réserves + défaillance EOD + défaillance réserves)
     And in area "AREA", overall cost on "1 JAN 06:00" of year 1 is of 56040 Euro 
-    And the annual system cost is 9.408e+06
+    And the annual system cost is 9.41472e+06
 
 @short
 # Lot 2
@@ -109,7 +109,7 @@ Feature: reserves tests
     And in area "AREA", during year 1, for reserve "Res_2", reserve unsupplied power is always equal to 0 MWh
     And in area "AREA", overall cost on "1 JAN 06:00" of year 1 is of 80050 Euro 
     And in area "AREA", unsupplied energy on "2 JAN 09:00" of year 1 is of 100 MW
-    And the annual system cost is 1.344e+07
+    And the annual system cost is 1.34484e+07
 
 #
 # Pour les tests du lot 3 : se référer au document "Schema_de_tests_des_réserves_3_nov_2024.pptx"
@@ -566,7 +566,7 @@ Feature: reserves tests
     And the simulation takes less than 20 seconds
     And in area "AREA", during year 1, for cluster "st1" and reserve "Res_1", total reserve participation power is 33400 MWh
     And in area "AREA", battery level on "1 JAN 06:00" of year 1 is 0 MWh
-    And the annual system cost is 3.02e+06
+    And the annual system cost is 3.521e+06
     And in area "AREA", during year 1, loss of load lasts 3 hours
 
 @short
@@ -586,7 +586,7 @@ Feature: reserves tests
     And in area "AREA", during year 1, for cluster "st1" and reserve "Res_1", on "1 JAN 06:00", reserve participation power is 0 MWh
     And in area "AREA", battery level on "1 JAN 06:00" of year 1 is 0 MWh
     And in area "AREA", battery level on "1 JAN 10:00" of year 1 is 200 MWh
-    And the annual system cost is 3.08e+06
+    And the annual system cost is 3.572e+06
     And in area "AREA", during year 1, loss of load lasts 3 hours
 
 @short
@@ -606,7 +606,7 @@ Scenario: ST_3UP_unavailable_reserves_test3
     And in area "AREA", during year 1, for cluster "st1" and reserve "Res_1", on "1 JAN 06:00", reserve participation power is 0 MWh
     And in area "AREA", battery level on "1 JAN 06:00" of year 1 is 0 MWh
     And in area "AREA", battery level on "1 JAN 10:00" of year 1 is 200 MWh
-    And the annual system cost is 3.08e+06
+    And the annual system cost is 3.572e+06
     And in area "AREA", during year 1, loss of load lasts 3 hours
 
 @short
@@ -627,7 +627,7 @@ Scenario: ST_3UP_unavailable_reserves_test3
     And in area "AREA", during year 1, for cluster "st1" and reserve "Res_1", on "1 JAN 06:00", reserve participation power is 0 MWh
     And in area "AREA", battery level on "1 JAN 06:00" of year 1 is 0 MWh
     And in area "AREA", battery level on "1 JAN 10:00" of year 1 is 200 MWh
-    And the annual system cost is 6.44e+06
+    And the annual system cost is 6.686e+06
     And in area "AREA", during year 1, loss of load lasts 3 hours
 
 @short


### PR DESCRIPTION
OV COST = SOME COST + RES PARTICIPATION COST

There was a bug before that lead to RES PARTICIPATION COST being computed to 0. Since we fixed this bug, we also need to update the reference OV COST.