### PR TITLE
Fix: wrong values for STS in districts [ANT-5827]

### DIFF
--- a/src/solver/variable/dynamicAggregation/setDataAllYears.cpp
+++ b/src/solver/variable/dynamicAggregation/setDataAllYears.cpp
@@ -211,10 +211,10 @@ void SetDataAllYears::appendToSurvey(SurveyResults& survey, Category::Precision 
                   "_WITHDRAWAL",
                   survey);
 
-    processGroups(averageStsWithdrawal_,
-                  stdDevStsWithdrawal_,
-                  minStsWithdrawal_,
-                  maxStsWithdrawal_,
+    processGroups(averageStsLevel_,
+                  stdDevStsLevel_,
+                  minStsLevel_,
+                  maxStsLevel_,
                   stsGroupNames_,
                   precision,
                   "_LEVEL",


### PR DESCRIPTION
## Description PR GitHub

### 🐛 Fix: wrong values for STS in districts

**Summary**

The STS (State) values reported for districts were incorrectly using the withdrawal member data (`averageStsWithdrawal_`, `stdDevStsWithdrawal_`, `minStsWithdrawal_`, `maxStsWithdrawal_`) instead of the level member data. This resulted in wrong STS values being exposed in the simulation output.

**Changes**

- `src/solver/variable/dynamicAggregation/setDataAllYears.cpp`: replaced the withdrawal members with the correct level members (`averageStsLevel_`, `stdDevStsLevel_`, `minStsLevel_`, `maxStsLevel_`) in the `processGroups` call for the `_LEVEL` suffix.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Related issues**

- N/A