### PR TITLE
Remove SHARED simulation-table-writers, export symbols, etc.

### DIFF
--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -9,6 +9,7 @@ on:
     - dependabot/*
     - release/*
     - copilot/*
+    - fix/rm-shared # TODO remove
   schedule:
   - cron: '21 2 * * *'
   workflow_call:

--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -9,7 +9,6 @@ on:
     - dependabot/*
     - release/*
     - copilot/*
-    - fix/rm-shared # TODO remove
   schedule:
   - cron: '21 2 * * *'
   workflow_call:

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -82,7 +82,6 @@ target_link_libraries(single_problem_api
 add_executable(antares-problem-generator main.cpp)
 target_link_libraries(antares-problem-generator
 	single_problem_api)
-copy_project_shared_lib(simulation-table-writers antares-problem-generator)
 
 install(DIRECTORY include/antares
         DESTINATION "include")

--- a/src/cmake/utils.cmake
+++ b/src/cmake/utils.cmake
@@ -18,19 +18,6 @@ macro(copy_dependency deps target)
 
 endmacro()
 
-# Copy a project-built shared library (e.g. parquet_writer) next to a consuming
-# executable so it can be found at runtime on Windows. Unlike copy_dependency(),
-# this works with non-IMPORTED targets using $<TARGET_FILE:...> generator expressions.
-macro(copy_project_shared_lib shared_lib target)
-    if (MSVC)
-        add_custom_command(TARGET ${target} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                $<TARGET_FILE:${shared_lib}>
-                $<TARGET_FILE_DIR:${target}>
-        )
-    endif ()
-endmacro()
-
 function(get_linux_lsb_release_information)
     find_program(LSB_RELEASE_EXEC lsb_release)
     if (NOT LSB_RELEASE_EXEC)

--- a/src/libs/antares/writer/CMakeLists.txt
+++ b/src/libs/antares/writer/CMakeLists.txt
@@ -1,34 +1,17 @@
 project(result-writer)
 
-include(GenerateExportHeader)
-
 find_package(Parquet REQUIRED)
 find_package(Arrow REQUIRED)
 
-add_library(simulation-table-writers SHARED
+add_library(simulation-table-writers
         LegacySimulationTablesWriter.cpp
         include/antares/writer/simulation_table_writer.h
         private/parquet_arrow_utils.h
         columnToArrowAdapter.cpp
-        simulation_table_writer.cpp
-)
-
-generate_export_header(simulation-table-writers
-    BASE_NAME SIMULATION_TABLE_WRITERS
-    EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/simulation-table-writers_export.h"
-)
-
-set_target_properties(simulation-table-writers PROPERTIES
-    VISIBILITY_INLINES_HIDDEN YES
-)
-
-set_target_properties(simulation-table-writers PROPERTIES
-    WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
+        simulation_table_writer.cpp)
 
 target_include_directories(simulation-table-writers
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>  # For the generated simulation-table-writers_export.h
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/private
@@ -38,10 +21,6 @@ target_link_libraries(simulation-table-writers
   PUBLIC
   Antares::simulation-table
   Antares::exception
-  # Arrow/Parquet must be PUBLIC so their symbols are exported from the .so.
-  # This lets consumers (e.g. test executables) resolve Arrow/Parquet symbols
-  # transitively without duplicating the static library's global objects,
-  # which would cause double-free at program exit.
   "$<IF:$<BOOL:${ARROW_BUILD_STATIC}>,Arrow::arrow_static,Arrow::arrow_shared>"
   "$<IF:$<BOOL:${ARROW_BUILD_STATIC}>,Parquet::parquet_static,Parquet::parquet_shared>")
 
@@ -66,7 +45,6 @@ add_library(Antares::result_writer ALIAS result_writer)
 target_include_directories(result_writer
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>  # For the generated simulation-table-writers_export.h
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/private
 )
@@ -94,6 +72,3 @@ install(DIRECTORY include/antares
         DESTINATION "include"
 )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/simulation-table-writers_export.h"
-        DESTINATION "include/antares/writer"
-)

--- a/src/libs/antares/writer/include/antares/writer/LegacySimulationTablesWriter.h
+++ b/src/libs/antares/writer/include/antares/writer/LegacySimulationTablesWriter.h
@@ -8,12 +8,12 @@
 #include "antares/io/outputs/OptimisationsSimulationTable.h"
 #include "antares/io/outputs/SimulationTable.h"
 
-#include "simulation-table-writers_export.h"
+#include "simulation_table_writer.h"
 #include "table_format.h"
 
 namespace Antares::Writer
 {
-class SIMULATION_TABLE_WRITERS_EXPORT LegacySimulationTablesWriter
+class LegacySimulationTablesWriter
 {
 public:
     LegacySimulationTablesWriter(const std::filesystem::path& folder,

--- a/src/libs/antares/writer/include/antares/writer/simulation_table_writer.h
+++ b/src/libs/antares/writer/include/antares/writer/simulation_table_writer.h
@@ -5,7 +5,6 @@
 
 #include <filesystem>
 
-#include "simulation-table-writers_export.h"
 #include "table_format.h"
 
 namespace Antares::IO::Outputs
@@ -16,7 +15,7 @@ class SimulationTable;
 namespace Antares::Writer
 {
 
-class SIMULATION_TABLE_WRITERS_EXPORT SimulationTableWriter final
+class SimulationTableWriter final
 {
 public:
     SimulationTableWriter(const std::filesystem::path& filePath, TableFormat tableFormat);

--- a/src/modeler/CMakeLists.txt
+++ b/src/modeler/CMakeLists.txt
@@ -24,7 +24,6 @@ import_std_libs(antares-modeler)
 executable_strip(antares-modeler)
 
 copy_dependency(sirius_solver antares-modeler)
-copy_project_shared_lib(simulation-table-writers antares-modeler)
 
 install(TARGETS antares-modeler EXPORT antares-modeler DESTINATION bin)
 

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -104,7 +104,6 @@ import_std_libs(antares-solver)
 executable_strip(antares-solver)
 
 copy_dependency(sirius_solver antares-solver)
-copy_project_shared_lib(simulation-table-writers antares-solver)
 
 #TODO : not working inside macro
 install(TARGETS antares-solver EXPORT antares-solver DESTINATION bin)

--- a/src/tests/src/io/outputs/CMakeLists.txt
+++ b/src/tests/src/io/outputs/CMakeLists.txt
@@ -31,8 +31,6 @@ add_boost_test(testOutputs
 target_compile_definitions(testOutputs PRIVATE
         RESOURCES_DIR="${CMAKE_SOURCE_DIR}/resources"
 )
-
-copy_project_shared_lib(Antares::simulation-table-writers testOutputs)
 # ---------------------------------------
 # test-parquet-simulation-table-writer
 # ---------------------------------------
@@ -47,7 +45,3 @@ add_boost_test(test-parquet-simulation-table-writer
         # gp : headers from target "simulation-table-writers" are needed to compile "test-parquet-simulation-table-writer"
         # gp : but they can't be located by this target, so we add the following instruction.
         "${CMAKE_SOURCE_DIR}/src/libs/antares/writer")
-
-copy_project_shared_lib(Antares::simulation-table-writers test-parquet-simulation-table-writer)
-
-copy_project_shared_lib(simulation-table-writers testOutputs)

--- a/src/tools/batchrun/CMakeLists.txt
+++ b/src/tools/batchrun/CMakeLists.txt
@@ -53,5 +53,4 @@ target_link_libraries(${execname}
 
 import_std_libs(${execname})
 executable_strip(${execname})
-copy_project_shared_lib(simulation-table-writers ${execname})
 

--- a/src/tools/config/CMakeLists.txt
+++ b/src/tools/config/CMakeLists.txt
@@ -48,4 +48,4 @@ target_link_libraries(${execname}
 
 import_std_libs(${execname})
 executable_strip(${execname})
-copy_project_shared_lib(simulation-table-writers ${execname})
+

--- a/src/tools/finder/CMakeLists.txt
+++ b/src/tools/finder/CMakeLists.txt
@@ -40,5 +40,3 @@ target_link_libraries(${execname}
 
 import_std_libs(${execname})
 executable_strip(${execname})
-copy_project_shared_lib(simulation-table-writers ${execname})
-

--- a/src/tools/vacuum/CMakeLists.txt
+++ b/src/tools/vacuum/CMakeLists.txt
@@ -48,4 +48,4 @@ target_link_libraries(${execname}
 
 import_std_libs(${execname})
 executable_strip(${execname})
-copy_project_shared_lib(simulation-table-writers ${execname})
+

--- a/src/tools/yby-aggregator/CMakeLists.txt
+++ b/src/tools/yby-aggregator/CMakeLists.txt
@@ -68,5 +68,3 @@ target_link_libraries(${execname}
 
 import_std_libs(${execname})
 executable_strip(${execname})
-copy_project_shared_lib(simulation-table-writers ${execname})
-


### PR DESCRIPTION
Having SHARED `simulation-table-writers` causes double free errors because of static symbols. We try to have it as a static library instead (the default)

## Before
<img width="355" height="249" alt="image" src="https://github.com/user-attachments/assets/22d37074-60d4-4d99-ba95-7cc1338ba4d6" />

## After
<img width="355" height="249" alt="image" src="https://github.com/user-attachments/assets/a995e54f-4423-4039-ad33-ab205167e862" />