### PR TITLE
fixed race condition in tests-simle-study

### DIFF
--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -280,6 +280,7 @@ void TestingSimulationObserver::notifyHebdoProblem(const PROBLEME_HEBDO& problem
                                                    int optimizationNumber,
                                                    std::string_view name)
 {
+    std::lock_guard<std::mutex> lock(mutex);
     auto* pb = problemeHebdo.ProblemeAResoudre.get();
     std::string nameStr(name.begin(), name.end());
     auto& toInsert = problems[std::make_pair(optimizationNumber, nameStr)];

--- a/src/tests/inmemory-study/include/in-memory-study.h
+++ b/src/tests/inmemory-study/include/in-memory-study.h
@@ -4,6 +4,7 @@
 #pragma once
 #define WIN32_LEAN_AND_MEAN
 #include <limits>
+#include <mutex>
 
 #include "antares/io/outputs/SimulationTable.h"
 #include "antares/solver/simulation/ISimulationObserver.h"
@@ -312,7 +313,7 @@ public:
     };
 
     std::map<std::pair<int, std::string>, SingleProblem> problems;
-
+    std::mutex mutex;
     void notifyHebdoProblem(const PROBLEME_HEBDO& problemeHebdo,
                             int optimizationNumber,
                             std::string_view name) override;


### PR DESCRIPTION
**Context**

The replacement of QueueService by a ThreadPool introduced an intermittent segfault (~2% of runs) in the parallel test case.

**Root cause**

TestingSimulationObserver::notifyHebdoProblem is called concurrently by multiple worker threads and performs unsynchronized insertions into a shared std::map. When two threads insert simultaneously, the internal red-black tree gets corrupted during rebalancing, causing a segfault in std::_Rb_tree_insert_and_rebalance.

This was not an issue with the previous QueueService, which serialized task execution. The ThreadPool runs MC years truly in parallel, exposing the missing synchronization.

**Fix**

Add a std::mutex to TestingSimulationObserver and lock it in notifyHebdoProblem.

**Diagnosis tools used**
Helgrind to rule out data races in the ThreadPool and solver.hxx synchronization logic
GDB with --catch_system_errors=no to capture the crash backtrace
Stress testing (500 runs loop) to confirm the fix