### PR TITLE
refactor(binding-constraint): remove unused code

### DIFF
--- a/src/libs/antares/study/binding_constraint/BindingConstraint.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraint.cpp
@@ -3,8 +3,6 @@
 
 #include "antares/study/binding_constraint/BindingConstraint.h"
 
-#include <algorithm>
-#include <cmath>
 #include <functional>
 #include <vector>
 
@@ -13,12 +11,6 @@
 #include "antares/utils/utils.h"
 
 using namespace Antares;
-
-#ifdef _MSC_VER
-#define SNPRINTF sprintf_s
-#else
-#define SNPRINTF snprintf
-#endif
 
 namespace Antares::Data
 {

--- a/src/libs/antares/study/binding_constraint/BindingConstraint.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraint.cpp
@@ -213,7 +213,6 @@ void BindingConstraint::offset(const ThermalCluster* cluster, int o)
 void BindingConstraint::resetToDefaultValues()
 {
     pEnabled = true;
-    pComments.clear();
     RHSTimeSeries_.reset();
 }
 
@@ -340,8 +339,6 @@ void BindingConstraint::clear()
     // Name / ID
     this->pName.clear();
     this->pID.clear();
-    // No comments
-    this->pComments.clear();
     // The type must be `hourly` by default for studies <=3.1, which was the only
     // type of binding constraints supported.
     this->pType = typeUnknown;
@@ -350,108 +347,6 @@ void BindingConstraint::clear()
     // Enabled: True by default to automatically allow the use of bindingconstraint
     // from old studies (<= 3.1)
     this->pEnabled = true;
-}
-
-bool BindingConstraint::contains(const Area* area) const
-{
-    for (const auto& [sourceLink, _]: pLinkWeights)
-    {
-        if (sourceLink->from == area || sourceLink->with == area)
-        {
-            return true;
-        }
-    }
-
-    for (const auto& [thermalCluster, _]: pClusterWeights)
-    {
-        if (thermalCluster->parentArea == area)
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-void BindingConstraint::buildFormula(std::string& s) const
-{
-    char tmp[42];
-    for (const auto& [sourceLink, weight]: pLinkWeights)
-    {
-        if (!sourceLink)
-        {
-            s += " + ";
-        }
-        SNPRINTF(tmp, sizeof(tmp), "%.2f", weight);
-
-        s += '(' + std::string(tmp) + " x " + (sourceLink ? sourceLink->getName() : "");
-
-        if (auto at = pLinkOffsets.find(sourceLink); at != pLinkOffsets.end())
-        {
-            int o = at->second;
-            if (o > 0)
-            {
-                s += " x (t + " + std::to_string(pLinkOffsets.find(sourceLink)->second) + ')';
-            }
-            if (o < 0)
-            {
-                s += " x (t - " + std::to_string(std::abs(pLinkOffsets.find(sourceLink)->second))
-                     + ')';
-            }
-        }
-
-        s += ')';
-    }
-
-    for (const auto [thermalCluster, weight]: pClusterWeights)
-    {
-        if (!thermalCluster)
-        {
-            s += " + ";
-        }
-        SNPRINTF(tmp, sizeof(tmp), "%.2f", weight);
-
-        s += '(' + std::string(tmp) + " x " + (thermalCluster ? thermalCluster->getFullName() : "");
-
-        if (auto at = pClusterOffsets.find(thermalCluster); at != pClusterOffsets.end())
-        {
-            int o = at->second;
-            if (o > 0)
-            {
-                s += " x (t + " + std::to_string(pClusterOffsets.find(thermalCluster)->second)
-                     + ')';
-            }
-            if (o < 0)
-            {
-                s += " x (t - "
-                     + std::to_string(std::abs(pClusterOffsets.find(thermalCluster)->second)) + ')';
-            }
-        }
-
-        if (!thermalCluster->isActive())
-        {
-            s += " x N/A";
-        }
-
-        s += ')';
-    }
-}
-
-bool BindingConstraint::contains(const BindingConstraint* bc) const
-{
-    return (this == bc);
-}
-
-bool BindingConstraint::contains(const AreaLink* lnk) const
-{
-    const auto i = pLinkWeights.find(lnk);
-    return (i != pLinkWeights.end());
-}
-
-bool BindingConstraint::contains(const ThermalCluster* cluster) const
-{
-    const auto i = pClusterWeights.find(cluster);
-    return (i != pClusterWeights.end());
 }
 
 void BindingConstraint::enabled(bool v)
@@ -657,7 +552,6 @@ void BindingConstraint::copyFrom(const BindingConstraint* original)
     pFilterYearByYear = original->pFilterYearByYear;
     pFilterSynthesis = original->pFilterSynthesis;
     pEnabled = original->pEnabled;
-    pComments = original->pComments;
     group_ = original->group_;
     RHSTimeSeries_.copyFrom(original->RHSTimeSeries_);
 }

--- a/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
+++ b/src/libs/antares/study/binding_constraint/BindingConstraintLoader.cpp
@@ -154,20 +154,10 @@ bool BindingConstraintLoader::loadTimeSeriesLegacyStudies(
                                      Matrix<>::optFixedSize,
                                      &env.matrixBuffer))
     {
-        if (bindingConstraint->pComments.empty())
-        {
-            logs.info() << " added `" << bindingConstraint->pName << "` ("
-                        << BindingConstraint::TypeToCString(bindingConstraint->pType) << ", "
-                        << BindingConstraint::OperatorToShortCString(bindingConstraint->pOperator)
-                        << ')';
-        }
-        else
-        {
-            logs.info() << " added `" << bindingConstraint->pName << "` ("
-                        << BindingConstraint::TypeToCString(bindingConstraint->pType) << ", "
-                        << BindingConstraint::OperatorToShortCString(bindingConstraint->pOperator)
-                        << ") " << bindingConstraint->pComments;
-        }
+        logs.info() << " added `" << bindingConstraint->pName << "` ("
+                    << BindingConstraint::TypeToCString(bindingConstraint->pType) << ", "
+                    << BindingConstraint::OperatorToShortCString(bindingConstraint->pOperator)
+                    << ')';
 
         // 0 is BindingConstraint::opLess
         int columnNumber;
@@ -244,9 +234,10 @@ void BindingConstraintLoader::populateConstraint(const EnvForLoading& env,
             bc->pFilterSynthesis = stringIntoDatePrecision(std::string(p->value));
             continue;
         }
+        // Metadata, don't read
+        // Kept for compatibility with existing studies
         if (p->key == "comments")
         {
-            bc->pComments = std::string(p->value);
             continue;
         }
         if (p->key == "group")

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
@@ -71,10 +71,6 @@ public:
     using Set = std::set<std::shared_ptr<BindingConstraint>, CompareBindingConstraintName>;
     //! Map of weight (for links)
     using linkWeightMap = std::map<const AreaLink*, double, CompareLinkName>;
-    //! Iterator
-    using iterator = linkWeightMap::iterator;
-    //! Const iterator
-    using const_iterator = linkWeightMap::const_iterator;
 
     //! Map of weight (for thermal clusters)
     using clusterWeightMap = std::map<const ThermalCluster*, double, CompareClusterName>;

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.h
@@ -145,13 +145,6 @@ public:
     const std::string& id() const;
     //@}
 
-    //! \name Comments
-    //@{
-    /*!
-    ** \brief Get the comments
-    */
-    const std::string& comments() const;
-
     //! \name Group
     //@{
     /*!
@@ -160,22 +153,7 @@ public:
     std::string group() const;
     void group(std::string group_name);
 
-    /*!
-    ** \brief Set the comments
-    */
-    void comments(const std::string& newcomments);
-    //@}
-
     void resetToDefaultValues();
-
-    //! \name iterator
-    //@{
-    iterator begin();
-    const_iterator begin() const;
-
-    iterator end();
-    const_iterator end() const;
-    //@}
 
     bool skipped() const;
     bool isActive() const;
@@ -309,27 +287,6 @@ public:
     void clearAndReset(const std::string& name, Type newType, Operator op);
     //@}
 
-    /*!
-    ** \brief Get if the given binding constraint is identical
-    */
-    bool contains(const BindingConstraint* bc) const;
-    /*!
-    ** \brief Get if the binding constraint is linked with a given area
-    */
-    bool contains(const Area* area) const;
-
-    /*!
-    ** \brief Get if the binding constraint is linked with an interconnection or thermal cluster
-    */
-    bool contains(const AreaLink* lnk) const;
-
-    bool contains(const ThermalCluster* clstr) const;
-
-    /*!
-    ** \brief Build a human readable formula for the binding constraint
-    */
-    void buildFormula(std::string& s) const;
-
     BindingConstraintStructures initLinkArrays() const;
 
     template<class Env>
@@ -365,8 +322,6 @@ private:
     unsigned int pFilterSynthesis = filterNone;
     //! Enabled / Disabled
     bool pEnabled = false;
-    //! Comments
-    std::string pComments;
     //! Group
     std::string group_ = "default";
 

--- a/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.hxx
+++ b/src/libs/antares/study/include/antares/study/binding_constraint/BindingConstraint.hxx
@@ -17,16 +17,6 @@ inline const std::string& BindingConstraint::id() const
     return pID;
 }
 
-inline const std::string& BindingConstraint::comments() const
-{
-    return pComments;
-}
-
-inline void BindingConstraint::comments(const std::string& newcomments)
-{
-    pComments = newcomments;
-}
-
 inline unsigned int BindingConstraint::linkCount() const
 {
     return (unsigned int)pLinkWeights.size();
@@ -70,26 +60,6 @@ inline bool BindingConstraint::skipped() const
 inline bool BindingConstraint::isActive() const
 {
     return enabled() && !skipped();
-}
-
-inline BindingConstraint::iterator BindingConstraint::begin()
-{
-    return pLinkWeights.begin();
-}
-
-inline BindingConstraint::iterator BindingConstraint::end()
-{
-    return pLinkWeights.end();
-}
-
-inline BindingConstraint::const_iterator BindingConstraint::begin() const
-{
-    return pLinkWeights.begin();
-}
-
-inline BindingConstraint::const_iterator BindingConstraint::end() const
-{
-    return pLinkWeights.end();
 }
 
 template<class Env>

--- a/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
@@ -65,7 +65,6 @@ BOOST_AUTO_TEST_CASE(load_basic_attributes)
     BOOST_CHECK_EQUAL(constraint->operatorType(), BindingConstraint::Operator::opEquality);
     BOOST_CHECK_EQUAL(constraint->yearByYearFilter(), FilterFlag::filterAnnual);
     BOOST_CHECK_EQUAL(constraint->synthesisFilter(), FilterFlag::filterHourly);
-    BOOST_CHECK_EQUAL(constraint->comments(), "dummy_comment");
     BOOST_CHECK_EQUAL(constraint->group(), "dummy_group");
 }
 

--- a/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_constraint.cpp
@@ -1055,13 +1055,11 @@ BOOST_AUTO_TEST_CASE(BindingConstraint_resetToDefaultValues)
 {
     BindingConstraint bc;
     bc.enabled(false);
-    bc.comments("some comment");
     bc.RHSTimeSeries().resize(2, 5);
 
     bc.resetToDefaultValues();
 
     BOOST_CHECK_EQUAL(bc.enabled(), true);
-    BOOST_CHECK(bc.comments().empty());
     BOOST_CHECK_EQUAL(bc.RHSTimeSeries().width, 0u);
     BOOST_CHECK_EQUAL(bc.RHSTimeSeries().height, 0u);
 }
@@ -1105,38 +1103,6 @@ BOOST_AUTO_TEST_CASE(BindingConstraint_clearAndReset_weekly)
     BOOST_CHECK_EQUAL(bc.type(), BindingConstraint::typeWeekly);
     BOOST_CHECK_EQUAL(bc.RHSTimeSeries().width, (unsigned int)BindingConstraint::columnMax);
     BOOST_CHECK_EQUAL(bc.RHSTimeSeries().height, 366u);
-}
-
-BOOST_AUTO_TEST_CASE(BindingConstraint_iterators)
-{
-    auto study = std::make_unique<Study>();
-    auto area1 = addAreaToListOfAreas(study->areas, "area1");
-    auto area2 = addAreaToListOfAreas(study->areas, "area2");
-    auto area3 = addAreaToListOfAreas(study->areas, "area3");
-    auto link1 = AreaAddLinkBetweenAreas(area1, area2);
-    auto link2 = AreaAddLinkBetweenAreas(area1, area3);
-
-    BindingConstraint bc;
-    bc.weight(link1, 1.5);
-    bc.weight(link2, 2.5);
-
-    std::map<const AreaLink*, double> visited;
-    for (const auto& [link, weight]: bc)
-    {
-        visited[link] = weight;
-    }
-
-    BOOST_REQUIRE_EQUAL(visited.size(), 2);
-    BOOST_CHECK_CLOSE(visited[link1], 1.5, 0.0001);
-    BOOST_CHECK_CLOSE(visited[link2], 2.5, 0.0001);
-
-    const BindingConstraint& constBc = bc;
-    std::size_t constCount = 0;
-    for (auto it = constBc.begin(); it != constBc.end(); ++it)
-    {
-        ++constCount;
-    }
-    BOOST_CHECK_EQUAL(constCount, 2u);
 }
 
 BOOST_AUTO_TEST_CASE(BindingConstraint_skipped_isActive_enabled)
@@ -1218,122 +1184,6 @@ BOOST_AUTO_TEST_CASE(BindingConstraint_offset_setters_eraseOnZero)
     BOOST_CHECK_EQUAL(bc.offset(cluster.get()), 7);
     bc.offset(cluster.get(), 0);
     BOOST_CHECK_EQUAL(bc.offset(cluster.get()), 0);
-}
-
-BOOST_AUTO_TEST_CASE(BindingConstraint_contains_bindingConstraint)
-{
-    BindingConstraint bc;
-    BindingConstraint other;
-    BOOST_CHECK_EQUAL(bc.contains(&bc), true);
-    BOOST_CHECK_EQUAL(bc.contains(&other), false);
-}
-
-BOOST_AUTO_TEST_CASE(BindingConstraint_contains_area)
-{
-    auto study = std::make_unique<Study>();
-    auto area1 = addAreaToListOfAreas(study->areas, "area1");
-    auto area2 = addAreaToListOfAreas(study->areas, "area2");
-    auto area3 = addAreaToListOfAreas(study->areas, "area3");
-    auto link = AreaAddLinkBetweenAreas(area1, area2);
-    auto cluster = std::make_shared<ThermalCluster>(area3);
-    area3->thermal.list.addToCompleteList(cluster);
-    area3->thermal.list.buildIndexes();
-
-    BindingConstraint bc;
-    bc.weight(link, 1.0);
-    bc.weight(cluster.get(), 1.0);
-
-    BOOST_CHECK_EQUAL(bc.contains(area1), true);
-    BOOST_CHECK_EQUAL(bc.contains(area2), true);
-    BOOST_CHECK_EQUAL(bc.contains(area3), true);
-
-    auto area4 = addAreaToListOfAreas(study->areas, "area4");
-    BOOST_CHECK_EQUAL(bc.contains(area4), false);
-}
-
-BOOST_AUTO_TEST_CASE(BindingConstraint_contains_link_and_cluster)
-{
-    auto study = std::make_unique<Study>();
-    auto area1 = addAreaToListOfAreas(study->areas, "area1");
-    auto area2 = addAreaToListOfAreas(study->areas, "area2");
-    auto area3 = addAreaToListOfAreas(study->areas, "area3");
-    auto link1 = AreaAddLinkBetweenAreas(area1, area2);
-    auto link2 = AreaAddLinkBetweenAreas(area1, area3);
-    auto cluster1 = std::make_shared<ThermalCluster>(area1);
-    cluster1->setName("cluster1");
-    area1->thermal.list.addToCompleteList(cluster1);
-    auto cluster2 = std::make_shared<ThermalCluster>(area1);
-    cluster2->setName("cluster2");
-    area1->thermal.list.addToCompleteList(cluster2);
-    area1->thermal.list.buildIndexes();
-
-    BindingConstraint bc;
-    bc.weight(link1, 1.0);
-    bc.weight(cluster1.get(), 1.0);
-
-    BOOST_CHECK_EQUAL(bc.contains(link1), true);
-    BOOST_CHECK_EQUAL(bc.contains(link2), false);
-    BOOST_CHECK_EQUAL(bc.contains(cluster1.get()), true);
-    BOOST_CHECK_EQUAL(bc.contains(cluster2.get()), false);
-}
-
-BOOST_AUTO_TEST_CASE(BindingConstraint_buildFormula_linksWithOffsets)
-{
-    auto study = std::make_unique<Study>();
-    auto area1 = addAreaToListOfAreas(study->areas, "area1");
-    auto area2 = addAreaToListOfAreas(study->areas, "area2");
-    auto area3 = addAreaToListOfAreas(study->areas, "area3");
-    auto linkPos = AreaAddLinkBetweenAreas(area1, area2);
-    auto linkNeg = AreaAddLinkBetweenAreas(area1, area3);
-
-    BindingConstraint bc;
-    bc.weight(linkPos, 2.0);
-    bc.offset(linkPos, 3);
-    bc.weight(linkNeg, 4.0);
-    bc.offset(linkNeg, -5);
-
-    std::string formula;
-    bc.buildFormula(formula);
-
-    BOOST_CHECK(formula.find(linkPos->getName() + " x (t + 3)") != std::string::npos);
-    BOOST_CHECK(formula.find(linkNeg->getName() + " x (t - 5)") != std::string::npos);
-}
-
-BOOST_AUTO_TEST_CASE(BindingConstraint_buildFormula_clusterActiveInactive)
-{
-    auto study = std::make_unique<Study>();
-    auto area1 = addAreaToListOfAreas(study->areas, "area1");
-    auto activeCluster = std::make_shared<ThermalCluster>(area1);
-    activeCluster->setName("active_cluster");
-    activeCluster->enabled = true;
-    activeCluster->mustrun = false;
-    area1->thermal.list.addToCompleteList(activeCluster);
-
-    auto inactiveCluster = std::make_shared<ThermalCluster>(area1);
-    inactiveCluster->setName("inactive_cluster");
-    inactiveCluster->enabled = true;
-    inactiveCluster->mustrun = true;
-    area1->thermal.list.addToCompleteList(inactiveCluster);
-    area1->thermal.list.buildIndexes();
-
-    BindingConstraint bc;
-    bc.weight(activeCluster.get(), 1.0);
-    bc.weight(inactiveCluster.get(), 2.0);
-
-    std::string formula;
-    bc.buildFormula(formula);
-
-    const auto activePos = formula.find(activeCluster->getFullName());
-    const auto inactivePos = formula.find(inactiveCluster->getFullName());
-    BOOST_REQUIRE(activePos != std::string::npos);
-    BOOST_REQUIRE(inactivePos != std::string::npos);
-
-    const auto activeTerm = formula.substr(activePos, formula.find(')', activePos) - activePos);
-    const auto inactiveTerm = formula.substr(inactivePos,
-                                             formula.find(')', inactivePos) - inactivePos);
-
-    BOOST_CHECK(activeTerm.find("N/A") == std::string::npos);
-    BOOST_CHECK(inactiveTerm.find("N/A") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(BindingConstraint_initLinkArrays)

--- a/src/tests/src/libs/antares/study/constraint/test_group.cpp
+++ b/src/tests/src/libs/antares/study/constraint/test_group.cpp
@@ -81,7 +81,6 @@ BOOST_FIXTURE_TEST_CASE(WhenLoadingAConstraint_AGroupExists, Fixture)
     BOOST_CHECK_EQUAL(constraint->operatorType(), BindingConstraint::Operator::opEquality);
     BOOST_CHECK_EQUAL(constraint->yearByYearFilter(), FilterFlag::filterAnnual);
     BOOST_CHECK_EQUAL(constraint->synthesisFilter(), FilterFlag::filterHourly);
-    BOOST_CHECK_EQUAL(constraint->comments(), "dummy_comment");
     BOOST_CHECK_EQUAL(constraint->group(), "dummy_group");
 }
 


### PR DESCRIPTION
Removes dead code from `BindingConstraint`, discovered while reviewing #3901 (which added coverage tests for this class).

## Changes

- **`comments` field** and its accessors: removed. The `comments` key in `bindingconstraints.ini` is still skipped while parsing, kept for backward compatibility with existing studies (also covers the legacy-studies logging path in `BindingConstraintLoader`).
- **`begin()` / `end()` iterators** over link weights (and the now-unused `iterator` / `const_iterator` typedefs): removed.
- **All `contains()` overloads** (`BindingConstraint*`, `Area*`, `AreaLink*`, `ThermalCluster*`): removed.
- **`buildFormula()`**: removed.
- Leftover cleanups: `SNPRINTF` macro and `<algorithm>` / `<cmath>` includes in `BindingConstraint.cpp` (only used by `buildFormula`).
- Tests: dropped the `comments()` assertion in `load_basic_attributes` / `WhenLoadingAConstraint_AGroupExists`, and removed the test cases from #3901 that exercised the removed API (`BindingConstraint_iterators`, `BindingConstraint_contains_*`, `BindingConstraint_buildFormula_*`); `BindingConstraint_resetToDefaultValues` is kept minus the `comments` checks.

## Verification

- Full Debug build: 169 targets, 0 errors
- Full ctest suite: 90/90 tests passed
- Formatted with `src/format-code.sh` (clang-format 18.1.3)

Based on #3901 — please review that PR first (or squash this one into it).