### PR TITLE
changed variable names in for thermal and hydro is st for legacy

### DIFF
--- a/docs/user-guide/modeler/03-outputs.md
+++ b/docs/user-guide/modeler/03-outputs.md
@@ -102,21 +102,27 @@ is not part of the mapping is written to the `output` column unchanged.
 
 Currently mapped names, grouped by domain:
 
-| Domain             | Legacy variable name                  | `output` value       |
-|--------------------|---------------------------------------|----------------------|
-| Link               | `DirectFlow`                          | `flow`               |
-| Link               | `PositiveDirectFlow`                  | `direct_flow`        |
-| Link               | `PositiveIndirectFlow`                | `indirect_flow`      |
-| Thermal            | `DispatchableProduction`              | `generation_power`   |
-| Thermal            | `NODU`                                | `num_units_on`       |
-| Thermal            | `NumberStartingDispatchableUnits`     | `num_units_starting` |
-| Thermal            | `NumberStopingDispatchableUnits`      | `num_units_stopping` |
-| Thermal            | `NumberBreakingDownDispatchableUnits` | `num_units_failing`  |
-| Short term storage | `Injection`                           | `injection_power`    |
-| Short term storage | `Withdrawal`                          | `withdrawal_power`   |
-| Short term storage | `Level`                               | `level`              |
-| Area               | `UnsuppliedEnergy`                    | `unsupplied_energy`  |
-| Area               | `Spillage`                            | `spilled_energy`     |
+| Domain             | Legacy variable name                  | `output` value        |
+|--------------------|---------------------------------------|-----------------------|
+| Link               | `DirectFlow`                          | `flow`                |
+| Link               | `PositiveDirectFlow`                  | `direct_flow`         |
+| Link               | `PositiveIndirectFlow`                | `indirect_flow`       |
+| Thermal            | `DispatchableProduction`              | `generation_power`    |
+| Thermal            | `NODU`                                | `num_units_on`        |
+| Thermal            | `NumberStartingDispatchableUnits`     | `num_units_starting`  |
+| Thermal            | `NumberStopingDispatchableUnits`      | `num_units_stopping`  |
+| Thermal            | `NumberBreakingDownDispatchableUnits` | `num_units_failing`   |
+| Short term storage | `Injection`                           | `injection_power`     |
+| Short term storage | `Withdrawal`                          | `withdrawal_power`    |
+| Short term storage | `Level`                               | `level`               |
+| Short term storage | `CostVariationInjection`              | `injection_variation` |
+| Short term storage | `CostVariationWithdrawal`             | `withdrawal_variation`|
+| Area               | `UnsuppliedEnergy`                    | `unsupplied_energy`   |
+| Area               | `Spillage`                            | `spilled_energy`      |
+| Hydro              | `HydProd`                             | `withdrawal_power`    |
+| Hydro              | `Pumping`                             | `injection_power`     |
+| Hydro              | `HydroLevel`                          | `level`               |
+| Hydro              | `Overflow`                            | `overflow`            |
 
 This mapping only affects how legacy variables are labelled in the simulation table; it does not change
 the values nor the structure of the output. The mapping is gradually extended as more legacy variables

--- a/docs/user-guide/modeler/03-outputs.md
+++ b/docs/user-guide/modeler/03-outputs.md
@@ -110,7 +110,7 @@ Currently mapped names, grouped by domain:
 | Thermal            | `DispatchableProduction`              | `generation_power`    |
 | Thermal            | `NODU`                                | `num_units_on`        |
 | Thermal            | `NumberStartingDispatchableUnits`     | `num_units_starting`  |
-| Thermal            | `NumberStopingDispatchableUnits`      | `num_units_stopping`  |
+| Thermal            | `NumberStoppingDispatchableUnits`     | `num_units_stopping`  |
 | Thermal            | `NumberBreakingDownDispatchableUnits` | `num_units_failing`   |
 | Short term storage | `Injection`                           | `injection_power`     |
 | Short term storage | `Withdrawal`                          | `withdrawal_power`    |

--- a/src/solver/optimisation/LegacyNameMapper.cpp
+++ b/src/solver/optimisation/LegacyNameMapper.cpp
@@ -16,22 +16,26 @@ const std::unordered_map<std::string, std::string> LegacyNameMapper::variableNam
   {"DispatchableProduction", "generation_power"},
   {"NODU", "num_units_on"},
   {"NumberStartingDispatchableUnits", "num_units_starting"},
-  {"NumberStopingDispatchableUnits", "num_units_stopping"},
   {"NumberBreakingDownDispatchableUnits", "num_units_failing"},
+  {"NumberStoppingDispatchableUnits", "num_units_stopping"},
 
   // Short term storage
   {"Injection", "injection_power"},
   {"Withdrawal", "withdrawal_power"},
   {"Level", "level"},
-  // CostVariationInjection
-  // CostVariationWithdrawal
-  // Overflow
+  {"CostVariationInjection", "injection_variation"},
+  {"CostVariationWithdrawal", "withdrawal_variation"},
 
   // Area
   {"UnsuppliedEnergy", "unsupplied_energy"},
   {"Spillage", "spilled_energy"},
 
   // Hydro
+  {"HydProd", "withdrawal_power"},
+  {"Pumping", "injection_power"},
+  {"HydroLevel", "level"},
+  {"Overflow", "overflow"},
+
   // Identity
 };
 

--- a/src/tests/src/solver/optimisation/test_legacy_name_mapper.cpp
+++ b/src/tests/src/solver/optimisation/test_legacy_name_mapper.cpp
@@ -84,4 +84,64 @@ BOOST_AUTO_TEST_CASE(known_cost_variation_withdrawal_is_mapped)
     BOOST_CHECK_EQUAL(mapper.mapOutput("CostVariationWithdrawal"), "withdrawal_variation");
 }
 
+BOOST_AUTO_TEST_CASE(known_direct_flow_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("DirectFlow"), "flow");
+}
+
+BOOST_AUTO_TEST_CASE(known_positive_direct_flow_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("PositiveDirectFlow"), "direct_flow");
+}
+
+BOOST_AUTO_TEST_CASE(known_positive_indirect_flow_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("PositiveIndirectFlow"), "indirect_flow");
+}
+
+BOOST_AUTO_TEST_CASE(known_dispatachable_production_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("DispatchableProduction"), "generation_power");
+}
+
+BOOST_AUTO_TEST_CASE(known_nodu_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("NODU"), "num_units_on");
+}
+
+BOOST_AUTO_TEST_CASE(known_number_starting_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("NumberStartingDispatchableUnits"), "num_units_starting");
+}
+
+BOOST_AUTO_TEST_CASE(known_injection_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("Injection"), "injection_power");
+}
+
+BOOST_AUTO_TEST_CASE(known_withdrawal_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("Withdrawal"), "withdrawal_power");
+}
+
+BOOST_AUTO_TEST_CASE(known_level_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("Level"), "level");
+}
+
+BOOST_AUTO_TEST_CASE(unknown_name_is_returned_unchanged)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("SomeUnknownVariable"), "SomeUnknownVariable");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/optimisation/test_legacy_name_mapper.cpp
+++ b/src/tests/src/solver/optimisation/test_legacy_name_mapper.cpp
@@ -23,12 +23,6 @@ BOOST_AUTO_TEST_CASE(known_spillage_is_mapped)
     BOOST_CHECK_EQUAL(mapper.mapOutput("Spillage"), "spilled_energy");
 }
 
-BOOST_AUTO_TEST_CASE(unknown_name_is_returned_unchanged)
-{
-    const LegacyNameMapper mapper;
-    BOOST_CHECK_EQUAL(mapper.mapOutput("HydProd"), "HydProd");
-}
-
 BOOST_AUTO_TEST_CASE(empty_name_is_returned_unchanged)
 {
     const LegacyNameMapper mapper;
@@ -40,6 +34,54 @@ BOOST_AUTO_TEST_CASE(mapping_is_case_sensitive)
     const LegacyNameMapper mapper;
     BOOST_CHECK_EQUAL(mapper.mapOutput("unsuppliedenergy"), "unsuppliedenergy");
     BOOST_CHECK_EQUAL(mapper.mapOutput("UNSUPPLIEDENERGY"), "UNSUPPLIEDENERGY");
+}
+
+BOOST_AUTO_TEST_CASE(known_hydprod_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("HydProd"), "withdrawal_power");
+}
+
+BOOST_AUTO_TEST_CASE(known_pumping_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("Pumping"), "injection_power");
+}
+
+BOOST_AUTO_TEST_CASE(known_hydro_level_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("HydroLevel"), "level");
+}
+
+BOOST_AUTO_TEST_CASE(known_overflow_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("Overflow"), "overflow");
+}
+
+BOOST_AUTO_TEST_CASE(known_number_stopping_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("NumberStoppingDispatchableUnits"), "num_units_stopping");
+}
+
+BOOST_AUTO_TEST_CASE(known_number_breaking_down_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("NumberBreakingDownDispatchableUnits"), "num_units_failing");
+}
+
+BOOST_AUTO_TEST_CASE(known_cost_variation_injection_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("CostVariationInjection"), "injection_variation");
+}
+
+BOOST_AUTO_TEST_CASE(known_cost_variation_withdrawal_is_mapped)
+{
+    const LegacyNameMapper mapper;
+    BOOST_CHECK_EQUAL(mapper.mapOutput("CostVariationWithdrawal"), "withdrawal_variation");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
fix: update legacy output variable name mappings [ANT-5301]

Align legacy variable names with the ST naming convention:

- HydProd → withdrawal_power
- Pumping → injection_power
- HydroLevel → level
- Overflow → overflow
- NumberStoppingDispatchableUnits → num_units_stopping
- NumberBreakingDownDispatchableUnits → num_units_failing
- CostVariationInjection → injection_variation
- CostVariationWithdrawal → withdrawal_variation

Added unit tests for each new mapping.