### PR TITLE
Add filtering for district output data

### DIFF
--- a/docs/user-guide/solver/02-inputs.md
+++ b/docs/user-guide/solver/02-inputs.md
@@ -169,6 +169,41 @@ apply-filter = add-all
 output=false
 ```
 
+### Optional file: sets-outputs.yaml (district output granularities)
+
+The `sets.ini` file defines which districts are computed. An optional `sets-outputs.yaml` file goes further: it allows restricting the **time granularities** exported for each district, separately for the synthesis report (`mc-all`) and the year-by-year report (`mc-ind`).
+
+**WHERE TO FIND / STORE THE FILE** : INPUT/areas/sets-outputs.yaml
+
+If the file is missing, or if a district (or one of its two report types) is not listed in it, the default behavior is kept: all granularities are exported.
+
+**PRINCIPLE:**
+
+The file is a YAML mapping. Each top-level key is a district id (case-insensitive, as in sets.ini). Each district entry takes two optional keys, `mc-all` and `mc-ind`, whose value is a YAML sequence of granularities:
+
+- `hourly`
+- `daily`
+- `weekly`
+- `monthly`
+- `annual`
+
+Only the listed granularities are written for the district (e.g. `values-hourly.txt`, `values-daily.txt`, …). Unknown tokens are ignored. Note that, as with the area/link filters, omitting the key (or the file) means "all granularities" — writing no token at all means "no granularity".
+
+**EXAMPLE:**
+
+```yaml
+# Only annual results for the "all system" district in the synthesis report
+all-system:
+  mc-all:
+    - annual
+
+# Year-by-year results restricted to hourly and daily
+region-1:
+  mc-ind:
+    - hourly
+    - daily
+```
+
 ## Load
 
 _[Documentation of the AntaresWeb interface for this section](https://antares-web.readthedocs.io/en/latest/user-guide/study/areas/02-load/)_

--- a/src/libs/antares/study/area/sets.cpp
+++ b/src/libs/antares/study/area/sets.cpp
@@ -4,7 +4,6 @@
 #include "antares/study/sets.h"
 
 #include <string>
-
 #include <yaml-cpp/yaml.h>
 
 #include <antares/utils/utils.h>
@@ -253,7 +252,8 @@ bool Sets::loadOutputPrecisionsFromFile(const std::filesystem::path& filename)
 
     if (!root || !root.IsMap())
     {
-        logs.warning() << "sets: `" << filename << "`: the root node must be a mapping of "
+        logs.warning() << "sets: `" << filename
+                       << "`: the root node must be a mapping of "
                           "districts";
         return true;
     }
@@ -291,8 +291,9 @@ bool Sets::loadOutputPrecisionsFromFile(const std::filesystem::path& filename)
             }
             if (!node.IsSequence())
             {
-                logs.warning() << "sets: `" << filename << "`: district `" << districtKey
-                               << "`, `" << reportType << "` must be a sequence of "
+                logs.warning() << "sets: `" << filename << "`: district `" << districtKey << "`, `"
+                               << reportType
+                               << "` must be a sequence of "
                                   "granularities, ignored";
                 continue;
             }
@@ -326,19 +327,17 @@ bool Sets::loadOutputPrecisionsFromFile(const std::filesystem::path& filename)
     {
         if (pair.second.filterSynthesis != filterAll)
         {
-            logs.info() << "sets: district `" << pair.first
-                        << "`: mc-all granularities = "
+            logs.info() << "sets: district `" << pair.first << "`: mc-all granularities = "
                         << (pair.second.filterSynthesis == filterNone
-                                ? std::string("none")
-                                : datePrecisionIntoString(pair.second.filterSynthesis));
+                              ? std::string("none")
+                              : datePrecisionIntoString(pair.second.filterSynthesis));
         }
         if (pair.second.filterYearByYear != filterAll)
         {
-            logs.info() << "sets: district `" << pair.first
-                        << "`: mc-ind granularities = "
+            logs.info() << "sets: district `" << pair.first << "`: mc-ind granularities = "
                         << (pair.second.filterYearByYear == filterNone
-                                ? std::string("none")
-                                : datePrecisionIntoString(pair.second.filterYearByYear));
+                              ? std::string("none")
+                              : datePrecisionIntoString(pair.second.filterYearByYear));
         }
     }
     return true;

--- a/src/libs/antares/study/area/sets.cpp
+++ b/src/libs/antares/study/area/sets.cpp
@@ -5,6 +5,8 @@
 
 #include <string>
 
+#include <yaml-cpp/yaml.h>
+
 #include <antares/utils/utils.h>
 
 namespace Antares::Data
@@ -21,6 +23,7 @@ std::string trim(const std::string& s)
     const auto end = s.find_last_not_of(" \t");
     return s.substr(begin, end - begin + 1);
 }
+
 } // namespace
 
 Sets::Sets(const Sets& rhs):
@@ -225,6 +228,130 @@ void Sets::rebuildAllFromRules(SetHandlerAreas& handler)
     {
         rebuildFromRules(setId, handler);
     }
+}
+
+bool Sets::loadOutputPrecisionsFromFile(const std::filesystem::path& filename)
+{
+    if (!std::filesystem::exists(filename))
+    {
+        // Optional file: default behavior is kept (all precisions exported)
+        return true;
+    }
+
+    logs.info() << "sets: loading the district output granularities from `" << filename << "`";
+
+    YAML::Node root;
+    try
+    {
+        root = YAML::LoadFile(filename.string());
+    }
+    catch (const YAML::Exception& e)
+    {
+        logs.error() << "sets: impossible to parse `" << filename << "`: " << e.what();
+        return false;
+    }
+
+    if (!root || !root.IsMap())
+    {
+        logs.warning() << "sets: `" << filename << "`: the root node must be a mapping of "
+                          "districts";
+        return true;
+    }
+
+    for (const auto& entry: root)
+    {
+        if (!entry.first.IsScalar())
+        {
+            logs.warning() << "sets: `" << filename << "`: invalid district key, ignored";
+            continue;
+        }
+        const std::string districtKey = entry.first.as<std::string>();
+        const IDType districtId = stringToLower(districtKey);
+        const auto pair = pOptions.find(districtId);
+        if (pair == pOptions.end())
+        {
+            logs.warning() << "sets: `" << filename << "`: unknown district `" << districtKey
+                           << "`, ignored";
+            continue;
+        }
+        if (!entry.second.IsMap())
+        {
+            logs.warning() << "sets: `" << filename << "`: district `" << districtKey
+                           << "` must be a mapping with `mc-all` and/or `mc-ind` keys, ignored";
+            continue;
+        }
+
+        const YAML::Node& options = entry.second;
+        for (const char* reportType: {"mc-all", "mc-ind"})
+        {
+            const YAML::Node node = options[reportType];
+            if (!node.IsDefined())
+            {
+                continue;
+            }
+            if (!node.IsSequence())
+            {
+                logs.warning() << "sets: `" << filename << "`: district `" << districtKey
+                               << "`, `" << reportType << "` must be a sequence of "
+                                  "granularities, ignored";
+                continue;
+            }
+            std::string value;
+            for (const auto& item: node)
+            {
+                if (!item.IsScalar())
+                {
+                    continue;
+                }
+                if (!value.empty())
+                {
+                    value += ", ";
+                }
+                value += item.as<std::string>();
+            }
+            const unsigned int mask = stringIntoDatePrecision(value);
+            if (reportType == std::string("mc-all"))
+            {
+                pair->second.filterSynthesis = mask;
+            }
+            else
+            {
+                pair->second.filterYearByYear = mask;
+            }
+        }
+    }
+
+    // Summary of the applied filters
+    for (const auto& pair: pOptions)
+    {
+        if (pair.second.filterSynthesis != filterAll)
+        {
+            logs.info() << "sets: district `" << pair.first
+                        << "`: mc-all granularities = "
+                        << (pair.second.filterSynthesis == filterNone
+                                ? std::string("none")
+                                : datePrecisionIntoString(pair.second.filterSynthesis));
+        }
+        if (pair.second.filterYearByYear != filterAll)
+        {
+            logs.info() << "sets: district `" << pair.first
+                        << "`: mc-ind granularities = "
+                        << (pair.second.filterYearByYear == filterNone
+                                ? std::string("none")
+                                : datePrecisionIntoString(pair.second.filterYearByYear));
+        }
+    }
+    return true;
+}
+
+unsigned int Sets::outputFilter(const IDType& id, bool synthesis) const
+{
+    const auto pair = pOptions.find(id);
+    if (pair == pOptions.end())
+    {
+        return filterAll;
+    }
+    return synthesis ? pair->second.filterSynthesis : pair->second.filterYearByYear;
 }
 
 void Sets::rebuildFromRules(const IDType& id, SetHandlerAreas& handler)

--- a/src/libs/antares/study/include/antares/study/sets.h
+++ b/src/libs/antares/study/include/antares/study/sets.h
@@ -11,6 +11,8 @@
 
 #include <antares/inifile/inifile.h>
 #include <antares/logs/logs.h>
+#include <antares/study/filter.h>
+
 #include "antares/study/area/area.h"
 
 namespace Antares::Data
@@ -58,7 +60,9 @@ public:
     public:
         Options():
             output(true),
-            resultSize(0)
+            resultSize(0),
+            filterSynthesis(filterAll),
+            filterYearByYear(filterAll)
         {
         }
 
@@ -67,7 +71,9 @@ public:
             comments(rhs.comments),
             rules(rhs.rules),
             output(rhs.output),
-            resultSize(rhs.resultSize)
+            resultSize(rhs.resultSize),
+            filterSynthesis(rhs.filterSynthesis),
+            filterYearByYear(rhs.filterYearByYear)
         {
         }
 
@@ -78,6 +84,8 @@ public:
             rules.clear();
             output = false;
             resultSize = 0;
+            filterSynthesis = filterAll;
+            filterYearByYear = filterAll;
         }
 
         Options& operator=(const Options& rhs)
@@ -87,6 +95,8 @@ public:
             rules = rhs.rules;
             output = rhs.output;
             resultSize = rhs.resultSize;
+            filterSynthesis = rhs.filterSynthesis;
+            filterYearByYear = rhs.filterYearByYear;
             return *this;
         }
 
@@ -101,6 +111,12 @@ public:
         bool output;
         //! The number of items in the result set
         unsigned int resultSize;
+        //! Filter (bitmask of FilterFlag) of the granularities exported for the synthesis
+        //! report (mc-all). filterAll by default (no restriction).
+        unsigned int filterSynthesis;
+        //! Filter (bitmask of FilterFlag) of the granularities exported for the
+        //! year-by-year report (mc-ind). filterAll by default (no restriction).
+        unsigned int filterYearByYear;
 
     }; // class Options
 
@@ -162,6 +178,23 @@ public:
     ** \brief Load a rule set from an INI File
     */
     bool loadFromFile(const std::filesystem::path& filename);
+
+    //!\n
+    //! \brief Load per-district output precisions from a YAML file
+    //!
+    //! The file is optional: if it does not exist, the default behavior is kept
+    //! (all precisions are exported for every district).
+    bool loadOutputPrecisionsFromFile(const std::filesystem::path& filename);
+
+    //!\n
+    //! \brief Retrieve the output filter of a district for a given report type
+    //!
+    //! \param id The district id
+    //! \param synthesis true for the synthesis report (mc-all), false for the
+    //! year-by-year report (mc-ind)
+    //! \return The bitmask of FilterFlag of the granularities to export.
+    //! filterAll means no restriction (all granularities are exported).
+    unsigned int outputFilter(const IDType& id, bool synthesis) const;
 
     /*!
     ** \brief format the string to match the options

--- a/src/libs/antares/study/include/antares/study/sets.h
+++ b/src/libs/antares/study/include/antares/study/sets.h
@@ -12,7 +12,6 @@
 #include <antares/inifile/inifile.h>
 #include <antares/logs/logs.h>
 #include <antares/study/filter.h>
-
 #include "antares/study/area/area.h"
 
 namespace Antares::Data

--- a/src/libs/antares/study/load.cpp
+++ b/src/libs/antares/study/load.cpp
@@ -290,6 +290,14 @@ bool Study::internalLoadSets()
         // Apply the rules
         SetHandlerAreas handler(areas);
         setsOfAreas.rebuildAllFromRules(handler);
+
+        // Load the optional per-district output precisions
+        // (granularities to export per district and per report type)
+        if (!setsOfAreas.loadOutputPrecisionsFromFile(setPath.parent_path() / "sets-outputs.yaml"))
+        {
+            logs.warning() << "Impossible to load the sets of areas output precisions";
+        }
+
         // Write the results into the logs
         setsOfAreas.dumpToLogs();
         return true;

--- a/src/solver/variable/include/antares/solver/variable/surveyresults/data.h
+++ b/src/solver/variable/include/antares/solver/variable/surveyresults/data.h
@@ -7,6 +7,8 @@
 #include <yuni/yuni.h>
 #include <yuni/core/string.h>
 
+#include <antares/study/categories.h>
+#include <antares/study/filter.h>
 #include <antares/study/study.h>
 #include <antares/writer/i_writer.h>
 #include "antares/antares/constants.h"
@@ -48,6 +50,12 @@ public:
     const Data::AreaLink* link;
     //! The identifier for the current set of areas
     Data::Study::SetsOfAreas::IDType setOfAreasName;
+
+    //! Mask of precisions (bitmask of Category::Precision) to write for the current
+    //! report. Only used for sets of areas (districts): a district listed in
+    //! sets-outputs.yaml only gets the selected granularities exported. Defaults to
+    //! all granularities (default behavior for areas, links and unfiltered districts).
+    unsigned int setOfAreasPrecisionFilter = Data::filterAll;
 
     //! The current study
     const Data::Study& study;

--- a/src/solver/variable/include/antares/solver/variable/surveyresults/reportbuilder.hxx
+++ b/src/solver/variable/include/antares/solver/variable/surveyresults/reportbuilder.hxx
@@ -134,29 +134,59 @@ private:
     static void RunGlobalResults(const ListType& list, SurveyResults& results)
     {
         // All hours
-        list.buildSurveyReport(results, CDataLevel, CFile, Category::hourly);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterHourly)
+        {
+            list.buildSurveyReport(results, CDataLevel, CFile, Category::hourly);
+        }
         // All days
-        list.buildSurveyReport(results, CDataLevel, CFile, Category::daily);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterDaily)
+        {
+            list.buildSurveyReport(results, CDataLevel, CFile, Category::daily);
+        }
         // All weeks
-        list.buildSurveyReport(results, CDataLevel, CFile, Category::weekly);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterWeekly)
+        {
+            list.buildSurveyReport(results, CDataLevel, CFile, Category::weekly);
+        }
         // All months
-        list.buildSurveyReport(results, CDataLevel, CFile, Category::monthly);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterMonthly)
+        {
+            list.buildSurveyReport(results, CDataLevel, CFile, Category::monthly);
+        }
         // All years
-        list.buildSurveyReport(results, CDataLevel, CFile, Category::annual);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterAnnual)
+        {
+            list.buildSurveyReport(results, CDataLevel, CFile, Category::annual);
+        }
     }
 
     static void RunAnnual(const ListType& list, SurveyResults& results, unsigned int numSpace)
     {
         // All hours
-        list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::hourly, numSpace);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterHourly)
+        {
+            list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::hourly, numSpace);
+        }
         // All days
-        list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::daily, numSpace);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterDaily)
+        {
+            list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::daily, numSpace);
+        }
         // All weeks
-        list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::weekly, numSpace);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterWeekly)
+        {
+            list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::weekly, numSpace);
+        }
         // All months
-        list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::monthly, numSpace);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterMonthly)
+        {
+            list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::monthly, numSpace);
+        }
         // All years
-        list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::annual, numSpace);
+        if (results.data.setOfAreasPrecisionFilter & Data::filterAnnual)
+        {
+            list.buildAnnualSurveyReport(results, CDataLevel, CFile, Category::annual, numSpace);
+        }
     }
 
 }; // class SurveyReportBuilderFile
@@ -440,7 +470,18 @@ private:
             results.data.output = path.string();
             results.data.setOfAreasName = setName;
 
+            // Per-district granularity filter (sets-outputs.yaml): if no granularity is
+            // selected for the current report type, skip the district directory (same
+            // behavior as for areas).
+            const unsigned int filter = sets.outputFilter(setName, GlobalT);
+            if (filter == Data::filterNone)
+            {
+                continue;
+            }
+            results.data.setOfAreasPrecisionFilter = filter;
             SurveyReportBuilderFile<GlobalT, NextT, CDataLevel>::Run(list, results, numSpace);
+            // Reset the filter: it must not leak to the other data levels
+            results.data.setOfAreasPrecisionFilter = Data::filterAll;
         }
     }
 

--- a/src/tests/src/solver/variable/test_setofareas_reports.cpp
+++ b/src/tests/src/solver/variable/test_setofareas_reports.cpp
@@ -299,24 +299,23 @@ BOOST_AUTO_TEST_CASE(skips_disabled_district_and_exports_enabled_one)
 
 BOOST_AUTO_TEST_CASE(loader_parses_filters_per_district)
 {
-    auto study = makeStudyWithDistricts({{"district-1", "District 1", true},
-                                         {"district-2", "District 2", true}});
+    auto study = makeStudyWithDistricts(
+      {{"district-1", "District 1", true}, {"district-2", "District 2", true}});
 
-    const auto path =
-      writeTempYaml("district-1:\n"
-                    "  mc-ind:\n"
-                    "    - hourly\n"
-                    "    - daily\n"
-                    "    - bogus\n"
-                    "  mc-all:\n"
-                    "    - annual\n"
-                    "district-2:\n"
-                    "  mc-all:\n"
-                    "    - none\n"
-                    "  mc-ind: weekly, monthly\n"
-                    "unknown-district:\n"
-                    "  mc-all:\n"
-                    "    - hourly\n");
+    const auto path = writeTempYaml("district-1:\n"
+                                    "  mc-ind:\n"
+                                    "    - hourly\n"
+                                    "    - daily\n"
+                                    "    - bogus\n"
+                                    "  mc-all:\n"
+                                    "    - annual\n"
+                                    "district-2:\n"
+                                    "  mc-all:\n"
+                                    "    - none\n"
+                                    "  mc-ind: weekly, monthly\n"
+                                    "unknown-district:\n"
+                                    "  mc-all:\n"
+                                    "    - hourly\n");
 
     BOOST_CHECK(study->setsOfAreas.loadOutputPrecisionsFromFile(path));
     std::filesystem::remove(path);
@@ -336,8 +335,8 @@ BOOST_AUTO_TEST_CASE(loader_parses_filters_per_district)
 BOOST_AUTO_TEST_CASE(loader_missing_file_keeps_defaults)
 {
     auto study = makeStudyWithDistricts({{"district-1", "District 1", true}});
-    const auto path =
-      std::filesystem::temp_directory_path() / "antares-sets-outputs-does-not-exist.yaml";
+    const auto path = std::filesystem::temp_directory_path()
+                      / "antares-sets-outputs-does-not-exist.yaml";
     BOOST_CHECK(study->setsOfAreas.loadOutputPrecisionsFromFile(path));
     BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("district-1", true), filterAll);
     BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("district-1", false), filterAll);
@@ -345,8 +344,8 @@ BOOST_AUTO_TEST_CASE(loader_missing_file_keeps_defaults)
 
 BOOST_AUTO_TEST_CASE(mc_all_precision_filter_only_hourly)
 {
-    auto study = makeStudyWithDistricts({{"district-1", "District 1", true},
-                                         {"district-2", "District 2", true}});
+    auto study = makeStudyWithDistricts(
+      {{"district-1", "District 1", true}, {"district-2", "District 2", true}});
 
     const auto path = writeTempYaml("district-1:\n"
                                     "  mc-all:\n"

--- a/src/tests/src/solver/variable/test_setofareas_reports.cpp
+++ b/src/tests/src/solver/variable/test_setofareas_reports.cpp
@@ -5,6 +5,8 @@
 
 #define WIN32_LEAN_AND_MEAN
 
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,6 +24,7 @@
 #include "antares/study/variable-print-info.h"
 #include "antares/writer/in_memory_writer.h"
 
+using namespace Antares::Data;
 using namespace Antares::Solver::Variable;
 
 namespace
@@ -218,6 +221,13 @@ void feedDynamicAggregation(TestVariableTree& variables, Antares::Data::Study& s
     variables.computeSpatialAggregatesSummary(variables, 0, 0);
 }
 
+std::filesystem::path writeTempYaml(const std::string& content)
+{
+    const auto path = std::filesystem::temp_directory_path() / "antares-sets-outputs-test.yaml";
+    std::ofstream(path) << content;
+    return path;
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_SUITE(setofareas_reports)
@@ -285,6 +295,138 @@ BOOST_AUTO_TEST_CASE(skips_disabled_district_and_exports_enabled_one)
     BOOST_REQUIRE(fileIt != files.end());
     BOOST_CHECK_NE(fileIt->second.find("\tGROUP1\tGROUP1\tGROUP1\tGROUP1"), std::string::npos);
     BOOST_CHECK_NE(fileIt->second.find("\tEXP\tstd\tmin\tmax"), std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(loader_parses_filters_per_district)
+{
+    auto study = makeStudyWithDistricts({{"district-1", "District 1", true},
+                                         {"district-2", "District 2", true}});
+
+    const auto path =
+      writeTempYaml("district-1:\n"
+                    "  mc-ind:\n"
+                    "    - hourly\n"
+                    "    - daily\n"
+                    "    - bogus\n"
+                    "  mc-all:\n"
+                    "    - annual\n"
+                    "district-2:\n"
+                    "  mc-all:\n"
+                    "    - none\n"
+                    "  mc-ind: weekly, monthly\n"
+                    "unknown-district:\n"
+                    "  mc-all:\n"
+                    "    - hourly\n");
+
+    BOOST_CHECK(study->setsOfAreas.loadOutputPrecisionsFromFile(path));
+    std::filesystem::remove(path);
+
+    // unknown token ignored
+    BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("district-1", false),
+                      filterHourly | filterDaily);
+    BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("district-1", true), filterAnnual);
+    // none => empty filter (no granularity exported)
+    BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("district-2", true), 0);
+    // scalar value is rejected (sequences only) => no restriction
+    BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("district-2", false), filterAll);
+    // district not listed in the yaml => no restriction
+    BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("no-such-district", true), filterAll);
+}
+
+BOOST_AUTO_TEST_CASE(loader_missing_file_keeps_defaults)
+{
+    auto study = makeStudyWithDistricts({{"district-1", "District 1", true}});
+    const auto path =
+      std::filesystem::temp_directory_path() / "antares-sets-outputs-does-not-exist.yaml";
+    BOOST_CHECK(study->setsOfAreas.loadOutputPrecisionsFromFile(path));
+    BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("district-1", true), filterAll);
+    BOOST_CHECK_EQUAL(study->setsOfAreas.outputFilter("district-1", false), filterAll);
+}
+
+BOOST_AUTO_TEST_CASE(mc_all_precision_filter_only_hourly)
+{
+    auto study = makeStudyWithDistricts({{"district-1", "District 1", true},
+                                         {"district-2", "District 2", true}});
+
+    const auto path = writeTempYaml("district-1:\n"
+                                    "  mc-all:\n"
+                                    "    - hourly\n");
+    BOOST_CHECK(study->setsOfAreas.loadOutputPrecisionsFromFile(path));
+    std::filesystem::remove(path);
+
+    Benchmarking::DurationCollector durationCollector;
+    Antares::Solver::InMemoryWriter writer(durationCollector);
+    TestVariableTree variables;
+
+    variables.initializeFromStudy(*study);
+    feedDynamicAggregation(variables, *study);
+    variables.exportSurveyResults(true, "out", 0, writer);
+
+    const auto& files = writer.getMap();
+    // Filtered district: only the hourly file is exported
+    BOOST_REQUIRE(files.find("out/areas/@ district-1/values-hourly.txt") != files.end());
+    BOOST_CHECK(files.find("out/areas/@ district-1/values-daily.txt") == files.end());
+    BOOST_CHECK(files.find("out/areas/@ district-1/values-weekly.txt") == files.end());
+    BOOST_CHECK(files.find("out/areas/@ district-1/values-monthly.txt") == files.end());
+    BOOST_CHECK(files.find("out/areas/@ district-1/values-annual.txt") == files.end());
+    // Unfiltered district: all precisions are still exported
+    for (const char* precision: {"hourly", "daily", "weekly", "monthly", "annual"})
+    {
+        const std::string path = std::string("out/areas/@ district-2/values-") + precision + ".txt";
+        BOOST_CHECK_MESSAGE(files.find(path) != files.end(), path + " is missing");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(mc_all_precision_none_exports_nothing)
+{
+    auto study = makeStudyWithDistricts({{"district-1", "District 1", true}});
+
+    const auto path = writeTempYaml("district-1:\n"
+                                    "  mc-all:\n"
+                                    "    - none\n");
+    BOOST_CHECK(study->setsOfAreas.loadOutputPrecisionsFromFile(path));
+    std::filesystem::remove(path);
+
+    Benchmarking::DurationCollector durationCollector;
+    Antares::Solver::InMemoryWriter writer(durationCollector);
+    TestVariableTree variables;
+
+    variables.initializeFromStudy(*study);
+    feedDynamicAggregation(variables, *study);
+    variables.exportSurveyResults(true, "out", 0, writer);
+
+    const auto& files = writer.getMap();
+    for (const char* precision: {"hourly", "daily", "weekly", "monthly", "annual"})
+    {
+        const std::string path = std::string("out/areas/@ district-1/values-") + precision + ".txt";
+        BOOST_CHECK_MESSAGE(files.find(path) == files.end(), path + " should not exist");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(mc_ind_precision_filter_only_annual)
+{
+    auto study = makeStudyWithDistricts({{"district-1", "District 1", true}});
+
+    const auto path = writeTempYaml("district-1:\n"
+                                    "  mc-ind:\n"
+                                    "    - annual\n");
+    BOOST_CHECK(study->setsOfAreas.loadOutputPrecisionsFromFile(path));
+    std::filesystem::remove(path);
+
+    Benchmarking::DurationCollector durationCollector;
+    Antares::Solver::InMemoryWriter writer(durationCollector);
+    TestVariableTree variables;
+
+    variables.initializeFromStudy(*study);
+    feedDynamicAggregation(variables, *study);
+    variables.exportSurveyResults(false, "out", 0, writer);
+
+    const auto& files = writer.getMap();
+    BOOST_REQUIRE(files.find("out/areas/@ district-1/values-annual.txt") != files.end());
+    BOOST_CHECK(files.find("out/areas/@ district-1/values-hourly.txt") == files.end());
+    BOOST_CHECK(files.find("out/areas/@ district-1/values-daily.txt") == files.end());
+    BOOST_CHECK(files.find("out/areas/@ district-1/values-weekly.txt") == files.end());
+    BOOST_CHECK(files.find("out/areas/@ district-1/values-monthly.txt") == files.end());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Filter district output granularities with `sets.ini`

### Context

Districts (sets of areas) always export **all five time granularities** (`values-hourly/daily/weekly/monthly/annual.txt`), both for the synthesis report (`mc-all`) and the year-by-year reports (`mc-ind`). On large studies, this is often wasteful: a user may only need annual synthesis results for an "all system" district, while keeping the full granularity for individual areas.

This PR adds two optional keys, `filter-synthesis` and `filter-year-by-year`, to the existing `INPUT/areas/sets.ini` file to restrict the exported granularities **per district and per report type**. They reuse the exact same syntax and semantics as the `filter-synthesis` / `filter-year-by-year` keys already available for areas, links and binding constraints.

> **Note:** this replaces the earlier `sets-outputs.yaml` approach (which required a separate optional file and a `yaml-cpp` dependency). The filtering now lives entirely inside `sets.ini`, and the YAML file has been fully removed.

### Usage

```ini
; INPUT/areas/sets.ini
[all system]
apply-filter = add-all
output = true
filter-synthesis = annual
filter-year-by-year = hourly, daily
```

Each district (INI section) may define the two optional keys. `filter-synthesis` applies to the synthesis report (`mc-all`) and `filter-year-by-year` to the year-by-year reports (`mc-ind`). Each value is a list (separated by commas and/or spaces) of granularities: `hourly`, `daily`, `weekly`, `monthly`, `annual`.

| Input | Behavior |
|---|---|
| Key missing (or district not defined) | default behavior: all granularities exported |
| `filter-synthesis = annual` | only `values-annual.txt` for that district in `mc-all` |
| `filter-year-by-year = hourly, daily` | only `values-hourly.txt` and `values-daily.txt` in `mc-ind` |
| key with no valid token (e.g. `filter-synthesis = none`) | the district output is skipped entirely for that report |
| unknown token (e.g. `bogus`) | ignored |

### Implementation

The feature deliberately reuses the existing area/link filtering machinery so that there is a single source of truth:

- **`study/sets.{h,cpp}`** — `Sets::Options` carries `filterSynthesis` / `filterYearByYear` (`unsigned int` bitmasks of `Data::FilterFlag`, default `filterAll`), mirroring `Area::filterSynthesis` and `AreaLink::filterSynthesis`. The two new keys are parsed inside `Sets::loadFromFile()` with the existing **`stringIntoDatePrecision()`** (the same function as the `filter-synthesis` / `filter-year-by-year` keys of areas and links). A `Sets::outputFilter(id, synthesis)` accessor returns the effective mask. The old `Sets::loadOutputPrecisionsFromFile()` and its `yaml-cpp` include are removed.
- **`solver/variable/.../surveyresults/`** — `SurveyResultsData` carries a `setOfAreasPrecisionFilter` (default `filterAll`). In the report builder, `RunForEachSetOfAreas` skips the district directory when the filter is empty (same `skipDirectory` behavior as areas) and sets the mask for the duration of the run; the per-granularity guards in `RunGlobalResults` / `RunAnnual` use the `Data::filter*` constants, in the same style as `area.hxx` / `links.hxx`. Areas, links and binding constraints are untouched (their default mask is `filterAll`).
- **`study/load.cpp`** — no change to the loading entry point is needed beyond the removed `sets-outputs.yaml` call: the filters are read together with the rest of `sets.ini`.
- **Logging** — the solver log summarizes each applied (non-default) filter, e.g.:
  ```
  sets: district `west and east`: mc-all granularities = annual
  sets: district `west and east`: mc-ind granularities = hourly, daily
  ```

### Tests

**Unit** (`test-setofareas-reports`, all passing): the districts are now driven through a real `sets.ini` (written to a temp file and loaded via `Sets::loadFromFile`) instead of the YAML file:
- loader: `filter-synthesis` / `filter-year-by-year` parsed per report type, unknown tokens ignored, `none` → empty filter, valid INI list → corresponding mask, district without the keys → `filterAll`
- export (synthesis): filtered district gets only the selected `values-*.txt`, an unfiltered district still gets all five
- export (synthesis): `none` → no district file at all
- export (year-by-year): filtered district gets only the selected `values-*.txt`

**End-to-end**: ran `antares-solver` on a `short-tests` study (`021 Four areas - DC law`, economy mode, 1 MC year) with two districts — an unfiltered `all areas` and a filtered `west and east` (`filter-synthesis = annual`, `filter-year-by-year = hourly, daily`). The unfiltered district exported all five granularities for both reports, while the filtered district exported only `annual` in `mc-all` and only `hourly` + `daily` in `mc-ind`; per-area outputs remained unfiltered. The solver log reported the applied filters and no "Invalid property" warnings were emitted.

### Documentation

`docs/user-guide/solver/02-inputs.md`: the `sets.ini` section now documents the two new keys (in the PRINCIPLE list and with an example), and the previous `sets-outputs.yaml` section has been removed.

### Notes / non-goals

- Output **variables** (columns) per district are intentionally *not* part of this PR; column selection remains globally handled by the variables inspector.
- Granularity filtering for areas/links already exists via their INI keys — this PR only extends the same concept to districts, using the same keys.
- The `sets-outputs.yaml` file (and the `yaml-cpp` dependency it required) is fully removed, with no backward-compatibility path.