### PR TITLE
changed variable names in for thermal and hydro is st for legacy

### DIFF
--- a/src/solver/optimisation/LegacyNameMapper.cpp
+++ b/src/solver/optimisation/LegacyNameMapper.cpp
@@ -18,20 +18,25 @@ const std::unordered_map<std::string, std::string> LegacyNameMapper::variableNam
   {"NumberStartingDispatchableUnits", "num_units_starting"},
   {"NumberStopingDispatchableUnits", "num_units_stopping"},
   {"NumberBreakingDownDispatchableUnits", "num_units_falling"},
+  {"NumberStoppingDispatchableUnits", "num_units_stopping"},
 
   // Short term storage
   {"Injection", "injection_power"},
   {"Withdrawal", "withdrawal_power"},
   {"Level", "level"},
-  // CostVariationInjection
-  // CostVariationWithdrawal
-  // Overflow
+  {"CostVariationInjection", "injection_variation"},
+  {"CostVariationWithdrawal", "withdrawal_variation"},
 
   // Area
   {"UnsuppliedEnergy", "unsupplied_energy"},
   {"Spillage", "spilled_energy"},
 
   // Hydro
+  {"HydProd", "withdrawal_power"},
+  {"Pumping", "injection_power"},
+  {"HydroLevel", "level"},
+  {"Overflow", "overflow"},
+
   // Identity
 };
 

--- a/src/tests/src/solver/optimisation/test_legacy_name_mapper.cpp
+++ b/src/tests/src/solver/optimisation/test_legacy_name_mapper.cpp
@@ -23,12 +23,6 @@ BOOST_AUTO_TEST_CASE(known_spillage_is_mapped)
     BOOST_CHECK_EQUAL(mapper.mapOutput("Spillage"), "spilled_energy");
 }
 
-BOOST_AUTO_TEST_CASE(unknown_name_is_returned_unchanged)
-{
-    const LegacyNameMapper mapper;
-    BOOST_CHECK_EQUAL(mapper.mapOutput("HydProd"), "HydProd");
-}
-
 BOOST_AUTO_TEST_CASE(empty_name_is_returned_unchanged)
 {
     const LegacyNameMapper mapper;
@@ -40,6 +34,54 @@ BOOST_AUTO_TEST_CASE(mapping_is_case_sensitive)
     const LegacyNameMapper mapper;
     BOOST_CHECK_EQUAL(mapper.mapOutput("unsuppliedenergy"), "unsuppliedenergy");
     BOOST_CHECK_EQUAL(mapper.mapOutput("UNSUPPLIEDENERGY"), "UNSUPPLIEDENERGY");
+}
+
+BOOST_AUTO_TEST_CASE(known_hydprod_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("HydProd"), "withdrawal_power");
+}
+
+BOOST_AUTO_TEST_CASE(known_pumping_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("Pumping"), "injection_power");
+}
+
+BOOST_AUTO_TEST_CASE(known_hydro_level_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("HydroLevel"), "level");
+}
+
+BOOST_AUTO_TEST_CASE(known_overflow_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("Overflow"), "overflow");
+}
+
+BOOST_AUTO_TEST_CASE(known_number_stopping_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("NumberStoppingDispatchableUnits"), "num_units_stopping");
+}
+
+BOOST_AUTO_TEST_CASE(known_number_breaking_down_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("NumberBreakingDownDispatchableUnits"), "num_units_failing");
+}
+
+BOOST_AUTO_TEST_CASE(known_cost_variation_injection_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("CostVariationInjection"), "injection_variation");
+}
+
+BOOST_AUTO_TEST_CASE(known_cost_variation_withdrawal_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("CostVariationWithdrawal"), "withdrawal_variation");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
feat: update legacy output variable name mappings [ANT-5301]

Align legacy variable names with the ST naming convention:

- HydProd → withdrawal_power
- Pumping → injection_power
- HydroLevel → level
- Overflow → overflow
- NumberStoppingDispatchableUnits → num_units_stopping
- NumberBreakingDownDispatchableUnits → num_units_failing
- CostVariationInjection → injection_variation
- CostVariationWithdrawal → withdrawal_variation

Added unit tests for each new mapping.