### PR TITLE
Make OptimEntityContainer own the linear problem lifetime

### DIFF
--- a/src/api/include/antares/api/singleProblemGetter.h
+++ b/src/api/include/antares/api/singleProblemGetter.h
@@ -15,10 +15,13 @@ namespace Antares::Solver::Implementation
 class SingleProblemGetter;
 }
 
+namespace Antares::LinearProblem
+{
+class ILinearProblem;
+} // namespace Antares::LinearProblem
+
 namespace Antares::Solver
 {
-struct ProblemEntity;
-
 class SingleProblemGetter final
 {
 public:
@@ -38,7 +41,7 @@ public:
     void writeStudyDescriptionFiles(const std::filesystem::path& outputDir);
     bool areWeeksIndependent() const;
     void printProblems() const;
-    Solver::ProblemEntity getMasterProblem() const;
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> getMasterProblem() const;
 
 private:
     std::unique_ptr<Implementation::SingleProblemGetter> impl_;

--- a/src/api/include/antares/api/singleProblemGetter.h
+++ b/src/api/include/antares/api/singleProblemGetter.h
@@ -31,7 +31,7 @@ public:
     // NOTE week indices start at 1
     // year indices start at 0
     WeeklyDataFromAntares getWeeklyData(WeeklyProblemId id);
-    std::unique_ptr<LinearProblem::Api::ILinearProblem> getWeeklyProblem(WeeklyProblemId id);
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> getWeeklyProblem(WeeklyProblemId id);
 
     // TODO[FOM] This should not be necessary
     void writeNTCTimeSeries(const std::filesystem::path& outputDir);

--- a/src/api/private/singleProblemGetterImpl.h
+++ b/src/api/private/singleProblemGetterImpl.h
@@ -42,7 +42,7 @@ public:
       std::pair<std::unique_ptr<Data::Study>, Solver::IResultWriter::Ptr>&& loadedPair);
     ConstantDataFromAntares getConstantData() const;
     WeeklyDataFromAntares getWeeklyData(WeeklyProblemId id);
-    std::unique_ptr<LinearProblem::Api::ILinearProblem> getWeeklyProblem(WeeklyProblemId id);
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> getWeeklyProblem(WeeklyProblemId id);
     std::vector<WeeklyProblemId> getProblemIds() const;
 
     void writeNTCTimeSeries(const std::filesystem::path& outputDir);
@@ -61,7 +61,8 @@ private:
     const YearlyData& getYearlyData(unsigned year);
     YearlyData computeHydroLevels(unsigned year, const std::vector<double>& initialLevel);
     void initializeRandomNumbers();
-    void fillProblem(LinearProblem::Api::ILinearProblem& problem, const WeeklyProblemId& id);
+    void fillProblem(std::shared_ptr<LinearProblem::Api::ILinearProblem> problem,
+                     const WeeklyProblemId& id);
     void setWeeklyData(WeeklyProblemId& id);
     Antares::Data::Area::ScratchMap scratchmap_;
     HebdoProblemToLpsTranslator translator_;

--- a/src/api/private/singleProblemGetterImpl.h
+++ b/src/api/private/singleProblemGetterImpl.h
@@ -50,7 +50,7 @@ public:
     int nbYears() const;
     int nbWeeks() const;
     bool areWeeksIndependent() const;
-    Solver::ProblemEntity getMasterProblem() const;
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> getMasterProblem() const;
     void writeMasterAndStructure() const;
     void printProblems();
     std::set<int> playedYears() const;

--- a/src/api/singleProblemGetter.cpp
+++ b/src/api/singleProblemGetter.cpp
@@ -28,7 +28,7 @@ WeeklyDataFromAntares SingleProblemGetter::getWeeklyData(WeeklyProblemId id)
     return impl_->getWeeklyData(id);
 }
 
-std::unique_ptr<LinearProblem::Api::ILinearProblem> SingleProblemGetter::getWeeklyProblem(
+std::shared_ptr<LinearProblem::Api::ILinearProblem> SingleProblemGetter::getWeeklyProblem(
   WeeklyProblemId id)
 {
     return impl_->getWeeklyProblem(id);

--- a/src/api/singleProblemGetter.cpp
+++ b/src/api/singleProblemGetter.cpp
@@ -59,7 +59,7 @@ void SingleProblemGetter::printProblems() const
     impl_->printProblems();
 }
 
-Solver::ProblemEntity SingleProblemGetter::getMasterProblem() const
+std::shared_ptr<LinearProblem::Api::ILinearProblem> SingleProblemGetter::getMasterProblem() const
 {
     return impl_->getMasterProblem();
 }

--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -337,7 +337,7 @@ WeeklyDataFromAntares SingleProblemGetter::getWeeklyData(WeeklyProblemId id)
     return translator_.translate(pb_.ProblemeAResoudre.get(), problemName({id.year, id.week + 1}));
 }
 
-std::unique_ptr<ILinearProblem> SingleProblemGetter::getWeeklyProblem(WeeklyProblemId id)
+std::shared_ptr<ILinearProblem> SingleProblemGetter::getWeeklyProblem(WeeklyProblemId id)
 {
     setWeeklyData(id);
     auto& ProblemeAResoudre = pb_.ProblemeAResoudre;
@@ -357,14 +357,14 @@ std::unique_ptr<ILinearProblem> SingleProblemGetter::getWeeklyProblem(WeeklyProb
                                                                id.week);
     }
 
-    std::unique_ptr<ILinearProblem>
-      linearProblem = std::make_unique<Antares::LinearProblem::Api::StructuredLinearProblem>();
-    fillProblem(*linearProblem, id);
+    auto linearProblem = std::make_shared<Antares::LinearProblem::Api::StructuredLinearProblem>();
+    fillProblem(linearProblem, id);
 
     return linearProblem;
 }
 
-void SingleProblemGetter::fillProblem(ILinearProblem& problem, const WeeklyProblemId& id)
+void SingleProblemGetter::fillProblem(std::shared_ptr<ILinearProblem> problem,
+                                      const WeeklyProblemId& id)
 {
     const int opt = optimizationNumber - 1;
     assert(opt >= 0 && opt < 2);
@@ -374,11 +374,7 @@ void SingleProblemGetter::fillProblem(ILinearProblem& problem, const WeeklyProbl
     const ILinearProblemData* modelerDataSeries = hasModelerData ? modelerData->dataSeries.get()
                                                                  : nullptr;
 
-    // Non-owning: the caller owns the problem and it outlives this function, in which the
-    // container (and thus its reference to the problem) is destroyed.
-    std::shared_ptr<ILinearProblem> nonOwningProblem(&problem,
-                                                     [](ILinearProblem*) { /* non-owning */ });
-    LinearProblem::OptimEntityContainer optimEntityContainer(nonOwningProblem);
+    LinearProblem::OptimEntityContainer optimEntityContainer(problem);
     if (hasModelerData)
     {
         modelerData->bendersDecomposition.setCurrentProblemId(problemName({id.year, id.week + 1}));
@@ -500,13 +496,13 @@ bool SingleProblemGetter::areWeeksIndependent() const
                                });
 }
 
-void writeWeekMPS(const std::unique_ptr<ILinearProblem>& weekly,
+void writeWeekMPS(const ILinearProblem& weekly,
                   const WeeklyProblemId& id,
                   IResultWriter::Ptr& resultWriter)
 {
     auto name = problemName(id);
 
-    IO::Outputs::MPSGenerator mpsGenerator(*weekly, name + ".mps", true);
+    IO::Outputs::MPSGenerator mpsGenerator(weekly, name + ".mps", true);
     std::string mps = mpsGenerator.run();
 
     logs.info() << "Printing problem: " << name << '\n';
@@ -582,7 +578,7 @@ void SingleProblemGetter::printProblems()
     {
         logs.info() << " year: " << id.year << ", week: " << id.week;
         auto weekly = getWeeklyProblem(id);
-        writeWeekMPS(weekly, id, resultWriter_);
+        writeWeekMPS(*weekly, id, resultWriter_);
     }
 
     if (pb_.modelerData)

--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -374,7 +374,11 @@ void SingleProblemGetter::fillProblem(ILinearProblem& problem, const WeeklyProbl
     const ILinearProblemData* modelerDataSeries = hasModelerData ? modelerData->dataSeries.get()
                                                                  : nullptr;
 
-    LinearProblem::OptimEntityContainer optimEntityContainer(problem);
+    // Non-owning: the caller owns the problem and it outlives this function, in which the
+    // container (and thus its reference to the problem) is destroyed.
+    std::shared_ptr<ILinearProblem> nonOwningProblem(&problem,
+                                                     [](ILinearProblem*) { /* non-owning */ });
+    LinearProblem::OptimEntityContainer optimEntityContainer(nonOwningProblem);
     if (hasModelerData)
     {
         modelerData->bendersDecomposition.setCurrentProblemId(problemName({id.year, id.week + 1}));

--- a/src/api/singleProblemGetterImpl.cpp
+++ b/src/api/singleProblemGetterImpl.cpp
@@ -510,7 +510,7 @@ void writeWeekMPS(const ILinearProblem& weekly,
     resultWriter->addEntryFromBuffer(name + ".mps", mps);
 }
 
-Solver::ProblemEntity SingleProblemGetter::getMasterProblem() const
+std::shared_ptr<ILinearProblem> SingleProblemGetter::getMasterProblem() const
 {
     using namespace Antares::Solver;
     using namespace Antares::LinearProblem;
@@ -538,7 +538,7 @@ void SingleProblemGetter::writeMasterAndStructure() const
 
     FillContext fillContext = {0, 167, 0, 167, 0};
 
-    auto [masterProblem, _] = getMasterProblem();
+    auto masterProblem = getMasterProblem();
 
     if (!masterProblem)
     {

--- a/src/modeler-optimisation-container/OptimEntityContainer.cpp
+++ b/src/modeler-optimisation-container/OptimEntityContainer.cpp
@@ -11,8 +11,8 @@ using namespace Antares::LinearProblem::Api;
 namespace Antares::LinearProblem
 {
 
-OptimEntityContainer::OptimEntityContainer(Api::ILinearProblem& linearProblem):
-    linearProblem_(linearProblem)
+OptimEntityContainer::OptimEntityContainer(std::shared_ptr<Api::ILinearProblem> linearProblem):
+    linearProblem_(std::move(linearProblem))
 {
 }
 
@@ -39,7 +39,7 @@ VariabilityType OptimEntityContainer::getConstraintVariability(const Component& 
 
 void OptimEntityContainer::addStartColumn()
 {
-    variableStartColumn_.push_back(linearProblem_.variableCount());
+    variableStartColumn_.push_back(linearProblem_->variableCount());
 }
 
 std::span<const std::unique_ptr<IMipVariable>> OptimEntityContainer::getComponentVariable(
@@ -47,7 +47,7 @@ std::span<const std::unique_ptr<IMipVariable>> OptimEntityContainer::getComponen
   unsigned index,
   std::size_t nbTimeSteps) const
 {
-    const auto& variables = linearProblem_.getVariables();
+    const auto& variables = linearProblem_->getVariables();
     unsigned startColumn = getVariableStartColumn(component, index);
     return {variables.data() + startColumn, nbTimeSteps};
 }
@@ -57,7 +57,7 @@ std::span<const std::unique_ptr<IMipConstraint>> OptimEntityContainer::component
   unsigned index,
   std::size_t nbTimeSteps) const
 {
-    const auto& constraints = linearProblem_.getConstraints();
+    const auto& constraints = linearProblem_->getConstraints();
     unsigned startLine = getConstraintStartLine(component, index);
     return {constraints.data() + startLine, nbTimeSteps};
 }
@@ -104,7 +104,7 @@ void OptimEntityContainer::registerConstraint(const Component& component,
 {
     auto& optimComponent = optimComponents_.at(component.Id());
     optimComponent.modelConstraintStartLines.push_back(
-      static_cast<unsigned>(linearProblem_.constraintCount()));
+      static_cast<unsigned>(linearProblem_->constraintCount()));
     optimComponent.modelConstraintsVariability.push_back(variability);
     optimComponent.modelConstraintCounts.push_back(count);
 }

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #pragma once
+#include <memory>
 #include <span>
 #include <unordered_map>
 #include <vector>
@@ -28,7 +29,10 @@ struct OptimComponent
 class OptimEntityContainer
 {
 public:
-    OptimEntityContainer(Api::ILinearProblem& linearProblem);
+    // The container owns (shares) the lifetime of the linear problem: every variable
+    // and constraint entity it references lives inside linearProblem_, so keeping
+    // it alive here guarantees the referenced entities remain valid.
+    explicit OptimEntityContainer(std::shared_ptr<Api::ILinearProblem> linearProblem);
 
     unsigned getVariableStartColumn(const ModelerStudy::SystemModel::Component& component,
                                     unsigned index) const;
@@ -55,9 +59,9 @@ public:
         return optimComponent.modelConstraintCounts.at(index);
     }
 
-    Api::ILinearProblem& Problem()
+    Api::ILinearProblem& Problem() const
     {
-        return linearProblem_;
+        return *linearProblem_;
     }
 
     std::span<const std::unique_ptr<Api::IMipVariable>> getComponentVariable(
@@ -83,6 +87,6 @@ public:
 private:
     std::vector<unsigned int> variableStartColumn_;
     std::unordered_map<std::string, OptimComponent> optimComponents_;
-    Api::ILinearProblem& linearProblem_;
+    std::shared_ptr<Api::ILinearProblem> linearProblem_;
 };
 } // namespace Antares::LinearProblem

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -59,9 +59,9 @@ public:
         return optimComponent.modelConstraintCounts.at(index);
     }
 
-    Api::ILinearProblem& Problem() const
+    [[nodiscard]] const std::shared_ptr<Api::ILinearProblem>& Problem() const
     {
-        return *linearProblem_;
+        return linearProblem_;
     }
 
     std::span<const std::unique_ptr<Api::IMipVariable>> getComponentVariable(

--- a/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
+++ b/src/modeler-optimisation-container/include/antares/modeler-optimisation-container/OptimEntityContainer.h
@@ -59,7 +59,7 @@ public:
         return optimComponent.modelConstraintCounts.at(index);
     }
 
-    [[nodiscard]] const std::shared_ptr<Api::ILinearProblem>& Problem() const
+    [[nodiscard]] std::shared_ptr<Api::ILinearProblem> Problem() const
     {
         return linearProblem_;
     }

--- a/src/modeler/modeler/Modeler.cpp
+++ b/src/modeler/modeler/Modeler.cpp
@@ -170,7 +170,7 @@ LocationAnalysis analyzeLocation(const ModelerData& data, const Config::Location
     return result;
 }
 
-std::unique_ptr<ILinearProblem> getProblem(bool isMip,
+std::shared_ptr<ILinearProblem> getProblem(bool isMip,
                                            const ResolutionMode& resolutionMode,
                                            const std::optional<std::string>& solver)
 {
@@ -181,9 +181,9 @@ std::unique_ptr<ILinearProblem> getProblem(bool isMip,
             throw std::invalid_argument(
               "Please provide a solver for sequential subproblem resolution");
         }
-        return std::make_unique<OrtoolsLinearProblem>(isMip, solver.value());
+        return std::make_shared<OrtoolsLinearProblem>(isMip, solver.value());
     }
-    return std::make_unique<StructuredLinearProblem>();
+    return std::make_shared<StructuredLinearProblem>();
 }
 
 ProblemEntity buildProblem(const ModelerData& data,
@@ -199,11 +199,10 @@ ProblemEntity buildProblem(const ModelerData& data,
     {
         return {nullptr, nullptr};
     }
-    auto problem = getProblem(isMip, resolutionMode, solver);
     // The container owns (shares) the problem's lifetime: it keeps it alive for
     // post-solve consumers that read variable solution values through it.
-    std::shared_ptr<ILinearProblem> sharedProblem(std::move(problem));
-    auto optimEntityContainer = std::make_unique<OptimEntityContainer>(sharedProblem);
+    auto problem = getProblem(isMip, resolutionMode, solver);
+    auto optimEntityContainer = std::make_unique<OptimEntityContainer>(problem);
 
     SystemLinearProblemBuilder builder(data.system.get(),
                                        data.dataSeries.get(),
@@ -213,7 +212,8 @@ ProblemEntity buildProblem(const ModelerData& data,
 
     bendersDecomposition->setCurrentProblemId(problemId);
     builder.build(timeScenarioCtx, location);
-    return {std::move(sharedProblem), (std::move(optimEntityContainer))};
+    ProblemEntity result{std::move(problem), std::move(optimEntityContainer)};
+    return result;
 }
 
 IMipSolution* Modeler::solveSubproblem()

--- a/src/modeler/modeler/Modeler.cpp
+++ b/src/modeler/modeler/Modeler.cpp
@@ -200,6 +200,7 @@ std::shared_ptr<ILinearProblem> buildProblem(const ModelerData& data,
         return nullptr;
     }
     auto problem = getProblem(isMip, resolutionMode, solver);
+    bendersDecomposition->setCurrentProblemId(problemId);
     OptimEntityContainer temporaryContainer(problem);
     SystemLinearProblemBuilder(data.system.get(),
                                data.dataSeries.get(),

--- a/src/modeler/modeler/Modeler.cpp
+++ b/src/modeler/modeler/Modeler.cpp
@@ -186,34 +186,51 @@ std::shared_ptr<ILinearProblem> getProblem(bool isMip,
     return std::make_shared<StructuredLinearProblem>();
 }
 
-ProblemEntity buildProblem(const ModelerData& data,
-                           const Config::Location& location,
-                           const std::string& problemId,
-                           BendersDecomposition* bendersDecomposition,
-                           const FillContext& timeScenarioCtx,
-                           const ResolutionMode& resolutionMode,
-                           const std::optional<std::string>& solver)
+std::shared_ptr<ILinearProblem> buildProblem(const ModelerData& data,
+                                             const Config::Location& location,
+                                             const std::string& problemId,
+                                             BendersDecomposition* bendersDecomposition,
+                                             const FillContext& timeScenarioCtx,
+                                             const ResolutionMode& resolutionMode,
+                                             const std::optional<std::string>& solver)
 {
     auto [hasCompatibleVariable, isMip] = analyzeLocation(data, location);
     if (!hasCompatibleVariable)
     {
-        return {nullptr, nullptr};
+        return nullptr;
+    }
+    auto problem = getProblem(isMip, resolutionMode, solver);
+    OptimEntityContainer temporaryContainer(problem);
+    SystemLinearProblemBuilder(data.system.get(),
+                               data.dataSeries.get(),
+                               data.scenarioGroupRepository,
+                               bendersDecomposition,
+                               temporaryContainer)
+      .build(timeScenarioCtx, location);
+    return problem;
+}
+
+std::unique_ptr<OptimEntityContainer> buildSubProblemContainer(
+  ModelerData& data,
+  const FillContext& timeScenarioCtx,
+  const std::optional<std::string>& solver)
+{
+    auto [hasCompatibleVariable, isMip] = analyzeLocation(data, Config::Location::SUBPROBLEMS);
+    if (!hasCompatibleVariable)
+    {
+        return nullptr;
     }
     // The container owns (shares) the problem's lifetime: it keeps it alive for
     // post-solve consumers that read variable solution values through it.
-    auto problem = getProblem(isMip, resolutionMode, solver);
+    auto problem = getProblem(isMip, data.resolutionMode, solver);
     auto optimEntityContainer = std::make_unique<OptimEntityContainer>(problem);
-
-    SystemLinearProblemBuilder builder(data.system.get(),
-                                       data.dataSeries.get(),
-                                       data.scenarioGroupRepository,
-                                       bendersDecomposition,
-                                       *optimEntityContainer);
-
-    bendersDecomposition->setCurrentProblemId(problemId);
-    builder.build(timeScenarioCtx, location);
-    ProblemEntity result{std::move(problem), std::move(optimEntityContainer)};
-    return result;
+    SystemLinearProblemBuilder(data.system.get(),
+                               data.dataSeries.get(),
+                               data.scenarioGroupRepository,
+                               &data.bendersDecomposition,
+                               *optimEntityContainer)
+      .build(timeScenarioCtx, Config::Location::SUBPROBLEMS);
+    return optimEntityContainer;
 }
 
 IMipSolution* Modeler::solveSubproblem()
@@ -300,27 +317,24 @@ void Modeler::buildProblems()
 
 void Modeler::buildMasterProblem()
 {
-    auto masterEntities = buildProblem(data_,
-                                       Config::Location::MASTER,
-                                       "master",
-                                       &data_.bendersDecomposition,
-                                       *timeScenarioCtx_,
-                                       ResolutionMode::BENDERS_DECOMPOSITION,
-                                       std::nullopt);
-    masterProblem_ = std::move(masterEntities.problem);
+    masterProblem_ = buildProblem(data_,
+                                  Config::Location::MASTER,
+                                  "master",
+                                  &data_.bendersDecomposition,
+                                  *timeScenarioCtx_,
+                                  ResolutionMode::BENDERS_DECOMPOSITION,
+                                  std::nullopt);
 }
 
 void Modeler::buildSubProblem()
 {
-    auto [subproblem, subproblemOptimEntityContainer] = buildProblem(data_,
-                                                                     Config::Location::SUBPROBLEMS,
-                                                                     "1-1",
-                                                                     &data_.bendersDecomposition,
-                                                                     *timeScenarioCtx_,
-                                                                     data_.resolutionMode,
-                                                                     parameters_.solver);
-    subproblems_.emplace_back(std::move(subproblem));
-    subproblemOptimEntityContainer_ = std::move(subproblemOptimEntityContainer);
+    subproblemOptimEntityContainer_ = buildSubProblemContainer(data_,
+                                                               *timeScenarioCtx_,
+                                                               parameters_.solver);
+    if (subproblemOptimEntityContainer_)
+    {
+        subproblems_.emplace_back(subproblemOptimEntityContainer_->Problem());
+    }
 }
 
 void Modeler::run()

--- a/src/modeler/modeler/Modeler.cpp
+++ b/src/modeler/modeler/Modeler.cpp
@@ -200,7 +200,10 @@ ProblemEntity buildProblem(const ModelerData& data,
         return {nullptr, nullptr};
     }
     auto problem = getProblem(isMip, resolutionMode, solver);
-    auto optimEntityContainer = std::make_unique<OptimEntityContainer>(*problem);
+    // The container owns (shares) the problem's lifetime: it keeps it alive for
+    // post-solve consumers that read variable solution values through it.
+    std::shared_ptr<ILinearProblem> sharedProblem(std::move(problem));
+    auto optimEntityContainer = std::make_unique<OptimEntityContainer>(sharedProblem);
 
     SystemLinearProblemBuilder builder(data.system.get(),
                                        data.dataSeries.get(),
@@ -210,7 +213,7 @@ ProblemEntity buildProblem(const ModelerData& data,
 
     bendersDecomposition->setCurrentProblemId(problemId);
     builder.build(timeScenarioCtx, location);
-    return {std::move(problem), (std::move(optimEntityContainer))};
+    return {std::move(sharedProblem), (std::move(optimEntityContainer))};
 }
 
 IMipSolution* Modeler::solveSubproblem()

--- a/src/modeler/modeler/include/antares/solver/modeler/Modeler.h
+++ b/src/modeler/modeler/include/antares/solver/modeler/Modeler.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <filesystem>
+#include <memory>
 
 #include <antares/optimisation/linear-problem-api/linearProblem.h>
 #include "antares/io/outputs/SimulationTable.h"
@@ -35,7 +36,8 @@ class ILoader;
 
 struct ProblemEntity
 {
-    std::unique_ptr<LinearProblem::Api::ILinearProblem> problem;
+    // Shared with the container, which references the problem's entities.
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> problem;
     std::unique_ptr<LinearProblem::OptimEntityContainer> optimEntityContainer;
 };
 
@@ -73,13 +75,13 @@ public:
 
     ILoader& loader_; // gp : make it private
 
-    [[nodiscard]] const std::unique_ptr<LinearProblem::Api::ILinearProblem>& masterProblem() const
+    [[nodiscard]] const std::shared_ptr<LinearProblem::Api::ILinearProblem>& masterProblem() const
     {
         return masterProblem_;
     }
 
-    [[nodiscard]] const std::vector<std::unique_ptr<LinearProblem::Api::ILinearProblem>>&
-    subproblems() const
+    [[nodiscard]]
+    const std::vector<std::shared_ptr<LinearProblem::Api::ILinearProblem>>& subproblems() const
     {
         return subproblems_;
     }
@@ -95,8 +97,9 @@ private:
       const LinearProblem::OptimEntityContainer& subproblemOptimEntityContainer,
       const LinearProblem::Api::FillContext& timeScenarioCtx) const;
 
-    std::unique_ptr<LinearProblem::Api::ILinearProblem> masterProblem_ = nullptr;
-    std::vector<std::unique_ptr<LinearProblem::Api::ILinearProblem>> subproblems_;
+    // Shared with the containers referencing them.
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> masterProblem_ = nullptr;
+    std::vector<std::shared_ptr<LinearProblem::Api::ILinearProblem>> subproblems_;
     std::unique_ptr<LinearProblem::OptimEntityContainer> subproblemOptimEntityContainer_ = nullptr;
     std::unique_ptr<LinearProblem::Api::FillContext> timeScenarioCtx_ = nullptr;
     LinearProblem::Api::IMipSolution* subProbSolution_ = nullptr;

--- a/src/modeler/modeler/include/antares/solver/modeler/Modeler.h
+++ b/src/modeler/modeler/include/antares/solver/modeler/Modeler.h
@@ -34,20 +34,22 @@ namespace Antares::Solver
 {
 class ILoader;
 
-struct ProblemEntity
-{
-    // Shared with the container, which references the problem's entities.
-    std::shared_ptr<LinearProblem::Api::ILinearProblem> problem;
-    std::unique_ptr<LinearProblem::OptimEntityContainer> optimEntityContainer;
-};
+// Returns the shared problem, or nullptr if no variable is compatible with the location.
+std::shared_ptr<LinearProblem::Api::ILinearProblem> buildProblem(
+  const Antares::Solver::ModelerData& data,
+  const Config::Location& location,
+  const std::string& problemId,
+  LinearProblem::BendersDecomposition* bendersDecomposition,
+  const LinearProblem::Api::FillContext& timeScenarioCtx,
+  const ResolutionMode& resolutionMode,
+  const std::optional<std::string>& solver);
 
-ProblemEntity buildProblem(const Antares::Solver::ModelerData& data,
-                           const Config::Location& location,
-                           const std::string& problemId,
-                           LinearProblem::BendersDecomposition* bendersDecomposition,
-                           const LinearProblem::Api::FillContext& timeScenarioCtx,
-                           const ResolutionMode& resolutionMode,
-                           const std::optional<std::string>& solver);
+// Returns the optimisation entity container (which shares the problem's lifetime),
+// or nullptr if buildProblem did not build a problem for the location.
+std::unique_ptr<LinearProblem::OptimEntityContainer> buildSubProblemContainer(
+  Antares::Solver::ModelerData& data,
+  const LinearProblem::Api::FillContext& timeScenarioCtx,
+  const std::optional<std::string>& solver);
 
 std::filesystem::path makeOutputPath(std::filesystem::path studyPath);
 
@@ -98,10 +100,10 @@ private:
       const LinearProblem::Api::FillContext& timeScenarioCtx) const;
 
     // Shared with the containers referencing them.
-    std::shared_ptr<LinearProblem::Api::ILinearProblem> masterProblem_ = nullptr;
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> masterProblem_;
     std::vector<std::shared_ptr<LinearProblem::Api::ILinearProblem>> subproblems_;
-    std::unique_ptr<LinearProblem::OptimEntityContainer> subproblemOptimEntityContainer_ = nullptr;
-    std::unique_ptr<LinearProblem::Api::FillContext> timeScenarioCtx_ = nullptr;
+    std::unique_ptr<LinearProblem::OptimEntityContainer> subproblemOptimEntityContainer_;
+    std::unique_ptr<LinearProblem::Api::FillContext> timeScenarioCtx_;
     LinearProblem::Api::IMipSolution* subProbSolution_ = nullptr;
     ModelerParameters parameters_;
     ModelerData data_;

--- a/src/solver/optim-model-filler/ComponentFiller.cpp
+++ b/src/solver/optim-model-filler/ComponentFiller.cpp
@@ -115,7 +115,7 @@ class AddVariableVisitor
 {
 public:
     AddVariableVisitor(const Variable& variable,
-                       Api::ILinearProblem& linear_problem,
+                       std::shared_ptr<Api::ILinearProblem> linear_problem,
                        const VariableNames& variableNames,
                        const Dimensions& dimensions);
 
@@ -131,13 +131,13 @@ public:
 
 private:
     const bool isInteger_;
-    Api::ILinearProblem& linear_problem_;
+    std::shared_ptr<Api::ILinearProblem> linear_problem_;
     const VariableNames& variableNames_;
     const Dimensions& dims_;
 };
 
 AddVariableVisitor::AddVariableVisitor(const Variable& variable,
-                                       Api::ILinearProblem& linear_problem,
+                                       std::shared_ptr<Api::ILinearProblem> linear_problem,
                                        const VariableNames& variableNames,
                                        const Dimensions& dimensions):
     isInteger_(variable.Type() != ValueType::FLOAT),
@@ -154,7 +154,7 @@ void AddVariableVisitor::operator()(double lb, double ub) const
     {
         for (std::size_t j = 0; j < dims_.getTimesteps().size(); ++j)
         {
-            linear_problem_.addVariable(lb, ub, isInteger_, variableNames_.name(index));
+            linear_problem_->addVariable(lb, ub, isInteger_, variableNames_.name(index));
             index++;
         }
     }
@@ -176,7 +176,7 @@ void AddVariableVisitor::operator()(const std::vector<double>& lb, double ub) co
     {
         for (const auto t: dims_.getTimesteps())
         {
-            linear_problem_.addVariable(lb[t], ub, isInteger_, variableNames_.name(index));
+            linear_problem_->addVariable(lb[t], ub, isInteger_, variableNames_.name(index));
             index++;
         }
     }
@@ -197,7 +197,7 @@ void AddVariableVisitor::operator()(double lb, const std::vector<double>& ub) co
     {
         for (const auto t: dims_.getTimesteps())
         {
-            linear_problem_.addVariable(lb, ub[t], isInteger_, variableNames_.name(index));
+            linear_problem_->addVariable(lb, ub[t], isInteger_, variableNames_.name(index));
             index++;
         }
     }
@@ -220,7 +220,7 @@ void AddVariableVisitor::operator()(const std::vector<double>& lb,
     {
         for (const auto t: dims_.getTimesteps())
         {
-            linear_problem_.addVariable(lb[t], ub[t], isInteger_, variableNames_.name(index));
+            linear_problem_->addVariable(lb[t], ub[t], isInteger_, variableNames_.name(index));
             index++;
         }
     }
@@ -287,9 +287,9 @@ void ComponentFiller::addVariables(const Api::FillContext& ctx)
     for (const auto& variable: variables | locationFilter())
     {
         const auto& lb = valueOrDefault(variable.LowerBound(),
-                                        variable.Type() == ValueType::BOOL ? 0 : -pb_.infinity());
+                                        variable.Type() == ValueType::BOOL ? 0 : -pb_->infinity());
         const auto& ub = valueOrDefault(variable.UpperBound(),
-                                        variable.Type() == ValueType::BOOL ? 1 : pb_.infinity());
+                                        variable.Type() == ValueType::BOOL ? 1 : pb_->infinity());
 
         optimEntityContainer_.addStartColumn();
 
@@ -313,7 +313,7 @@ void ComponentFiller::addVariables(const Api::FillContext& ctx)
         {
             bendersDecomposition_->collectCouplingVariables(variableNames.names(),
                                                             static_cast<unsigned>(
-                                                              pb_.variableCount()));
+                                                              pb_->variableCount()));
         }
     }
 }
@@ -321,11 +321,11 @@ void ComponentFiller::addVariables(const Api::FillContext& ctx)
 void ComponentFiller::addStaticConstraint(const LinearConstraint& linear_constraint,
                                           const std::string& constraint_id) const
 {
-    auto* ct = pb_.addConstraint(linear_constraint.lb[0],
-                                 linear_constraint.ub[0],
-                                 component_.Id() + "." + constraint_id);
+    auto* ct = pb_->addConstraint(linear_constraint.lb[0],
+                                  linear_constraint.ub[0],
+                                  component_.Id() + "." + constraint_id);
 
-    const auto& solverVariables = pb_.getVariables();
+    const auto& solverVariables = pb_->getVariables();
     const auto& coefsPerVar = linear_constraint.coef_per_var[0];
 
     for (const auto& [index, value]: coefsPerVar)
@@ -341,7 +341,7 @@ void ComponentFiller::addTimeDependentConstraints(const LinearConstraint& linear
 {
     const auto dims = getDimensions(ctx);
 
-    const auto& solverVariables = pb_.getVariables();
+    const auto& solverVariables = pb_->getVariables();
     const auto firstTimestep = dims.getTimesteps().initialTime;
 
     const bool isDrop = constraint.outOfBoundsProcessingMode() == OutOfBoundsProcessingMode::DROP;
@@ -369,10 +369,10 @@ void ComponentFiller::addTimeDependentConstraints(const LinearConstraint& linear
                 continue;
             }
 
-            auto* ct = pb_.addConstraint(linear_constraints.lb[localIndex],
-                                         linear_constraints.ub[localIndex],
-                                         component_.Id() + "." + constraint_id + '_'
-                                           + std::to_string(t));
+            auto* ct = pb_->addConstraint(linear_constraints.lb[localIndex],
+                                          linear_constraints.ub[localIndex],
+                                          component_.Id() + "." + constraint_id + '_'
+                                            + std::to_string(t));
 
             const auto& coefsPerVar = linear_constraints.coef_per_var[localIndex];
             for (const auto& [index, value]: coefsPerVar)
@@ -386,10 +386,10 @@ void ComponentFiller::addTimeDependentConstraints(const LinearConstraint& linear
         for (const auto t: dims.getTimesteps())
         {
             const auto localIndex = static_cast<std::size_t>(t - firstTimestep);
-            auto* ct = pb_.addConstraint(linear_constraints.lb[localIndex],
-                                         linear_constraints.ub[localIndex],
-                                         component_.Id() + "." + constraint_id + '_'
-                                           + std::to_string(t));
+            auto* ct = pb_->addConstraint(linear_constraints.lb[localIndex],
+                                          linear_constraints.ub[localIndex],
+                                          component_.Id() + "." + constraint_id + '_'
+                                            + std::to_string(t));
 
             const auto& coefsPerVar = linear_constraints.coef_per_var[localIndex];
             for (const auto& [index, value]: coefsPerVar)
@@ -441,11 +441,11 @@ void ComponentFiller::addConstraints(const Api::FillContext& ctx)
 
 void ComponentFiller::addStaticObjective(const Optimization::LinearExpression& expression) const
 {
-    const auto& solverVariables = pb_.getVariables();
+    const auto& solverVariables = pb_->getVariables();
 
     for (const auto& [index, value]: expression)
     {
-        pb_.setObjectiveCoefficient(solverVariables[index].get(), value);
+        pb_->setObjectiveCoefficient(solverVariables[index].get(), value);
     }
 }
 
@@ -471,7 +471,7 @@ void ComponentFiller::addObjectives(const Api::FillContext& ctx)
         addStaticObjective(linearExpression);
         objectiveOffset += linearExpression.constant();
     }
-    pb_.setObjectiveOffset(pb_.getObjectiveOffset() + objectiveOffset);
+    pb_->setObjectiveOffset(pb_->getObjectiveOffset() + objectiveOffset);
 }
 
 VariabilityType ComponentFiller::getVariability(const Node* node, const Component& component) const

--- a/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ComponentFiller.h
+++ b/src/solver/optim-model-filler/include/antares/solver/optim-model-filler/ComponentFiller.h
@@ -56,7 +56,7 @@ private:
 
     const ModelerStudy::SystemModel::Component& component_;
     OptimEntityContainer& optimEntityContainer_;
-    Api::ILinearProblem& pb_;
+    std::shared_ptr<Api::ILinearProblem> pb_;
     const LinearProblem::Api::ILinearProblemData* data_;
     const LinearProblem::ScenarioGroupRepository& scenarioGroupRepo_;
     const Solver::Config::Location targetLocation_;

--- a/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
+++ b/src/solver/optimisation/ComponentToAreaConnectionFiller.cpp
@@ -108,7 +108,7 @@ void ComponentToAreaConnectionFiller::addExpressionToConstraint(
   const FillContext& ctx,
   const std::vector<IMipConstraint*>& constraints) const
 {
-    const auto& solverVariables = pb_.getVariables();
+    const auto& solverVariables = pb_->getVariables();
 
     for (unsigned h(0); h <= ctx.getLocalLastTimeStep(); ++h)
     {
@@ -130,7 +130,7 @@ std::vector<IMipConstraint*> ComponentToAreaConnectionFiller::fetchConstraints(
     std::vector<IMipConstraint*> constraints(ctx.getLocalNumberOfTimeSteps());
     for (unsigned h(0); h <= ctx.getLocalLastTimeStep(); ++h)
     {
-        constraints[h] = pb_.getConstraint(constraintsIndices[h]);
+        constraints[h] = pb_->getConstraint(constraintsIndices[h]);
     }
     return constraints;
 }

--- a/src/solver/optimisation/LegacyFiller.cpp
+++ b/src/solver/optimisation/LegacyFiller.cpp
@@ -13,7 +13,7 @@ namespace Antares::Optimization
 LegacyFiller::LegacyFiller(LinearProblem::Api::ILinearProblem& linearProblem,
                            const PROBLEME_HEBDO* problemeHebdo):
     problemeAResoudre_(problemeHebdo->ProblemeAResoudre.get()),
-    linearProblem_(linearProblem)
+    linearProblem_(&linearProblem)
 {
 }
 
@@ -39,13 +39,13 @@ void LegacyFiller::CopyMatrix() const
 {
     for (int idxRow = 0; idxRow < problemeAResoudre_->NombreDeContraintes; ++idxRow)
     {
-        auto* ct = linearProblem_.getConstraint(idxRow);
+        auto* ct = linearProblem_->getConstraint(idxRow);
         int debutLigne = problemeAResoudre_->IndicesDebutDeLigne[idxRow];
         for (int idxCoef = 0; idxCoef < problemeAResoudre_->NombreDeTermesDesLignes[idxRow];
              ++idxCoef)
         {
             int pos = debutLigne + idxCoef;
-            auto* var = linearProblem_.getVariable(problemeAResoudre_->IndicesColonnes[pos]);
+            auto* var = linearProblem_->getVariable(problemeAResoudre_->IndicesColonnes[pos]);
             ct->setCoefficient(var, problemeAResoudre_->CoefficientsDeLaMatriceDesContraintes[pos]);
         }
     }
@@ -58,19 +58,19 @@ void LegacyFiller::CreateVariable(unsigned idxVar) const
     const int typeVar = problemeAResoudre_->TypeDeVariable[idxVar];
 
     double min_l = (typeVar == VARIABLE_NON_BORNEE || typeVar == VARIABLE_BORNEE_SUPERIEUREMENT)
-                     ? -linearProblem_.infinity()
+                     ? -linearProblem_->infinity()
                      : bMin;
     double max_l = (typeVar == VARIABLE_NON_BORNEE || typeVar == VARIABLE_BORNEE_INFERIEUREMENT)
-                     ? linearProblem_.infinity()
+                     ? linearProblem_->infinity()
                      : bMax;
     const bool isIntegerVariable = problemeAResoudre_->VariablesEntieres[idxVar];
 
-    auto* var = linearProblem_.addVariable(min_l,
-                                           max_l,
-                                           isIntegerVariable,
-                                           GetVariableName(idxVar));
-    linearProblem_.setObjectiveCoefficient(var, problemeAResoudre_->CoutLineaire[idxVar]);
-    // linearProblem_.setObjectiveOffset(problemeAResoudre_->)
+    auto* var = linearProblem_->addVariable(min_l,
+                                            max_l,
+                                            isIntegerVariable,
+                                            GetVariableName(idxVar));
+    linearProblem_->setObjectiveCoefficient(var, problemeAResoudre_->CoutLineaire[idxVar]);
+    // linearProblem_->setObjectiveOffset(problemeAResoudre_->)
 }
 
 void LegacyFiller::CopyVariables() const
@@ -83,7 +83,7 @@ void LegacyFiller::CopyVariables() const
 
 void LegacyFiller::UpdateContraints(unsigned idxRow) const
 {
-    double bMin = -linearProblem_.infinity(), bMax = linearProblem_.infinity();
+    double bMin = -linearProblem_->infinity(), bMax = linearProblem_->infinity();
     switch (problemeAResoudre_->Sens[idxRow])
     {
     case '=':
@@ -97,7 +97,7 @@ void LegacyFiller::UpdateContraints(unsigned idxRow) const
         break;
     }
 
-    linearProblem_.addConstraint(bMin, bMax, GetConstraintName(idxRow));
+    linearProblem_->addConstraint(bMin, bMax, GetConstraintName(idxRow));
 }
 
 void LegacyFiller::CopyRows() const

--- a/src/solver/optimisation/ThermalCapacityFiller.cpp
+++ b/src/solver/optimisation/ThermalCapacityFiller.cpp
@@ -72,7 +72,7 @@ IMipVariable* ThermalCapacityFiller::getDispatchableProductionVariable(int therm
                                                                        unsigned pdt)
 {
     auto varIndex = variableManager_.DispatchableProduction(thermalClusterIndex, pdt);
-    return pb_.getVariable(varIndex);
+    return pb_->getVariable(varIndex);
 }
 
 void ThermalCapacityFiller::addCapacityFieldConstraint(
@@ -81,22 +81,22 @@ void ThermalCapacityFiller::addCapacityFieldConstraint(
   const int clusterIndex,
   const std::string& namePrefix)
 {
-    const auto& solverVariables = pb_.getVariables();
+    const auto& solverVariables = pb_->getVariables();
     for (auto localIndex(ctx.getLocalFirstTimeStep()); localIndex <= ctx.getLocalLastTimeStep();
          ++localIndex)
     {
         auto pdt = localIndex % problemeHebdo_->NombreDePasDeTempsPourUneOptimisation;
         IMipVariable* dispatchableProduction = getDispatchableProductionVariable(clusterIndex, pdt);
-        double infinity = pb_.infinity();
+        double infinity = pb_->infinity();
         // When a thermal-capacity-connection exists, the legacy thermal capacity timeseries
         // is replaced by the capacity expression coming from the connected GEMS port.
         dispatchableProduction->setUb(infinity);
 
-        auto* ct = pb_.addConstraint(-infinity,
-                                     linearExpression[localIndex].constant(),
-                                     namePrefix
-                                       + fmt::format("::hour<{}>",
-                                                     pdt + problemeHebdo_->weekInTheYear * 168));
+        auto* ct = pb_->addConstraint(-infinity,
+                                      linearExpression[localIndex].constant(),
+                                      namePrefix
+                                        + fmt::format("::hour<{}>",
+                                                      pdt + problemeHebdo_->weekInTheYear * 168));
         ct->setCoefficient(dispatchableProduction, 1.0);
 
         for (const auto& [varIndex, coef]: linearExpression[localIndex])

--- a/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/ComponentToAreaConnectionFiller.h
@@ -51,7 +51,7 @@ private:
     const PROBLEME_HEBDO* problemeHebdo_;
     const ModelerStudy::SystemModel::System* modelerSystem_;
     LinearProblem::OptimEntityContainer& optimEntityContainer_;
-    LinearProblem::Api::ILinearProblem& pb_;
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> pb_;
     const LinearProblem::Api::ILinearProblemData* data_;
     const LinearProblem::ScenarioGroupRepository& scenarioGroupRepo_;
 

--- a/src/solver/optimisation/include/antares/solver/optimisation/LegacyFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/LegacyFiller.h
@@ -22,7 +22,7 @@ public:
 private:
     const PROBLEME_ANTARES_A_RESOUDRE* problemeAResoudre_;
 
-    LinearProblem::Api::ILinearProblem& linearProblem_;
+    LinearProblem::Api::ILinearProblem* linearProblem_;
     void CreateVariable(unsigned idxVar) const;
     void CopyVariables() const;
     void UpdateContraints(unsigned idxRow) const;

--- a/src/solver/optimisation/include/antares/solver/optimisation/ThermalCapacityFiller.h
+++ b/src/solver/optimisation/include/antares/solver/optimisation/ThermalCapacityFiller.h
@@ -46,7 +46,7 @@ private:
     const PROBLEME_HEBDO* problemeHebdo_;
     const ModelerStudy::SystemModel::System* modelerSystem_;
     LinearProblem::OptimEntityContainer& optimEntityContainer_;
-    LinearProblem::Api::ILinearProblem& pb_;
+    std::shared_ptr<LinearProblem::Api::ILinearProblem> pb_;
     const LinearProblem::Api::ILinearProblemData* data_;
     const LinearProblem::ScenarioGroupRepository& scenarioGroupRepo_;
 

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -49,7 +49,6 @@ using Solver::IResultWriter;
 struct SimplexResult
 {
     TIME_MEASURE timeMeasure;
-    std::shared_ptr<LegacyOrtoolsLinearProblem> originalProblem;
     double objectiveValue;
 };
 
@@ -220,12 +219,14 @@ static SimplexResult OPT_TryToCallSimplex(const SingleOptimOptions& options,
     const bool isMip = problemeHebdo->OptimisationAvecVariablesEntieres;
 
     auto ortoolsProblem = std::make_shared<LegacyOrtoolsLinearProblem>(isMip, options.solverName);
-    problemeHebdo->ortoolsProblem = ortoolsProblem;
     FillContext fillCtx = buildFillContext(problemeHebdo, NumIntervalle);
     const ILinearProblemData* modelerDataSeries = hasModelerData ? modelerData->dataSeries.get()
                                                                  : nullptr;
 
-    problemeHebdo->optimEntityContainer = std::make_unique<OptimEntityContainer>(*ortoolsProblem);
+    // The container owns the problem's lifetime: it keeps it alive for all the post-solve
+    // consumers (e.g. the hourly adequacy-patch GEMS evaluations) that read variable
+    // solution values through the container.
+    problemeHebdo->optimEntityContainer = std::make_unique<OptimEntityContainer>(ortoolsProblem);
     auto& optimEntityContainer = *problemeHebdo->optimEntityContainer;
 
     BendersDecomposition* bendersDecomposition = hasModelerData ? &modelerData->bendersDecomposition
@@ -274,9 +275,7 @@ static SimplexResult OPT_TryToCallSimplex(const SingleOptimOptions& options,
             logs.info() << " Solver: resolution failed";
             logs.debug() << " solver: resetting";
 
-            return {.timeMeasure = timeMeasure,
-                    .originalProblem = ortoolsProblem,
-                    .objectiveValue = 0};
+            return {.timeMeasure = timeMeasure, .objectiveValue = 0};
         }
         throw FatalError("Internal error: insufficient memory");
     }
@@ -323,9 +322,7 @@ static SimplexResult OPT_TryToCallSimplex(const SingleOptimOptions& options,
         measure.tick();
         timeMeasure.simulationTableFillTime = measure.duration_ms();
     }
-    return {.timeMeasure = timeMeasure,
-            .originalProblem = ortoolsProblem,
-            .objectiveValue = getObjectiveValue(solver.get())};
+    return {.timeMeasure = timeMeasure, .objectiveValue = getObjectiveValue(solver.get())};
 }
 
 bool OPT_AppelDuSimplexe(const SingleOptimOptions& options,
@@ -397,20 +394,21 @@ bool OPT_AppelDuSimplexe(const SingleOptimOptions& options,
     {
         const bool isMip = problemeHebdo->OptimisationAvecVariablesEntieres;
 
-        LegacyOrtoolsLinearProblem infeasibleProblem(isMip, options.solverName);
+        auto infeasibleProblem = std::make_shared<LegacyOrtoolsLinearProblem>(isMip,
+                                                                              options.solverName);
         FillContext fillCtx = buildFillContext(problemeHebdo, NumIntervalle);
 
         OptimEntityContainer optimEntityContainer(infeasibleProblem);
         fillLinearProblem(fillCtx, problemeHebdo, optimEntityContainer, nullptr);
 
-        auto MPproblem = infeasibleProblem.getMpSolver();
+        auto MPproblem = infeasibleProblem->getMpSolver();
         auto analyzer = makeUnfeasiblePbAnalyzer();
         analyzer->run(MPproblem.get());
         analyzer->printReport();
         mpsWriterFactory mps_writer_factory(problemeHebdo->ExportMPS,
                                             problemeHebdo->exportMPSOnError,
                                             optimizationNumber,
-                                            *simplexResult.originalProblem);
+                                            problemeHebdo->optimEntityContainer->Problem());
 
         auto mps_writer_on_error = mps_writer_factory.createOnOptimizationError();
         const std::string filename = createMPSfilename(optPeriodStringGenerator,

--- a/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
+++ b/src/solver/optimisation/opt_appel_solveur_lineaire.cpp
@@ -159,7 +159,7 @@ void fillLinearProblem(const FillContext& fillCtx,
 {
     std::vector<std::unique_ptr<LinearProblemFiller>> fillersCollection;
     fillersCollection.push_back(
-      std::make_unique<LegacyFiller>(optimEntityContainer.Problem(), problemeHebdo));
+      std::make_unique<LegacyFiller>(*optimEntityContainer.Problem(), problemeHebdo));
     Utils::TimeMeasurement measure;
     if (problemeHebdo->modelerData)
     {
@@ -408,7 +408,7 @@ bool OPT_AppelDuSimplexe(const SingleOptimOptions& options,
         mpsWriterFactory mps_writer_factory(problemeHebdo->ExportMPS,
                                             problemeHebdo->exportMPSOnError,
                                             optimizationNumber,
-                                            problemeHebdo->optimEntityContainer->Problem());
+                                            *problemeHebdo->optimEntityContainer->Problem());
 
         auto mps_writer_on_error = mps_writer_factory.createOnOptimizationError();
         const std::string filename = createMPSfilename(optPeriodStringGenerator,

--- a/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
+++ b/src/solver/simulation/include/antares/solver/simulation/sim_structure_probleme_economique.h
@@ -776,8 +776,9 @@ public:
 
     // TODO: 1 study but several PROBLEME_HEBDO, may cause race conditions
     Antares::Solver::ModelerData* modelerData = nullptr;
+    // Owns the weekly ILinearProblem; the problem outlives the container that references it
+    // and stays available for post-solve consumers (e.g. adequacy-patch GEMS evaluations).
     std::unique_ptr<Antares::LinearProblem::OptimEntityContainer> optimEntityContainer;
-    std::shared_ptr<Antares::LinearProblem::Api::ILinearProblem> ortoolsProblem;
 };
 
 // Import functions for capacity and hydro reserves

--- a/src/tests/inmemory-modeler/include/inmemory-modeler.h
+++ b/src/tests/inmemory-modeler/include/inmemory-modeler.h
@@ -49,7 +49,7 @@ struct LinearProblemBuildingFixture
 {
     std::unordered_map<std::string, Model> models;
     Antares::Expressions::Registry<Antares::Expressions::Nodes::Node> nodeRegistry;
-    std::unique_ptr<Antares::LinearProblem::Api::ILinearProblem> pb;
+    std::shared_ptr<Antares::LinearProblem::Api::ILinearProblem> pb;
     std::vector<Component> components;
     Antares::LinearProblem::DataImpl::LinearProblemData dummy_data_;
     ModelerData modelerData;

--- a/src/tests/inmemory-modeler/inmemory-modeler.cpp
+++ b/src/tests/inmemory-modeler/inmemory-modeler.cpp
@@ -40,8 +40,8 @@ void LinearProblemBuildingFixture::buildLinearProblem(
         auto name = scenario->group();
         scenarioGroupRepo.addScenario(name, std::move(scenario));
     }
-    pb = std::make_unique<MpsolverImpl::OrtoolsLinearProblem>(false, "sirius");
-    optimEntityContainer = std::make_unique<OptimEntityContainer>(*pb);
+    pb = std::make_shared<MpsolverImpl::OrtoolsLinearProblem>(false, "sirius");
+    optimEntityContainer = std::make_unique<OptimEntityContainer>(pb);
     optimEntityContainer->addFromSystemComponents(components);
     for (auto& component: components)
     {

--- a/src/tests/src/api_lib/test_single_problem_api.cpp
+++ b/src/tests/src/api_lib/test_single_problem_api.cpp
@@ -766,7 +766,7 @@ problem-2-2--optim-nb-1	component.x	1008
 
 void checkMasterProblem(const Implementation::SingleProblemGetter& getter)
 {
-    auto [masterPb, _] = getter.getMasterProblem();
+    auto masterPb = getter.getMasterProblem();
     BOOST_CHECK_EQUAL(masterPb->constraintCount(), 1);
     BOOST_CHECK_EQUAL(masterPb->variableCount(), 1);
     const auto& x = masterPb->getVariables().at(0);

--- a/src/tests/src/expressions/test_PrintAndEvalVisitors.cpp
+++ b/src/tests/src/expressions/test_PrintAndEvalVisitors.cpp
@@ -771,7 +771,7 @@ struct TimeDependentParameterFixture
     std::string compoName = "1245";
     std::vector<Component> components;
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepo;
-    MockLinearProblem linearProblem = MockLinearProblem(true);
+    std::shared_ptr<MockLinearProblem> linearProblem = std::make_shared<MockLinearProblem>(true);
     OptimEntityContainer optimContainer = OptimEntityContainer(linearProblem);
 
     std::unique_ptr<Antares::Expressions::Visitors::EvalVisitor> evalVisitor;
@@ -846,7 +846,7 @@ EvaluationResult CreateAndEvaluateTimeNode(Node* p)
     const std::vector<Component> components{createComponent(model, compoName, {param})};
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepo = makeScenarioGroupRepo(
       components.back());
-    MockLinearProblem linearProblem = MockLinearProblem(true);
+    std::shared_ptr<MockLinearProblem> linearProblem = std::make_shared<MockLinearProblem>(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
     const Antares::LinearProblem::Api::FillContext fillContext{first,
@@ -903,7 +903,7 @@ EvaluationResult CreateAndEvaluateTimeSumNode(Node* from, Node* to)
     const std::vector<Component> components{createComponent(model, compoName, {param})};
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepo = makeScenarioGroupRepo(
       components.back());
-    MockLinearProblem linearProblem = MockLinearProblem(true);
+    std::shared_ptr<MockLinearProblem> linearProblem = std::make_shared<MockLinearProblem>(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
 
@@ -976,7 +976,7 @@ EvaluationResult CreateAndEvaluateAllTimeSumNode()
     const std::vector<Component> components{createComponent(model, compoName, {param})};
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepo = makeScenarioGroupRepo(
       components.back());
-    MockLinearProblem linearProblem = MockLinearProblem(true);
+    std::shared_ptr<MockLinearProblem> linearProblem = std::make_shared<MockLinearProblem>(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
 
@@ -1092,7 +1092,7 @@ void evaluate_time_dependent_operation()
 
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepo = makeScenarioGroupRepo(
       components.back());
-    MockLinearProblem linearProblem = MockLinearProblem(true);
+    std::shared_ptr<MockLinearProblem> linearProblem = std::make_shared<MockLinearProblem>(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
 
@@ -1136,7 +1136,7 @@ void evaluate_time_dependent_operation_on_TimeShiftNode(Node* timeShift)
 
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepo = makeScenarioGroupRepo(
       components.back());
-    MockLinearProblem linearProblem = MockLinearProblem(true);
+    std::shared_ptr<MockLinearProblem> linearProblem = std::make_shared<MockLinearProblem>(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
     const Antares::LinearProblem::Api::FillContext fillContext{hours.at(0),
@@ -1187,7 +1187,7 @@ void evaluate_time_dependent_operation_on_TimeIndexNode(Node* timeIndex)
 
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepo = makeScenarioGroupRepo(
       components.back());
-    MockLinearProblem linearProblem = MockLinearProblem(true);
+    std::shared_ptr<MockLinearProblem> linearProblem = std::make_shared<MockLinearProblem>(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
     const Antares::LinearProblem::Api::FillContext fillContext{hours.at(0),
@@ -1751,18 +1751,18 @@ BOOST_FIXTURE_TEST_CASE(testVariableNodeEvaluation, MyDummyFixture)
 
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepo = makeScenarioGroupRepo(
       components.back());
-    PredfinedSolutionLinearProblemMock linearProblem(true);
+    auto linearProblem = std::make_shared<PredfinedSolutionLinearProblemMock>(true);
     OptimEntityContainer optimContainer(linearProblem);
     optimContainer.addFromSystemComponents(components);
 
     optimContainer.addStartColumn();
-    linearProblem.addVariableValue(12.5); // my_const_variable
+    linearProblem->addVariableValue(12.5); // my_const_variable
     std::vector<double> timeDepentVariableValues = {45.3, 78.9, 714.5};
 
     optimContainer.addStartColumn();
     for (const auto& value: timeDepentVariableValues)
     {
-        linearProblem.addVariableValue(value);
+        linearProblem->addVariableValue(value);
     }
 
     Node* root = create<VariableNode>("my_const_variable",

--- a/src/tests/src/expressions/test_evaluate-function-operators.cpp
+++ b/src/tests/src/expressions/test_evaluate-function-operators.cpp
@@ -77,7 +77,7 @@ struct CreateEvalVisitor
 
 private:
     DataImpl::LinearProblemData data_;
-    MockLinearProblem linearProblem_;
+    std::shared_ptr<MockLinearProblem> linearProblem_;
     std::unique_ptr<OptimEntityContainer> optimEntityContainer_;
     Api::FillContext fillCtx_;
     Model model_;
@@ -87,7 +87,7 @@ private:
 };
 
 CreateEvalVisitor::CreateEvalVisitor():
-    linearProblem_(true),
+    linearProblem_(std::make_shared<MockLinearProblem>(true)),
     fillCtx_(0, 3, 0, 3, 0),
     model_(
       createModelWithParameters({Parameter("p", TimeDependent::YES, ScenarioDependent::NO),

--- a/src/tests/src/expressions/test_evaluate-sum-operators.cpp
+++ b/src/tests/src/expressions/test_evaluate-sum-operators.cpp
@@ -81,7 +81,7 @@ struct build_eval_visitor_fixture
 
 private:
     DataImpl::LinearProblemData data_;
-    MockLinearProblem linearProblem_;
+    std::shared_ptr<MockLinearProblem> linearProblem_;
     std::unique_ptr<OptimEntityContainer> optimEntityContainer_;
     Api::FillContext fillCtx_;
     Model model_;
@@ -91,7 +91,7 @@ private:
 };
 
 build_eval_visitor_fixture::build_eval_visitor_fixture():
-    linearProblem_(true),
+    linearProblem_(std::make_shared<MockLinearProblem>(true)),
     fillCtx_(0, 2, 0, 2, 0),
     model_(
       createModelWithParameters({Parameter("p", TimeDependent::YES, ScenarioDependent::NO),

--- a/src/tests/src/io/outputs/testSimulationTable.cpp
+++ b/src/tests/src/io/outputs/testSimulationTable.cpp
@@ -618,9 +618,9 @@ struct BasicProblemFixture: Test::Modeler::LinearProblemBuildingFixture, Simulat
         }
     }
 
-    void setOptimEntityContainer(MockLinearProblem* linearProblem)
+    void setOptimEntityContainer(std::shared_ptr<MockLinearProblem> linearProblem)
     {
-        optimEntityContainer = std::make_unique<OptimEntityContainer>(*linearProblem);
+        optimEntityContainer = std::make_unique<OptimEntityContainer>(linearProblem);
     }
 
     void PrepareData()
@@ -667,7 +667,7 @@ struct BasicProblemFixture: Test::Modeler::LinearProblemBuildingFixture, Simulat
     }
 
     void build(const FillContext& fillContext = {0, 4, 0, 4, 0},
-               MockLinearProblem* linearProblem = nullptr)
+               std::shared_ptr<MockLinearProblem> linearProblem = nullptr)
     {
         if (!linearProblem)
         {
@@ -676,7 +676,7 @@ struct BasicProblemFixture: Test::Modeler::LinearProblemBuildingFixture, Simulat
 
         PrepareData();
         setOptimEntityContainer(linearProblem);
-        AddRandomVariablesAndContraints(fillContext, linearProblem);
+        AddRandomVariablesAndContraints(fillContext, linearProblem.get());
     }
 
     std::unique_ptr<OptimEntityContainer> optimEntityContainer = nullptr;
@@ -693,14 +693,14 @@ auto count_lines = [](std::string_view s)
 BOOST_AUTO_TEST_CASE(TemplateFunction_VariableEntries_AllCombinations)
 {
     SimulationTable table;
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
     const FillContext fillContext(0, 9, 0, 9, 0); // 10 time steps
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
 
     const auto& component = components.front();
 
     addVariableEntries(table,
-                       linearProblem,
+                       *linearProblem,
                        fillContext,
                        component,
                        *optimEntityContainer,
@@ -851,13 +851,13 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_ModelerIntegration)
 {
     SimulationTable table;
     FillContext fillContext(0, 4, 0, 4, 0); // 5 time steps
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
     LinearProblemData data;
 
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
     MockMipSolution solution;
     BOOST_CHECK_NO_THROW(FillSimulationTable(table,
-                                             linearProblem,
+                                             *linearProblem,
                                              45.0,
                                              getModelerData(),
                                              *optimEntityContainer,
@@ -870,11 +870,11 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_WeeklyBlockTimeIndexUsesLocalStep)
 {
     SimulationTable table;
     FillContext fillContext(0, 1, 168, 169, 0); // 1 local time steps, week 2 globally
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
 
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
     FillSimulationTable(table,
-                        linearProblem,
+                        *linearProblem,
                         45.0,
                         getModelerData(),
                         *optimEntityContainer,
@@ -893,11 +893,11 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_DailyBlockTimeIndexUsesLocalStep)
 {
     SimulationTable table;
     FillContext fillContext(0, 1, 24, 25, 0); // 1 local time steps, day 2 globally
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
 
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
     FillSimulationTable(table,
-                        linearProblem,
+                        *linearProblem,
                         45.0,
                         getModelerData(),
                         *optimEntityContainer,
@@ -916,11 +916,11 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_SingleBlockTimeIndexUsesLocalStep)
 {
     SimulationTable table;
     FillContext fillContext(0, 1, 24, 25, 0); // 2 local time steps, single block
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
 
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
     FillSimulationTable(table,
-                        linearProblem,
+                        *linearProblem,
                         45.0,
                         getModelerData(),
                         *optimEntityContainer,
@@ -939,11 +939,11 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_WeeklyBlockConstraintTimeIndexUsesLocal
 {
     SimulationTable table;
     FillContext fillContext(0, 1, 168, 169, 0); // 2 local time steps, week 2 globally
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
 
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
     FillSimulationTable(table,
-                        linearProblem,
+                        *linearProblem,
                         45.0,
                         getModelerData(),
                         *optimEntityContainer,
@@ -962,11 +962,11 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_ForceScenarioIndexForTimeOnlyVariables)
 {
     SimulationTable table;
     FillContext fillContext(0, 1, 0, 1, 0); // 2 local time steps
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
 
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
     FillSimulationTable(table,
-                        linearProblem,
+                        *linearProblem,
                         45.0,
                         getModelerData(),
                         *optimEntityContainer,
@@ -985,11 +985,11 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_BlockTimeIndexAbsentForScenarioOnlyOutp
 {
     SimulationTable table;
     FillContext fillContext(0, 1, 0, 1, 0); // 2 local time steps
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
 
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
     FillSimulationTable(table,
-                        linearProblem,
+                        *linearProblem,
                         45.0,
                         getModelerData(),
                         *optimEntityContainer,
@@ -1007,11 +1007,11 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_VariabilityCombinations)
 {
     SimulationTable table;
     FillContext fillContext(0, 1, 0, 1, 0); // 2 local time steps
-    MockLinearProblem linearProblem(true);
+    auto linearProblem = std::make_shared<MockLinearProblem>(true);
 
-    build(fillContext, &linearProblem);
+    build(fillContext, linearProblem);
     FillSimulationTable(table,
-                        linearProblem,
+                        *linearProblem,
                         45.0,
                         getModelerData(),
                         *optimEntityContainer,
@@ -1048,7 +1048,7 @@ BOOST_AUTO_TEST_CASE(FillSimulationTable_SkipsDroppedDualExtraOutputTimesteps)
 
     FillContext fillContext(0, 2, 0, 2, 0);
     pb = std::make_unique<OrtoolsLinearProblem>(true, "scip");
-    optimEntityContainer = std::make_unique<OptimEntityContainer>(*pb);
+    optimEntityContainer = std::make_unique<OptimEntityContainer>(pb);
     optimEntityContainer->addFromSystemComponents(components);
 
     std::vector<std::unique_ptr<LinearProblemFiller>> fillers;

--- a/src/tests/src/modeler/UtilMocks.h
+++ b/src/tests/src/modeler/UtilMocks.h
@@ -461,7 +461,7 @@ struct MyDummyFixture: Antares::Expressions::Registry<Antares::Expressions::Node
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepository = makeScenarioGroupRepo(
       components.front());
 
-    MockLinearProblem linearProblem = MockLinearProblem(true);
+    std::shared_ptr<MockLinearProblem> linearProblem = std::make_shared<MockLinearProblem>(true);
     Antares::LinearProblem::Api::FillContext ctx{0, 0, 0, 0, 0};
 
     Antares::LinearProblem::OptimEntityContainer optimEntityContainer = Antares::LinearProblem::

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/FillerContext.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/FillerContext.h
@@ -30,10 +30,10 @@ void VarFillerContext::addVariables([[maybe_unused]] const FillContext& ctx)
     {
         for (unsigned scenario: ctx.getSelectedScenarios())
         {
-            optimEntityContainer_.Problem().addNumVariable(timeseries[timestep][scenario],
-                                                           timeseries[timestep][scenario],
-                                                           "variable-ts" + std::to_string(timestep)
-                                                             + "-sc" + std::to_string(scenario));
+            optimEntityContainer_.Problem()->addNumVariable(timeseries[timestep][scenario],
+                                                            timeseries[timestep][scenario],
+                                                            "variable-ts" + std::to_string(timestep)
+                                                              + "-sc" + std::to_string(scenario));
         }
     }
 }

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/OneConstraintFiller.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/OneConstraintFiller.h
@@ -26,7 +26,7 @@ void OneConstraintFiller::addVariables([[maybe_unused]] const FillContext& ctx)
 
 void OneConstraintFiller::addConstraints([[maybe_unused]] const FillContext& ctx)
 {
-    optimEntityContainer_.Problem().addConstraint(1, 2, "constraint-by-OneConstraintFiller");
+    optimEntityContainer_.Problem()->addConstraint(1, 2, "constraint-by-OneConstraintFiller");
 }
 
 void OneConstraintFiller::addObjectives([[maybe_unused]] const FillContext& ctx)

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/OneVarFiller.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/OneVarFiller.h
@@ -25,7 +25,7 @@ private:
 
 void OneVarFiller::addVariables([[maybe_unused]] const FillContext& ctx)
 {
-    optimEntityContainer_.Problem().addNumVariable(0, 1, added_var_name_);
+    optimEntityContainer_.Problem()->addNumVariable(0, 1, added_var_name_);
 }
 
 void OneVarFiller::addConstraints([[maybe_unused]] const FillContext& ctx)
@@ -34,8 +34,8 @@ void OneVarFiller::addConstraints([[maybe_unused]] const FillContext& ctx)
 
 void OneVarFiller::addObjectives([[maybe_unused]] const FillContext& ctx)
 {
-    auto* var = optimEntityContainer_.Problem().lookupVariable(added_var_name_);
-    optimEntityContainer_.Problem().setObjectiveCoefficient(var, 1);
+    auto* var = optimEntityContainer_.Problem()->lookupVariable(added_var_name_);
+    optimEntityContainer_.Problem()->setObjectiveCoefficient(var, 1);
 }
 
 } // namespace Antares::LinearProblem::Api

--- a/src/tests/src/optimisation/linear-problem/mock-fillers/TwoVarsTwoConstraintsFiller.h
+++ b/src/tests/src/optimisation/linear-problem/mock-fillers/TwoVarsTwoConstraintsFiller.h
@@ -22,14 +22,14 @@ public:
 
 void TwoVarsTwoConstraintsFiller::addVariables([[maybe_unused]] const FillContext& ctx)
 {
-    optimEntityContainer_.Problem().addNumVariable(0, 1, "var-1-by-TwoVarsTwoConstraintsFiller");
-    optimEntityContainer_.Problem().addNumVariable(0, 3, "var-2-by-TwoVarsTwoConstraintsFiller");
+    optimEntityContainer_.Problem()->addNumVariable(0, 1, "var-1-by-TwoVarsTwoConstraintsFiller");
+    optimEntityContainer_.Problem()->addNumVariable(0, 3, "var-2-by-TwoVarsTwoConstraintsFiller");
 }
 
 void TwoVarsTwoConstraintsFiller::addConstraints([[maybe_unused]] const FillContext& ctx)
 {
-    optimEntityContainer_.Problem().addConstraint(1, 2, "constr-1-by-TwoVarsTwoConstraintsFiller");
-    optimEntityContainer_.Problem().addConstraint(1, 3, "constr-2-by-TwoVarsTwoConstraintsFiller");
+    optimEntityContainer_.Problem()->addConstraint(1, 2, "constr-1-by-TwoVarsTwoConstraintsFiller");
+    optimEntityContainer_.Problem()->addConstraint(1, 3, "constr-2-by-TwoVarsTwoConstraintsFiller");
 }
 
 void TwoVarsTwoConstraintsFiller::addObjectives([[maybe_unused]] const FillContext& ctx)

--- a/src/tests/src/optimisation/linear-problem/testLinearProblemBuilder.cpp
+++ b/src/tests/src/optimisation/linear-problem/testLinearProblemBuilder.cpp
@@ -22,13 +22,13 @@ struct Fixture
 {
     Fixture()
     {
-        pb = std::make_unique<OrtoolsLinearProblem>(false, "sirius");
+        pb = std::make_shared<OrtoolsLinearProblem>(false, "sirius");
     }
 
     std::vector<std::unique_ptr<LinearProblemFiller>> fillers;
     LinearProblemData LP_Data;
     FillContext ctx = {0, 0, 0, 0, 0}; // dummy value for other tests than context
-    std::unique_ptr<ILinearProblem> pb;
+    std::shared_ptr<ILinearProblem> pb;
 };
 
 BOOST_AUTO_TEST_SUITE(tests_on_linear_problem_builder)
@@ -44,7 +44,7 @@ BOOST_FIXTURE_TEST_CASE(no_filler_given_to_builder___nothing_built, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(one_var_filler___the_var_is_built, Fixture)
 {
-    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(*pb);
+    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(pb);
     fillers.push_back(std::make_unique<OneVarFiller>(optimEntityContainer));
 
     LinearProblemBuilder lpBuilder(fillers);
@@ -59,7 +59,7 @@ BOOST_FIXTURE_TEST_CASE(one_var_filler___the_var_is_built, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(one_constraint_filler___the_constraint_is_built, Fixture)
 {
-    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(*pb);
+    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(pb);
     fillers.push_back(std::make_unique<OneConstraintFiller>(optimEntityContainer));
 
     LinearProblemBuilder lpBuilder(fillers);
@@ -72,7 +72,7 @@ BOOST_FIXTURE_TEST_CASE(one_constraint_filler___the_constraint_is_built, Fixture
 
 BOOST_FIXTURE_TEST_CASE(two_fillers_given_to_builder___all_is_built, Fixture)
 {
-    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(*pb);
+    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(pb);
     fillers.push_back(std::make_unique<OneVarFiller>(optimEntityContainer));
     fillers.push_back(std::make_unique<OneConstraintFiller>(optimEntityContainer));
 
@@ -86,7 +86,7 @@ BOOST_FIXTURE_TEST_CASE(two_fillers_given_to_builder___all_is_built, Fixture)
 
 BOOST_FIXTURE_TEST_CASE(three_fillers_given_to_builder___3_vars_3_constr_are_built, Fixture)
 {
-    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(*pb);
+    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(pb);
     fillers.push_back(std::make_unique<OneVarFiller>(optimEntityContainer));
     fillers.push_back(std::make_unique<OneConstraintFiller>(optimEntityContainer));
     fillers.push_back(std::make_unique<TwoVarsTwoConstraintsFiller>(optimEntityContainer));
@@ -100,7 +100,7 @@ BOOST_FIXTURE_TEST_CASE(three_fillers_given_to_builder___3_vars_3_constr_are_bui
 
 BOOST_FIXTURE_TEST_CASE(FillerWithContext, Fixture)
 {
-    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(*pb);
+    Antares::LinearProblem::OptimEntityContainer optimEntityContainer(pb);
     fillers.push_back(std::make_unique<VarFillerContext>(optimEntityContainer));
 
     ctx = FillContext(0, 5, 0, 5, 0);

--- a/src/tests/src/solver/optim-model-filler/test-component-filler-to-master-pb.cpp
+++ b/src/tests/src/solver/optim-model-filler/test-component-filler-to-master-pb.cpp
@@ -31,7 +31,7 @@ public:
         variables(VariablesCreator::Create(nodeRegistry)),
         objectives(ObjectivesCreator::Create(nodeRegistry)),
         constraints(ConstraintsCreators::Create(nodeRegistry)),
-        linear_pb(false, "sirius"),
+        linear_pb(std::make_shared<OrtoolsLinearProblem>(false, "sirius")),
         optimEntityContainer(linear_pb)
     {
         createModel();
@@ -49,7 +49,7 @@ public:
     // We define a component under the form of a smart ptr because class Component default
     // constructor is forbidden, so we can't have : Component component;
     std::unique_ptr<Component> component;
-    OrtoolsLinearProblem linear_pb;
+    std::shared_ptr<OrtoolsLinearProblem> linear_pb;
 
     LinearProblemData dummy_data;
     ScenarioGroupRepository scenario_group_repo;
@@ -120,8 +120,8 @@ BOOST_FIXTURE_TEST_CASE(adding_variables_to_master_pb_actually_adds_only_master_
     componentFiller.addVariables(time_scenario_ctx);
 
     // Assert
-    BOOST_CHECK_EQUAL(linear_pb.variableCount(), 1);
-    auto* var = linear_pb.lookupVariable("my-component.var-2");
+    BOOST_CHECK_EQUAL(linear_pb->variableCount(), 1);
+    auto* var = linear_pb->lookupVariable("my-component.var-2");
     BOOST_REQUIRE(var);
 
     BOOST_CHECK(bendersDecomposition.couplings().empty());
@@ -141,8 +141,8 @@ BOOST_FIXTURE_TEST_CASE(adding_variables_to_pb_actually_adds_only_subproblem_var
     componentFiller.addVariables(time_scenario_ctx);
 
     // Assert
-    BOOST_CHECK_EQUAL(linear_pb.variableCount(), 1);
-    auto* var = linear_pb.lookupVariable("my-component.var-1");
+    BOOST_CHECK_EQUAL(linear_pb->variableCount(), 1);
+    auto* var = linear_pb->lookupVariable("my-component.var-1");
     BOOST_REQUIRE(var);
     BOOST_CHECK(bendersDecomposition.couplings().empty());
 }
@@ -162,15 +162,15 @@ BOOST_FIXTURE_TEST_CASE(adding_objectives_to_pb_actually_adds_only_subproblem_ob
     componentFiller.addObjectives(time_scenario_ctx);
 
     // Assert
-    BOOST_CHECK_EQUAL(linear_pb.variableCount(), 2);
-    auto* var1 = linear_pb.lookupVariable("my-component.var-1");
-    auto* var2 = linear_pb.lookupVariable("my-component.var-2");
+    BOOST_CHECK_EQUAL(linear_pb->variableCount(), 2);
+    auto* var1 = linear_pb->lookupVariable("my-component.var-1");
+    auto* var2 = linear_pb->lookupVariable("my-component.var-2");
     BOOST_REQUIRE(var1);
     BOOST_REQUIRE(var2);
 
-    BOOST_CHECK_EQUAL(linear_pb.getObjectiveCoefficient(var1), 1);
+    BOOST_CHECK_EQUAL(linear_pb->getObjectiveCoefficient(var1), 1);
     // No objective associated to var2 found in problem
-    BOOST_CHECK_EQUAL(linear_pb.getObjectiveCoefficient(var2), 0);
+    BOOST_CHECK_EQUAL(linear_pb->getObjectiveCoefficient(var2), 0);
     BOOST_CHECK(bendersDecomposition.couplings().empty());
 }
 
@@ -185,7 +185,7 @@ BOOST_FIXTURE_TEST_CASE(adding_objectives_to_master_pb_actually_adds_only_master
                                     &bendersDecomposition);
 
     componentFiller.addVariables(time_scenario_ctx);
-    BOOST_CHECK_EQUAL(linear_pb.variableCount(), 0);
+    BOOST_CHECK_EQUAL(linear_pb->variableCount(), 0);
     BOOST_CHECK(bendersDecomposition.couplings().empty());
 }
 
@@ -203,7 +203,7 @@ BOOST_FIXTURE_TEST_CASE(mixed_variable_listed_in_benders_decomposition,
                                  &bendersDecomposition);
 
     masterFiller.addVariables(time_scenario_ctx);
-    BOOST_CHECK_EQUAL(linear_pb.variableCount(), 1);
+    BOOST_CHECK_EQUAL(linear_pb->variableCount(), 1);
 
     BOOST_REQUIRE_EQUAL(bendersDecomposition.couplings().size(), 1);
     // couplings = {{"master", {"my-component.var-1", 0}}
@@ -230,7 +230,7 @@ BOOST_FIXTURE_TEST_CASE(adding_two_constraints_one_sub_one_master_in_sub,
 
     componentFiller.addVariables(time_scenario_ctx);
     componentFiller.addConstraints(time_scenario_ctx);
-    BOOST_CHECK_EQUAL(linear_pb.getConstraints().size(), 1);
+    BOOST_CHECK_EQUAL(linear_pb->getConstraints().size(), 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(adding_two_constraints_one_sub_one_master_in_master,
@@ -245,6 +245,6 @@ BOOST_FIXTURE_TEST_CASE(adding_two_constraints_one_sub_one_master_in_master,
 
     masterFiller.addVariables(time_scenario_ctx);
     masterFiller.addConstraints(time_scenario_ctx);
-    BOOST_CHECK_EQUAL(linear_pb.getConstraints().size(), 1);
+    BOOST_CHECK_EQUAL(linear_pb->getConstraints().size(), 1);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/src/solver/optim-model-filler/visitorFixture.hpp
+++ b/src/tests/src/solver/optim-model-filler/visitorFixture.hpp
@@ -52,7 +52,7 @@ struct MockLinearProblemData: Api::ILinearProblemData
 template<class Visitor>
 struct VisitorFixture: Registry<Node>
 {
-    MockLinearProblem linearProblem;
+    std::shared_ptr<MockLinearProblem> linearProblem;
     MockLinearProblemData data;
     Api::EmptyScenario empty_scenario;
     ScenarioGroupRepository scenarioGroupRepository;
@@ -63,7 +63,7 @@ struct VisitorFixture: Registry<Node>
     Api::FillContext ctx{0, 0, 0, 0, 0};
 
     VisitorFixture():
-        linearProblem(false),
+        linearProblem(std::make_shared<MockLinearProblem>(false)),
         scenarioGroupRepository(createScenario()),
         optimContainer(linearProblem),
         components(1, setupComponent())
@@ -71,11 +71,11 @@ struct VisitorFixture: Registry<Node>
         optimContainer.addFromSystemComponents(components);
         {
             optimContainer.addStartColumn();
-            linearProblem.addNumVariable(0, 1, "var1");
+            linearProblem->addNumVariable(0, 1, "var1");
             optimContainer.addStartColumn();
-            linearProblem.addNumVariable(0, 1, "var2");
+            linearProblem->addNumVariable(0, 1, "var2");
             optimContainer.addStartColumn();
-            linearProblem.addNumVariable(0, 1, "var3");
+            linearProblem->addNumVariable(0, 1, "var3");
         }
     }
 

--- a/src/tests/src/solver/optimisation/FillerFixture.cpp
+++ b/src/tests/src/solver/optimisation/FillerFixture.cpp
@@ -21,7 +21,8 @@ using namespace Api;
 using namespace DataImpl;
 
 FillerFixture::FillerFixture():
-    linearProblem(true, "scip"),
+    linearProblem(
+      std::make_shared<Antares::LinearProblem::MpsolverImpl::OrtoolsLinearProblem>(true, "scip")),
     linearProblemData((DataSeriesRepository()))
 {
 }
@@ -63,7 +64,7 @@ void FillerFixture::addLegacyVariables(const std::vector<std::string>& variableN
 {
     for (const auto& variable: variableNames)
     {
-        linearProblem.addVariable(-999, 999, false, variable);
+        linearProblem->addVariable(-999, 999, false, variable);
     }
 }
 
@@ -82,7 +83,7 @@ void FillerFixture::addModelerVariables(unsigned int ts_start,
                 for (auto t = ts_start; t <= ts_end; ++t)
                 {
                     auto name = buildVariableName(component.Id(), variable.Id(), {}, t);
-                    linearProblem.addVariable(-999, 999, false, name);
+                    linearProblem->addVariable(-999, 999, false, name);
                 }
             }
             else
@@ -91,7 +92,7 @@ void FillerFixture::addModelerVariables(unsigned int ts_start,
                                               variable.Id(),
                                               std::nullopt,
                                               std::nullopt);
-                linearProblem.addVariable(-999, 999, false, name);
+                linearProblem->addVariable(-999, 999, false, name);
             }
         }
     }
@@ -101,7 +102,7 @@ void FillerFixture::addEmptyConstraintsToLinearProblem(std::vector<std::string>&
 {
     for (const auto& name: names)
     {
-        linearProblem.addConstraint(rhs, rhs, name);
+        linearProblem->addConstraint(rhs, rhs, name);
     }
 }
 

--- a/src/tests/src/solver/optimisation/FillerFixture.h
+++ b/src/tests/src/solver/optimisation/FillerFixture.h
@@ -16,7 +16,7 @@ struct FillerFixture
     std::unique_ptr<PROBLEME_HEBDO> problemeHebdo;
     std::unique_ptr<Antares::Solver::ModelerData> modelerData;
     std::vector<Antares::ModelerStudy::SystemModel::Library> libraries;
-    Antares::LinearProblem::MpsolverImpl::OrtoolsLinearProblem linearProblem;
+    std::shared_ptr<Antares::LinearProblem::MpsolverImpl::OrtoolsLinearProblem> linearProblem;
     Antares::LinearProblem::ScenarioGroupRepository scenarioGroupRepository;
     Antares::LinearProblem::DataImpl::LinearProblemData linearProblemData;
 

--- a/src/tests/src/solver/optimisation/adequacy_patch/test_compute_gems_contribution.cpp
+++ b/src/tests/src/solver/optimisation/adequacy_patch/test_compute_gems_contribution.cpp
@@ -76,7 +76,7 @@ system:
 struct GemsContributionFixture
 {
     GemsContributionFixture():
-        linearProblem(true, "scip")
+        linearProblem(std::make_shared<MpsolverImpl::OrtoolsLinearProblem>(true, "scip"))
     {
         modelerData = buildModelerSystem();
 
@@ -120,7 +120,7 @@ struct GemsContributionFixture
                 for (unsigned t = 0; t <= ctx.getLocalLastTimeStep(); ++t)
                 {
                     auto name = buildVariableName(component.Id(), variable.Id(), {}, t);
-                    linearProblem.addVariable(-999, 999, false, name);
+                    linearProblem->addVariable(-999, 999, false, name);
                 }
             }
         }
@@ -129,7 +129,7 @@ struct GemsContributionFixture
     PROBLEME_HEBDO problemeHebdo{};
     std::unique_ptr<Solver::ModelerData> modelerData;
     std::vector<Library> libraries;
-    MpsolverImpl::OrtoolsLinearProblem linearProblem;
+    std::shared_ptr<MpsolverImpl::OrtoolsLinearProblem> linearProblem;
     ScenarioGroupRepository scenarioGroupRepository;
 };
 

--- a/src/tests/src/solver/optimisation/test_ThermalCapacityFiller.cpp
+++ b/src/tests/src/solver/optimisation/test_ThermalCapacityFiller.cpp
@@ -325,18 +325,18 @@ BOOST_AUTO_TEST_CASE(add_two_max_generation_from_capacity_constraints)
             const auto& area = areas[areaIndex];
             const auto& cluster = connectedClusterPerAreas[areaIndex];
 
-            auto maxGenConstraint = linearProblem.lookupConstraint(
+            auto maxGenConstraint = linearProblem->lookupConstraint(
               fmt::format(maxGenerationFromCapacityConstraintFormat, area, cluster, pdt));
-            const auto* dispatchableVar = linearProblem.lookupVariable(
+            const auto* dispatchableVar = linearProblem->lookupVariable(
               fmt::format(dispatchableProductionVariableFormat, area, cluster, pdt));
             BOOST_CHECK_EQUAL(maxGenConstraint->getCoefficient(dispatchableVar), 1);
 
             const auto& areaExpectedResult = expectedGemsVariableCoefPerConnection[areaIndex];
-            const auto* portVariable = linearProblem.lookupVariable(
+            const auto* portVariable = linearProblem->lookupVariable(
               fmt::format(portVariableFormat, areaExpectedResult.terms[pdt].first, pdt));
             BOOST_CHECK_EQUAL(maxGenConstraint->getCoefficient(portVariable),
                               areaExpectedResult.terms[pdt].second);
-            BOOST_CHECK_EQUAL(maxGenConstraint->getLb(), -linearProblem.infinity());
+            BOOST_CHECK_EQUAL(maxGenConstraint->getLb(), -linearProblem->infinity());
             BOOST_CHECK_EQUAL(maxGenConstraint->getUb(), areaExpectedResult.upperBounds[pdt]);
         }
     }

--- a/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
+++ b/src/tests/src/solver/optimisation/test_area_connections--spillage--unsupE.cpp
@@ -96,7 +96,7 @@ struct AreaConnectionFixture
     ScenarioGroupRepository scenarioGroupRepository; // Empty
 
     // ... Hybrid / Legacy linear problem
-    MpsolverImpl::OrtoolsLinearProblem linearProblem;
+    std::shared_ptr<MpsolverImpl::OrtoolsLinearProblem> linearProblem;
     std::unique_ptr<PROBLEME_HEBDO> problemeHebdo;
     std::unique_ptr<OptimEntityContainer> optimContainer;
 
@@ -107,7 +107,7 @@ private:
 };
 
 AreaConnectionFixture::AreaConnectionFixture():
-    linearProblem(true, "scip")
+    linearProblem(std::make_shared<MpsolverImpl::OrtoolsLinearProblem>(true, "scip"))
 {
     modelerData = buildModelerSystem();
 
@@ -149,7 +149,7 @@ void AreaConnectionFixture::addComponentsVariablesToLP()
             for (unsigned t = 0; t <= fill_ctx.getLocalLastTimeStep(); ++t)
             {
                 auto name = buildVariableName(component.Id(), variable.Id(), {}, t);
-                linearProblem.addVariable(-999, 999, false, name);
+                linearProblem->addVariable(-999, 999, false, name);
             }
         }
     }
@@ -171,7 +171,7 @@ void AreaConnectionFixture::addConstraintsToLinearProblem(std::vector<std::strin
 {
     for (const auto& name: names)
     {
-        linearProblem.addConstraint(low_bound, up_bound, name);
+        linearProblem->addConstraint(low_bound, up_bound, name);
     }
 }
 
@@ -221,20 +221,20 @@ BOOST_FIXTURE_TEST_CASE(injecting_spillage_and_unsupplied_energy_bounds, AreaCon
     // ---------
     // Checks
     // ---------
-    const auto* var1_t0 = linearProblem.lookupVariable("component_with_vars.var_1_t0");
+    const auto* var1_t0 = linearProblem->lookupVariable("component_with_vars.var_1_t0");
 
-    const auto* fictive_load_ct_t0 = linearProblem.lookupConstraint(fictiveLoadsConstrName);
+    const auto* fictive_load_ct_t0 = linearProblem->lookupConstraint(fictiveLoadsConstrName);
     BOOST_CHECK_EQUAL(fictive_load_ct_t0->getCoefficient(var1_t0), -2.);
     BOOST_CHECK_EQUAL(fictive_load_ct_t0->getLb(), 0. + 30.);
     BOOST_CHECK_EQUAL(fictive_load_ct_t0->getUb(), 50. + 30.);
 
-    const auto* max_unsupE_ct_t0 = linearProblem.lookupConstraint(maxUnsupEconstrName);
+    const auto* max_unsupE_ct_t0 = linearProblem->lookupConstraint(maxUnsupEconstrName);
     BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getCoefficient(var1_t0), -0.5);
     BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getLb(), 0. - 10.);
     BOOST_CHECK_EQUAL(max_unsupE_ct_t0->getUb(), 50. - 10.);
 
-    auto dummy_ct = linearProblem.lookupConstraint("dummy constaint");
-    auto other_dummy_ct = linearProblem.lookupConstraint("dummy constaint");
+    auto dummy_ct = linearProblem->lookupConstraint("dummy constaint");
+    auto other_dummy_ct = linearProblem->lookupConstraint("dummy constaint");
     BOOST_CHECK_EQUAL(dummy_ct->getCoefficient(var1_t0), 0);
     BOOST_CHECK_EQUAL(other_dummy_ct->getCoefficient(var1_t0), 0);
 }

--- a/src/tests/src/solver/optimisation/test_componentToAreaConnectionFiller.cpp
+++ b/src/tests/src/solver/optimisation/test_componentToAreaConnectionFiller.cpp
@@ -117,12 +117,12 @@ struct ComponentToAreaConnectionFillerFixture
     std::unique_ptr<PROBLEME_HEBDO> problemeHebdo;
     std::unique_ptr<Solver::ModelerData> modelerData;
     std::vector<Library> libraries;
-    MpsolverImpl::OrtoolsLinearProblem linearProblem;
+    std::shared_ptr<MpsolverImpl::OrtoolsLinearProblem> linearProblem;
     ScenarioGroupRepository scenarioGroupRepository;
     std::remove_reference_t<LinearProblemData&> data;
 
     ComponentToAreaConnectionFillerFixture():
-        linearProblem(true, "scip")
+        linearProblem(std::make_shared<MpsolverImpl::OrtoolsLinearProblem>(true, "scip"))
     {
         problemeHebdo = std::make_unique<PROBLEME_HEBDO>();
         problemeHebdo->ProblemeAResoudre = std::make_unique<PROBLEME_ANTARES_A_RESOUDRE>();
@@ -173,7 +173,7 @@ struct ComponentToAreaConnectionFillerFixture
                     for (auto t = ts_start; t <= ts_end; ++t)
                     {
                         auto name = buildVariableName(component.Id(), variable.Id(), {}, t);
-                        linearProblem.addVariable(-999, 999, false, name);
+                        linearProblem->addVariable(-999, 999, false, name);
                     }
                 }
                 else
@@ -182,7 +182,7 @@ struct ComponentToAreaConnectionFillerFixture
                                                   variable.Id(),
                                                   std::nullopt,
                                                   std::nullopt);
-                    linearProblem.addVariable(-999, 999, false, name);
+                    linearProblem->addVariable(-999, 999, false, name);
                 }
             }
         }
@@ -192,7 +192,7 @@ struct ComponentToAreaConnectionFillerFixture
     {
         for (const auto& name: names)
         {
-            linearProblem.addConstraint(rhs, rhs, name);
+            linearProblem->addConstraint(rhs, rhs, name);
         }
     }
 
@@ -258,11 +258,11 @@ BOOST_AUTO_TEST_CASE(add_one_term_to_balance_constraint_named)
 
     addConstraintsFromConnectionsToLP({0, 0, 0, 0, 0}, optimEntityContainer);
 
-    const auto* balance_ct = linearProblem.lookupConstraint("AreaBalance::area<area1>::hour<0>");
+    const auto* balance_ct = linearProblem->lookupConstraint("AreaBalance::area<area1>::hour<0>");
 
-    const auto* nc_var_t0 = linearProblem.lookupVariable("component_with_vars.no_connect_var_t0");
-    const auto* var1_t0 = linearProblem.lookupVariable("component_with_vars.var_1_t0");
-    const auto* var2_t0 = linearProblem.lookupVariable("component_with_vars.var_2_t0");
+    const auto* nc_var_t0 = linearProblem->lookupVariable("component_with_vars.no_connect_var_t0");
+    const auto* var1_t0 = linearProblem->lookupVariable("component_with_vars.var_1_t0");
+    const auto* var2_t0 = linearProblem->lookupVariable("component_with_vars.var_2_t0");
 
     BOOST_CHECK_EQUAL(balance_ct->getCoefficient(nc_var_t0), 0);
     BOOST_CHECK_EQUAL(balance_ct->getCoefficient(var1_t0), -5);
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(add_one_term_to_balance_constraint_named)
     BOOST_CHECK_EQUAL(balance_ct->getLb(), 10 + 2 * 4 - 6);
     BOOST_CHECK_EQUAL(balance_ct->getUb(), 10 + 2 * 4 - 6);
 
-    auto other_ct = linearProblem.lookupConstraint("whatever");
+    auto other_ct = linearProblem->lookupConstraint("whatever");
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(nc_var_t0), 0);
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(var1_t0), 0);
     BOOST_CHECK_EQUAL(other_ct->getCoefficient(var2_t0), 0);
@@ -297,15 +297,17 @@ BOOST_AUTO_TEST_CASE(add_two_terms_to_balance_constraint_not_named)
 
     addConstraintsFromConnectionsToLP({0, 1, 10, 11, 0}, optimEntityContainer);
 
-    auto balance_ct_t10 = linearProblem.lookupConstraint("c1");
-    auto balance_ct_t11 = linearProblem.lookupConstraint("c2");
+    auto balance_ct_t10 = linearProblem->lookupConstraint("c1");
+    auto balance_ct_t11 = linearProblem->lookupConstraint("c2");
 
-    const auto* nc_var_t10 = linearProblem.lookupVariable("component_with_vars.no_connect_var_t10");
-    const auto* var1_t10 = linearProblem.lookupVariable("component_with_vars.var_1_t10");
-    const auto* var2_t10 = linearProblem.lookupVariable("component_with_vars.var_2_t10");
-    const auto* nc_var_t11 = linearProblem.lookupVariable("component_with_vars.no_connect_var_t11");
-    const auto* var1_t11 = linearProblem.lookupVariable("component_with_vars.var_1_t11");
-    const auto* var2_t11 = linearProblem.lookupVariable("component_with_vars.var_2_t11");
+    const auto* nc_var_t10 = linearProblem->lookupVariable(
+      "component_with_vars.no_connect_var_t10");
+    const auto* var1_t10 = linearProblem->lookupVariable("component_with_vars.var_1_t10");
+    const auto* var2_t10 = linearProblem->lookupVariable("component_with_vars.var_2_t10");
+    const auto* nc_var_t11 = linearProblem->lookupVariable(
+      "component_with_vars.no_connect_var_t11");
+    const auto* var1_t11 = linearProblem->lookupVariable("component_with_vars.var_1_t11");
+    const auto* var2_t11 = linearProblem->lookupVariable("component_with_vars.var_2_t11");
 
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(nc_var_t10), 0);
     BOOST_CHECK_EQUAL(balance_ct_t10->getCoefficient(var1_t10), -5);


### PR DESCRIPTION
## PR Title

**Share `ILinearProblem` ownership with `OptimEntityContainer` to support post-solve GEMS evaluation**

## Description

### Summary

Refactors `ILinearProblem` ownership from `std::unique_ptr` to `std::shared_ptr` so that `OptimEntityContainer` co-owns the linear problem it references, and removes the redundant problem pointers that had to keep the problem alive elsewhere.

### Motivation

Hourly adequacy-patch GEMS contribution evaluations run **after** the weekly simplex solve and read variable solution values through the `OptimEntityContainer`. Previously the container only held a reference to the problem, so the problem had to be kept alive by out-of-band owners (`PROBLEME_HEBDO::ortoolsProblem`, `SimplexResult::originalProblem`, and the `Modeler`'s `unique_ptr` members). That was fragile: any consumer relying on the container could see a dead problem. The container now owns the problem's lifetime for all post-solve consumers.

### Changes

- **`OptimEntityContainer`**: constructor now takes a `std::shared_ptr<ILinearProblem>`; the container keeps the problem alive.
- **`Modeler`** (`Modeler.h` / modeler problem building): `masterProblem_`, `subproblems_`, and `ProblemEntity.problem` changed from `unique_ptr` to `shared_ptr`. `buildProblem` shares the freshly built problem with the container it creates before returning.
- **`PROBLEME_HEBDO`**: dropped the now-redundant `ortoolsProblem` member — the weekly problem is only reachable via `optimEntityContainer`.
- **`OPT_TryToCallSimplex`**: removed `SimplexResult::originalProblem`. The infeasible-problem path builds its problem as a `shared_ptr` and retrieves the problem for MPS export from `optimEntityContainer->Problem()`.
- **Adequacy patch CSR** (`set_variable_boundaries.cpp`): added a debug log line printing the GEMS contribution per area (supporting work for the GEMS-in-adequacy-patch feature).

### Tests

Mechanical ownership updates across fixtures that previously held the problem by value or `unique_ptr`; they now use `std::shared_ptr` and pass it to `OptimEntityContainer` (direct `OptimEntityContainer(pb)` construction instead of `OptimEntityContainer(*pb)`):

- Expression evaluation tests (`test_PrintAndEvalVisitors`, `test_evaluate-function-operators`, `test_evaluate-sum-operators`)
- Simulation table tests (`testSimulationTable`)
- Modeler tests (`UtilMocks`, `inmemory-modeler`, `testLinearProblemBuilder`, `test-component-filler-to-master-pb`, `visitorFixture`)
- Optimisation filler tests (`FillerFixture`, `test_ThermalCapacityFiller`, `test_area_connections--spillage--unsupE`, `test_componentToAreaConnectionFiller`, `test_compute_gems_contribution`)