### PR TITLE
Add const correctness to AreaList and simulation functions

### DIFF
--- a/src/libs/antares/study/area/list.cpp
+++ b/src/libs/antares/study/area/list.cpp
@@ -1205,7 +1205,7 @@ void AreaList::updateNameIDSet() const
     }
 }
 
-Area::ScratchMap AreaList::buildScratchMap(uint numspace)
+Area::ScratchMap AreaList::buildScratchMap(uint numspace) const
 {
     Area::ScratchMap scratchmap;
     each([&scratchmap, &numspace](Area& a) { scratchmap.try_emplace(&a, a.scratchpad[numspace]); });

--- a/src/libs/antares/study/include/antares/study/area/area.h
+++ b/src/libs/antares/study/include/antares/study/area/area.h
@@ -438,7 +438,7 @@ public:
     //@{
 
     /// create a map with the corresponding scratchpad for each area link to this numspace
-    Area::ScratchMap buildScratchMap(uint numspace);
+    Area::ScratchMap buildScratchMap(uint numspace) const;
 
     /*!
     ** \brief Update the name id set

--- a/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
@@ -751,6 +751,6 @@ public:
 };
 
 // Import functions for capacity and hydro reserves
-void importCapacityReservations(Antares::Data::AreaList& areas, PROBLEME_HEBDO& problem);
-void importHydroReserves(Antares::Data::AreaList& areas, PROBLEME_HEBDO& problem);
+void importCapacityReservations(const Antares::Data::AreaList& areas, PROBLEME_HEBDO& problem);
+void importHydroReserves(const Antares::Data::AreaList& areas, PROBLEME_HEBDO& problem);
 #endif

--- a/src/solver/simulation/include/antares/solver/simulation/simulation.h
+++ b/src/solver/simulation/include/antares/solver/simulation/simulation.h
@@ -22,7 +22,7 @@ void SIM_AllocationProblemeHebdo(const Antares::Data::Study& study,
 /*!
 ** \brief Alloue et initialise un probleme hebdo
 */
-void SIM_InitialisationProblemeHebdo(Antares::Data::Study& study,
+void SIM_InitialisationProblemeHebdo(const Antares::Data::Study& study,
                                      PROBLEME_HEBDO& problem,
                                      unsigned int NombreDePasDeTemps,
                                      uint numspace);

--- a/src/solver/simulation/sim_calcul_economique.cpp
+++ b/src/solver/simulation/sim_calcul_economique.cpp
@@ -21,14 +21,14 @@ using namespace Antares::Data;
 
 constexpr double LEVEL_TOLERANCE_MWH = 1.e-6;
 
-void importCapacityReservations(AreaList& areas, PROBLEME_HEBDO& problem)
+void importCapacityReservations(const AreaList& areas, PROBLEME_HEBDO& problem)
 {
     int globalReserveIndex = 0;
     problem.allReserves = std::vector<::AREA_RESERVES_VECTOR>(areas.size());
     for (uint areaIndex = 0; areaIndex != areas.size(); areaIndex++)
     {
         int areaReserveIndex = 0;
-        auto area = areas[areaIndex];
+        const auto* area = areas[areaIndex];
         auto& areaReserves = problem.allReserves.value()[areaIndex];
         for (auto type: {ReserveType::DOWN, ReserveType::UP})
         {
@@ -64,8 +64,8 @@ void importCapacityReservations(AreaList& areas, PROBLEME_HEBDO& problem)
     }
 }
 
-static void importShortTermStorages(Data::Parameters parameters,
-                                    AreaList& areas,
+static void importShortTermStorages(const Data::Parameters parameters,
+                                    const AreaList& areas,
                                     std::vector<::AREA_INPUT>& ShortTermStorageOut,
                                     PROBLEME_HEBDO& problem)
 {
@@ -190,7 +190,7 @@ static void importShortTermStorages(Data::Parameters parameters,
     }
 }
 
-void importHydroReserves(AreaList& areas, PROBLEME_HEBDO& problem)
+void importHydroReserves(const AreaList& areas, PROBLEME_HEBDO& problem)
 {
     int globalReserveIndex = 0;
     int globalHydroParticipationIndex = 0;
@@ -198,7 +198,7 @@ void importHydroReserves(AreaList& areas, PROBLEME_HEBDO& problem)
     {
         int areaReserveIndex = 0;
         int areaClusterParticipationIndex = 0;
-        auto area = areas[areaIndex];
+        const auto* area = areas[areaIndex];
         auto& hydro = area->hydro;
 
         if (area->allCapacityReservations && hydro.reserveParticipationContainer)
@@ -253,14 +253,14 @@ void importHydroReserves(AreaList& areas, PROBLEME_HEBDO& problem)
     }
 }
 
-void SIM_InitialisationProblemeHebdo(Study& study,
+void SIM_InitialisationProblemeHebdo(const Study& study,
                                      PROBLEME_HEBDO& problem,
                                      unsigned int NombreDePasDeTemps,
                                      uint numspace)
 {
     int NombrePaliers;
 
-    auto& parameters = study.parameters;
+    const auto& parameters = study.parameters;
 
     // For hybrid studies
     problem.modelerData = study.getModelerData();


### PR DESCRIPTION
This PR adds `const` correctness across several areas of the codebase:

- **`AreaList::buildScratchMap`**: Marked as `const` since it does not modify the object
- **`importCapacityReservations` / `importHydroReserves`**: Parameters changed from `AreaList&` to `const AreaList&` as these functions only read from areas
- **`SIM_InitialisationProblemeHebdo`**: Study parameter changed to `const Study&` since it only reads study data

These changes improve API safety by making it clear which functions are non-mutating and allowing them to be called with const references.