### PR TITLE
Fix: boost set to config dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ if (${BUILD_MERSENNE_TWISTER_PYBIND11})
 endif ()
 
 #Boost header libraries
-find_package(Boost REQUIRED)
+find_package(Boost CONFIG REQUIRED)
 
 find_package(antlr4-runtime REQUIRED)
 find_package(yaml-cpp REQUIRED)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(solver_api
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>
 )
 
-find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(Boost CONFIG REQUIRED COMPONENTS iostreams)
 target_link_libraries(solver_api
         PRIVATE
         Antares::concurrency

--- a/src/api_client_example/CMakeLists.txt
+++ b/src/api_client_example/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD 20)
 find_package(antlr4-runtime REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(fmt REQUIRED)
-find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(Boost CONFIG REQUIRED COMPONENTS iostreams)
 
 
 add_subdirectory(src)

--- a/src/api_client_example/tests/CMakeLists.txt
+++ b/src/api_client_example/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost CONFIG COMPONENTS unit_test_framework REQUIRED)
 
 add_executable(test_client)
 

--- a/src/io/inputs/data-series-csv-importer/CMakeLists.txt
+++ b/src/io/inputs/data-series-csv-importer/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(data-series-csv-importer
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(Boost CONFIG REQUIRED COMPONENTS iostreams)
 # Link dependencies
 target_link_libraries(data-series-csv-importer
         PUBLIC

--- a/src/packaging/Config.cmake.in
+++ b/src/packaging/Config.cmake.in
@@ -55,7 +55,7 @@ find_dependency(antlr4-runtime REQUIRED)
 find_dependency(fmt REQUIRED)
 find_dependency(Arrow REQUIRED)
 find_dependency(Parquet REQUIRED)
-find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(Boost CONFIG REQUIRED COMPONENTS iostreams)
 include("${CMAKE_CURRENT_LIST_DIR}/AntaresTargets.cmake")
 
 check_required_components(Antares)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(unit_tests_antares VERSION 1.0)
 
-find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+find_package(Boost CONFIG COMPONENTS unit_test_framework REQUIRED)
 
 # Make found targets globally available.
 if (Boost_FOUND)


### PR DESCRIPTION
Starting from version 9.13, OR-Tools added Boost as a dependency.

To avoid conflicts with OR-Tools's boost-1.87 by using `find_package` in CONFIG mode. It should also fix the occasional conflict with system's boost.

https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure