### PR TITLE
fix(final reservoir level): adjustment for non-January hydro initialization

### DIFF
--- a/src/solver/hydro/management/PrepareInflows.cpp
+++ b/src/solver/hydro/management/PrepareInflows.cpp
@@ -4,6 +4,8 @@
 
 #include "antares/solver/hydro/management/PrepareInflows.h"
 
+#include <antares/antares/constants.h>
+
 namespace Antares
 {
 
@@ -75,14 +77,16 @@ void PrepareInflows::changeInflowsToAccommodateFinalLevels(uint year)
           }
 
           // Must be done before prepareMonthlyTargetGenerations
+          int firstHydroMonth = area.hydro.initializeReservoirLevelDate;
+          int lastHydroMonth = (firstHydroMonth + 11) % MONTHS_PER_YEAR;
           double delta = area.hydro.deltaBetweenFinalAndInitialLevels[year].value();
           if (delta < 0)
           {
-              data.inflows[0] -= delta;
+              data.inflows[firstHydroMonth] -= delta;
           }
           else if (delta > 0)
           {
-              data.inflows[11] -= delta;
+              data.inflows[lastHydroMonth] -= delta;
           }
       });
 }


### PR DESCRIPTION
# Context
The final reservoir level adjustment currently assumes that the hydro simulation starts in January by applying the inflow correction to months `0` and `11`.
This is correct when initializeReservoirLevelDate is January, but not when the hydro year starts in another month.
The intended behaviour is:

- if delta < 0, the additional water should be available from the first month of the hydro simulation;
- if delta > 0, the correction should be applied to the last month of the hydro simulation, as this represents the amount of water that must remain in the reservoir at the end of the hydro period.

Therefore, the first and last hydro months should be derived from area.hydro.initializeReservoirLevelDate instead of being hard-coded to January and December.

For example, if the hydro year starts in November, the last hydro month is October.
For the default January initialization, this change preserves the existing behaviour (firstHydroMonth = 0, lastHydroMonth = 11).