### PR TITLE
feat(ci): Add vcpkg asset cache configuration to prevent dependency rot

### DIFF
--- a/.github/workflows/oracle8.yml
+++ b/.github/workflows/oracle8.yml
@@ -64,11 +64,16 @@ jobs:
       # Note: we need to use environment variables instead of workflow variables
       #       because github messes up path variables when running in container,
       #       see https://github.com/actions/runner/issues/2058
+      env:
+        # Mirror of the source archives vcpkg downloads, keyed by SHA512. Lets branches
+        # with a frozen baseline keep building after upstream mirrors purge old versions.
+        ASSET_SOURCES: "clear;x-azurl,${{ vars.VCPKG_ASSET_BASE_URL || 'https://github.com/AntaresSimulatorTeam/antares-vcpkg-registry/releases/download' }}/baseline-56bb2411609227288b70117ead2c47585ba07713/,,read"
       run: |
         git submodule update --init vcpkg && ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
         echo "VCPKG_ROOT=$GITHUB_WORKSPACE/vcpkg" >> $GITHUB_ENV
         echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg_cache" >> $GITHUB_ENV
         echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg_cache,readwrite" >> $GITHUB_ENV
+        echo "X_VCPKG_ASSET_SOURCES=$ASSET_SOURCES" >> $GITHUB_ENV
 
     - name: Restore vcpkg binary dir from cache
       id: cache-vcpkg-binary

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,6 +18,9 @@ jobs:
       ORTOOLS_DIR: ${{ github.workspace }}/or-tools
       # Caching strategy of VCPKG dependencies
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
+      # Mirror of the source archives vcpkg downloads, keyed by SHA512. Lets branches
+      # with a frozen baseline keep building after upstream mirrors purge old versions.
+      X_VCPKG_ASSET_SOURCES: "clear;x-azurl,${{ vars.VCPKG_ASSET_BASE_URL || 'https://github.com/AntaresSimulatorTeam/antares-vcpkg-registry/releases/download' }}/baseline-56bb2411609227288b70117ead2c47585ba07713/,,read"
       BUILD_WRAPPER_OUT_DIR: ${{ github.workspace }}/_build/output # Directory where build-wrapper output will be placed
       #config in env to be accessible at each step
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -44,6 +44,9 @@ jobs:
       os: ubuntu-22.04
       # Caching strategy of VCPKG dependencies
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
+      # Mirror of the source archives vcpkg downloads, keyed by SHA512. Lets branches
+      # with a frozen baseline keep building after upstream mirrors purge old versions.
+      X_VCPKG_ASSET_SOURCES: "clear;x-azurl,${{ vars.VCPKG_ASSET_BASE_URL || 'https://github.com/AntaresSimulatorTeam/antares-vcpkg-registry/releases/download' }}/baseline-56bb2411609227288b70117ead2c47585ba07713/,,read"
 
     runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -44,6 +44,9 @@ jobs:
       triplet: x64-windows-release
       # Caching strategy of VCPKG dependencies
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
+      # Mirror of the source archives vcpkg downloads, keyed by SHA512. Lets branches
+      # with a frozen baseline keep building after upstream mirrors purge old versions.
+      X_VCPKG_ASSET_SOURCES: "clear;x-azurl,${{ vars.VCPKG_ASSET_BASE_URL || 'https://github.com/AntaresSimulatorTeam/antares-vcpkg-registry/releases/download' }}/baseline-56bb2411609227288b70117ead2c47585ba07713/,,read"
 
     runs-on: windows-2022
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/docs/developer-guide/3-Build.md
+++ b/docs/developer-guide/3-Build.md
@@ -26,6 +26,37 @@ The first step will be to install VCPKG using its bootstrap script:
     ./bootstrap-vcpkg.sh
     ```
 
+### Asset cache (recommended, required on maintenance branches)
+
+vcpkg downloads each dependency's source archive from its original upstream URL. Those URLs rot:
+mirrors regularly purge superseded versions (MSYS2 in particular deletes old packages within
+months). A maintenance branch such as `release/9.3.x` deliberately pins an old vcpkg baseline, so
+it keeps asking for exactly those vanished files and the download step fails.
+
+To avoid this, point vcpkg at the team's asset mirror, which stores every archive we have ever
+needed keyed by its SHA512:
+
+=== "Windows"
+
+    ```
+    set X_VCPKG_ASSET_SOURCES=clear;x-azurl,https://github.com/AntaresSimulatorTeam/antares-vcpkg-registry/releases/download/baseline-56bb2411609227288b70117ead2c47585ba07713/,,read
+    ```
+
+=== "Linux"
+
+    ```
+    export X_VCPKG_ASSET_SOURCES="clear;x-azurl,https://github.com/AntaresSimulatorTeam/antares-vcpkg-registry/releases/download/baseline-56bb2411609227288b70117ead2c47585ba07713/,,read"
+    ```
+
+The `baseline-...` part of the URL is **this branch's vcpkg baseline** — the
+`default-registry.baseline` value in `vcpkg-configuration.json`. Each baseline has its own
+release, so if you are building a different branch, read its baseline and substitute it.
+
+The mirror is public and read-only, so no credentials are needed. vcpkg still falls back to the
+original URL whenever an archive is not mirrored yet. If you hit a download failure for a file the
+mirror does not have, follow the recovery procedure in the
+[antares-vcpkg-registry README](https://github.com/AntaresSimulatorTeam/antares-vcpkg-registry) to add it.
+
 ## Configure build with CMake
 
 The preferred way of building the project is to use a pre-compiled version of OR-Tools and to install

--- a/docs/developer-guide/CMakeUserPresetsExample.json
+++ b/docs/developer-guide/CMakeUserPresetsExample.json
@@ -7,6 +7,7 @@
       "environment": {
         "VCPKG_ROOT": "../vcpkg",
         "VCPKG_BINARY_SOURCES": "clear;files,/tmp/deps/vcpkg_cache/binary-cache,readwrite",
+        "X_VCPKG_ASSET_SOURCES": "clear;x-azurl,https://github.com/AntaresSimulatorTeam/antares-vcpkg-registry/releases/download/baseline-56bb2411609227288b70117ead2c47585ba07713/,,read",
         "CCACHE_DIR": "/tmp/deps/ccache",
         "VCPKG_INSTALL_OPTIONS": "--x-buildtrees-root=/tmp/deps/vcpkg_cache/buildtrees;--x-packages-root=/tmp/deps/vcpkg_cache/packages"
       },


### PR DESCRIPTION
- Updated developer guide with steps to configure asset cache for vcpkg.
- Modified GitHub workflows to include `X_VCPKG_ASSET_SOURCES` for consistent builds.
- Enhanced default CMakeUserPresets with asset cache settings.