### PR TITLE
refactor(dependencies): remove deps study->solver-variable

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(single_problem_api
         PUBLIC
         Antares::study
         Antares::optim-model-filler
+        antares-solver-variable
         Antares::lps)
 
 # TODO move

--- a/src/api/main.cpp
+++ b/src/api/main.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 
 #include <antares/logs/logs.h>
+#include <antares/solver/variable/registerThematicTrimmingVariables.h>
 #include "antares/api/modelerProblems.h"
 #include "antares/api/singleProblemGetter.h"
 
@@ -13,6 +14,8 @@ using namespace Antares::Solver;
 
 int main(const int argc, const char** argv)
 {
+    Antares::Solver::Variable::RegisterThematicTrimmingVariables();
+
     if (argc < 2)
     {
         Antares::logs.error() << "Please provide valid study path.";

--- a/src/libs/antares/study/CMakeLists.txt
+++ b/src/libs/antares/study/CMakeLists.txt
@@ -318,7 +318,6 @@ target_link_libraries(study
         Antares::exception
         fmt::fmt
         Antares::benchmarking
-        antares-solver-variable
         Antares::additional-constraint-rhs-antlr-interface
         Antares::reserves-parsing-antlr-interface
 )

--- a/src/libs/antares/study/include/antares/study/variable-print-info.h
+++ b/src/libs/antares/study/include/antares/study/variable-print-info.h
@@ -4,6 +4,7 @@
 #ifndef __SOLVER_VARIABLE_PRINT_POLICY_H__
 #define __SOLVER_VARIABLE_PRINT_POLICY_H__
 
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -66,6 +67,20 @@ public:
 
 private:
     AllVariablesPrintInfo* allvarsinfo;
+};
+
+// The concrete list of output variables is only known by the solver-runtime layer
+// (antares::Solver::Variable). Rather than depending on it directly, study exposes this
+// registry: the solver layer registers a provider once at startup (see
+// antares::Solver::Variable::RegisterThematicTrimmingVariables()), and study calls
+// populate() whenever it needs the list, without knowing where it comes from.
+class ThematicTrimmingVariableRegistry
+{
+public:
+    using Provider = std::function<void(variablePrintInfoCollector&)>;
+
+    static void setProvider(Provider provider);
+    static void populate(variablePrintInfoCollector& collector);
 };
 
 // Variables print info collection. Mainly a vector of pointers to print info.

--- a/src/libs/antares/study/parameters.cpp
+++ b/src/libs/antares/study/parameters.cpp
@@ -14,7 +14,6 @@
 #include <antares/inifile/inifile.h>
 #include <antares/logs/logs.h>
 #include <antares/utils/utils.h>
-#include "antares/solver/variable/economy/all.h"
 #include "antares/study/load-options.h"
 
 namespace Antares::Data
@@ -272,7 +271,7 @@ void Parameters::reset()
     // Reset output variables print info tool
     variablesPrintInfo.clear();
     variablePrintInfoCollector collector(&variablesPrintInfo);
-    Antares::Solver::Variable::Economy::AllVariables::RetrieveVariableList(collector);
+    ThematicTrimmingVariableRegistry::populate(collector);
     thematicTrimming = false;
 
     resetPlayedYears(1);

--- a/src/libs/antares/study/variable-print-info.cpp
+++ b/src/libs/antares/study/variable-print-info.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 
+#include <antares/logs/logs.h>
 #include <antares/study/study.h>
 #include "antares/study/categories.h"
 
@@ -61,6 +62,36 @@ void variablePrintInfoCollector::add(const std::string& name,
                                      unsigned int fileLevel)
 {
     allvarsinfo->add(name, VariablePrintInfo(dataLevel, fileLevel));
+}
+
+// ============================================================
+// Thematic trimming variable registry
+// ============================================================
+namespace
+{
+ThematicTrimmingVariableRegistry::Provider& thematicTrimmingProvider()
+{
+    static ThematicTrimmingVariableRegistry::Provider instance;
+    return instance;
+}
+} // namespace
+
+void ThematicTrimmingVariableRegistry::setProvider(Provider provider)
+{
+    thematicTrimmingProvider() = std::move(provider);
+}
+
+void ThematicTrimmingVariableRegistry::populate(variablePrintInfoCollector& collector)
+{
+    if (const auto& provider = thematicTrimmingProvider())
+    {
+        provider(collector);
+    }
+    else
+    {
+        logs.warning() << "No thematic trimming variable provider registered: the list of "
+                          "output variables will be empty";
+    }
 }
 
 // ============================================================

--- a/src/solver/main.cpp
+++ b/src/solver/main.cpp
@@ -8,6 +8,7 @@
 #include <antares/locale/locale.h>
 #include <antares/logs/logs.h>
 #include <antares/memory/memory.h>
+#include <antares/solver/variable/registerThematicTrimmingVariables.h>
 #include "antares/application/application.h"
 
 using namespace Antares;
@@ -89,6 +90,8 @@ int main(int argc, const char** argv)
 {
     try
     {
+        Antares::Solver::Variable::RegisterThematicTrimmingVariables();
+
         Antares::Solver::Application application;
         auto& durationCollector = application.getDurationCollector();
 

--- a/src/solver/variable/CMakeLists.txt
+++ b/src/solver/variable/CMakeLists.txt
@@ -81,6 +81,8 @@ source_group("variable\\adequacy" FILES ${SRC_VARIABLE_ADEQUACY})
 
 set(SRC_VARIABLE_ECONOMY
         include/antares/solver/variable/economy/all.h
+        include/antares/solver/variable/registerThematicTrimmingVariables.h
+        registerThematicTrimmingVariables.cpp
         include/antares/solver/variable/economy/economy_base.h
         include/antares/solver/variable/economy/links.h
 

--- a/src/solver/variable/include/antares/solver/variable/registerThematicTrimmingVariables.h
+++ b/src/solver/variable/include/antares/solver/variable/registerThematicTrimmingVariables.h
@@ -1,0 +1,13 @@
+// Copyright 2007-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+
+namespace Antares::Solver::Variable
+{
+// Registers the concrete list of thematic-trimming output variables with
+// Antares::Data::ThematicTrimmingVariableRegistry. Must be called once, before any
+// Antares::Data::Parameters::reset()/loadFromINI() call, by every executable that loads a
+// study (see src/solver/main.cpp, src/api/main.cpp).
+void RegisterThematicTrimmingVariables();
+} // namespace Antares::Solver::Variable

--- a/src/solver/variable/registerThematicTrimmingVariables.cpp
+++ b/src/solver/variable/registerThematicTrimmingVariables.cpp
@@ -1,0 +1,17 @@
+// Copyright 2007-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+
+#include "antares/solver/variable/registerThematicTrimmingVariables.h"
+
+#include <antares/solver/variable/economy/all.h>
+#include <antares/study/variable-print-info.h>
+
+namespace Antares::Solver::Variable
+{
+void RegisterThematicTrimmingVariables()
+{
+    Antares::Data::ThematicTrimmingVariableRegistry::setProvider(
+      [](Antares::Data::variablePrintInfoCollector& collector)
+      { Economy::AllVariables::RetrieveVariableList(collector); });
+}
+} // namespace Antares::Solver::Variable

--- a/src/tests/inmemory-study/in-memory-study.cpp
+++ b/src/tests/inmemory-study/in-memory-study.cpp
@@ -5,11 +5,13 @@
 
 #include "in-memory-study.h"
 
+#include <antares/solver/variable/registerThematicTrimmingVariables.h>
 #include "antares/application/ScenarioBuilderOwner.h"
 #include "antares/utils/utils.h"
 
 void initializeStudy(Study* study)
 {
+    Antares::Solver::Variable::RegisterThematicTrimmingVariables();
     study->parameters.reset();
 }
 

--- a/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
@@ -5,4 +5,5 @@ include(${CMAKE_SOURCE_DIR}/src/tests/macros.cmake)
 # ====================================
 add_boost_test(parameters-tests
   SRC parameters-tests.cpp
-  LIBS Antares::study)
+  LIBS Antares::study
+  antares-solver-variable)

--- a/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
+++ b/src/tests/src/libs/antares/study/parameters/CMakeLists.txt
@@ -5,5 +5,5 @@ include(${CMAKE_SOURCE_DIR}/src/tests/macros.cmake)
 # ====================================
 add_boost_test(parameters-tests
   SRC parameters-tests.cpp
-  LIBS Antares::study
-  antares-solver-variable)
+  LIBS antares-solver-variable
+  Antares::study)

--- a/src/tests/src/libs/antares/study/parameters/parameters-tests.cpp
+++ b/src/tests/src/libs/antares/study/parameters/parameters-tests.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <antares/solver/variable/registerThematicTrimmingVariables.h>
 #include <antares/study/study.h>
 
 using namespace Antares;
@@ -126,6 +127,11 @@ IniFile invalidINI()
 
 struct Fixture
 {
+    Fixture()
+    {
+        Antares::Solver::Variable::RegisterThematicTrimmingVariables();
+    }
+
     Parameters p;
     StudyLoadOptions options;
     StudyVersion version = StudyVersion::latest();

--- a/src/tests/src/solver/simulation/tests-ts-numbers.cpp
+++ b/src/tests/src/solver/simulation/tests-ts-numbers.cpp
@@ -10,6 +10,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <antares/solver/simulation/timeseries-numbers.h>
+#include <antares/solver/variable/registerThematicTrimmingVariables.h>
 #include <antares/utils/utils.h>
 #include "antares/solver/ts-generator/generator.h"
 
@@ -20,6 +21,7 @@ using namespace Antares::Solver::TimeSeriesNumbers;
 
 void initializeStudy(Study::Ptr study, unsigned int nbYears = 1)
 {
+    Antares::Solver::Variable::RegisterThematicTrimmingVariables();
     study->parameters.reset();
 
     study->runtime.rangeLimits.year[rangeBegin] = 0;


### PR DESCRIPTION
## Remove `study`'s dependency on `antares-solver-variable`
 
  ### Context

  `study` (layer 2, "a leaf in the dependency graph" per `docs/architecture/cmake-dependency-rules.md`) linked `antares-solver-variable` (layer 5)  purely so `Parameters::reset()` could call Antares::Solver::Variable::Economy::AllVariables::RetrieveVariableList(collector)`, seeding the  output-variable print-info list. Unlike the other headers already relocated in this refactor (`law.h`, `prepro.h`, `categories.h`, which were  dependency-free), `RetrieveVariableList` is real solver-layer code — it recurses through ~60 template-based `VCard` classes pulled in via a  194-line `economy/all.h` aggregator. It can't be moved down; the call itself needed to go the other way.

  ### Fix: registration instead of a direct call

  - **`study`** (`variable-print-info.h`/`.cpp`): added `ThematicTrimmingVariableRegistry`, a small `setProvider()`/`populate()` static registry  with no solver dependency. `populate()` calls whatever provider was registered, or logs a warning and no-ops if nothing was registered yet.
  - **`parameters.cpp`**: now calls `ThematicTrimmingVariableRegistry::populate(collector)` instead of
  `AllVariables::RetrieveVariableList(collector)` directly, and no longer includes `economy/all.h`.
  - **`study`'s CMakeLists**: dropped the `antares-solver-variable` link entirely — nothing else in `study` needed it.
  - **`solver/variable`**: new `registerThematicTrimmingVariables.h`/`.cpp` — a thin adapter that registers the real provider (a lambda calling  `Economy::AllVariables::RetrieveVariableList`).
  - **Wired at the real entry points**, each calling `RegisterThematicTrimmingVariables()` once before any `Parameters` loading: `solver/main.cpp`  and `api/main.cpp` (production), plus `in-memory-study.cpp`'s shared test helper, `tests-ts-numbers.cpp`'s local helper, and
  `parameters-tests.cpp`'s fixture (tests).
  - `single_problem_api` and `parameters-tests` gained a link to `antares-solver-variable` — for `single_problem_api` this only changes  *visibility* (it already had the dependency transitively via `antares-solver-simulation`, PRIVATE; now PUBLIC so `antares-problem-generator`'s  `main.cpp` can reach the registration header directly). For `parameters-tests` it's a genuinely new, expected link — tests are free to combine  layers.

  ### A bug this caught

  Registering "only where `reset()` is called" isn't quite enough: `Parameters::loadFromINI` unconditionally calls `prepareForSimulation()`, whose  renewable/adequacy-patch/unit-commitment "excluded variables" logic does `variablesPrintInfo.at(varname)` — which throws `std::out_of_range` if  the list is empty and any variable needs excluding, not just when `select_var` ini keys are used. This surfaced immediately as 3 failing test  cases (`std::out_of_range: map::at`) once `parameters-tests` no longer got the list for free via header-only template instantiation. Fixed by  registering in that test's fixture and linking `antares-solver-variable` there too. Confirms the provider must be registered by *anything* that  calls `loadFromINI`, not just `reset()` in isolation.