### PR TITLE
chore(docker): add jemalloc build recipe for Oracle Linux 8

### DIFF
--- a/docker/jemalloc-oraclelinux
+++ b/docker/jemalloc-oraclelinux
@@ -1,0 +1,48 @@
+# This Dockerfile is a reproducibility recipe: it builds libjemalloc.so.2 on
+# Oracle Linux 8, documenting exactly how the shared library used by the
+# Antares Solver on that platform was produced, so it can be rebuilt in the
+# same way if the original build environment is no longer available.
+#
+# Builds jemalloc from the GitHub source tarball.
+#
+# Build with the default version (5.3.1):
+#   docker build -t jemalloc:5.3.1 .
+#
+# Or override the version:
+#   docker build --build-arg JEMALLOC_VERSION=5.2.1 -t jemalloc:5.2.1 .
+
+FROM oraclelinux:8
+
+# Version of jemalloc to download and build (configurable)
+ARG JEMALLOC_VERSION=5.3.1
+
+# jemalloc's GitHub tarball does not ship a generated `configure` script,
+# so autotools are needed to generate it via autogen.sh.
+RUN yum install -y \
+        autoconf \
+        automake \
+        ca-certificates \
+        gcc \
+        make \
+        wget \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+WORKDIR /usr/local/src
+
+RUN wget -q -O jemalloc-${JEMALLOC_VERSION}.tar.gz \
+        "https://github.com/jemalloc/jemalloc/archive/refs/tags/${JEMALLOC_VERSION}.tar.gz" \
+    && tar xzf jemalloc-${JEMALLOC_VERSION}.tar.gz \
+    && cd "jemalloc-${JEMALLOC_VERSION}" \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr/local \
+        --with-version="${JEMALLOC_VERSION}-0-g000000" \
+    && make -j"$(nproc)" \
+    && make install \
+    && echo /usr/local/lib > /etc/ld.so.conf.d/jemalloc.conf \
+    && ldconfig \
+    && cd / \
+    && rm -rf /usr/local/src/jemalloc-${JEMALLOC_VERSION} /usr/local/src/jemalloc-${JEMALLOC_VERSION}.tar.gz
+
+# Sanity check: the shared library must be visible to the linker
+RUN ldconfig -p | grep -q libjemalloc


### PR DESCRIPTION
## Motivation

The `libjemalloc.so.2` shared library shipped with the Antares Solver for Oracle Linux 8 was built in a one-off environment. To guarantee we can reproduce that exact build later (e.g. if the original environment is no longer available, or we need to rebuild for a new release), we need a documented, reproducible recipe.

## Method

This PR adds `docker/jemalloc-oraclelinux`, a Dockerfile that:

- starts from `oraclelinux:8`
- installs autotools, since jemalloc's GitHub tarball does not ship a generated `configure` script (`autogen.sh` is run first)
- downloads a pinned jemalloc release (default 5.3.1, overridable via `--build-arg JEMALLOC_VERSION=...`)
- builds and installs it under `/usr/local`, registers the library path in `ld.so.conf.d`, and ends with a sanity check that `libjemalloc.so.2` is visible to the linker

The file is purely a build recipe for `libjemalloc.so.2` on Oracle Linux 8 — it is kept in the repository for reproducibility reasons and is not part of the solver build itself.
